### PR TITLE
Add models.dev browser to provider setup

### DIFF
--- a/apps/server/src/providers/anthropic/index.ts
+++ b/apps/server/src/providers/anthropic/index.ts
@@ -12,16 +12,19 @@ const PROVIDER_LABEL = "Anthropic";
 export interface AnthropicProviderOptions {
   apiKey: string;
   model?: string;
+  baseUrl?: string;
   /** Injected in tests to mock HTTP without touching global fetch. */
   fetch?: typeof fetch;
 }
 
 function createAnthropicClient(
   apiKey: string,
+  baseUrl?: string,
   fetchImpl?: typeof fetch,
 ): Anthropic {
   return new Anthropic({
     apiKey,
+    ...(baseUrl?.trim() ? { baseURL: baseUrl.trim() } : {}),
     ...(fetchImpl ? { fetch: fetchImpl } : {}),
   });
 }
@@ -52,7 +55,7 @@ export function createAnthropicProvider(
   options: AnthropicProviderOptions,
 ): ProviderClient {
   const model = options.model ?? "claude-sonnet-4-6";
-  const client = createAnthropicClient(options.apiKey, options.fetch);
+  const client = createAnthropicClient(options.apiKey, options.baseUrl, options.fetch);
 
   return {
     name: "anthropic",

--- a/apps/server/src/providers/create.ts
+++ b/apps/server/src/providers/create.ts
@@ -27,16 +27,20 @@ function createProvider(options: CreateProviderOptions): ProviderClient {
     options.userConfig?.customModels,
   );
 
+  const baseUrlOverride = options.userConfig?.baseUrl?.trim();
+
   switch (options.provider) {
     case "openai":
       return createOpenAIProvider({
         apiKey: options.apiKey,
         model,
+        ...(baseUrlOverride ? { baseUrl: baseUrlOverride } : {}),
       });
     case "anthropic":
       return createAnthropicProvider({
         apiKey: options.apiKey,
         model,
+        ...(baseUrlOverride ? { baseUrl: baseUrlOverride } : {}),
       });
     case "openrouter":
       return createOpenRouterProvider({
@@ -47,18 +51,18 @@ function createProvider(options: CreateProviderOptions): ProviderClient {
       return createGeminiProvider({
         apiKey: options.apiKey,
         model,
+        ...(baseUrlOverride ? { baseUrl: baseUrlOverride } : {}),
       });
     case "openai_compatible": {
-      const baseUrl = options.userConfig?.baseUrl?.trim();
       const displayName = options.userConfig?.displayName?.trim();
 
-      if (!baseUrl || !displayName) {
+      if (!baseUrlOverride || !displayName) {
         throw new Error("OpenAI-compatible provider requires baseUrl and displayName.");
       }
 
       return createOpenAICompatibleProvider({
         apiKey: options.apiKey,
-        baseUrl,
+        baseUrl: baseUrlOverride,
         model,
         displayName,
       });

--- a/apps/server/src/providers/gemini/index.ts
+++ b/apps/server/src/providers/gemini/index.ts
@@ -20,10 +20,15 @@ const DEFAULT_MODEL = "gemini-2.5-flash";
 export interface GeminiProviderOptions {
   apiKey: string;
   model?: string;
+  baseUrl?: string;
 }
 
-function createGeminiClient(apiKey: string): GoogleGenAI {
-  return new GoogleGenAI({ apiKey });
+function createGeminiClient(apiKey: string, baseUrl?: string): GoogleGenAI {
+  const trimmed = baseUrl?.trim();
+  return new GoogleGenAI({
+    apiKey,
+    ...(trimmed ? { httpOptions: { baseUrl: trimmed } } : {}),
+  });
 }
 
 function formatGeminiError(error: unknown): Error {
@@ -172,7 +177,7 @@ export function createGeminiProvider(
   options: GeminiProviderOptions,
 ): ProviderClient {
   const model = options.model ?? DEFAULT_MODEL;
-  const client = createGeminiClient(options.apiKey);
+  const client = createGeminiClient(options.apiKey, options.baseUrl);
 
   return {
     name: "gemini",

--- a/apps/server/src/providers/models.test.ts
+++ b/apps/server/src/providers/models.test.ts
@@ -35,6 +35,14 @@ describe("resolveModel", () => {
     expect(getDefaultModel("gemini")).toBe("gemini-2.5-flash");
   });
 
+  test("passes through non-catalog models for native providers", () => {
+    expect(resolveModel("anthropic", "claude-haiku-4-5-20251001")).toBe(
+      "claude-haiku-4-5-20251001",
+    );
+    expect(resolveModel("openai", "gpt-4o-2025-08")).toBe("gpt-4o-2025-08");
+    expect(resolveModel("gemini", "gemini-3.0-ultra")).toBe("gemini-3.0-ultra");
+  });
+
   test("resolves compatible models from custom list", () => {
     const customModels = [{ id: "llama3.2", default: true }];
     expect(resolveModel("openai_compatible", "llama3.2", customModels)).toBe(

--- a/apps/server/src/providers/models.ts
+++ b/apps/server/src/providers/models.ts
@@ -1,21 +1,12 @@
 import { findCustomModel, type CustomModelEntry } from "@tinyclaw/core";
 import type { ProviderName } from "@tinyclaw/core";
+import type { ProviderModelOption as ContractProviderModelOption } from "@tinyclaw/core/contract";
 import { resolveCompatibleDefaultModel } from "./compatible-models";
 
-export interface ProviderModelOption {
-  id: string;
-  name: string;
-  provider: ProviderName;
+export type ProviderModelOption = ContractProviderModelOption & {
   contextWindow: number;
   maxOutputTokens: number;
-  default?: boolean;
-  /** OpenRouter only: whether extended thinking (`reasoning`) is sent for this model. */
-  supportsThinking?: boolean;
-  /** Catalog estimate: USD per 1M input tokens */
-  inputPerMillionUsd?: number;
-  /** Catalog estimate: USD per 1M output tokens */
-  outputPerMillionUsd?: number;
-}
+};
 
 export const AVAILABLE_MODELS: ProviderModelOption[] = [
   {
@@ -206,6 +197,13 @@ export function resolveModel(
     if (option?.provider === provider) {
       return trimmed;
     }
+  }
+
+  if (
+    trimmed &&
+    (provider === "openai" || provider === "anthropic" || provider === "gemini")
+  ) {
+    return trimmed;
   }
 
   return getDefaultModel(provider, customModels);

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -38,8 +38,8 @@ import type {
   ThinkingSettingsResponse,
   UpdateThinkingRequest,
   UserProviderConfig,
-  type ProviderChatOptions,
-  type ProviderClient,
+  ProviderChatOptions,
+  ProviderClient,
 } from "@tinyclaw/core";
 import {
   isValidBaseUrl,
@@ -741,10 +741,13 @@ export class AgentService {
       throw new Error("API key is required.");
     }
 
-    const compatibleFields =
+    const compatibleFields: Pick<
+      UserProviderConfig,
+      "displayName" | "baseUrl" | "customModels"
+    > =
       provider === "openai_compatible"
         ? this.buildCompatibleProviderFields(request)
-        : {};
+        : this.buildNativeBaseUrlFields(request);
 
     const customModels = compatibleFields.customModels;
     const selectedModel = request.model?.trim()
@@ -809,6 +812,22 @@ export class AgentService {
     }
 
     return { displayName, baseUrl, customModels };
+  }
+
+  private buildNativeBaseUrlFields(
+    request: ConfigureProviderRequest,
+  ): Pick<UserProviderConfig, "baseUrl"> {
+    const raw = request.baseUrl?.trim();
+    if (!raw) {
+      return {};
+    }
+
+    const normalized = normalizeBaseUrl(raw);
+    if (!isValidBaseUrl(normalized)) {
+      throw new Error("A valid http(s) base URL is required.");
+    }
+
+    return { baseUrl: normalized };
   }
 
   async listProfiles(): Promise<ListProfilesResponse> {
@@ -966,7 +985,7 @@ export class AgentService {
           )
         : null;
 
-    this.syncUsagePricingContext(providerName, modelId);
+    this.syncUsagePricingContext(providerName);
 
     const trackedProvider =
       provider && this.llmUsageTracker && modelId
@@ -981,7 +1000,6 @@ export class AgentService {
 
   private syncUsagePricingContext(
     provider: ReturnType<typeof detectProvider>,
-    modelId: string | null,
   ): void {
     this.llmUsageTracker?.setPricingContext({
       provider,

--- a/apps/web/src/components/ModelsBrowseList.tsx
+++ b/apps/web/src/components/ModelsBrowseList.tsx
@@ -1,0 +1,168 @@
+import { useMemo, useState } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import { type ModelsDevRow, useModelsDev } from "@/hooks/use-models-dev";
+import type { SelectedProvider } from "@/lib/models";
+import { cn } from "@/lib/utils";
+
+export type BrowseSelectHandler = (
+  provider: SelectedProvider,
+  modelId: string,
+  row: ModelsDevRow,
+) => void;
+
+interface ModelsBrowseListProps {
+  onSelect: BrowseSelectHandler;
+  className?: string;
+}
+
+export function ModelsBrowseList({ onSelect, className }: ModelsBrowseListProps) {
+  const { data: rows = [], isLoading, error } = useModelsDev();
+  const [search, setSearch] = useState("");
+  const [costFilter, setCostFilter] = useState<"all" | "free">("all");
+  const [hideDeprecated, setHideDeprecated] = useState(true);
+
+  const filtered = useMemo(() => {
+    let result = rows;
+    if (costFilter === "free") result = result.filter((row) => row.isFree);
+    if (hideDeprecated) result = result.filter((row) => !row.deprecated);
+    if (search) {
+      const query = search.toLowerCase();
+      result = result.filter(
+        (row) =>
+          row.providerName.toLowerCase().includes(query) ||
+          row.modelName.toLowerCase().includes(query) ||
+          row.modelId.toLowerCase().includes(query),
+      );
+    }
+    return [...result].sort((a, b) => {
+      const publicA = a.isZen && a.isFree && !a.deprecated;
+      const publicB = b.isZen && b.isFree && !b.deprecated;
+      if (publicA !== publicB) return publicA ? -1 : 1;
+      if (a.isFree !== b.isFree) return a.isFree ? -1 : 1;
+      const byProvider = a.providerName.localeCompare(b.providerName);
+      if (byProvider !== 0) return byProvider;
+      return a.modelName.localeCompare(b.modelName);
+    });
+  }, [rows, costFilter, hideDeprecated, search]);
+
+  const freeCount = filtered.filter((row) => row.isFree).length;
+
+  return (
+    <div className={cn("flex flex-col", className)}>
+      <div className="flex flex-wrap items-center gap-2 border-b border-border px-3 py-2">
+        <Input
+          placeholder="Search provider or model..."
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          className="min-w-[140px] flex-1"
+        />
+        <Select
+          value={costFilter}
+          onValueChange={(value) => setCostFilter(value as "all" | "free")}
+        >
+          <SelectTrigger className="w-[110px]">
+            <SelectValue>{costFilter === "free" ? "Free only" : "All"}</SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All</SelectItem>
+            <SelectItem value="free">Free only</SelectItem>
+          </SelectContent>
+        </Select>
+        <label className="flex h-8 cursor-pointer items-center gap-2 text-sm text-foreground">
+          <input
+            type="checkbox"
+            className="size-4 rounded border-input"
+            checked={hideDeprecated}
+            onChange={(event) => setHideDeprecated(event.target.checked)}
+          />
+          Hide deprecated
+        </label>
+      </div>
+
+      <div className="border-b border-border px-3 py-1.5 text-xs text-muted-foreground">
+        {filtered.length} models · {freeCount} free
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {isLoading ? (
+          <div className="flex justify-center py-8">
+            <Spinner className="size-4 text-muted-foreground" />
+          </div>
+        ) : error ? (
+          <div className="px-3 py-8 text-center text-sm text-destructive">
+            Failed to load: {String(error)}
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="px-3 py-8 text-center text-sm text-muted-foreground">
+            No models found
+          </div>
+        ) : (
+          filtered.map((row) => {
+            const isPublicKey = row.isZen && row.isFree && !row.deprecated;
+            return (
+              <button
+                key={`${row.providerId}-${row.modelId}`}
+                type="button"
+                onClick={() => onSelect(row.tinyclawProvider, row.modelId, row)}
+                className="flex w-full cursor-pointer items-start gap-2.5 border-b border-border px-3 py-2 text-left transition-colors last:border-0 hover:bg-muted"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="mb-0.5 text-xs text-muted-foreground">
+                    {row.providerName}
+                  </div>
+                  <div className="truncate text-sm font-medium leading-tight text-foreground">
+                    {row.modelName}
+                  </div>
+                  <div className="mt-0.5 truncate font-mono text-[0.7rem] text-muted-foreground">
+                    {row.modelId}
+                  </div>
+                </div>
+
+                <div className="flex shrink-0 flex-col items-end gap-1 pt-0.5 text-xs text-muted-foreground">
+                  <div className="flex items-center gap-1">
+                    {isPublicKey && (
+                      <span className="inline-flex items-center rounded bg-sky-500/15 px-1.5 py-0.5 text-[0.6rem] font-bold uppercase tracking-wide text-sky-400 ring-1 ring-sky-500/30">
+                        public
+                      </span>
+                    )}
+                    {row.isFree && (
+                      <span className="inline-flex items-center rounded bg-emerald-500/15 px-1.5 py-0.5 text-[0.6rem] font-bold uppercase tracking-wide text-emerald-400 ring-1 ring-emerald-500/30">
+                        FREE
+                      </span>
+                    )}
+                    {row.context > 0 && (
+                      <span>
+                        {row.context >= 1000
+                          ? `${Math.round(row.context / 1000)}K`
+                          : row.context}
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex gap-1">
+                    {row.toolCall && (
+                      <span className="rounded bg-muted px-1 py-0.5 text-[0.6rem]">tools</span>
+                    )}
+                    {row.vision && (
+                      <span className="rounded bg-muted px-1 py-0.5 text-[0.6rem]">vision</span>
+                    )}
+                    {row.reasoning && (
+                      <span className="rounded bg-muted px-1 py-0.5 text-[0.6rem]">reasoning</span>
+                    )}
+                  </div>
+                </div>
+              </button>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ModelsBrowseList.tsx
+++ b/apps/web/src/components/ModelsBrowseList.tsx
@@ -62,13 +62,13 @@ export function ModelsBrowseList({ onSelect, className }: ModelsBrowseListProps)
           placeholder="Search provider or model..."
           value={search}
           onChange={(event) => setSearch(event.target.value)}
-          className="min-w-[140px] flex-1"
+          className="min-w-35 flex-1"
         />
         <Select
           value={costFilter}
           onValueChange={(value) => setCostFilter(value as "all" | "free")}
         >
-          <SelectTrigger className="w-[110px]">
+          <SelectTrigger className="w-27.5">
             <SelectValue>{costFilter === "free" ? "Free only" : "All"}</SelectValue>
           </SelectTrigger>
           <SelectContent>
@@ -112,7 +112,14 @@ export function ModelsBrowseList({ onSelect, className }: ModelsBrowseListProps)
                 key={`${row.providerId}-${row.modelId}`}
                 type="button"
                 onClick={() => onSelect(row.tinyclawProvider, row.modelId, row)}
-                className="flex w-full cursor-pointer items-start gap-2.5 border-b border-border px-3 py-2 text-left transition-colors last:border-0 hover:bg-muted"
+                disabled={!row.supported}
+                title={row.unsupportedReason}
+                className={cn(
+                  "flex w-full items-start gap-2.5 border-b border-border px-3 py-2 text-left transition-colors last:border-0",
+                  row.supported
+                    ? "cursor-pointer hover:bg-muted"
+                    : "cursor-not-allowed opacity-50",
+                )}
               >
                 <div className="min-w-0 flex-1">
                   <div className="mb-0.5 text-xs text-muted-foreground">
@@ -138,6 +145,14 @@ export function ModelsBrowseList({ onSelect, className }: ModelsBrowseListProps)
                         FREE
                       </span>
                     )}
+                    {row.experimental && (
+                      <span
+                        title="Untested with tinyclaw — feature support (tools, JSON mode, streaming) may vary."
+                        className="inline-flex items-center rounded bg-amber-500/15 px-1.5 py-0.5 text-[0.6rem] font-bold uppercase tracking-wide text-amber-400 ring-1 ring-amber-500/30"
+                      >
+                        experimental
+                      </span>
+                    )}
                     {row.context > 0 && (
                       <span>
                         {row.context >= 1000
@@ -155,6 +170,11 @@ export function ModelsBrowseList({ onSelect, className }: ModelsBrowseListProps)
                     )}
                     {row.reasoning && (
                       <span className="rounded bg-muted px-1 py-0.5 text-[0.6rem]">reasoning</span>
+                    )}
+                    {!row.supported && (
+                      <span className="rounded bg-muted px-1 py-0.5 text-[0.6rem] uppercase">
+                        n/a
+                      </span>
                     )}
                   </div>
                 </div>

--- a/apps/web/src/components/ProviderSetupForm.tsx
+++ b/apps/web/src/components/ProviderSetupForm.tsx
@@ -1,5 +1,8 @@
 import type { ConfigureProviderResponse } from "@tinyclaw/core/contract";
 import { EyeIcon, EyeOffIcon } from "lucide-react";
+import { useState } from "react";
+import { ModelsBrowseList } from "@/components/ModelsBrowseList";
+import type { ModelsDevRow } from "@/hooks/use-models-dev";
 import { Button } from "@/components/ui/button";
 import {
   InputGroup,
@@ -38,171 +41,215 @@ export function ProviderSetupForm({
   onSuccess,
 }: ProviderSetupFormProps) {
   const form = useProviderSetupForm({ onSuccess });
+  const [isBrowsing, setIsBrowsing] = useState(false);
 
   const formSpacing = density === "compact" ? "space-y-4" : "space-y-5";
 
+  function handleBrowseSelect(provider: SelectedProvider, modelId: string, row: ModelsDevRow) {
+    form.handleBrowseSelect(provider, modelId, row);
+    setIsBrowsing(false);
+  }
+
   return (
     <form className={formSpacing} onSubmit={(event) => void form.handleSubmit(event)}>
-      {showHeading ? (
+      {showHeading && (
         <div>
           <h3 className="text-sm font-medium text-foreground">Connect a provider</h3>
           <p className="mt-1 text-xs text-muted-foreground">
             Choose a provider, paste your API key, and pick a default model.
           </p>
         </div>
-      ) : null}
+      )}
 
-      <ProviderSelect
-        selectedProvider={form.selectedProvider}
-        disabled={form.busy}
-        density={density}
-        onSelect={form.handleProviderSelect}
-      />
-
-      {form.selectedProvider === "openai_compatible" ? (
-        <CustomCompatibleProviderFields
-          displayName={form.displayName}
-          baseUrl={form.baseUrl}
-          apiKey={form.apiKey}
-          customModels={form.customModels}
-          disabled={form.busy}
-          density={density}
-          displayNameError={form.displayNameError}
-          baseUrlError={form.baseUrlError}
-          modelsError={form.modelsError}
-          onDisplayNameChange={form.setDisplayName}
-          onBaseUrlChange={form.setBaseUrl}
-          onCustomModelsChange={form.setCustomModels}
-        />
-      ) : null}
-
-      <FormField
-        id="api-key"
-        label={form.selectedProvider === "openai_compatible" ? "API key (optional)" : "API key"}
-        density={density}
-        footer={
-          form.apiKeyError ? (
-            <p id="api-key-error" className="text-sm text-destructive" role="alert">
-              {form.apiKeyError}
-            </p>
-          ) : (
-            <p id="api-key-hint" className="text-xs text-muted-foreground">
-              Paste the API key from your{" "}
-              {PROVIDER_OPTIONS.find((option) => option.id === form.selectedProvider)?.label ??
-                "provider"}{" "}
-              dashboard.
-            </p>
-          )
-        }
-      >
-        <InputGroup>
-          <InputGroupInput
-            id="api-key"
-            type={form.showApiKey ? "text" : "password"}
-            autoComplete="off"
-            placeholder={apiKeyPlaceholder(form.selectedProvider)}
-            value={form.apiKey}
-            disabled={form.busy}
-            aria-invalid={form.apiKeyError != null}
-            aria-describedby={form.apiKeyError ? "api-key-error" : "api-key-hint"}
-            onBlur={form.handleApiKeyBlur}
-            onChange={(event) => form.handleApiKeyChange(event.target.value)}
-          />
-          <InputGroupAddon align="inline-end">
-            <InputGroupButton
-              size="icon-sm"
-              aria-label={form.showApiKey ? "Hide API key" : "Show API key"}
-              onClick={() => form.setShowApiKey((current) => !current)}
-            >
-              {form.showApiKey ? <EyeOffIcon /> : <EyeIcon />}
-            </InputGroupButton>
-          </InputGroupAddon>
-        </InputGroup>
-      </FormField>
-
-      <FormField id="model" label="Model" density={density}>
+      <FormField id="provider" label="Provider" density={density}>
         <Select
-          value={form.selectedModel}
-          disabled={form.busy || form.filteredModels.length === 0}
-          onValueChange={(value) => form.setSelectedModel(value != null ? String(value) : "")}
+          value={isBrowsing ? "__browse__" : form.selectedProvider}
+          disabled={form.busy}
+          onValueChange={(v) => {
+            if (v === "__browse__") {
+              setIsBrowsing(true);
+            } else if (isSelectedProvider(v)) {
+              setIsBrowsing(false);
+              form.handleProviderSelect(v);
+            }
+          }}
         >
-          <SelectTrigger id="model" className="w-full">
-            <SelectValue placeholder="Select a model" />
+          <SelectTrigger
+            id="provider"
+            className={density === "compact" ? "w-full" : "w-full sm:max-w-sm"}
+          >
+            <SelectValue>
+              {isBrowsing
+                ? "Browse models.dev…"
+                : (PROVIDER_OPTIONS.find((o) => o.id === form.selectedProvider)?.label ??
+                  form.selectedProvider)}
+            </SelectValue>
           </SelectTrigger>
           <SelectContent>
-            {form.filteredModels.map((model) => (
-              <SelectItem key={model.id} value={model.id}>
-                {model.name}
-                {model.default ? " (default)" : ""}
+            {PROVIDER_OPTIONS.map((option) => (
+              <SelectItem key={option.id} value={option.id}>
+                {option.label}
               </SelectItem>
             ))}
+            <SelectItem value="__browse__">Browse models.dev…</SelectItem>
           </SelectContent>
         </Select>
       </FormField>
 
-      {form.selectedProvider === "openrouter" ? (
-        <FormField
-          id="custom-model"
-          density={density}
-          label={
-            <>
-              Custom model ID <span className="font-normal text-muted-foreground">(optional)</span>
-            </>
-          }
-          footer={
-            form.customModelError ? (
-              <p id="custom-model-error" className="text-sm text-destructive" role="alert">
-                {form.customModelError}
-              </p>
-            ) : (
-              <p id="custom-model-hint" className="text-xs text-muted-foreground">
-                Overrides the catalog selection when set. Use vendor/model format from OpenRouter.
-              </p>
-            )
-          }
-        >
-          <InputGroup>
-            <InputGroupInput
-              id="custom-model"
-              type="text"
-              autoComplete="off"
-              placeholder="anthropic/claude-sonnet-4-6"
-              value={form.customModel}
+      {isBrowsing ? (
+        <ModelsBrowseList
+          onSelect={handleBrowseSelect}
+          className="h-72 rounded-md border border-border"
+        />
+      ) : (
+        <>
+          {form.selectedProvider === "openai_compatible" ? (
+            <CustomCompatibleProviderFields
+              displayName={form.displayName}
+              baseUrl={form.baseUrl}
+              apiKey={form.apiKey}
+              customModels={form.customModels}
               disabled={form.busy}
-              aria-invalid={form.customModelError != null}
-              aria-describedby={
-                form.customModelError ? "custom-model-error" : "custom-model-hint"
-              }
-              onChange={(event) => form.handleCustomModelChange(event.target.value)}
+              density={density}
+              displayNameError={form.displayNameError}
+              baseUrlError={form.baseUrlError}
+              modelsError={form.modelsError}
+              onDisplayNameChange={form.setDisplayName}
+              onBaseUrlChange={form.setBaseUrl}
+              onCustomModelsChange={form.setCustomModels}
             />
-          </InputGroup>
-        </FormField>
-      ) : null}
+          ) : null}
 
-      {form.formError ? (
-        <p className="text-sm text-destructive" role="alert">
-          {form.formError}
-        </p>
-      ) : null}
+          <FormField
+            id="api-key"
+            label={form.selectedProvider === "openai_compatible" ? "API key (optional)" : "API key"}
+            density={density}
+            footer={
+              form.apiKeyError ? (
+                <p id="api-key-error" className="text-sm text-destructive" role="alert">
+                  {form.apiKeyError}
+                </p>
+              ) : (
+                <p id="api-key-hint" className="text-xs text-muted-foreground">
+                  Paste the API key from your{" "}
+                  {PROVIDER_OPTIONS.find((option) => option.id === form.selectedProvider)?.label ??
+                    "provider"}{" "}
+                  dashboard.
+                </p>
+              )
+            }
+          >
+            <InputGroup>
+              <InputGroupInput
+                id="api-key"
+                type={form.showApiKey ? "text" : "password"}
+                autoComplete="off"
+                placeholder={apiKeyPlaceholder(form.selectedProvider)}
+                value={form.apiKey}
+                disabled={form.busy}
+                aria-invalid={form.apiKeyError != null}
+                aria-describedby={form.apiKeyError ? "api-key-error" : "api-key-hint"}
+                onBlur={form.handleApiKeyBlur}
+                onChange={(event) => form.handleApiKeyChange(event.target.value)}
+              />
+              <InputGroupAddon align="inline-end">
+                <InputGroupButton
+                  size="icon-sm"
+                  aria-label={form.showApiKey ? "Hide API key" : "Show API key"}
+                  onClick={() => form.setShowApiKey((current) => !current)}
+                >
+                  {form.showApiKey ? <EyeOffIcon /> : <EyeIcon />}
+                </InputGroupButton>
+              </InputGroupAddon>
+            </InputGroup>
+          </FormField>
 
-      <div className="flex flex-wrap gap-2">
-        <Button
-          type="submit"
-          disabled={
-            form.busy ||
-            (form.selectedProvider !== "openai_compatible" && !form.apiKey.trim())
-          }
-        >
-          {form.busy ? (
-            <>
-              <Spinner className="mr-2" />
-              Saving…
-            </>
-          ) : (
-            submitLabel
-          )}
-        </Button>
-      </div>
+          <FormField id="model" label="Model" density={density}>
+            <Select
+              value={form.selectedModel}
+              disabled={form.busy || form.filteredModels.length === 0}
+              onValueChange={(value) => form.setSelectedModel(value != null ? String(value) : "")}
+            >
+              <SelectTrigger id="model" className="w-full">
+                <SelectValue placeholder="Select a model" />
+              </SelectTrigger>
+              <SelectContent>
+                {form.filteredModels.map((model) => (
+                  <SelectItem key={model.id} value={model.id}>
+                    {model.name}
+                    {model.default ? " (default)" : ""}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </FormField>
+
+          {form.selectedProvider === "openrouter" ? (
+            <FormField
+              id="custom-model"
+              density={density}
+              label={
+                <>
+                  Custom model ID{" "}
+                  <span className="font-normal text-muted-foreground">(optional)</span>
+                </>
+              }
+              footer={
+                form.customModelError ? (
+                  <p id="custom-model-error" className="text-sm text-destructive" role="alert">
+                    {form.customModelError}
+                  </p>
+                ) : (
+                  <p id="custom-model-hint" className="text-xs text-muted-foreground">
+                    Overrides the catalog selection when set. Use vendor/model format from OpenRouter.
+                  </p>
+                )
+              }
+            >
+              <InputGroup>
+                <InputGroupInput
+                  id="custom-model"
+                  type="text"
+                  autoComplete="off"
+                  placeholder="anthropic/claude-sonnet-4-6"
+                  value={form.customModel}
+                  disabled={form.busy}
+                  aria-invalid={form.customModelError != null}
+                  aria-describedby={
+                    form.customModelError ? "custom-model-error" : "custom-model-hint"
+                  }
+                  onChange={(event) => form.handleCustomModelChange(event.target.value)}
+                />
+              </InputGroup>
+            </FormField>
+          ) : null}
+
+          {form.formError ? (
+            <p className="text-sm text-destructive" role="alert">
+              {form.formError}
+            </p>
+          ) : null}
+
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="submit"
+              disabled={
+                form.busy ||
+                (form.selectedProvider !== "openai_compatible" && !form.apiKey.trim())
+              }
+            >
+              {form.busy ? (
+                <>
+                  <Spinner className="mr-2" />
+                  Saving…
+                </>
+              ) : (
+                submitLabel
+              )}
+            </Button>
+          </div>
+        </>
+      )}
     </form>
   );
 }
@@ -213,56 +260,4 @@ function isSelectedProvider(value: string | null): value is SelectedProvider {
   }
 
   return PROVIDER_OPTIONS.some((option) => option.id === value);
-}
-
-export function ProviderSelect({
-  id = "provider",
-  label = "Provider",
-  selectedProvider,
-  disabled,
-  excludeProvider,
-  density = "default",
-  onSelect,
-}: {
-  id?: string;
-  label?: string;
-  selectedProvider: SelectedProvider;
-  disabled?: boolean;
-  density?: "default" | "compact";
-  /** Hide one provider (e.g. the active one when switching). */
-  excludeProvider?: SelectedProvider;
-  onSelect: (provider: SelectedProvider) => void;
-}) {
-  const options = excludeProvider
-    ? PROVIDER_OPTIONS.filter((option) => option.id !== excludeProvider)
-    : PROVIDER_OPTIONS;
-  const selectedOption = PROVIDER_OPTIONS.find((option) => option.id === selectedProvider);
-
-  return (
-    <FormField id={id} label={label} density={density}>
-      <Select
-        value={selectedProvider}
-        disabled={disabled}
-        onValueChange={(value) => {
-          if (value != null && isSelectedProvider(value)) {
-            onSelect(value);
-          }
-        }}
-      >
-        <SelectTrigger
-          id={id}
-          className={density === "compact" ? "w-full" : "w-full sm:max-w-sm"}
-        >
-          <SelectValue>{selectedOption?.label ?? selectedProvider}</SelectValue>
-        </SelectTrigger>
-        <SelectContent>
-          {options.map((option) => (
-            <SelectItem key={option.id} value={option.id}>
-              {option.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </FormField>
-  );
 }

--- a/apps/web/src/hooks/use-models-dev.ts
+++ b/apps/web/src/hooks/use-models-dev.ts
@@ -1,0 +1,88 @@
+import { queryOptions, useQuery } from "@tanstack/react-query";
+import { queryKeys } from "@/lib/query-keys";
+import type { SelectedProvider } from "@/lib/models";
+
+export interface ModelsDevRow {
+  providerId: string;
+  providerName: string;
+  apiUrl: string;
+  modelId: string;
+  modelName: string;
+  isFree: boolean;
+  deprecated: boolean;
+  context: number;
+  toolCall: boolean;
+  reasoning: boolean;
+  vision: boolean;
+  isZen: boolean;
+  tinyclawProvider: SelectedProvider;
+}
+
+// opencode (Zen) maps to openai_compatible — free models work without an API key.
+const PROVIDER_MAP: Record<string, SelectedProvider> = {
+  openai: "openai",
+  anthropic: "anthropic",
+  google: "gemini",
+  openrouter: "openrouter",
+  opencode: "openai_compatible",
+};
+
+async function fetchModelsDev(): Promise<ModelsDevRow[]> {
+  const res = await fetch("https://models.dev/api.json");
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+  const data = (await res.json()) as Record<string, unknown>;
+  const rows: ModelsDevRow[] = [];
+
+  for (const [providerId, p] of Object.entries(data)) {
+    const provider = p as Record<string, unknown>;
+    const providerName = (provider.name as string | undefined) ?? providerId;
+    const apiUrl = (provider.api as string | undefined) ?? "";
+    const models = (provider.models as Record<string, unknown> | undefined) ?? {};
+
+    for (const [modelId, m] of Object.entries(models)) {
+      const model = m as Record<string, unknown>;
+      const cost = model.cost as Record<string, number> | number | undefined;
+      let inputCost: number | undefined;
+      let outputCost: number | undefined;
+
+      if (typeof cost === "object" && cost !== null) {
+        inputCost = cost.input;
+        outputCost = cost.output;
+      } else if (typeof cost === "number") {
+        inputCost = outputCost = cost;
+      }
+
+      const limit = (model.limit as Record<string, number> | undefined) ?? {};
+      const modalities = (model.modalities as Record<string, string[]> | undefined) ?? {};
+
+      rows.push({
+        providerId,
+        providerName,
+        apiUrl,
+        modelId,
+        modelName: (model.name as string | undefined) ?? modelId,
+        isFree: inputCost === 0 && outputCost === 0,
+        deprecated: (model.status as string | undefined) === "deprecated",
+        context: (limit.context as number | undefined) ?? 0,
+        toolCall: !!(model.tool_call as boolean | undefined),
+        reasoning: !!(model.reasoning as boolean | undefined),
+        vision: (modalities.input ?? []).includes("image"),
+        isZen: providerId === "opencode",
+        tinyclawProvider: PROVIDER_MAP[providerId] ?? "openai_compatible",
+      });
+    }
+  }
+
+  return rows;
+}
+
+export const modelsDevQueryOptions = queryOptions({
+  queryKey: queryKeys.modelsDev,
+  queryFn: fetchModelsDev,
+  staleTime: 1000 * 60 * 30,
+});
+
+export function useModelsDev() {
+  return useQuery(modelsDevQueryOptions);
+}

--- a/apps/web/src/hooks/use-models-dev.ts
+++ b/apps/web/src/hooks/use-models-dev.ts
@@ -16,16 +16,52 @@ export interface ModelsDevRow {
   vision: boolean;
   isZen: boolean;
   tinyclawProvider: SelectedProvider;
+  supported: boolean;
+  unsupportedReason?: string;
+  experimental: boolean;
 }
 
-// opencode (Zen) maps to openai_compatible — free models work without an API key.
-const PROVIDER_MAP: Record<string, SelectedProvider> = {
-  openai: "openai",
-  anthropic: "anthropic",
-  google: "gemini",
+const OFFICIAL_PROVIDER_IDS = new Set([
+  "openai",
+  "anthropic",
+  "google",
+  "openrouter",
+  "opencode",
+]);
+
+const NPM_MAP: Record<string, SelectedProvider> = {
+  "@ai-sdk/openai": "openai",
+  "@ai-sdk/anthropic": "anthropic",
+  "@ai-sdk/google": "gemini",
+};
+
+const PROVIDER_ID_OVERRIDES: Record<string, SelectedProvider> = {
   openrouter: "openrouter",
   opencode: "openai_compatible",
 };
+
+const UNSUPPORTED_NPM: Record<string, string> = {
+  "@ai-sdk/amazon-bedrock": "Requires AWS SigV4 auth",
+  "@ai-sdk/azure": "Requires Azure deployment routing",
+  "@ai-sdk/google-vertex": "Requires Google Cloud OAuth",
+  "@ai-sdk/google-vertex/anthropic": "Requires Google Cloud OAuth",
+  "@ai-sdk/gateway": "Requires Vercel AI Gateway",
+  "ai-gateway-provider": "Requires Cloudflare AI Gateway",
+  "merge-gateway-ai-sdk-provider": "Requires custom gateway auth",
+  "@jerome-benoit/sap-ai-provider-v2": "Requires SAP-specific auth",
+  "gitlab-ai-provider": "Requires GitLab Duo auth",
+  "venice-ai-sdk-provider": "Requires Venice-specific auth",
+};
+
+function resolveTinyclawProvider(
+  providerId: string,
+  npm: string | undefined,
+): SelectedProvider {
+  const override = PROVIDER_ID_OVERRIDES[providerId];
+  if (override) return override;
+  if (npm && NPM_MAP[npm]) return NPM_MAP[npm];
+  return "openai_compatible";
+}
 
 async function fetchModelsDev(): Promise<ModelsDevRow[]> {
   const res = await fetch("https://models.dev/api.json");
@@ -38,7 +74,12 @@ async function fetchModelsDev(): Promise<ModelsDevRow[]> {
     const provider = p as Record<string, unknown>;
     const providerName = (provider.name as string | undefined) ?? providerId;
     const apiUrl = (provider.api as string | undefined) ?? "";
+    const npm = provider.npm as string | undefined;
     const models = (provider.models as Record<string, unknown> | undefined) ?? {};
+    const tinyclawProvider = resolveTinyclawProvider(providerId, npm);
+    const unsupportedReason = npm ? UNSUPPORTED_NPM[npm] : undefined;
+    const supported = !unsupportedReason;
+    const experimental = supported && !OFFICIAL_PROVIDER_IDS.has(providerId);
 
     for (const [modelId, m] of Object.entries(models)) {
       const model = m as Record<string, unknown>;
@@ -69,7 +110,10 @@ async function fetchModelsDev(): Promise<ModelsDevRow[]> {
         reasoning: !!(model.reasoning as boolean | undefined),
         vision: (modalities.input ?? []).includes("image"),
         isZen: providerId === "opencode",
-        tinyclawProvider: PROVIDER_MAP[providerId] ?? "openai_compatible",
+        tinyclawProvider,
+        supported,
+        ...(unsupportedReason ? { unsupportedReason } : {}),
+        experimental,
       });
     }
   }

--- a/apps/web/src/hooks/use-provider-setup-form.ts
+++ b/apps/web/src/hooks/use-provider-setup-form.ts
@@ -2,6 +2,7 @@ import type { ConfigureProviderResponse } from "@tinyclaw/core/contract";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { ModelListRow } from "@/components/ModelListEditor";
 import { toCustomModelEntries } from "@/components/CustomCompatibleProviderFields";
+import type { ModelsDevRow } from "@/hooks/use-models-dev";
 import { useAppContext } from "@/context/app-context";
 import { useModelsQuery } from "@/hooks/use-app-queries";
 import { formatError } from "@/lib/client";
@@ -111,6 +112,27 @@ export function useProviderSetupForm(options: UseProviderSetupFormOptions = {}) 
       setModelsError(null);
     }
   }, []);
+
+  const handleBrowseSelect = useCallback(
+    (provider: SelectedProvider, modelId: string, row: ModelsDevRow) => {
+      handleProviderSelect(provider);
+      if (provider === "openrouter") {
+        setCustomModel(modelId);
+        setCustomModelError(null);
+      } else if (provider === "openai_compatible") {
+        setDisplayName(row.providerName);
+        setBaseUrl(row.apiUrl.replace(/\/$/, ""));
+        setCustomModels([{ id: modelId, name: row.modelName }]);
+        setSelectedModel(modelId);
+        if (row.isZen && row.isFree && !row.deprecated) {
+          setApiKey("public");
+        }
+      } else {
+        setSelectedModel(modelId);
+      }
+    },
+    [handleProviderSelect],
+  );
 
   const handleCustomModelChange = useCallback((value: string) => {
     setCustomModel(value);
@@ -245,6 +267,7 @@ export function useProviderSetupForm(options: UseProviderSetupFormOptions = {}) 
     handleApiKeyBlur,
     handleApiKeyChange,
     handleProviderSelect,
+    handleBrowseSelect,
     handleCustomModelChange,
     handleSubmit,
     formatSuccessMessage: (result: ConfigureProviderResponse) =>

--- a/apps/web/src/hooks/use-provider-setup-form.ts
+++ b/apps/web/src/hooks/use-provider-setup-form.ts
@@ -1,4 +1,4 @@
-import type { ConfigureProviderResponse } from "@tinyclaw/core/contract";
+import type { ConfigureProviderResponse, ProviderModelOption } from "@tinyclaw/core/contract";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { ModelListRow } from "@/components/ModelListEditor";
 import { toCustomModelEntries } from "@/components/CustomCompatibleProviderFields";
@@ -42,6 +42,7 @@ export function useProviderSetupForm(options: UseProviderSetupFormOptions = {}) 
   const [displayName, setDisplayName] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
   const [customModels, setCustomModels] = useState<ModelListRow[]>([{ id: "", name: "" }]);
+  const [extraModels, setExtraModels] = useState<ProviderModelOption[]>([]);
   const [displayNameError, setDisplayNameError] = useState<string | null>(null);
   const [baseUrlError, setBaseUrlError] = useState<string | null>(null);
   const [modelsError, setModelsError] = useState<string | null>(null);
@@ -59,8 +60,13 @@ export function useProviderSetupForm(options: UseProviderSetupFormOptions = {}) 
       return modelsFromCustomRows(customModels);
     }
 
-    return filterModelsByProvider(catalog, selectedProvider);
-  }, [catalog, selectedProvider, customModels]);
+    const catalogModels = filterModelsByProvider(catalog, selectedProvider);
+    const catalogIds = new Set(catalogModels.map((model) => model.id));
+    const extras = extraModels.filter(
+      (model) => model.provider === selectedProvider && !catalogIds.has(model.id),
+    );
+    return [...catalogModels, ...extras];
+  }, [catalog, selectedProvider, customModels, extraModels]);
 
   useEffect(() => {
     if (filteredModels.length === 0) {
@@ -107,6 +113,7 @@ export function useProviderSetupForm(options: UseProviderSetupFormOptions = {}) 
     }
 
     if (provider !== "openai_compatible") {
+      setBaseUrl("");
       setDisplayNameError(null);
       setBaseUrlError(null);
       setModelsError(null);
@@ -128,7 +135,26 @@ export function useProviderSetupForm(options: UseProviderSetupFormOptions = {}) 
           setApiKey("public");
         }
       } else {
+        setExtraModels((current) => {
+          if (
+            current.some(
+              (model) => model.provider === provider && model.id === modelId,
+            )
+          ) {
+            return current;
+          }
+          return [
+            ...current,
+            {
+              id: modelId,
+              name: row.modelName,
+              provider,
+              ...(row.context > 0 ? { contextWindow: row.context } : {}),
+            },
+          ];
+        });
         setSelectedModel(modelId);
+        setBaseUrl(row.apiUrl.replace(/\/$/, ""));
       }
     },
     [handleProviderSelect],

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -196,6 +196,11 @@ export function buildConfigureProviderRequest(options: {
     };
   }
 
+  const baseUrl = options.baseUrl?.trim();
+  if (baseUrl) {
+    return { ...request, baseUrl };
+  }
+
   return request;
 }
 

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -32,4 +32,5 @@ export const queryKeys = {
     settings: ["telegram", "settings"] as const,
   },
   userContext: ["userContext"] as const,
+  modelsDev: ["modelsDev"] as const,
 } as const;

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -6,7 +6,9 @@ import {
   EyeIcon,
   EyeOffIcon,
 } from "lucide-react";
-import { ProviderSelect, ProviderSetupForm } from "@/components/ProviderSetupForm";
+import { ProviderSetupForm } from "@/components/ProviderSetupForm";
+import { ModelsBrowseList } from "@/components/ModelsBrowseList";
+import type { ModelsDevRow } from "@/hooks/use-models-dev";
 import { TelegramSettingsCard } from "@/components/TelegramSettingsCard";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { UserContextSettings } from "@/components/UserContextCard";
@@ -331,7 +333,7 @@ export function SettingsPage() {
             <div className="flex items-center gap-2">
               <TimezoneSelect
                 id="timezone"
-                className="w-[11rem] min-w-0 sm:w-[13rem]"
+                className="w-44 min-w-0 sm:w-52"
                 value={timezone}
                 disabled={saveTimezoneMutation.isPending}
                 emptyLabel="Select timezone"
@@ -406,7 +408,7 @@ export function SettingsPage() {
                   }
                 }}
               >
-                <SelectTrigger className="w-[7.25rem]" aria-label="Reasoning depth">
+                <SelectTrigger className="w-29" aria-label="Reasoning depth">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent align="end">
@@ -549,6 +551,25 @@ function SettingsSkeleton() {
   );
 }
 
+function InlineField({
+  id,
+  label,
+  children,
+}: {
+  id: string;
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-3">
+      <label htmlFor={id} className="w-24 shrink-0 text-sm font-medium text-foreground">
+        {label}
+      </label>
+      <div className="min-w-0 flex-1">{children}</div>
+    </div>
+  );
+}
+
 function SwitchProviderSection({
   currentProvider,
   catalog,
@@ -570,6 +591,7 @@ function SwitchProviderSection({
   const [selectedModel, setSelectedModel] = useState("");
   const [customModel, setCustomModel] = useState("");
   const [customModelError, setCustomModelError] = useState<string | null>(null);
+  const [isBrowsing, setIsBrowsing] = useState(false);
   const [displayName, setDisplayName] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
   const [customModels, setCustomModels] = useState<ModelListRow[]>([{ id: "", name: "" }]);
@@ -682,181 +704,233 @@ function SwitchProviderSection({
     }
   };
 
+  function handleBrowseSelect(provider: SelectedProvider, modelId: string, row: ModelsDevRow) {
+    setIsBrowsing(false);
+    setTargetProvider(provider);
+    setLocalError(null);
+    if (provider !== "openrouter") {
+      setCustomModel("");
+      setCustomModelError(null);
+    }
+    if (provider === "openrouter") {
+      setCustomModel(modelId);
+      setCustomModelError(null);
+    } else if (provider === "openai_compatible") {
+      setDisplayName(row.providerName);
+      setBaseUrl(row.apiUrl.replace(/\/$/, ""));
+      setCustomModels([{ id: modelId, name: row.modelName }]);
+      setSelectedModel(modelId);
+      if (row.isZen && row.isFree && !row.deprecated) {
+        setApiKey("public");
+      }
+    } else {
+      setSelectedModel(modelId);
+    }
+    if (apiKeyTouched && apiKey.trim()) {
+      setApiKeyError(validateApiKeyForProvider(apiKey, provider));
+    }
+  }
+
   return (
-    <form className="space-y-4" onSubmit={(event) => void handleSubmit(event)}>
-      <div className="grid gap-4 sm:grid-cols-2">
-        <ProviderSelect
-          id="switch-provider"
-          selectedProvider={targetProvider}
-          density="compact"
+    <form className="space-y-3" onSubmit={(event) => void handleSubmit(event)}>
+      <InlineField id="switch-provider" label="Provider">
+        <Select
+          value={isBrowsing ? "__browse__" : targetProvider}
           disabled={busy}
-          onSelect={(provider) => {
-            setTargetProvider(provider);
-            setLocalError(null);
-            if (provider !== "openrouter") {
-              setCustomModel("");
-              setCustomModelError(null);
-            }
-            if (apiKeyTouched && apiKey.trim()) {
-              setApiKeyError(validateApiKeyForProvider(apiKey, provider));
+          onValueChange={(v) => {
+            if (v === "__browse__") {
+              setIsBrowsing(true);
+            } else if (PROVIDER_OPTIONS.some((o) => o.id === v)) {
+              setIsBrowsing(false);
+              setTargetProvider(v as SelectedProvider);
+              setLocalError(null);
+              if (v !== "openrouter") {
+                setCustomModel("");
+                setCustomModelError(null);
+              }
+              if (apiKeyTouched && apiKey.trim()) {
+                setApiKeyError(validateApiKeyForProvider(apiKey, v as SelectedProvider));
+              }
             }
           }}
-        />
-
-        <FormField id="switch-model" label="Model" density="compact">
-          <Select
-            value={selectedModel}
-            disabled={busy || targetModels.length === 0}
-            onValueChange={(value) => setSelectedModel(value != null ? String(value) : "")}
-          >
-            <SelectTrigger id="switch-model" className="w-full">
-              <SelectValue placeholder="Select a model" />
-            </SelectTrigger>
-            <SelectContent>
-              {targetModels.map((model) => (
-                <SelectItem key={model.id} value={model.id}>
-                  {model.name}
-                  {model.default ? " (default)" : ""}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </FormField>
-      </div>
-
-      <FormField
-        id="switch-api-key"
-        label="API key"
-        density="compact"
-        footer={
-          apiKeyError ? (
-            <p id="switch-api-key-error" className="text-sm text-destructive" role="alert">
-              {apiKeyError}
-            </p>
-          ) : null
-        }
-      >
-        <InputGroup>
-          <InputGroupInput
-            id="switch-api-key"
-            type={showApiKey ? "text" : "password"}
-            autoComplete="off"
-            placeholder={apiKeyPlaceholder(targetProvider)}
-            value={apiKey}
-            disabled={busy}
-            aria-invalid={apiKeyError != null}
-            aria-describedby={apiKeyError ? "switch-api-key-error" : undefined}
-            onBlur={() => {
-              setApiKeyTouched(true);
-              if (!apiKey.trim()) {
-                setApiKeyError(null);
-                return;
-              }
-              setApiKeyError(validateApiKeyForProvider(apiKey, targetProvider));
-            }}
-            onChange={(event) => {
-              const value = event.target.value;
-              setApiKey(value);
-              setLocalError(null);
-              if (apiKeyTouched && value.trim()) {
-                setApiKeyError(validateApiKeyForProvider(value, targetProvider));
-              } else if (apiKeyError) {
-                setApiKeyError(null);
-              }
-            }}
-          />
-          <InputGroupAddon align="inline-end">
-            <InputGroupButton
-              size="icon-sm"
-              aria-label={showApiKey ? "Hide API key" : "Show API key"}
-              onClick={() => setShowApiKey((current) => !current)}
-            >
-              {showApiKey ? <EyeOffIcon /> : <EyeIcon />}
-            </InputGroupButton>
-          </InputGroupAddon>
-        </InputGroup>
-      </FormField>
-
-      {targetProvider === "openrouter" ? (
-        <FormField
-          id="switch-custom-model"
-          density="compact"
-          label={
-            <>
-              Custom model ID <span className="font-normal text-muted-foreground">(optional)</span>
-            </>
-          }
-          footer={
-            customModelError ? (
-              <p id="switch-custom-model-error" className="text-sm text-destructive" role="alert">
-                {customModelError}
-              </p>
-            ) : (
-              <p id="switch-custom-model-hint" className="text-xs text-muted-foreground">
-                Overrides the catalog selection when set.
-              </p>
-            )
-          }
         >
-          <InputGroup>
-            <InputGroupInput
-              id="switch-custom-model"
-              type="text"
-              autoComplete="off"
-              placeholder="anthropic/claude-sonnet-4-6"
-              value={customModel}
-              disabled={busy}
-              aria-invalid={customModelError != null}
-              aria-describedby={
-                customModelError ? "switch-custom-model-error" : "switch-custom-model-hint"
-              }
-              onChange={(event) => {
-                const value = event.target.value;
-                setCustomModel(value);
-                setCustomModelError(validateCustomOpenRouterModel(value));
-              }}
-            />
-          </InputGroup>
-        </FormField>
-      ) : null}
+          <SelectTrigger id="switch-provider" className="w-full">
+            <SelectValue>
+              {isBrowsing
+                ? "Browse models.dev…"
+                : (PROVIDER_OPTIONS.find((o) => o.id === targetProvider)?.label ?? targetProvider)}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            {PROVIDER_OPTIONS.map((option) => (
+              <SelectItem key={option.id} value={option.id}>
+                {option.label}
+              </SelectItem>
+            ))}
+            <SelectItem value="__browse__">Browse models.dev…</SelectItem>
+          </SelectContent>
+        </Select>
+      </InlineField>
 
-      {targetProvider === "openai_compatible" ? (
-        <CustomCompatibleProviderFields
-          displayName={displayName}
-          baseUrl={baseUrl}
-          apiKey={apiKey}
-          customModels={customModels}
-          disabled={busy}
-          density="compact"
-          displayNameError={displayNameError}
-          baseUrlError={baseUrlError}
-          modelsError={modelsError}
-          onDisplayNameChange={setDisplayName}
-          onBaseUrlChange={setBaseUrl}
-          onCustomModelsChange={setCustomModels}
+      {isBrowsing ? (
+        <ModelsBrowseList
+          onSelect={handleBrowseSelect}
+          className="h-72 rounded-md border border-border"
         />
-      ) : null}
+      ) : (
+        <>
+          <InlineField id="switch-model" label="Model">
+            <Select
+              value={selectedModel}
+              disabled={busy || targetModels.length === 0}
+              onValueChange={(value) => setSelectedModel(value != null ? String(value) : "")}
+            >
+              <SelectTrigger id="switch-model" className="w-full">
+                <SelectValue placeholder="Select a model" />
+              </SelectTrigger>
+              <SelectContent>
+                {targetModels.map((model) => (
+                  <SelectItem key={model.id} value={model.id}>
+                    {model.name}
+                    {model.default ? " (default)" : ""}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </InlineField>
 
-      {localError ? (
-        <p className="text-sm text-destructive" role="alert">
-          {localError}
-        </p>
-      ) : null}
+          <div>
+            <InlineField id="switch-api-key" label="API key">
+              <InputGroup>
+                <InputGroupInput
+                  id="switch-api-key"
+                  type={showApiKey ? "text" : "password"}
+                  autoComplete="off"
+                  placeholder={apiKeyPlaceholder(targetProvider)}
+                  value={apiKey}
+                  disabled={busy}
+                  aria-invalid={apiKeyError != null}
+                  aria-describedby={apiKeyError ? "switch-api-key-error" : undefined}
+                  onBlur={() => {
+                    setApiKeyTouched(true);
+                    if (!apiKey.trim()) {
+                      setApiKeyError(null);
+                      return;
+                    }
+                    setApiKeyError(validateApiKeyForProvider(apiKey, targetProvider));
+                  }}
+                  onChange={(event) => {
+                    const value = event.target.value;
+                    setApiKey(value);
+                    setLocalError(null);
+                    if (apiKeyTouched && value.trim()) {
+                      setApiKeyError(validateApiKeyForProvider(value, targetProvider));
+                    } else if (apiKeyError) {
+                      setApiKeyError(null);
+                    }
+                  }}
+                />
+                <InputGroupAddon align="inline-end">
+                  <InputGroupButton
+                    size="icon-sm"
+                    aria-label={showApiKey ? "Hide API key" : "Show API key"}
+                    onClick={() => setShowApiKey((current) => !current)}
+                  >
+                    {showApiKey ? <EyeOffIcon /> : <EyeIcon />}
+                  </InputGroupButton>
+                </InputGroupAddon>
+              </InputGroup>
+            </InlineField>
+            {apiKeyError && (
+              <p id="switch-api-key-error" className="mt-1.5 pl-[calc(6rem+0.75rem)] text-sm text-destructive" role="alert">
+                {apiKeyError}
+              </p>
+            )}
+          </div>
 
-      <Button
-        type="submit"
-        size="sm"
-        disabled={busy || (targetProvider !== "openai_compatible" && !apiKey.trim())}
-      >
-        {busy ? (
-          <>
-            <Spinner className="mr-2" />
-            Switching…
-          </>
-        ) : (
-          `Switch to ${formatProviderLabel(targetProvider)}`
-        )}
-      </Button>
+          {targetProvider === "openrouter" ? (
+            <FormField
+              id="switch-custom-model"
+              density="compact"
+              label={
+                <>
+                  Custom model ID{" "}
+                  <span className="font-normal text-muted-foreground">(optional)</span>
+                </>
+              }
+              footer={
+                customModelError ? (
+                  <p id="switch-custom-model-error" className="text-sm text-destructive" role="alert">
+                    {customModelError}
+                  </p>
+                ) : (
+                  <p id="switch-custom-model-hint" className="text-xs text-muted-foreground">
+                    Overrides the catalog selection when set.
+                  </p>
+                )
+              }
+            >
+              <InputGroup>
+                <InputGroupInput
+                  id="switch-custom-model"
+                  type="text"
+                  autoComplete="off"
+                  placeholder="anthropic/claude-sonnet-4-6"
+                  value={customModel}
+                  disabled={busy}
+                  aria-invalid={customModelError != null}
+                  aria-describedby={
+                    customModelError ? "switch-custom-model-error" : "switch-custom-model-hint"
+                  }
+                  onChange={(event) => {
+                    const value = event.target.value;
+                    setCustomModel(value);
+                    setCustomModelError(validateCustomOpenRouterModel(value));
+                  }}
+                />
+              </InputGroup>
+            </FormField>
+          ) : null}
+
+          {targetProvider === "openai_compatible" ? (
+            <CustomCompatibleProviderFields
+              displayName={displayName}
+              baseUrl={baseUrl}
+              apiKey={apiKey}
+              customModels={customModels}
+              disabled={busy}
+              density="compact"
+              displayNameError={displayNameError}
+              baseUrlError={baseUrlError}
+              modelsError={modelsError}
+              onDisplayNameChange={setDisplayName}
+              onBaseUrlChange={setBaseUrl}
+              onCustomModelsChange={setCustomModels}
+            />
+          ) : null}
+
+          {localError ? (
+            <p className="text-sm text-destructive" role="alert">
+              {localError}
+            </p>
+          ) : null}
+
+          <Button
+            type="submit"
+            size="sm"
+            disabled={busy || (targetProvider !== "openai_compatible" && !apiKey.trim())}
+          >
+            {busy ? (
+              <>
+                <Spinner className="mr-2" />
+                Switching…
+              </>
+            ) : (
+              `Switch to ${formatProviderLabel(targetProvider)}`
+            )}
+          </Button>
+        </>
+      )}
     </form>
   );
 }
@@ -1025,7 +1099,7 @@ function ConnectedProviderSection({
             disabled={modelBusy || configuredModels.length === 0}
             onValueChange={(value) => onModelDraftChange(value != null ? String(value) : "")}
           >
-            <SelectTrigger id="connected-model" className="w-[11rem] sm:w-[13rem]">
+            <SelectTrigger id="connected-model" className="w-44 sm:w-52">
               <SelectValue placeholder="Select model" />
             </SelectTrigger>
             <SelectContent align="end">

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -842,7 +842,7 @@ function SwitchProviderSection({
               </InputGroup>
             </InlineField>
             {apiKeyError && (
-              <p id="switch-api-key-error" className="mt-1.5 pl-[calc(6rem+0.75rem)] text-sm text-destructive" role="alert">
+              <p id="switch-api-key-error" className="mt-1.5 pl-27 text-sm text-destructive" role="alert">
                 {apiKeyError}
               </p>
             )}

--- a/packages/agent/src/chat.ts
+++ b/packages/agent/src/chat.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentChannel,
   AutomationDefinition,
   ChatMessage,
   CompactionResponse,
@@ -12,7 +13,7 @@ import type {
 
 export interface AgentRequest {
   prompt: string;
-  channel: "web" | "cli" | "telegram" | "automation";
+  channel: AgentChannel;
 }
 
 export interface AgentDependencies {

--- a/packages/agent/src/prompt.ts
+++ b/packages/agent/src/prompt.ts
@@ -1,4 +1,4 @@
-import type { ToolDefinition } from "@tinyclaw/core";
+import type { AgentChannel, ToolDefinition } from "@tinyclaw/core";
 
 export function buildAutomationSystemPrompt(tools: ToolDefinition[]): string {
   const toolCatalog =
@@ -36,7 +36,7 @@ export function buildAutomationSystemPrompt(tools: ToolDefinition[]): string {
 
 export function buildAutomationUserPrompt(
   prompt: string,
-  channel: "web" | "cli" | "telegram",
+  channel: AgentChannel,
 ): string {
   return [
     `Channel: ${channel}`,

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -387,7 +387,10 @@ export interface ProviderModelOption {
   id: string;
   name: string;
   provider: ProviderName;
+  contextWindow?: number;
+  maxOutputTokens?: number;
   default?: boolean;
+  supportsThinking?: boolean;
   inputPerMillionUsd?: number;
   outputPerMillionUsd?: number;
 }

--- a/packages/core/src/user-config.test.ts
+++ b/packages/core/src/user-config.test.ts
@@ -48,4 +48,20 @@ describe("user config compatible provider", () => {
     expect(loaded?.baseUrl).toBe("http://localhost:11434/v1");
     expect(loaded?.customModels?.[0]?.id).toBe("llama3.2");
   });
+
+  test("round-trips base_url for native providers", async () => {
+    configDir = await mkdtemp(join(tmpdir(), "tinyclaw-config-"));
+    process.env.TINYCLAW_CONFIG_DIR = configDir;
+
+    await saveUserConfig({
+      provider: "anthropic",
+      apiKey: "kimi-key",
+      baseUrl: "https://api.kimi.com/coding/v1",
+      model: "claude-sonnet-4-6",
+    });
+
+    const loaded = await loadUserConfig();
+    expect(loaded?.provider).toBe("anthropic");
+    expect(loaded?.baseUrl).toBe("https://api.kimi.com/coding/v1");
+  });
 });

--- a/packages/core/src/user-config.ts
+++ b/packages/core/src/user-config.ts
@@ -100,12 +100,14 @@ export async function loadUserConfig(): Promise<UserProviderConfig | null> {
   const model = values.model?.trim();
   const timezone = readTimezone(values);
   const thinking = readThinkingSettings(values);
+  const baseUrl = readBaseUrl(values);
   const compatible = readCompatibleProviderFields(provider, values);
 
   return {
     provider,
     apiKey,
     ...(model ? { model } : {}),
+    ...(baseUrl ? { baseUrl } : {}),
     ...compatible,
     ...(timezone ? { timezone } : {}),
     thinkingEnabled: thinking.enabled,
@@ -298,10 +300,14 @@ function readTimezone(values: Record<string, string>): string | undefined {
   return timezone && isValidTimezone(timezone) ? timezone : undefined;
 }
 
+function readBaseUrl(values: Record<string, string>): string | undefined {
+  return values.base_url?.trim() ? normalizeBaseUrl(values.base_url) : undefined;
+}
+
 function readCompatibleProviderFields(
   provider: UserProviderName,
   values: Record<string, string>,
-): Pick<UserProviderConfig, "displayName" | "baseUrl" | "customModels"> {
+): Pick<UserProviderConfig, "displayName" | "customModels"> {
   if (provider !== "openai_compatible") {
     return {};
   }
@@ -309,14 +315,10 @@ function readCompatibleProviderFields(
   const displayName = values.display_name?.trim()
     ? validateDisplayName(values.display_name)
     : undefined;
-  const baseUrl = values.base_url?.trim()
-    ? normalizeBaseUrl(values.base_url)
-    : undefined;
   const customModels = parseCustomModelsJson(values.models_json);
 
   return {
     ...(displayName ? { displayName } : {}),
-    ...(baseUrl ? { baseUrl } : {}),
     ...(customModels ? { customModels } : {}),
   };
 }


### PR DESCRIPTION
## Summary

Surface the full models.dev catalog inside the provider dropdown so users can pick a free model (especially OpenCode/Zen public-key models) without hunting for an API key first.

## Changes

- **New `useModelsDev` hook** — fetches `models.dev/api.json` via React Query (30 min stale time)
- **`ModelsBrowseList`** — searchable, filterable list with `FREE` and `public` badges. OpenCode/Zen free non-deprecated models float to the top and auto-fill `apiKey="public"` (no real key needed)
- **Inline browse option** — "Browse models.dev…" lives inside the Provider select in both `ProviderSetupForm` (onboarding) and the Settings switch-provider section. Picking a row auto-fills provider, model, and (for `openai_compatible`) `displayName`, `baseUrl`, `customModels`
- **Switch-provider form refactor** — uses inline label/input rows via a shared `InlineField` helper for a cleaner compact layout
- Removed dead `ProviderSelect` component (no remaining usages)

## Test plan

- [ ] Open Settings → switch provider → pick "Browse models.dev…" → select a free OpenCode model → verify `apiKey` is `public`, `baseUrl` is set, model is selected
- [ ] Pick a paid provider model (Anthropic, OpenAI) → verify provider + model auto-fill, API key field becomes editable
- [ ] Pick a non-mapped provider (e.g. Mistral) → verify it falls back to `openai_compatible` with `baseUrl` set
- [ ] Search/filter (free only, hide deprecated) works as expected
- [ ] Onboarding `ProviderSetupForm` shows the same browse option and behavior