### PR TITLE
feat: let automations inspect prior runs

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -17,7 +17,10 @@ import { McpService } from "./services/mcp-service";
 import { SkillsService } from "./services/skills-service";
 import { AuthService } from "./services/auth-service";
 import { OrgService } from "./services/org-service";
-import { createAutomationTools } from "./tools/automation-tools";
+import {
+  createAutomationRunHistoryTools,
+  createAutomationTools,
+} from "./tools/automation-tools";
 import { TINYCLAW_API_VERSION } from "@tinyclaw/core";
 import {
   DEFAULT_SERVER_HOST,
@@ -105,6 +108,7 @@ const automationRunner = new AutomationRunner(
 );
 
 agent.setAutomationTools(createAutomationTools(automationService, automationRunner));
+agent.setAutomationRunHistoryTools(createAutomationRunHistoryTools(automationService));
 agent.setAutomationRunner(automationRunner);
 
 const taskService = new TaskService(database.adapter);

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -226,6 +226,7 @@ export class AgentService {
   private readonly agentQuestionnaireState: AgentQuestionnaireState;
   private readonly superBotTools: ToolDefinition[];
   private automationTools: ToolDefinition[] = [];
+  private automationRunHistoryTools: ToolDefinition[] = [];
   private questionTools: ToolDefinition[] = [];
   private todoTools: ToolDefinition[] = [];
   private automationRunner: AutomationRunner | null = null;
@@ -271,6 +272,10 @@ export class AgentService {
   setAutomationTools(tools: ToolDefinition[]): void {
     this.automationTools = tools;
     this.sessions.clear();
+  }
+
+  setAutomationRunHistoryTools(tools: ToolDefinition[]): void {
+    this.automationRunHistoryTools = tools;
   }
 
   setAutomationRunner(runner: AutomationRunner): void {
@@ -708,16 +713,21 @@ export class AgentService {
     orgId: string,
     profileId: string,
     prompt: string,
+    automationId?: string,
+    automationRunId?: string,
   ): Promise<string> {
     if (!this._providerConfigured) {
       throw new Error("Provider is not configured.");
     }
 
     const profile = await this.requireProfile(orgId, profileId);
-    const tools = await this.resolveProfileTools(profile, {
-      includeAutomationTools: false,
-      includeTodoTools: false,
-    });
+    const tools = [
+      ...(await this.resolveProfileTools(profile, {
+        includeAutomationTools: false,
+        includeTodoTools: false,
+      })),
+      ...this.automationRunHistoryTools,
+    ];
     const { systemPrompt, soulActive } = await this.resolveProfileSystemPrompt(
       orgId,
       profileId,
@@ -736,6 +746,8 @@ export class AgentService {
       soul: soulActive,
       userTimezone,
       toolContext: buildToolExecutionContext({
+        automationId,
+        automationRunId,
         orgId,
         profileId,
       }),

--- a/apps/server/src/services/automation-runner.ts
+++ b/apps/server/src/services/automation-runner.ts
@@ -44,6 +44,8 @@ export class AutomationRunner {
         orgId,
         automation.profileId,
         automation.prompt,
+        automationId,
+        run.id,
       );
 
       const completedRun = await this.automationService.completeRun(run.id, automationId, { output });

--- a/apps/server/src/services/automation.test.ts
+++ b/apps/server/src/services/automation.test.ts
@@ -220,6 +220,59 @@ describe("AutomationRunner", () => {
     expect(runs[0]?.output).toBe("Hello from automation");
   });
 
+  test("passes automation scope to the agent prompt", async () => {
+    const db = await createTestDb();
+    const service = new AutomationService(db, {
+      getUserTimezone: async () => "UTC",
+    });
+
+    const automation = await service.create(
+      ORG_ID,
+      {
+        name: "Scoped task",
+        description: "Run with history scope",
+        prompt: "Say hello",
+        trigger: { type: "manual" },
+      },
+      PROFILE_ID,
+    );
+
+    let received:
+      | {
+          orgId: string;
+          profileId: string;
+          prompt: string;
+          automationId?: string;
+          automationRunId?: string;
+        }
+      | undefined;
+
+    const agentService = {
+      runAutomationPrompt: async (
+        orgId: string,
+        profileId: string,
+        prompt: string,
+        automationId?: string,
+        automationRunId?: string,
+      ) => {
+        received = { orgId, profileId, prompt, automationId, automationRunId };
+        return "Hello from automation";
+      },
+    };
+
+    const runner = new AutomationRunner(service, agentService as never);
+    await runner.run(automation.id);
+
+    const runs = await service.listRuns(automation.id);
+    expect(received).toEqual({
+      orgId: ORG_ID,
+      profileId: PROFILE_ID,
+      prompt: "Say hello",
+      automationId: automation.id,
+      automationRunId: runs[0]?.id,
+    });
+  });
+
   test("writes failed run records", async () => {
     const db = await createTestDb();
     const service = new AutomationService(db, {

--- a/apps/server/src/tools/automation-tools.test.ts
+++ b/apps/server/src/tools/automation-tools.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from "bun:test";
 import { createInMemoryDatabaseAdapter } from "@tinyclaw/db";
 import { AutomationRunner } from "../services/automation-runner";
 import { AutomationService } from "../services/automation-service";
-import { createAutomationTools } from "./automation-tools";
+import {
+  createAutomationRunHistoryTools,
+  createAutomationTools,
+} from "./automation-tools";
 
 const ORG_ID = "org_test";
 const PROFILE_ID = "profile_default";
@@ -45,6 +48,18 @@ function getRunAutomationTool(
 
   if (!tool) {
     throw new Error("run_automation tool not found");
+  }
+
+  return tool;
+}
+
+function getPreviousAutomationRunsTool(service: AutomationService) {
+  const tool = createAutomationRunHistoryTools(service).find(
+    (entry) => entry.name === "list_previous_automation_runs",
+  );
+
+  if (!tool) {
+    throw new Error("list_previous_automation_runs tool not found");
   }
 
   return tool;
@@ -209,5 +224,96 @@ describe("run_automation tool", () => {
     const runs = await service.listRuns(automation.id);
     expect(runs[0]?.status).toBe("failed");
     expect(runs[0]?.error).toBe("Provider offline");
+  });
+});
+
+describe("list_previous_automation_runs tool", () => {
+  test("returns previous runs for the current automation only", async () => {
+    const db = await createTestDb();
+    const service = new AutomationService(db, {
+      getUserTimezone: async () => "UTC",
+    });
+
+    const automation = await service.create(
+      ORG_ID,
+      {
+        name: "Digest",
+        description: "Daily digest",
+        prompt: "Summarize news",
+        trigger: { type: "manual" },
+      },
+      PROFILE_ID,
+    );
+    const otherAutomation = await service.create(
+      ORG_ID,
+      {
+        name: "Other",
+        description: "Other task",
+        prompt: "Run",
+        trigger: { type: "manual" },
+      },
+      PROFILE_ID,
+    );
+
+    await db.insertAutomationRun({
+      id: "run_previous",
+      automationId: automation.id,
+      status: "completed",
+      startedAt: "2026-06-29T10:00:00.000Z",
+      completedAt: "2026-06-29T10:01:00.000Z",
+      output: "Yesterday summary",
+      error: null,
+    });
+    await db.insertAutomationRun({
+      id: "run_current",
+      automationId: automation.id,
+      status: "running",
+      startedAt: "2026-06-30T10:00:00.000Z",
+      completedAt: null,
+      output: null,
+      error: null,
+    });
+    await db.insertAutomationRun({
+      id: "run_other",
+      automationId: otherAutomation.id,
+      status: "completed",
+      startedAt: "2026-06-30T09:00:00.000Z",
+      completedAt: "2026-06-30T09:01:00.000Z",
+      output: "Hidden",
+      error: null,
+    });
+
+    const tool = getPreviousAutomationRunsTool(service);
+    const result = await tool.run(
+      { limit: 5 },
+      {
+        ...TOOL_CONTEXT,
+        automationId: automation.id,
+        automationRunId: "run_current",
+      } as never,
+    );
+
+    expect(result).toEqual([
+      {
+        id: "run_previous",
+        status: "completed",
+        startedAt: "2026-06-29T10:00:00.000Z",
+        completedAt: "2026-06-29T10:01:00.000Z",
+        output: "Yesterday summary",
+        error: null,
+      },
+    ]);
+  });
+
+  test("requires current automation context", async () => {
+    const db = await createTestDb();
+    const service = new AutomationService(db, {
+      getUserTimezone: async () => "UTC",
+    });
+    const tool = getPreviousAutomationRunsTool(service);
+
+    await expect(tool.run({}, TOOL_CONTEXT as never)).rejects.toThrow(
+      "automationId is required.",
+    );
   });
 });

--- a/apps/server/src/tools/automation-tools.ts
+++ b/apps/server/src/tools/automation-tools.ts
@@ -181,6 +181,52 @@ export function createAutomationTools(
   ];
 }
 
+export function createAutomationRunHistoryTools(
+  automationService: AutomationService,
+): ToolDefinition[] {
+  return [
+    {
+      name: "list_previous_automation_runs",
+      description:
+        "List recent previous runs for the currently running automation. Use this only when past outputs or failures would help complete the current automation run.",
+      parameters: {
+        type: "object",
+        properties: {
+          limit: {
+            type: "number",
+            description: "Maximum number of previous runs to return. Defaults to 5, max 20.",
+          },
+        },
+        additionalProperties: false,
+      },
+      async run(input, context) {
+        const orgId = requireOrgId(context);
+        const automationId = context.automationId?.trim();
+
+        if (!automationId) {
+          throw new Error("automationId is required.");
+        }
+
+        const limit = readLimit(input);
+        const fetchLimit = context.automationRunId ? limit + 1 : limit;
+        const runs = await automationService.listRuns(automationId, orgId, fetchLimit);
+
+        return runs
+          .filter((run) => run.id !== context.automationRunId)
+          .slice(0, limit)
+          .map((run) => ({
+            id: run.id,
+            status: run.status,
+            startedAt: run.startedAt,
+            completedAt: run.completedAt,
+            output: run.output,
+            error: run.error,
+          }));
+      },
+    },
+  ];
+}
+
 function requireOrgId(context: ToolContext): string {
   const orgId = context.orgId?.trim();
 
@@ -198,6 +244,20 @@ function readString(input: unknown, key: string): string | null {
 
   const value = (input as Record<string, unknown>)[key];
   return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function readLimit(input: unknown): number {
+  if (!input || typeof input !== "object") {
+    return 5;
+  }
+
+  const value = (input as Record<string, unknown>).limit;
+
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return 5;
+  }
+
+  return Math.min(20, Math.max(1, Math.trunc(value)));
 }
 
 function readTrigger(

--- a/apps/server/src/tools/automation-tools.ts
+++ b/apps/server/src/tools/automation-tools.ts
@@ -247,17 +247,13 @@ function readString(input: unknown, key: string): string | null {
 }
 
 function readLimit(input: unknown): number {
-  if (!input || typeof input !== "object") {
-    return 5;
-  }
+  const value =
+    input && typeof input === "object"
+      ? (input as Record<string, unknown>).limit
+      : undefined;
+  const limit = typeof value === "number" && Number.isFinite(value) ? value : 5;
 
-  const value = (input as Record<string, unknown>).limit;
-
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return 5;
-  }
-
-  return Math.min(20, Math.max(1, Math.trunc(value)));
+  return Math.min(20, Math.max(1, Math.trunc(limit)));
 }
 
 function readTrigger(

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -1332,6 +1332,7 @@ export interface ProviderClient {
 
 export interface ToolContext {
   automationId?: string;
+  automationRunId?: string;
   userId?: string;
   orgId?: string;
   profileId?: string;


### PR DESCRIPTION
## Summary

Automation runs can now inspect their own recent history on demand. Instead of always stuffing previous outputs into the prompt, the automation session gets a read-only `list_previous_automation_runs` tool and can decide when history is useful.

The tool is scoped from server-side context, so it only reads the current automation's runs and filters out the active in-progress run.

## Testing

- `bun test apps/server/src/services/automation.test.ts apps/server/src/tools/automation-tools.test.ts`
- `bun run --filter @tinyclaw/server test`
- `bun run --filter @tinyclaw/server build`
- `git diff --check`

## Post-Deploy Monitoring & Validation

- Watch server logs for `list_previous_automation_runs`, `automationId is required`, and `Automation not found`.
- Healthy signal: scheduled/manual automations continue completing, and history-aware prompts can call the new tool without exposing other automations.
- Failure signal: automation runs failing during tool calls or returning unexpected run history.
- Validation window: first day after deploy; owner: maintainer deploying the change.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
