### PR TITLE
Improve MCP page tool discovery and server management UI

### DIFF
--- a/apps/web/src/components/soul-tools/McpTab.tsx
+++ b/apps/web/src/components/soul-tools/McpTab.tsx
@@ -1,15 +1,15 @@
-import type { CreateMcpServerRequest, McpServerSummary } from "@tinyclaw/core/contract";
+import type { CachedMcpToolSummary, CreateMcpServerRequest, McpServerSummary } from "@tinyclaw/core/contract";
 import {
-  ChevronDownIcon,
-  ChevronRightIcon,
+  BlocksIcon,
+  EllipsisVerticalIcon,
   PlugIcon,
   PlusIcon,
   RefreshCwIcon,
   Trash2Icon,
 } from "lucide-react";
-import { useEffect, useState, type FormEvent, type ReactNode } from "react";
-import { client } from "@/lib/client";
+import { useState, type FormEvent, type ReactNode } from "react";
 import { useQueryClient } from "@tanstack/react-query";
+import { McpToolLabels, McpToolList } from "@/components/soul-tools/McpToolList";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -19,17 +19,23 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
-import { useMcpServersQuery } from "@/hooks/use-app-queries";
+import { useMcpServerDetailQuery, useMcpServersQuery } from "@/hooks/use-app-queries";
 import {
   useConnectMcpServerMutation,
   useCreateMcpServerMutation,
   useDeleteMcpServerMutation,
   useSyncMcpServerMutation,
 } from "@/hooks/use-resource-mutations";
-import { formatError } from "@/lib/client";
+import { client, formatError } from "@/lib/client";
 import { queryKeys } from "@/lib/query-keys";
 import { cn } from "@/lib/utils";
 
@@ -44,7 +50,8 @@ export function McpTab() {
   const syncMutation = useSyncMcpServerMutation();
   const [actionError, setActionError] = useState<string | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
-  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [detailServerId, setDetailServerId] = useState<string | null>(null);
+  const detailServer = servers.find((server) => server.id === detailServerId) ?? null;
 
   const loading = isLoading && servers.length === 0;
   const refreshing = isFetching && !loading;
@@ -73,6 +80,7 @@ export function McpTab() {
 
     try {
       await deleteMutation.mutateAsync(server.id);
+      setDetailServerId((current) => (current === server.id ? null : current));
     } catch (err) {
       setActionError(formatError(err));
     }
@@ -83,6 +91,7 @@ export function McpTab() {
 
     try {
       await connectMutation.mutateAsync(serverId);
+      setDetailServerId(serverId);
     } catch (err) {
       setActionError(formatError(err));
     }
@@ -93,6 +102,7 @@ export function McpTab() {
 
     try {
       await syncMutation.mutateAsync(serverId);
+      setDetailServerId(serverId);
     } catch (err) {
       setActionError(formatError(err));
     }
@@ -157,68 +167,41 @@ export function McpTab() {
                       <p className="text-sm font-medium text-foreground">{server.name}</p>
                       <StatusBadge status={server.status} />
                     </div>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      {server.toolCount} tool{server.toolCount === 1 ? "" : "s"}
-                      {server.lastError ? ` · ${server.lastError}` : ""}
-                    </p>
+                    {server.lastError ? (
+                      <p className="mt-1 text-xs text-destructive">{server.lastError}</p>
+                    ) : null}
+                    <McpToolLabels
+                      serverId={server.id}
+                      toolCount={server.toolCount}
+                      connected={server.status === "connected"}
+                      onShowAll={() => setDetailServerId(server.id)}
+                    />
                   </div>
 
-                  <div className="flex shrink-0 flex-wrap items-center gap-1">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      disabled={busy}
-                      onClick={() => void handleConnect(server.id)}
-                    >
-                      <PlugIcon className="size-4" aria-hidden />
-                      Connect
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      disabled={busy}
-                      onClick={() => void handleSync(server.id)}
-                    >
-                      Sync
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      disabled={busy}
-                      onClick={() => void handleDelete(server)}
-                    >
-                      <Trash2Icon className="size-4" aria-hidden />
-                      Delete
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-sm"
-                      aria-label={expandedId === server.id ? "Collapse tools" : "Expand tools"}
-                      onClick={() =>
-                        setExpandedId((current) => (current === server.id ? null : server.id))
-                      }
-                    >
-                      {expandedId === server.id ? (
-                        <ChevronDownIcon className="size-4" aria-hidden />
-                      ) : (
-                        <ChevronRightIcon className="size-4" aria-hidden />
-                      )}
-                    </Button>
-                  </div>
+                  <McpServerActions
+                    server={server}
+                    busy={busy}
+                    onViewTools={() => setDetailServerId(server.id)}
+                    onConnect={() => void handleConnect(server.id)}
+                    onSync={() => void handleSync(server.id)}
+                    onDelete={() => void handleDelete(server)}
+                  />
                 </div>
-
-                {expandedId === server.id ? (
-                  <ServerToolsPreview serverId={server.id} toolCount={server.toolCount} />
-                ) : null}
               </li>
             ))}
           </ul>
         )}
       </section>
