### PR TITLE
fix(server): return 400 for invalid channel values instead of 500

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -947,7 +947,7 @@ function parseChannel(value: string | undefined): AgentChannel {
     return value;
   }
 
-  throw new Error("Invalid channel. Expected cli, web, or telegram.");
+  throw new TinyClawApiError("Invalid channel. Expected cli, web, or telegram.", 400);
 }
 
 async function readJson<T>(request: Request): Promise<T> {


### PR DESCRIPTION
## Summary

Fix invalid channel validation to return `400 Bad Request` instead of `500 Internal Server Error`.

Previously, the `parseChannel()` helper threw a generic `Error` when receiving an unsupported channel value. Since the application's top-level error handler only maps `TinyClawApiError` instances to specific HTTP status codes, invalid channel requests were incorrectly returned as `500 Internal Server Error`.

This change updates the validation logic to throw a `TinyClawApiError` with status code `400`, ensuring invalid client input is correctly classified as a bad request.

## Changes

### Server

**Modified:** `apps/server/src/app.ts`

Updated `parseChannel()` to throw `TinyClawApiError` instead of a generic `Error`.

```ts
function parseChannel(value: string | undefined): AgentChannel {
  if (value === "cli" || value === "web" || value === "telegram") {
    return value;
  }

  throw new TinyClawApiError(
    "Invalid channel. Expected cli, web, or telegram.",
    400
  );
}
```

## Behavior Change

### Before

Requests containing an invalid channel value:

```json
{
  "channel": "discord"
}
```

Returned:

```http
500 Internal Server Error
```

### After

Requests containing an invalid channel value:

```json
{
  "channel": "discord"
}
```

Now return:

```http
400 Bad Request
```

with the existing validation message:

```json
{
  "error": "Invalid channel. Expected cli, web, or telegram."
}
```

## Affected Endpoints

* `POST /v1/sessions`
* `GET /v1/sessions`
* `POST /v1/automations/draft`

## Why

Invalid channel values are input validation errors caused by client requests and should be reported as `400 Bad Request`.

Returning a `500 Internal Server Error`:

* Makes client-side debugging harder.
* Prevents API consumers from distinguishing invalid input from server failures.
* Introduces false-positive server errors in monitoring and observability tools.

This change aligns the API behavior with standard HTTP semantics.

## Testing

### Automated Tests

```bash
bun test
```

The existing test suite already covers `TinyClawApiError` behavior. Since this change only updates the exception type being thrown, no additional tests were required.

### Verification

Confirmed that invalid channel values are now surfaced as `400 Bad Request` instead of `500 Internal Server Error`.

## Checklist

* [x] Fix invalid channel error classification
* [x] Preserve existing validation message
* [x] No breaking API changes
* [x] Existing tests pass

Fixes #36