### PR TITLE
fix(tools): add PathGuard to prevent path traversal in write_file/delete_file

### DIFF
--- a/packages/core/src/tools/builtin.test.ts
+++ b/packages/core/src/tools/builtin.test.ts
@@ -1,8 +1,8 @@
-import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
-import { deleteFileTool, writeFileTool } from "./builtin";
+import { deleteFileTool, PathGuardError, setDefaultFileGuardOptions, writeFileTool } from "./builtin";
 
 describe("file builtin tools", () => {
   let tempDir = "";
@@ -12,10 +12,12 @@ describe("file builtin tools", () => {
       await rm(tempDir, { recursive: true, force: true });
       tempDir = "";
     }
+    setDefaultFileGuardOptions({});
   });
 
   test("write_file creates nested files", async () => {
     tempDir = await mkdtemp(path.join(os.tmpdir(), "tinyclaw-write-"));
+    setDefaultFileGuardOptions({ allowedDirs: [tempDir] });
     const targetPath = path.join(tempDir, "nested", "hello.txt");
 
     const result = await writeFileTool.run(
@@ -30,8 +32,9 @@ describe("file builtin tools", () => {
 
   test("write_file resolves relative paths from cwd", async () => {
     tempDir = await mkdtemp(path.join(os.tmpdir(), "tinyclaw-write-"));
+    setDefaultFileGuardOptions({ allowedDirs: [tempDir], cwd: tempDir });
     const result = await writeFileTool.run(
-      { path: "notes.txt", content: "relative", cwd: tempDir },
+      { path: "notes.txt", content: "relative" },
       {},
     );
 
@@ -41,13 +44,129 @@ describe("file builtin tools", () => {
 
   test("delete_file removes a file", async () => {
     tempDir = await mkdtemp(path.join(os.tmpdir(), "tinyclaw-delete-"));
+    setDefaultFileGuardOptions({ allowedDirs: [tempDir] });
     const targetPath = path.join(tempDir, "remove-me.txt");
     await mkdir(path.dirname(targetPath), { recursive: true });
-    await writeFileTool.run({ path: targetPath, content: "temp" }, {});
+    await writeFile(targetPath, "temp", "utf8");
 
     const result = await deleteFileTool.run({ path: targetPath }, {});
 
     expect(result).toEqual({ path: targetPath, deleted: true });
     await expect(readFile(targetPath, "utf8")).rejects.toThrow();
+  });
+
+  // -----------------------------------------------------------------------
+  // Security tests
+  // -----------------------------------------------------------------------
+
+  test("rejects path traversal via ../ escape", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "tinyclaw-sec-"));
+    setDefaultFileGuardOptions({ allowedDirs: [tempDir] });
+    const escapePath = path.join(tempDir, "../../../etc/tinyclaw-exploit-test");
+
+    await expect(
+      writeFileTool.run({ path: escapePath, content: "ESCAPE" }, {}),
+    ).rejects.toThrow(PathGuardError);
+  });
+
+  test("rejects absolute path outside allowed dirs", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "tinyclaw-sec-"));
+    setDefaultFileGuardOptions({ allowedDirs: [tempDir] });
+
+    await expect(
+      writeFileTool.run({ path: "/etc/tinyclaw-should-fail", content: "NOPE" }, {}),
+    ).rejects.toThrow(PathGuardError);
+  });
+
+  test("rejects home directory expansion outside allowed dirs", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "tinyclaw-sec-"));
+    setDefaultFileGuardOptions({ allowedDirs: [tempDir] });
+
+    await expect(
+      writeFileTool.run({ path: "~/.ssh/tinyclaw-test", content: "SSH_KEY" }, {}),
+    ).rejects.toThrow(PathGuardError);
+  });
+
+  test("cwd injection falls back to safe cwd", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "tinyclaw-sec-"));
+    setDefaultFileGuardOptions({ allowedDirs: [tempDir], cwd: tempDir });
+
+    const result = await writeFileTool.run(
+      { path: "safe.txt", content: "OK", cwd: "/etc" },
+      {},
+    );
+
+    expect(result.path).toStartWith(tempDir);
+  });
+
+  test("rejects null byte in path", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "tinyclaw-sec-"));
+    setDefaultFileGuardOptions({ allowedDirs: [tempDir] });
+
+    await expect(
+      writeFileTool.run(
+        { path: path.join(tempDir, "safe.txt\0.sh"), content: "X" },
+        {},
+      ),
+    ).rejects.toThrow(PathGuardError);
+  });
+
+  test("rejects content exceeding max file size", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "tinyclaw-sec-"));
+    setDefaultFileGuardOptions({ allowedDirs: [tempDir], maxFileBytes: 100 });
+
+    await expect(
+      writeFileTool.run(
+        { path: path.join(tempDir, "big.txt"), content: "A".repeat(200) },
+        {},
+      ),
+    ).rejects.toThrow(PathGuardError);
+  });
+
+  test("delete_file rejects path outside allowed dirs", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "tinyclaw-sec-"));
+    setDefaultFileGuardOptions({ allowedDirs: [tempDir] });
+
+    await expect(
+      deleteFileTool.run({ path: "/etc/should-not-delete" }, {}),
+    ).rejects.toThrow(PathGuardError);
+  });
+
+  test("allows nested subdirectory writes", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "tinyclaw-sec-"));
+    setDefaultFileGuardOptions({ allowedDirs: [tempDir] });
+
+    const nestedPath = path.join(tempDir, "deep", "nested", "file.txt");
+    const result = await writeFileTool.run({ path: nestedPath, content: "deep" }, {});
+
+    expect(result.path).toBe(nestedPath);
+    expect(await readFile(nestedPath, "utf8")).toBe("deep");
+  });
+
+  test("rejects special filesystem paths", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "tinyclaw-sec-"));
+    setDefaultFileGuardOptions({ allowedDirs: [tempDir, "/dev"] });
+
+    await expect(
+      writeFileTool.run({ path: "/dev/null", content: "test" }, {}),
+    ).rejects.toThrow(PathGuardError);
+  });
+
+  test("multiple allowed directories", async () => {
+    const dirA = await mkdtemp(path.join(os.tmpdir(), "tinyclaw-sec-a-"));
+    const dirB = await mkdtemp(path.join(os.tmpdir(), "tinyclaw-sec-b-"));
+    setDefaultFileGuardOptions({ allowedDirs: [dirA, dirB] });
+
+    const pathA = path.join(dirA, "a.txt");
+    const pathB = path.join(dirB, "b.txt");
+
+    const resultA = await writeFileTool.run({ path: pathA, content: "A" }, {});
+    const resultB = await writeFileTool.run({ path: pathB, content: "B" }, {});
+
+    expect(resultA.path).toBe(pathA);
+    expect(resultB.path).toBe(pathB);
+
+    await rm(dirA, { recursive: true, force: true });
+    await rm(dirB, { recursive: true, force: true });
   });
 });