+
+      <McpServerToolsDialog
+        server={detailServer}
+        open={detailServerId !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setDetailServerId(null);
+          }
+        }}
+      />
 
       <CreateMcpServerDialog
         open={createOpen}
@@ -233,8 +216,9 @@ export function McpTab() {
           setActionError(null);
 
           try {
-            await createMutation.mutateAsync(request);
+            const response = await createMutation.mutateAsync(request);
             setCreateOpen(false);
+            setDetailServerId(response.server.id);
           } catch (err) {
             const message = formatError(err);
             setActionError(message);
@@ -246,88 +230,131 @@ export function McpTab() {
   );
 }
 
-function ServerToolsPreview({
-  serverId,
-  toolCount,
+function McpServerActions({
+  server,
+  busy,
+  onViewTools,
+  onConnect,
+  onSync,
+  onDelete,
 }: {
-  serverId: string;
-  toolCount: number;
+  server: McpServerSummary;
+  busy: boolean;
+  onViewTools: () => void;
+  onConnect: () => void;
+  onSync: () => void;
+  onDelete: () => void;
 }) {
-  const [tools, setTools] = useState<Array<{ name: string; description: string }> | null>(
-    null,
+  return (
+    <div className="flex shrink-0 items-center gap-1">
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        aria-label={`View tools for ${server.name}`}
+        onClick={onViewTools}
+      >
+        <BlocksIcon className="size-4" aria-hidden />
+      </Button>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              disabled={busy}
+              aria-label={`Actions for ${server.name}`}
+            />
+          }
+        >
+          <EllipsisVerticalIcon className="size-4" aria-hidden />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="min-w-40">
+          {server.status !== "connected" ? (
+            <DropdownMenuItem disabled={busy} onClick={onConnect}>
+              <PlugIcon aria-hidden />
+              Connect
+            </DropdownMenuItem>
+          ) : null}
+          <DropdownMenuItem disabled={busy} onClick={onSync}>
+            <RefreshCwIcon aria-hidden />
+            Sync tools
+          </DropdownMenuItem>
+          <DropdownMenuItem variant="destructive" disabled={busy} onClick={onDelete}>
+            <Trash2Icon aria-hidden />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   );
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+}
 
-  useEffect(() => {
-    if (toolCount === 0) {
-      return;
-    }
-
-    let cancelled = false;
-
-    async function loadTools() {
-      setLoading(true);
-      setError(null);
-
-      try {
-        const response = await client.getMcpServer(serverId);
-
-        if (!cancelled) {
-          setTools(
-            response.server.cachedTools.map((tool) => ({
-              name: tool.name,
-              description: tool.description,
-            })),
-          );
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setError(formatError(err));
-        }
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
-      }
-    }
-
-    void loadTools();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [serverId, toolCount]);
-
-  if (toolCount === 0) {
-    return (
-      <p className="mt-3 text-xs text-muted-foreground">
-        No cached tools yet. Connect and sync this server.
-      </p>
-    );
-  }
-
-  if (loading && tools === null) {
-    return <p className="mt-3 text-xs text-muted-foreground">Loading tools…</p>;
-  }
-
-  if (error) {
-    return <p className="mt-3 text-xs text-destructive">{error}</p>;
-  }
-
-  if (!tools || tools.length === 0) {
-    return null;
-  }
+function McpServerToolsDialog({
+  server,
+  open,
+  onOpenChange,
+}: {
+  server: McpServerSummary | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { data: detail, isLoading, error } = useMcpServerDetailQuery(
+    open && server ? server.id : null,
+  );
 
   return (
-    <ul className="mt-3 space-y-2 rounded-md border border-border bg-muted/20 p-3">
-      {tools.map((tool) => (
-        <li key={tool.name}>
-          <p className="text-sm text-foreground">{tool.name}</p>
-          <p className="text-xs text-muted-foreground">{tool.description}</p>
-        </li>
-      ))}
-    </ul>
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex h-[min(85dvh,42rem)] max-h-[min(90dvh,85vh)] w-[calc(100%-1.5rem)] flex-col gap-4 overflow-hidden p-4 sm:max-w-3xl sm:gap-6 sm:p-6">
+        {server ? (
+          <>
+            <DialogHeader className="gap-2 pr-8 sm:gap-3">
+              <DialogTitle className="flex flex-wrap items-center gap-2 text-base">
+                <span
+                  className="flex size-8 shrink-0 items-center justify-center rounded-md border border-border bg-muted/30 text-muted-foreground"
+                  aria-hidden
+                >
+                  <BlocksIcon className="size-4" />
+                </span>
+                {server.name}
+              </DialogTitle>
+              <DialogDescription className="leading-relaxed">
+                Tools exposed by this MCP server and available to assigned profiles.
+              </DialogDescription>
+              <div className="flex flex-wrap items-center gap-2 pt-1">
+                <StatusBadge status={server.status} />
+                <span className="text-xs text-muted-foreground">
+                  {server.toolCount} tool{server.toolCount === 1 ? "" : "s"}
+                </span>
+              </div>
+            </DialogHeader>
+
+            <div className="no-scrollbar min-h-0 flex-1 overflow-y-auto">
+              {isLoading && !detail ? (
+                <div className="flex items-center justify-center gap-2 py-16 text-sm text-muted-foreground">
+                  <Spinner className="size-4" />
+                  Loading tools…
+                </div>
+              ) : error ? (
+                <p className="rounded-md bg-destructive/10 px-3 py-2.5 text-sm text-destructive">
+                  {formatError(error)}
+                </p>
+              ) : !detail || detail.cachedTools.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  {server.status === "connected"
+                    ? "Connected, but no tools were discovered. Try Sync tools from the server menu."
+                    : "No cached tools yet. Connect and sync this server."}
+                </p>
+              ) : (
+                <McpToolList tools={detail.cachedTools} />
+              )}
+            </div>
+          </>
+        ) : null}
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -351,6 +378,7 @@ function CreateMcpServerDialog({
     ok: boolean;
     toolCount: number;
     message: string;
+    tools: CachedMcpToolSummary[];
   } | null>(null);
 
   const canSubmit = name.trim().length > 0 && url.trim().length > 0;
@@ -392,6 +420,7 @@ function CreateMcpServerDialog({
         setTestResult({
           ok: true,
           toolCount: result.toolCount,
+          tools: result.tools,
           message:
             result.toolCount === 0
               ? "Connected, but no tools were returned."
@@ -403,12 +432,14 @@ function CreateMcpServerDialog({
       setTestResult({
         ok: false,
         toolCount: 0,
+        tools: [],
         message: result.error ?? "Connection test failed.",
       });
     } catch (error) {
       setTestResult({
         ok: false,
         toolCount: 0,
+        tools: [],
         message: formatError(error),
       });
     } finally {
@@ -508,17 +539,28 @@ function CreateMcpServerDialog({
             </Button>
 
             {testResult ? (
-              <p
-                className={cn(
-                  "rounded-md px-3 py-2.5 text-sm",
-                  testResult.ok
-                    ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
-                    : "bg-destructive/10 text-destructive",
-                )}
-                role="status"
-              >
-                {testResult.message}
-              </p>
+              <div className="space-y-3">
+                <p
+                  className={cn(
+                    "rounded-md px-3 py-2.5 text-sm",
+                    testResult.ok
+                      ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+                      : "bg-destructive/10 text-destructive",
+                  )}
+                  role="status"
+                >
+                  {testResult.message}
+                </p>
+
+                {testResult.ok && testResult.tools.length > 0 ? (
+                  <div className="rounded-md border border-border bg-muted/20 p-3">
+                    <p className="mb-3 text-xs font-medium text-foreground">
+                      Discovered tools ({testResult.tools.length})
+                    </p>
+                    <McpToolList tools={testResult.tools} />
+                  </div>
+                ) : null}
+              </div>
             ) : null}
 
             {submitError ? (

--- a/apps/web/src/components/soul-tools/McpToolList.tsx
+++ b/apps/web/src/components/soul-tools/McpToolList.tsx
@@ -1,0 +1,307 @@
+import type { CachedMcpToolSummary } from "@tinyclaw/core/contract";
+import { ChevronRightIcon, SearchIcon } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import { useMcpServerDetailQuery } from "@/hooks/use-app-queries";
+import { parseMcpToolParameters } from "@/lib/mcp-tool-schema";
+import { cn } from "@/lib/utils";
+
+const maxVisibleToolLabels = 12;
+const searchThreshold = 4;
+
+interface McpToolLabelsProps {
+  serverId: string;
+  toolCount: number;
+  connected: boolean;
+  className?: string;
+  onShowAll?: () => void;
+}
+
+export function McpToolLabels({
+  serverId,
+  toolCount,
+  connected,
+  className,
+  onShowAll,
+}: McpToolLabelsProps) {
+  const { data: server, isLoading } = useMcpServerDetailQuery(toolCount > 0 ? serverId : null);
+  const tools = server?.cachedTools ?? [];
+
+  if (toolCount === 0) {
+    return null;
+  }
+
+  if (isLoading && tools.length === 0) {
+    return (
+      <div className={cn("mt-2 flex items-center gap-2", className)}>
+        <Spinner className="size-3.5" />
+        <span className="text-xs text-muted-foreground">Loading tools…</span>
+      </div>
+    );
+  }
+
+  if (tools.length === 0) {
+    return (
+      <p className={cn("mt-2 text-xs text-muted-foreground", className)}>
+        {connected
+          ? "No tools discovered yet. Try Sync."
+          : "Connect and sync to discover tools."}
+      </p>
+    );
+  }
+
+  const visibleTools = tools.slice(0, maxVisibleToolLabels);
+  const hiddenCount = tools.length - visibleTools.length;
+
+  return (
+    <div className={cn("mt-2 space-y-2", className)}>
+      <p className="text-xs text-muted-foreground">
+        {tools.length} exposed tool{tools.length === 1 ? "" : "s"}
+      </p>
+      <div className="flex flex-wrap gap-1.5">
+        {visibleTools.map((tool) => (
+          <McpToolLabel key={tool.name} tool={tool} connected={connected} />
+        ))}
+        {hiddenCount > 0 ? (
+          <button
+            type="button"
+            className={cn(
+              "rounded-full border border-dashed border-border px-2.5 py-0.5 font-mono text-[11px] transition-colors hover:bg-muted/50",
+              connected ? "text-emerald-800 dark:text-emerald-200" : "text-muted-foreground",
+            )}
+            onClick={onShowAll}
+          >
+            +{hiddenCount} more
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function McpToolLabel({
+  tool,
+  connected,
+}: {
+  tool: CachedMcpToolSummary;
+  connected: boolean;
+}) {
+  return (
+    <span
+      title={tool.description || tool.name}
+      className={cn(
+        "inline-flex max-w-full items-center truncate rounded-full border px-2.5 py-0.5 font-mono text-[11px]",
+        connected
+          ? "border-emerald-500/25 bg-emerald-500/10 text-emerald-800 dark:text-emerald-200"
+          : "border-border bg-muted/40 text-muted-foreground",
+      )}
+    >
+      {tool.name}
+    </span>
+  );
+}
+
+interface McpToolListProps {
+  tools: CachedMcpToolSummary[];
+  className?: string;
+  searchable?: boolean;
+}
+
+export function McpToolList({ tools, className, searchable = true }: McpToolListProps) {
+  const [query, setQuery] = useState("");
+  const [expandedName, setExpandedName] = useState<string | null>(null);
+
+  const filteredTools = useMemo(() => {
+    const trimmed = query.trim().toLowerCase();
+
+    if (!trimmed) {
+      return tools;
+    }
+
+    return tools.filter((tool) => {
+      const haystack = `${tool.name} ${tool.description ?? ""}`.toLowerCase();
+      return haystack.includes(trimmed);
+    });
+  }, [query, tools]);
+
+  if (tools.length === 0) {
+    return (
+      <p className={cn("text-xs text-muted-foreground", className)}>
+        No tools discovered yet.
+      </p>
+    );
+  }
+
+  const showSearch = searchable && tools.length >= searchThreshold;
+
+  return (
+    <div className={cn("space-y-3", className)}>
+      {showSearch ? (
+        <div className="relative">
+          <SearchIcon
+            className="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground"
+            aria-hidden
+          />
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search tools…"
+            className="h-8 pl-8 text-sm"
+          />
+        </div>
+      ) : null}
+
+      {filteredTools.length === 0 ? (
+        <p className="py-6 text-center text-sm text-muted-foreground">
+          No tools match &ldquo;{query.trim()}&rdquo;.
+        </p>
+      ) : (
+        <ul className="overflow-hidden rounded-md border border-border">
+          {filteredTools.map((tool) => (
+            <McpToolItem
+              key={tool.name}
+              tool={tool}
+              expanded={expandedName === tool.name}
+              onToggle={() =>
+                setExpandedName((current) => (current === tool.name ? null : tool.name))
+              }
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function McpToolItem({
+  tool,
+  expanded,
+  onToggle,
+}: {
+  tool: CachedMcpToolSummary;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const parameters = parseMcpToolParameters(tool.inputSchema);
+  const requiredCount = parameters.filter((parameter) => parameter.required).length;
+  const hasDetails = Boolean(tool.description) || parameters.length > 0;
+  const paramSummary =
+    parameters.length > 0
+      ? `${parameters.length} param${parameters.length === 1 ? "" : "s"}${
+          requiredCount > 0 ? ` · ${requiredCount} required` : ""
+        }`
+      : null;
+
+  return (
+    <li className="border-b border-border last:border-b-0">
+      <button
+        type="button"
+        className={cn(
+          "grid h-14 w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-start gap-2 px-3 py-2.5 text-left transition-colors hover:bg-muted/30",
+          expanded && "bg-muted/20",
+          !hasDetails && "cursor-default hover:bg-transparent",
+        )}
+        aria-expanded={hasDetails ? expanded : undefined}
+        disabled={!hasDetails}
+        onClick={hasDetails ? onToggle : undefined}
+      >
+        <span className="flex size-4 shrink-0 items-center justify-center overflow-hidden pt-0.5">
+          {hasDetails ? (
+            <ChevronRightIcon
+              className={cn(
+                "size-4 shrink-0 text-muted-foreground transition-transform duration-200",
+                expanded && "rotate-90",
+              )}
+              aria-hidden
+            />
+          ) : null}
+        </span>
+
+        <span className="min-w-0 pt-px">
+          <span className="block truncate font-mono text-sm leading-5 text-foreground">
+            {tool.name}
+          </span>
+          <span
+            className={cn(
+              "mt-0.5 block h-4 truncate text-xs leading-4 text-muted-foreground",
+              !paramSummary && "invisible",
+            )}
+          >
+            {paramSummary ?? "No parameters"}
+          </span>
+        </span>
+
+        <span
+          className={cn(
+            "mt-px hidden w-7 shrink-0 justify-self-end rounded-full bg-muted px-2 py-0.5 text-center font-mono text-[11px] leading-4 text-muted-foreground sm:inline",
+            !parameters.length && "invisible",
+          )}
+          aria-hidden
+        >
+          {parameters.length || 0}
+        </span>
+      </button>
+
+      <div
+        className={cn(
+          "grid transition-[grid-template-rows] duration-200 ease-out",
+          expanded && hasDetails ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+        )}
+      >
+        <div className="overflow-hidden">
+          {hasDetails ? (
+            <div className="space-y-3 border-t border-border/70 bg-muted/10 px-3 py-3 pl-9">
+              {tool.description ? (
+                <p className="text-xs leading-relaxed whitespace-pre-wrap text-muted-foreground">
+                  {tool.description}
+                </p>
+              ) : null}
+
+              {parameters.length > 0 ? (
+                <McpToolParameters parameters={parameters} />
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function McpToolParameters({
+  parameters,
+}: {
+  parameters: ReturnType<typeof parseMcpToolParameters>;
+}) {
+  return (
+    <div className="space-y-2">
+      <p className="text-xs font-medium text-foreground">Parameters</p>
+      <ul className="space-y-1.5">
+        {parameters.map((parameter) => (
+          <li
+            key={parameter.name}
+            className="rounded-md border border-border/70 bg-background/80 px-2.5 py-2"
+          >
+            <div className="flex flex-wrap items-center gap-1.5">
+              <code className="font-mono text-xs text-foreground">{parameter.name}</code>
+              <span className="rounded-full bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+                {parameter.type}
+              </span>
+              {parameter.required ? (
+                <span className="rounded-full bg-amber-500/10 px-1.5 py-0.5 text-[10px] text-amber-800 dark:text-amber-200">
+                  required
+                </span>
+              ) : null}
+            </div>
+            {parameter.description ? (
+              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                {parameter.description}
+              </p>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/components/soul-tools/McpToolList.tsx
+++ b/apps/web/src/components/soul-tools/McpToolList.tsx
@@ -147,7 +147,7 @@ export function McpToolList({ tools, className, searchable = true }: McpToolList
             value={query}
             onChange={(event) => setQuery(event.target.value)}
             placeholder="Search tools…"
-            className="h-8 pl-8 text-sm"
+            className="h-8 border-border/60 bg-muted/20 pl-8 text-sm shadow-none focus-visible:border-foreground/20 focus-visible:bg-background focus-visible:ring-1 focus-visible:ring-foreground/10 dark:bg-muted/15 dark:focus-visible:bg-background/60"
           />
         </div>
       ) : null}

--- a/apps/web/src/hooks/use-app-queries.ts
+++ b/apps/web/src/hooks/use-app-queries.ts
@@ -101,6 +101,22 @@ export function useMcpServersQuery() {
   return useQuery(mcpServersQueryOptions);
 }
 
+export function mcpServerDetailQueryOptions(serverId: string) {
+  return queryOptions({
+    queryKey: queryKeys.mcp.detail(serverId),
+    queryFn: async () => (await client.getMcpServer(serverId)).server,
+    staleTime: defaultStaleTime,
+    enabled: Boolean(serverId),
+  });
+}
+
+export function useMcpServerDetailQuery(serverId: string | null) {
+  return useQuery({
+    ...mcpServerDetailQueryOptions(serverId ?? ""),
+    enabled: Boolean(serverId),
+  });
+}
+
 export function toolQueryOptions(toolId: string) {
   return queryOptions({
     queryKey: queryKeys.tools.detail(toolId),

--- a/apps/web/src/hooks/use-resource-mutations.ts
+++ b/apps/web/src/hooks/use-resource-mutations.ts
@@ -172,7 +172,8 @@ export function useCreateMcpServerMutation() {
   return useMutation({
     mutationFn: (input: Parameters<typeof client.createMcpServer>[0]) =>
       client.createMcpServer(input),
-    onSuccess: async () => {
+    onSuccess: async (data) => {
+      queryClient.setQueryData(queryKeys.mcp.detail(data.server.id), data.server);
       await queryClient.invalidateQueries({ queryKey: queryKeys.mcp.all });
     },
   });
@@ -198,11 +199,9 @@ export function useConnectMcpServerMutation() {
 
   return useMutation({
     mutationFn: (serverId: string) => client.connectMcpServer(serverId),
-    onSuccess: async (_data, serverId) => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: queryKeys.mcp.all }),
-        queryClient.invalidateQueries({ queryKey: queryKeys.mcp.detail(serverId) }),
-      ]);
+    onSuccess: async (data, serverId) => {
+      queryClient.setQueryData(queryKeys.mcp.detail(serverId), data.server);
+      await queryClient.invalidateQueries({ queryKey: queryKeys.mcp.all });
     },
   });
 }
@@ -212,11 +211,9 @@ export function useSyncMcpServerMutation() {
 
   return useMutation({
     mutationFn: (serverId: string) => client.syncMcpServer(serverId),
-    onSuccess: async (_data, serverId) => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: queryKeys.mcp.all }),
-        queryClient.invalidateQueries({ queryKey: queryKeys.mcp.detail(serverId) }),
-      ]);
+    onSuccess: async (data, serverId) => {
+      queryClient.setQueryData(queryKeys.mcp.detail(serverId), data.server);
+      await queryClient.invalidateQueries({ queryKey: queryKeys.mcp.all });
     },
   });
 }

--- a/apps/web/src/lib/mcp-tool-schema.test.ts
+++ b/apps/web/src/lib/mcp-tool-schema.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import { parseMcpToolParameters } from "./mcp-tool-schema";
+
+describe("parseMcpToolParameters", () => {
+  it("returns an empty list for invalid schemas", () => {
+    expect(parseMcpToolParameters(null)).toEqual([]);
+    expect(parseMcpToolParameters("invalid")).toEqual([]);
+    expect(parseMcpToolParameters({})).toEqual([]);
+  });
+
+  it("extracts parameter metadata from JSON schema objects", () => {
+    expect(
+      parseMcpToolParameters({
+        type: "object",
+        required: ["path"],
+        properties: {
+          path: {
+            type: "string",
+            description: "File path to read",
+          },
+          encoding: {
+            type: ["string", "null"],
+            description: "Optional text encoding",
+          },
+        },
+      }),
+    ).toEqual([
+      {
+        name: "path",
+        type: "string",
+        description: "File path to read",
+        required: true,
+      },
+      {
+        name: "encoding",
+        type: "string | null",
+        description: "Optional text encoding",
+        required: false,
+      },
+    ]);
+  });
+});

--- a/apps/web/src/lib/mcp-tool-schema.ts
+++ b/apps/web/src/lib/mcp-tool-schema.ts
@@ -1,0 +1,51 @@
+export interface McpToolParameter {
+  name: string;
+  type: string;
+  description?: string;
+  required: boolean;
+}
+
+export function parseMcpToolParameters(inputSchema: unknown): McpToolParameter[] {
+  if (typeof inputSchema !== "object" || inputSchema === null) {
+    return [];
+  }
+
+  const schema = inputSchema as Record<string, unknown>;
+  const properties = schema.properties;
+  const required = Array.isArray(schema.required)
+    ? schema.required.filter((entry): entry is string => typeof entry === "string")
+    : [];
+
+  if (typeof properties !== "object" || properties === null) {
+    return [];
+  }
+
+  return Object.entries(properties as Record<string, unknown>).map(([name, property]) => {
+    const propertyRecord =
+      typeof property === "object" && property !== null
+        ? (property as Record<string, unknown>)
+        : {};
+
+    return {
+      name,
+      type: formatSchemaType(propertyRecord.type),
+      description:
+        typeof propertyRecord.description === "string"
+          ? propertyRecord.description
+          : undefined,
+      required: required.includes(name),
+    };
+  });
+}
+
+function formatSchemaType(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.filter((entry): entry is string => typeof entry === "string").join(" | ");
+  }
+
+  return "unknown";
+}


### PR DESCRIPTION
Fixes: https://github.com/ahmadrosid/tinyclaw/issues/23

- Show exposed tools per server with inline name labels on each row
- Open tool details in a searchable modal with parameter schema breakdown
- Use a compact accordion list with stable row height and hidden scrollbar
- Consolidate Connect, Sync, and Delete into a server actions dropdown
- Cache MCP server detail on connect, sync, and create via React Query