### PR TITLE
Add inbound document attachments to the Telegram bridge.

### DIFF
--- a/apps/platform/telegram/README.md
+++ b/apps/platform/telegram/README.md
@@ -40,7 +40,7 @@ Optional env vars:
 | `/profile` | Choose or switch bot profile |
 | `/status` | Server and model status |
 
-Send plain text or a photo (optional caption) to chat with the agent.
+Send plain text, a photo (optional caption), or a document (pdf, docx, txt, csv — max 5 MB) to chat with the agent.
 
 **Stopping a reply:** While the bot is working on an answer, send `/stop`. Any text already generated is sent first, then the bot replies `Stopped.`. If nothing is in progress, you get `Nothing to stop.`
 

--- a/apps/platform/telegram/src/attachments.test.ts
+++ b/apps/platform/telegram/src/attachments.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test, spyOn, afterEach } from "bun:test";
+import type { Context } from "grammy";
+import { MAX_DOCUMENT_BYTES } from "@tinyclaw/core/message-content";
+import {
+  buildTelegramDocumentInput,
+  OVERSIZED_FILE_REPLY,
+  UNSUPPORTED_DOCUMENT_TYPES_REPLY,
+  downloadTelegramFile,
+} from "./attachments";
+
+function createDocumentContext(options: {
+  fileId?: string;
+  fileName?: string;
+  mimeType?: string;
+  caption?: string;
+  fileSize?: number;
+}): Context {
+  return {
+    message: {
+      caption: options.caption,
+      document: {
+        file_id: options.fileId ?? "file-1",
+        file_name: options.fileName,
+        mime_type: options.mimeType,
+        file_size: options.fileSize,
+      },
+    },
+    api: {
+      token: "test-token",
+      getFile: async () => ({
+        file_path: "documents/report.pdf",
+        file_size: options.fileSize,
+      }),
+    },
+  } as unknown as Context;
+}
+
+describe("buildTelegramDocumentInput", () => {
+  let fetchSpy: ReturnType<typeof spyOn> | undefined;
+
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+  });
+
+  test("accepts pdf with caption", async () => {
+    fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("pdf-bytes", {
+        headers: { "content-type": "application/pdf" },
+      }),
+    );
+
+    const result = await buildTelegramDocumentInput(
+      createDocumentContext({
+        fileName: "report.pdf",
+        mimeType: "application/pdf",
+        caption: "Summarize this",
+      }),
+    );
+
+    expect(result).toEqual({
+      kind: "input",
+      input: {
+        message: "Summarize this",
+        documents: [
+          expect.objectContaining({
+            filename: "report.pdf",
+            mediaType: "application/pdf",
+            data: Buffer.from("pdf-bytes").toString("base64"),
+          }),
+        ],
+      },
+    });
+  });
+
+  test("accepts txt via filename when mime is octet-stream", async () => {
+    fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("hello", {
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+
+    const result = await buildTelegramDocumentInput(
+      createDocumentContext({
+        fileName: "notes.txt",
+        mimeType: "application/octet-stream",
+      }),
+    );
+
+    expect(result?.kind).toBe("input");
+    if (result?.kind === "input") {
+      expect(result.input.documents?.[0]?.mediaType).toBe("text/plain");
+    }
+  });
+
+  test("rejects xlsx documents", async () => {
+    fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("xlsx-bytes", {
+        headers: {
+          "content-type":
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        },
+      }),
+    );
+
+    const result = await buildTelegramDocumentInput(
+      createDocumentContext({
+        fileName: "sheet.xlsx",
+        mimeType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      }),
+    );
+
+    expect(result).toEqual({
+      kind: "reject",
+      message: UNSUPPORTED_DOCUMENT_TYPES_REPLY,
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("rejects oversized files before fetch when file_size is known", async () => {
+    fetchSpy = spyOn(globalThis, "fetch");
+
+    const result = await buildTelegramDocumentInput(
+      createDocumentContext({
+        fileName: "big.pdf",
+        mimeType: "application/pdf",
+        fileSize: MAX_DOCUMENT_BYTES + 1,
+      }),
+    );
+
+    expect(result).toEqual({ kind: "reject", message: OVERSIZED_FILE_REPLY });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("returns null for image documents", async () => {
+    const result = await buildTelegramDocumentInput(
+      createDocumentContext({
+        fileName: "photo.png",
+        mimeType: "image/png",
+      }),
+    );
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("downloadTelegramFile", () => {
+  test("surfaces download failures to caller", async () => {
+    const ctx = {
+      api: {
+        token: "test-token",
+        getFile: async () => {
+          throw new Error("network down");
+        },
+      },
+    } as unknown as Context;
+
+    await expect(downloadTelegramFile(ctx, "file-1", MAX_DOCUMENT_BYTES)).rejects.toThrow(
+      "network down",
+    );
+  });
+});

--- a/apps/platform/telegram/src/attachments.ts
+++ b/apps/platform/telegram/src/attachments.ts
@@ -1,0 +1,137 @@
+import type { Context } from "grammy";
+import type { SendMessageInput } from "@tinyclaw/core/contract";
+import {
+  MAX_DOCUMENT_BYTES,
+  normalizeDocumentMediaType,
+  validateDocumentAttachments,
+} from "@tinyclaw/core/message-content";
+
+const ALLOWED_DOCUMENT_MEDIA_TYPES = new Set([
+  "application/pdf",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "text/plain",
+  "text/csv",
+]);
+
+export const UNSUPPORTED_DOCUMENT_TYPES_REPLY =
+  "Unsupported file type. Send pdf, docx, txt, or csv (max 5 MB).";
+
+export const OVERSIZED_FILE_REPLY = "File is too large. Maximum size is 5 MB.";
+
+export const UNSUPPORTED_MEDIA_REPLY =
+  "Send text, a photo, or a supported document (pdf, docx, txt, csv — max 5 MB).";
+
+export const DOWNLOAD_FAILED_REPLY = "Could not download that file. Try again.";
+
+export class OversizedTelegramFileError extends Error {
+  constructor() {
+    super("File is too large.");
+    this.name = "OversizedTelegramFileError";
+  }
+}
+
+export interface DownloadedTelegramFile {
+  bytes: ArrayBuffer;
+  filePath: string;
+  contentType: string | null;
+}
+
+export async function downloadTelegramFile(
+  ctx: Context,
+  fileId: string,
+  maxBytes: number,
+): Promise<DownloadedTelegramFile> {
+  const file = await ctx.api.getFile(fileId);
+
+  if (!file.file_path) {
+    throw new Error("Telegram did not return a file path.");
+  }
+
+  if (file.file_size !== undefined && file.file_size > maxBytes) {
+    throw new OversizedTelegramFileError();
+  }
+
+  const token = ctx.api.token;
+  const url = `https://api.telegram.org/file/bot${token}/${file.file_path}`;
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`Failed to download file (${response.status}).`);
+  }
+
+  const bytes = await response.arrayBuffer();
+
+  if (bytes.byteLength > maxBytes) {
+    throw new OversizedTelegramFileError();
+  }
+
+  return {
+    bytes,
+    filePath: file.file_path,
+    contentType: response.headers.get("content-type"),
+  };
+}
+
+export type TelegramDocumentBuildResult =
+  | { kind: "input"; input: SendMessageInput }
+  | { kind: "reject"; message: string }
+  | null;
+
+export async function buildTelegramDocumentInput(
+  ctx: Context,
+): Promise<TelegramDocumentBuildResult> {
+  const document = ctx.message?.document;
+
+  if (!document) {
+    return null;
+  }
+
+  if (document.mime_type?.startsWith("image/")) {
+    return null;
+  }
+
+  const filename = document.file_name?.trim() || "document";
+  const mediaType = normalizeDocumentMediaType(document.mime_type ?? "", filename);
+
+  if (!ALLOWED_DOCUMENT_MEDIA_TYPES.has(mediaType)) {
+    return { kind: "reject", message: UNSUPPORTED_DOCUMENT_TYPES_REPLY };
+  }
+
+  if (document.file_size !== undefined && document.file_size > MAX_DOCUMENT_BYTES) {
+    return { kind: "reject", message: OVERSIZED_FILE_REPLY };
+  }
+
+  try {
+    const downloaded = await downloadTelegramFile(
+      ctx,
+      document.file_id,
+      MAX_DOCUMENT_BYTES,
+    );
+
+    const data = Buffer.from(downloaded.bytes).toString("base64");
+
+    try {
+      validateDocumentAttachments([{ filename, mediaType, data }]);
+    } catch {
+      return { kind: "reject", message: UNSUPPORTED_DOCUMENT_TYPES_REPLY };
+    }
+
+    return {
+      kind: "input",
+      input: {
+        message: ctx.message?.caption?.trim() ?? "",
+        documents: [{ filename, mediaType, data }],
+      },
+    };
+  } catch (error) {
+    if (error instanceof OversizedTelegramFileError) {
+      return { kind: "reject", message: OVERSIZED_FILE_REPLY };
+    }
+
+    throw error;
+  }
+}
+
+export function hasTelegramDocument(ctx: Context): boolean {
+  return Boolean(ctx.message?.document);
+}

--- a/apps/platform/telegram/src/chat-handler.test.ts
+++ b/apps/platform/telegram/src/chat-handler.test.ts
@@ -1,7 +1,8 @@
 import path from "node:path";
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, spyOn, afterEach } from "bun:test";
 import { TelegramAuthStore } from "./auth-store";
 import { createChatHandler } from "./chat-handler";
+import { UNSUPPORTED_DOCUMENT_TYPES_REPLY, UNSUPPORTED_MEDIA_REPLY } from "./attachments";
 import { SessionStore } from "./session-store";
 import {
   createMessageContext,
@@ -1191,6 +1192,164 @@ describe("bridge API integration", () => {
       expect(switchProfile.replies).toEqual([
         "Now using Research Bot. Chat history reset.",
       ]);
+    });
+  });
+});
+
+describe("createChatHandler document attachments", () => {
+  let fetchSpy: ReturnType<typeof spyOn> | undefined;
+
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+  });
+
+  function createDocumentContext(options: {
+    userId: number;
+    fileName: string;
+    mimeType: string;
+    caption?: string;
+  }) {
+    const base = createMessageContext({ userId: options.userId });
+    (base.ctx as { message: Record<string, unknown> }).message = {
+      document: {
+        file_id: "doc-1",
+        file_name: options.fileName,
+        mime_type: options.mimeType,
+      },
+      caption: options.caption,
+    };
+    (base.ctx as { api: Record<string, unknown> }).api = {
+      ...((base.ctx as { api?: Record<string, unknown> }).api ?? {}),
+      token: "test-token",
+      getFile: async () => ({ file_path: `documents/${options.fileName}` }),
+    };
+
+    return base;
+  }
+
+  test("forwards supported pdf documents to sendStream", async () => {
+    await withTempHome(async (homeDir) => {
+      await writeTelegramConfigIni(homeDir, {
+        botToken: "1234567890:TEST",
+        allowedUserIds: [4242],
+      });
+
+      fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response("pdf-content", {
+          headers: { "content-type": "application/pdf" },
+        }),
+      );
+
+      const authStore = new TelegramAuthStore();
+      await authStore.reload();
+      const { client, calls, getLastStreamInput } = createMockClient();
+      const sessionStore = new SessionStore(
+        path.join(homeDir, ".tinyclaw", "telegram", "chat-sessions.json"),
+      );
+      const orgStore = createTestOrgStore(homeDir);
+      await orgStore.load();
+      const handleMessage = createChatHandler({
+        client,
+        config: { botToken: "1234567890:TEST", profileId: "default" },
+        authStore,
+        sessionStore,
+        orgStore,
+      });
+
+      const { ctx, replies } = createDocumentContext({
+        userId: 4242,
+        fileName: "report.pdf",
+        mimeType: "application/pdf",
+        caption: "Summarize",
+      });
+
+      await handleMessage(ctx);
+
+      expect(calls.sendStream).toBe(1);
+      expect(getLastStreamInput()).toEqual({
+        message: "Summarize",
+        documents: [
+          expect.objectContaining({
+            filename: "report.pdf",
+            mediaType: "application/pdf",
+          }),
+        ],
+      });
+      expect(replies.at(-1)).toBe("Agent reply");
+    });
+  });
+
+  test("rejects unsupported documents without calling sendStream", async () => {
+    await withTempHome(async (homeDir) => {
+      await writeTelegramConfigIni(homeDir, {
+        botToken: "1234567890:TEST",
+        allowedUserIds: [4242],
+      });
+
+      fetchSpy = spyOn(globalThis, "fetch");
+
+      const authStore = new TelegramAuthStore();
+      await authStore.reload();
+      const { client, calls } = createMockClient();
+      const sessionStore = new SessionStore(
+        path.join(homeDir, ".tinyclaw", "telegram", "chat-sessions.json"),
+      );
+      const orgStore = createTestOrgStore(homeDir);
+      await orgStore.load();
+      const handleMessage = createChatHandler({
+        client,
+        config: { botToken: "1234567890:TEST", profileId: "default" },
+        authStore,
+        sessionStore,
+        orgStore,
+      });
+
+      const { ctx, replies } = createDocumentContext({
+        userId: 4242,
+        fileName: "sheet.xlsx",
+        mimeType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      });
+
+      await handleMessage(ctx);
+
+      expect(calls.sendStream).toBe(0);
+      expect(replies).toEqual([UNSUPPORTED_DOCUMENT_TYPES_REPLY]);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  test("replies with supported media guidance for other non-text messages", async () => {
+    await withTempHome(async (homeDir) => {
+      await writeTelegramConfigIni(homeDir, {
+        botToken: "1234567890:TEST",
+        allowedUserIds: [4242],
+      });
+
+      const authStore = new TelegramAuthStore();
+      await authStore.reload();
+      const { client, calls } = createMockClient();
+      const sessionStore = new SessionStore(
+        path.join(homeDir, ".tinyclaw", "telegram", "chat-sessions.json"),
+      );
+      const orgStore = createTestOrgStore(homeDir);
+      await orgStore.load();
+      const handleMessage = createChatHandler({
+        client,
+        config: { botToken: "1234567890:TEST", profileId: "default" },
+        authStore,
+        sessionStore,
+        orgStore,
+      });
+
+      const { ctx, replies } = createMessageContext({ userId: 4242 });
+      (ctx as { message: Record<string, unknown> }).message = {
+        voice: { file_id: "voice-1" },
+      };
+
+      await handleMessage(ctx);
+
+      expect(calls.sendStream).toBe(0);
+      expect(replies).toEqual([UNSUPPORTED_MEDIA_REPLY]);
     });
   });
 });

--- a/apps/platform/telegram/src/chat-handler.ts
+++ b/apps/platform/telegram/src/chat-handler.ts
@@ -24,6 +24,12 @@ import {
   registerActiveStream,
   stopActiveStream,
 } from "./active-stream";
+import {
+  buildTelegramDocumentInput,
+  DOWNLOAD_FAILED_REPLY,
+  hasTelegramDocument,
+  UNSUPPORTED_MEDIA_REPLY,
+} from "./attachments";
 import { buildTelegramImageInput } from "./images";
 import { normalizeHandshakeInput } from "@tinyclaw/core/telegram-config";
 import type { TelegramBridgeConfig } from "./config";
@@ -91,6 +97,11 @@ export function createChatHandler(deps: ChatHandlerDeps) {
             return;
           }
 
+          if (hasTelegramDocument(ctx)) {
+            await ctx.reply("Send your pairing code as text to link this chat.");
+            return;
+          }
+
           await ctx.reply("Text messages only.");
           return;
         }
@@ -116,10 +127,19 @@ export function createChatHandler(deps: ChatHandlerDeps) {
         return;
       }
 
+      const documentInput = await tryBuildDocumentInput(ctx);
+
+      if (documentInput) {
+        await handleChatMessage(ctx, documentInput, chatId);
+        return;
+      }
+
+      if (hasTelegramDocument(ctx)) {
+        return;
+      }
+
       if (!text) {
-        await ctx.reply(
-          "Send text or a photo (with optional caption). Other media is not supported yet.",
-        );
+        await ctx.reply(UNSUPPORTED_MEDIA_REPLY);
         return;
       }
 
@@ -231,6 +251,26 @@ export function createChatHandler(deps: ChatHandlerDeps) {
       return await buildTelegramImageInput(ctx);
     } catch (error) {
       await ctx.reply(formatError(error));
+      return null;
+    }
+  }
+
+  async function tryBuildDocumentInput(ctx: Context): Promise<SendMessageInput | null> {
+    try {
+      const result = await buildTelegramDocumentInput(ctx);
+
+      if (!result) {
+        return null;
+      }
+
+      if (result.kind === "reject") {
+        await ctx.reply(result.message);
+        return null;
+      }
+
+      return result.input;
+    } catch {
+      await ctx.reply(DOWNLOAD_FAILED_REPLY);
       return null;
     }
   }

--- a/apps/platform/telegram/src/format.ts
+++ b/apps/platform/telegram/src/format.ts
@@ -167,4 +167,4 @@ export const HELP_TEXT = `TinyClaw Telegram commands:
 /profile — choose or switch bot profile
 /status — server and model status
 
-Send text or a photo (optional caption) to chat with the agent.`;
+Send text, a photo, or a supported document (pdf, docx, txt, csv — max 5 MB) to chat with the agent.`;

--- a/apps/platform/telegram/src/images.ts
+++ b/apps/platform/telegram/src/images.ts
@@ -1,6 +1,7 @@
 import type { Context } from "grammy";
 import type { ImageAttachment } from "@tinyclaw/core/contract";
 import { MAX_IMAGE_BYTES } from "@tinyclaw/core/message-content";
+import { downloadTelegramFile, OversizedTelegramFileError } from "./attachments";
 
 export interface TelegramImageInput {
   message: string;
@@ -35,32 +36,21 @@ export async function downloadTelegramImage(
   ctx: Context,
   fileId: string,
 ): Promise<ImageAttachment> {
-  const file = await ctx.api.getFile(fileId);
+  try {
+    const downloaded = await downloadTelegramFile(ctx, fileId, MAX_IMAGE_BYTES);
+    const mediaType = inferMediaType(downloaded.filePath, downloaded.contentType);
 
-  if (!file.file_path) {
-    throw new Error("Telegram did not return a file path.");
+    return {
+      mediaType,
+      data: Buffer.from(downloaded.bytes).toString("base64"),
+    };
+  } catch (error) {
+    if (error instanceof OversizedTelegramFileError) {
+      throw new Error("Image is too large. Maximum size is 5 MB.");
+    }
+
+    throw error;
   }
-
-  const token = ctx.api.token;
-  const url = `https://api.telegram.org/file/bot${token}/${file.file_path}`;
-  const response = await fetch(url);
-
-  if (!response.ok) {
-    throw new Error(`Failed to download image (${response.status}).`);
-  }
-
-  const bytes = await response.arrayBuffer();
-
-  if (bytes.byteLength > MAX_IMAGE_BYTES) {
-    throw new Error("Image is too large. Maximum size is 5 MB.");
-  }
-
-  const mediaType = inferMediaType(file.file_path, response.headers.get("content-type"));
-
-  return {
-    mediaType,
-    data: Buffer.from(bytes).toString("base64"),
-  };
 }
 
 function inferMediaType(filePath: string, headerType: string | null): string {

--- a/apps/platform/telegram/src/test-helpers.ts
+++ b/apps/platform/telegram/src/test-helpers.ts
@@ -135,15 +135,17 @@ export function createMockClient(
   };
   const orgIds: string[] = [];
   let lastCreateSessionProfileId: string | undefined;
+  let lastStreamInput: unknown;
 
   let streamControl: MockStreamControl | null = null;
 
   const sendStream = async (
-    _input: unknown,
+    input: unknown,
     handlers: unknown,
     streamOptions?: { signal?: AbortSignal },
   ) => {
     calls.sendStream += 1;
+    lastStreamInput = input;
 
     if (!options.streaming) {
       return "Agent reply";
@@ -302,6 +304,7 @@ export function createMockClient(
     calls,
     orgIds,
     getLastCreateSessionProfileId: () => lastCreateSessionProfileId,
+    getLastStreamInput: () => lastStreamInput,
     getStreamControl: () => streamControl,
   };
 }


### PR DESCRIPTION
Users can send pdf, docx, txt, and csv files through Telegram with the same validation and agent pipeline as web chat, without re-uploading on the dashboard.