--- a/packages/core/src/tools/builtin.ts
+++ b/packages/core/src/tools/builtin.ts
@@ -1,7 +1,7 @@
 import { mkdir, unlink, writeFile } from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import type { ToolDefinition } from "../contract";
+import type { ToolContext, ToolDefinition } from "../contract";
+import { guardFilePath, PathGuardError, type PathGuardOptions } from "./paths";
 import { webSearchTool } from "./web-search";
 
 export interface WriteFileInput {
@@ -25,6 +25,12 @@ export interface DeleteFileOutput {
   deleted: true;
 }
 
+let defaultGuardOptions: PathGuardOptions = {};
+
+export function setDefaultFileGuardOptions(options: PathGuardOptions): void {
+  defaultGuardOptions = { ...options };
+}
+
 export const writeFileTool: ToolDefinition<WriteFileInput, WriteFileOutput> = {
   name: "write_file",
   description: "Write text content to a file. Creates parent directories if needed.",
@@ -41,27 +47,34 @@ export const writeFileTool: ToolDefinition<WriteFileInput, WriteFileOutput> = {
     required: ["path", "content"],
     additionalProperties: false,
   },
-  async run(input) {
-    const filePath = resolveFilePath(input, "path");
+  async run(input, context: ToolContext) {
+    const rawPath = readRequiredString(input, "path");
     const content = readRequiredString(input, "content");
+    const rawCwd = readOptionalString(input, "cwd");
+    const contentBytes = Buffer.byteLength(content, "utf8");
+
+    const guardOptions: PathGuardOptions = { ...defaultGuardOptions };
+    if (context.sessionId && !guardOptions.cwd) {
+      guardOptions.cwd = process.cwd();
+    }
+
+    const guarded = await guardFilePath(rawPath, rawCwd, contentBytes, guardOptions);
+    const filePath = guarded.resolved;
 
     await mkdir(path.dirname(filePath), { recursive: true });
     await writeFile(filePath, content, "utf8");
 
-    return {
-      path: filePath,
-      bytesWritten: Buffer.byteLength(content, "utf8"),
-    };
+    return { path: filePath, bytesWritten: contentBytes };
   },
 };
 
 export const deleteFileTool: ToolDefinition<DeleteFileInput, DeleteFileOutput> = {
   name: "delete_file",
-  description: "Delete a file from disk.",
+  description: "Delete a file from disk. Only files within the allowed workspace can be deleted.",
   parameters: {
     type: "object",
     properties: {
-      path: { type: "string", description: "File path to delete." },
+      path: { type: "string", description: "File path to delete. Must be within the allowed workspace." },
       cwd: {
         type: "string",
         description: "Base directory for relative paths. Defaults to the server working directory.",
@@ -70,15 +83,19 @@ export const deleteFileTool: ToolDefinition<DeleteFileInput, DeleteFileOutput> =
     required: ["path"],
     additionalProperties: false,
   },
-  async run(input) {
-    const filePath = resolveFilePath(input, "path");
+  async run(input, context: ToolContext) {
+    const rawPath = readRequiredString(input, "path");
+    const rawCwd = readOptionalString(input, "cwd");
 
-    await unlink(filePath);
+    const guardOptions: PathGuardOptions = { ...defaultGuardOptions };
+    if (context.sessionId && !guardOptions.cwd) {
+      guardOptions.cwd = process.cwd();
+    }
 
-    return {
-      path: filePath,
-      deleted: true,
-    };
+    const guarded = await guardFilePath(rawPath, rawCwd, undefined, guardOptions);
+    await unlink(guarded.resolved);
+
+    return { path: guarded.resolved, deleted: true };
   },
 };
 
@@ -87,27 +104,6 @@ export const builtinTools: ToolDefinition[] = [
   deleteFileTool,
   webSearchTool,
 ];
-
-function resolveFilePath(input: unknown, key: string): string {
-  const filePath = expandHome(readRequiredString(input, key));
-  const cwd = expandHome(readOptionalString(input, "cwd") ?? process.cwd());
-
-  return path.isAbsolute(filePath)
-    ? path.normalize(filePath)
-    : path.resolve(cwd, filePath);
-}
-
-function expandHome(filePath: string): string {
-  if (filePath === "~") {
-    return os.homedir();
-  }
-
-  if (filePath.startsWith("~/")) {
-    return path.join(os.homedir(), filePath.slice(2));
-  }
-
-  return filePath;
-}
 
 function readRequiredString(input: unknown, key: string): string {
   const value = readOptionalString(input, key);
@@ -127,3 +123,5 @@ function readOptionalString(input: unknown, key: string): string | null {
   const value = (input as Record<string, unknown>)[key];
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
+
+export { PathGuardError };

--- a/packages/core/src/tools/paths.ts
+++ b/packages/core/src/tools/paths.ts
@@ -1,4 +1,6 @@
-import { join } from "node:path";
+import { realpath } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { getUserConfigDir } from "../user-config";
 
 /** Agent-authored tool modules live under ~/.tinyclaw/tools/ by default. */
@@ -9,5 +11,108 @@ export function getCustomToolsDir(): string {
     return override;
   }
 
-  return join(getUserConfigDir(), "tools");
+  return path.join(getUserConfigDir(), "tools");
+}
+
+// ---------------------------------------------------------------------------
+// PathGuard — filesystem safety for LLM-controlled file operations
+// ---------------------------------------------------------------------------
+
+const DEFAULT_MAX_FILE_BYTES = 10 * 1024 * 1024; // 10 MB
+const SPECIAL_PATH_PREFIXES = ["/dev/", "/proc/", "/sys/"];
+
+export interface PathGuardOptions {
+  allowedDirs?: string[];
+  maxFileBytes?: number;
+  cwd?: string;
+}
+
+export class PathGuardError extends Error {
+  constructor(
+    message: string,
+    public readonly code: "TRAVERSAL" | "SPECIAL_FILE" | "NULL_BYTE" | "TOO_LARGE",
+  ) {
+    super(message);
+    this.name = "PathGuardError";
+  }
+}
+
+export async function guardFilePath(
+  rawPath: string,
+  rawCwd: string | undefined | null,
+  rawContentLength: number | undefined,
+  options: PathGuardOptions = {},
+): Promise<{ resolved: string; allowed: true }> {
+  const allowedDirs = options.allowedDirs ?? [options.cwd ?? process.cwd()];
+  const maxBytes = options.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES;
+  const defaultCwd = options.cwd ?? process.cwd();
+
+  if (rawPath.includes("\0")) {
+    throw new PathGuardError(`Path contains null byte`, "NULL_BYTE");
+  }
+
+  if (rawContentLength != null && rawContentLength > maxBytes) {
+    throw new PathGuardError(
+      `File content exceeds max ${maxBytes} bytes (got ${rawContentLength})`,
+      "TOO_LARGE",
+    );
+  }
+
+  const cwd = resolveSafeCwd(rawCwd, allowedDirs, defaultCwd);
+  const expanded = expandHome(rawPath);
+  const absolute = path.resolve(cwd, expanded);
+
+  for (const prefix of SPECIAL_PATH_PREFIXES) {
+    if (absolute === prefix.slice(0, -1) || absolute.startsWith(prefix)) {
+      throw new PathGuardError(`Special filesystem path: ${absolute}`, "SPECIAL_FILE");
+    }
+  }
+
+  let realPath: string;
+  try {
+    realPath = await realpath(absolute);
+  } catch {
+    try {
+      const realDir = await realpath(path.dirname(absolute));
+      realPath = path.resolve(realDir, path.basename(absolute));
+    } catch {
+      realPath = absolute;
+    }
+  }
+
+  if (!isWithinDirs(realPath, allowedDirs)) {
+    throw new PathGuardError(`Path outside allowed directories`, "TRAVERSAL");
+  }
+
+  return { resolved: realPath, allowed: true };
+}
+
+function expandHome(filePath: string): string {
+  if (filePath === "~") return getUserHome();
+  if (filePath.startsWith("~/")) return path.join(getUserHome(), filePath.slice(2));
+  return filePath;
+}
+
+function getUserHome(): string {
+  return process.env.HOME ?? os.homedir();
+}
+
+function isWithinDirs(target: string, dirs: string[]): boolean {
+  const normalized = target.endsWith(path.sep) ? target : target + path.sep;
+  for (const dir of dirs) {
+    const dirEnd = dir.endsWith(path.sep) ? dir : dir + path.sep;
+    if (normalized === dirEnd || normalized.startsWith(dirEnd)) return true;
+  }
+  return false;
+}
+
+function resolveSafeCwd(
+  rawCwd: string | undefined | null,
+  allowedDirs: string[],
+  defaultCwd: string,
+): string {
+  if (rawCwd == null || rawCwd.trim() === "") return defaultCwd;
+  const expanded = expandHome(rawCwd.trim());
+  const absolute = path.resolve(expanded);
+  return isWithinDirs(absolute, allowedDirs) ? absolute : defaultCwd;
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                           
  - Add `guardFilePath()` — validates file paths against allowed directories,                                                                                                                                                                                              
    resolves symlinks, rejects null bytes, special files (`/dev/`, `/proc/`,                                                                                                                                                                                               
    `/sys/`), and path traversal escapes                                                                                                                                                                                                                                   
  - `write_file` and `delete_file` now use `guardFilePath()` before fs operations                                                                                                                                                                                          
  - LLM-provided `cwd` validated against allowed dirs, falls back to safe default                                                                                                                                                                                          
  - Max file size enforced (10MB default)                                                                                                                                                                                                                                  
  - 10 new security tests                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                           
  ## Prior art                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                           
  Same class of bug that hit OpenClaw multiple times:                                                                                                                                                                                                                      
  - GHSA-qrq5-wjgg-rvqw                                                                                                                                                                                                                                                    
  - GHSA-xwjm-j929-xq7c                  
  - GHSA-cv7m-c9jx-vg7q                                                                                                                                                                                                                                                    
  - Issue [**#39672**](https://github.com/openclaw/openclaw/issues/39672) (Critical)                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                           
  Led them to create [@openclaw/fs-safe](https://github.com/openclaw/fs-safe).                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                           
  ## Files                               
                                                                                                                                                                                                                                                                           
  | File | Change |
  |------|--------|                                                                                                                                                                                                                                                        
  | `packages/core/src/tools/paths.ts` | New PathGuard functions |
  | `packages/core/src/tools/builtin.ts` | Integrate PathGuard into tools |                                                                                                                                                                                                
  | `packages/core/src/tools/builtin.test.ts` | 3 existing + 10 security tests |                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
                                                                                  