### PR TITLE
fix: enforce RBAC on automation & task mutations and profile binding (#107)

### DIFF
--- a/apps/platform/telegram/src/chat-handler.test.ts
+++ b/apps/platform/telegram/src/chat-handler.test.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { describe, expect, test, spyOn, afterEach } from "bun:test";
+import { describe, expect, test, spyOn, afterEach, setDefaultTimeout } from "bun:test";
 import { TelegramAuthStore } from "./auth-store";
 import { createChatHandler } from "./chat-handler";
 import { UNSUPPORTED_DOCUMENT_TYPES_REPLY, UNSUPPORTED_MEDIA_REPLY } from "./attachments";
@@ -13,6 +13,10 @@ import {
   withTempHome,
   writeTelegramConfigIni,
 } from "./test-helpers";
+
+// These handler tests run in ~0.2s locally but occasionally exceed the 5000ms
+// default under CI's concurrent all-workspace load. Give them more headroom.
+setDefaultTimeout(10_000);
 
 async function waitForCondition(
   condition: () => boolean,

--- a/apps/server/src/http/routes/automations.ts
+++ b/apps/server/src/http/routes/automations.ts
@@ -11,7 +11,10 @@ import type {
   UpdateAutomationRequest,
 } from "@nakama/core";
 import { errorResponse, getRequestAuth, json, parseChannel, readJson } from "../shared";
-import { requireActiveOrgIdFromContext } from "../org-guards";
+import {
+  requireActiveOrgIdFromContext,
+  requireNotViewerFromContext,
+} from "../org-guards";
 import type { HonoApp } from "../types";
 import type { ServerOptions } from "../context";
 
@@ -169,6 +172,7 @@ export function registerAutomationRoutes(app: HonoApp, options: ServerOptions): 
   }));
 
   app.post("/v1/automations/draft", async (c) => {
+    requireNotViewerFromContext(c);
     const body = await readJson<DraftAutomationRequest>(c.req.raw);
     const automation = await agent.draftAutomation(body.prompt, parseChannel(body.channel));
     return json<DraftAutomationResponse>({ automation });
@@ -182,6 +186,7 @@ export function registerAutomationRoutes(app: HonoApp, options: ServerOptions): 
   });
 
   app.post("/v1/automations", async (c) => {
+    requireNotViewerFromContext(c);
     const orgId = requireActiveOrgIdFromContext(c);
     const body = await readJson<CreateAutomationRequest>(c.req.raw);
     const automation = await automationService.create(orgId, body, body.profileId);
@@ -201,6 +206,7 @@ export function registerAutomationRoutes(app: HonoApp, options: ServerOptions): 
   });
 
   app.put("/v1/automations/:automationId", async (c) => {
+    requireNotViewerFromContext(c);
     const orgId = requireActiveOrgIdFromContext(c);
     const automationId = decodeURIComponent(c.req.param("automationId"));
     const body = await readJson<UpdateAutomationRequest>(c.req.raw);
@@ -217,6 +223,7 @@ export function registerAutomationRoutes(app: HonoApp, options: ServerOptions): 
   });
 
   app.delete("/v1/automations/:automationId", async (c) => {
+    requireNotViewerFromContext(c);
     const orgId = requireActiveOrgIdFromContext(c);
     const deleted = await automationService.delete(
       decodeURIComponent(c.req.param("automationId")),
@@ -229,6 +236,7 @@ export function registerAutomationRoutes(app: HonoApp, options: ServerOptions): 
   });
 
   app.post("/v1/automations/:automationId/run", async (c) => {
+    requireNotViewerFromContext(c);
     const orgId = requireActiveOrgIdFromContext(c);
     const auth = getRequestAuth(c);
     const automationId = decodeURIComponent(c.req.param("automationId"));
@@ -270,6 +278,7 @@ export function registerAutomationRoutes(app: HonoApp, options: ServerOptions): 
   });
 
   app.delete("/v1/automations/:automationId/runs/:runId", async (c) => {
+    requireNotViewerFromContext(c);
     const orgId = requireActiveOrgIdFromContext(c);
     const automationId = decodeURIComponent(c.req.param("automationId"));
     const runId = decodeURIComponent(c.req.param("runId"));

--- a/apps/server/src/http/routes/automations.ts
+++ b/apps/server/src/http/routes/automations.ts
@@ -186,10 +186,13 @@ export function registerAutomationRoutes(app: HonoApp, options: ServerOptions): 
   });
 
   app.post("/v1/automations", async (c) => {
-    requireNotViewerFromContext(c);
+    const auth = requireNotViewerFromContext(c);
     const orgId = requireActiveOrgIdFromContext(c);
     const body = await readJson<CreateAutomationRequest>(c.req.raw);
-    const automation = await automationService.create(orgId, body, body.profileId);
+    const automation = await automationService.create(orgId, body, body.profileId, {
+      orgRole: auth.orgRole,
+      isPlatformAdmin: auth.isPlatformAdmin,
+    });
     return json<AutomationResponse>({ automation }, 201);
   });
 

--- a/apps/server/src/http/routes/rbac-mutations.test.ts
+++ b/apps/server/src/http/routes/rbac-mutations.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test";
+import type { OrgRole } from "@nakama/core";
+import { createHonoApp } from "../app";
+import { AuthService } from "../../services/auth-service";
+import { OrgService } from "../../services/org-service";
+import { createInMemoryDatabaseAdapter } from "@nakama/db";
+import { loginUserSession } from "../test-session-helpers";
+import { setupTestConfigDir } from "../../test-config-dir";
+
+setupTestConfigDir("nakama-rbac-mutations-test-");
+
+const ORG_ID = "org_test";
+const PASSWORD = "password123";
+
+function createApp() {
+  const databaseAdapter = createInMemoryDatabaseAdapter();
+  const authService = new AuthService();
+  const calls: string[] = [];
+  const record = (name: string) =>
+    async (..._args: unknown[]) => {
+      calls.push(name);
+      return { id: "x", name: "x", prompt: "x" } as any;
+    };
+
+  const app = createHonoApp({
+    agent: {
+      listProfiles: async () => ({ profiles: [{ id: "default" }] }),
+      draftAutomation: record("agent.draftAutomation"),
+      runAutomation: async () => {
+        calls.push("agent.runAutomation");
+        return { skipped: false };
+      },
+      draftTaskPrompt: record("agent.draftTaskPrompt"),
+      runTask: async () => {
+        calls.push("agent.runTask");
+        return { skipped: false };
+      },
+    } as any,
+    automationService: {
+      create: record("automationService.create"),
+      update: record("automationService.update"),
+      delete: record("automationService.delete"),
+      get: async () => ({ id: "a", name: "a", prompt: "x" }),
+      deleteRun: record("automationService.deleteRun"),
+      listRuns: async () => [{ id: "r", status: "ok" }],
+    } as any,
+    taskService: {
+      create: record("taskService.create"),
+      update: record("taskService.update"),
+      delete: record("taskService.delete"),
+      get: async () => ({ id: "t", status: "todo" }),
+      listRuns: async () => [{ id: "r", status: "ok" }],
+    } as any,
+    systemStatus: { getStatus: async () => ({ ok: true }) } as any,
+    workerManager: {} as any,
+    mcpService: {} as any,
+    authService,
+    orgService: new OrgService(databaseAdapter, authService),
+    databaseAdapter,
+    webDistDir: null,
+  });
+
+  return { app, databaseAdapter, authService, calls };
+}
+
+async function seedUser(
+  databaseAdapter: ReturnType<typeof createInMemoryDatabaseAdapter>,
+  authService: AuthService,
+  email: string,
+  role: OrgRole,
+) {
+  const now = new Date().toISOString();
+  const userId = `user_${role}`;
+  await databaseAdapter.createUser({
+    id: userId,
+    email,
+    passwordHash: await authService.hashPassword(PASSWORD),
+    createdAt: now,
+    updatedAt: now,
+  });
+  await databaseAdapter.upsertOrganization({
+    id: ORG_ID,
+    name: "Test Org",
+    slug: "test-org",
+    createdAt: now,
+    updatedAt: now,
+  });
+  await databaseAdapter.upsertOrgMember({ orgId: ORG_ID, userId, role, createdAt: now });
+}
+
+// State-changing routes a viewer must not be able to reach.
+const MUTATING_ROUTES: Array<{ method: string; path: string; body?: unknown }> = [
+  { method: "POST", path: "/v1/automations/draft", body: { prompt: "x", channel: "web" } },
+  { method: "POST", path: "/v1/automations", body: { name: "x", prompt: "x" } },
+  { method: "PUT", path: "/v1/automations/a1", body: { name: "x" } },
+  { method: "DELETE", path: "/v1/automations/a1" },
+  { method: "POST", path: "/v1/automations/a1/run" },
+  { method: "DELETE", path: "/v1/automations/a1/runs/r1" },
+  { method: "POST", path: "/v1/tasks/draft-prompt", body: { title: "x", description: "x" } },
+  { method: "POST", path: "/v1/tasks", body: { title: "x", prompt: "x" } },
+  { method: "PUT", path: "/v1/tasks/t1", body: { title: "x" } },
+  { method: "DELETE", path: "/v1/tasks/t1" },
+  { method: "POST", path: "/v1/tasks/t1/run" },
+];
+
+describe("RBAC: viewer cannot reach state-changing automation/task routes", () => {
+  for (const route of MUTATING_ROUTES) {
+    test(`${route.method} ${route.path} -> 403 for viewer`, async () => {
+      const { app, databaseAdapter, authService, calls } = createApp();
+      await seedUser(databaseAdapter, authService, "viewer@example.com", "viewer");
+      const viewer = await loginUserSession(app, "viewer@example.com", PASSWORD, ORG_ID);
+
+      const response = await app.fetch(
+        new Request(`http://localhost:4310${route.path}`, {
+          method: route.method,
+          headers: viewer.headers({ "X-CSRF-Token": viewer.csrfToken }),
+          body: route.body ? JSON.stringify(route.body) : undefined,
+        }),
+      );
+
+      expect(response.status).toBe(403);
+      // Guard must reject before any service/agent side effect runs.
+      expect(calls).toEqual([]);
+    });
+  }
+});
+
+describe("RBAC: admin can still reach the same routes (not a 403)", () => {
+  test("POST /v1/automations is not forbidden for admin", async () => {
+    const { app, databaseAdapter, authService } = createApp();
+    await seedUser(databaseAdapter, authService, "admin@example.com", "admin");
+    const admin = await loginUserSession(app, "admin@example.com", PASSWORD, ORG_ID);
+
+    const response = await app.fetch(
+      new Request("http://localhost:4310/v1/automations", {
+        method: "POST",
+        headers: admin.headers({ "X-CSRF-Token": admin.csrfToken }),
+        body: JSON.stringify({ name: "x", prompt: "x" }),
+      }),
+    );
+
+    expect(response.status).not.toBe(403);
+  });
+});

--- a/apps/server/src/http/routes/tasks.ts
+++ b/apps/server/src/http/routes/tasks.ts
@@ -167,12 +167,15 @@ export function registerTaskRoutes(app: HonoApp, options: ServerOptions): void {
   });
 
   app.post("/v1/tasks", async (c) => {
-    requireNotViewerFromContext(c);
+    const auth = requireNotViewerFromContext(c);
     const orgId = requireActiveOrgIdFromContext(c);
     const body = await readJson<CreateTaskRequest>(c.req.raw);
 
     try {
-      const task = await taskService.create(orgId, body, body.profileId);
+      const task = await taskService.create(orgId, body, body.profileId, {
+        orgRole: auth.orgRole,
+        isPlatformAdmin: auth.isPlatformAdmin,
+      });
       return json<TaskResponse>({ task }, 201);
     } catch (error) {
       if (error instanceof Error) {
@@ -202,13 +205,15 @@ export function registerTaskRoutes(app: HonoApp, options: ServerOptions): void {
   });
 
   app.put("/v1/tasks/:taskId", async (c) => {
-    requireNotViewerFromContext(c);
+    const auth = requireNotViewerFromContext(c);
     const orgId = requireActiveOrgIdFromContext(c);
     const taskId = decodeURIComponent(c.req.param("taskId"));
     const body = await readJson<UpdateTaskRequest>(c.req.raw);
 
     try {
-      const task = await taskService.update(taskId, orgId, body);
+      const task = await taskService.update(taskId, orgId, body, {
+        access: { orgRole: auth.orgRole, isPlatformAdmin: auth.isPlatformAdmin },
+      });
       return json<TaskResponse>({ task });
     } catch (error) {
       if (error instanceof Error) {

--- a/apps/server/src/http/routes/tasks.ts
+++ b/apps/server/src/http/routes/tasks.ts
@@ -11,7 +11,10 @@ import type {
   UpdateTaskRequest,
 } from "@nakama/core";
 import { errorResponse, json, readJson } from "../shared";
-import { requireActiveOrgIdFromContext } from "../org-guards";
+import {
+  requireActiveOrgIdFromContext,
+  requireNotViewerFromContext,
+} from "../org-guards";
 import type { HonoApp } from "../types";
 import type { ServerOptions } from "../context";
 
@@ -149,6 +152,7 @@ export function registerTaskRoutes(app: HonoApp, options: ServerOptions): void {
   });
 
   app.post("/v1/tasks/draft-prompt", async (c) => {
+    requireNotViewerFromContext(c);
     const body = await readJson<DraftTaskPromptRequest>(c.req.raw);
 
     try {
@@ -163,6 +167,7 @@ export function registerTaskRoutes(app: HonoApp, options: ServerOptions): void {
   });
 
   app.post("/v1/tasks", async (c) => {
+    requireNotViewerFromContext(c);
     const orgId = requireActiveOrgIdFromContext(c);
     const body = await readJson<CreateTaskRequest>(c.req.raw);
 
@@ -197,6 +202,7 @@ export function registerTaskRoutes(app: HonoApp, options: ServerOptions): void {
   });
 
   app.put("/v1/tasks/:taskId", async (c) => {
+    requireNotViewerFromContext(c);
     const orgId = requireActiveOrgIdFromContext(c);
     const taskId = decodeURIComponent(c.req.param("taskId"));
     const body = await readJson<UpdateTaskRequest>(c.req.raw);
@@ -224,6 +230,7 @@ export function registerTaskRoutes(app: HonoApp, options: ServerOptions): void {
   });
 
   app.delete("/v1/tasks/:taskId", async (c) => {
+    requireNotViewerFromContext(c);
     const orgId = requireActiveOrgIdFromContext(c);
     const deleted = await taskService.delete(
       decodeURIComponent(c.req.param("taskId")),
@@ -236,6 +243,7 @@ export function registerTaskRoutes(app: HonoApp, options: ServerOptions): void {
   });
 
   app.post("/v1/tasks/:taskId/run", async (c) => {
+    requireNotViewerFromContext(c);
     const orgId = requireActiveOrgIdFromContext(c);
     const taskId = decodeURIComponent(c.req.param("taskId"));
     const task = await taskService.get(taskId, orgId);

--- a/apps/server/src/services/automation-service.ts
+++ b/apps/server/src/services/automation-service.ts
@@ -13,13 +13,18 @@ import {
   DEFAULT_TIMEZONE,
   isAutomationRunUnread,
   isWorkerSchedulable,
+  NakamaApiError,
   normalizeAutomationDelivery,
   resolveScheduleTimezone,
   summarizeAutomationUnreadCounts,
   validateAutomationDelivery,
   validateAutomationInput,
 } from "@nakama/core";
+import { canAccessSuperBotProfile } from "@nakama/core/profiles";
 import { DatabaseAutomationStore, type DatabaseAdapter } from "@nakama/db";
+
+/** Caller role context used to gate access to admin-only profiles (e.g. Super Bot). */
+export type ProfileAccess = Parameters<typeof canAccessSuperBotProfile>[0];
 
 export interface AutomationServiceOptions {
   getUserTimezone: () => Promise<string>;
@@ -78,6 +83,7 @@ export class AutomationService {
     orgId: string,
     input: CreateAutomationRequest,
     profileIdOverride?: string,
+    access?: ProfileAccess,
   ): Promise<StoredAutomation> {
     const userTimezone = await this.getUserTimezone();
     const trigger = resolveScheduleTimezone(input.trigger, userTimezone);
@@ -91,6 +97,7 @@ export class AutomationService {
     const profileId = await this.resolveProfileId(
       orgId,
       profileIdOverride ?? input.profileId,
+      access,
     );
     const delivery = normalizeAutomationDelivery(input.delivery);
     await validateAutomationDelivery(delivery, {
@@ -319,12 +326,19 @@ export class AutomationService {
     return computeAutomationNextRunAt(trigger, userTimezone);
   }
 
-  private async resolveProfileId(orgId: string, profileId?: string): Promise<string> {
+  private async resolveProfileId(
+    orgId: string,
+    profileId?: string,
+    access?: ProfileAccess,
+  ): Promise<string> {
     const trimmed = profileId?.trim();
 
     if (trimmed) {
       const profile = await this.db.getProfileForOrg(trimmed, orgId);
       if (profile) {
+        if (profile.isSuper && access && !canAccessSuperBotProfile(access)) {
+          throw new NakamaApiError("Super Bot is only available to org admins.", 403);
+        }
         return profile.id;
       }
 

--- a/apps/server/src/services/profile-access.test.ts
+++ b/apps/server/src/services/profile-access.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { NakamaApiError } from "@nakama/core";
+import {
+  createInMemoryDatabaseAdapter,
+  seedOrgDefaultProfile,
+  seedOrgSuperBotProfile,
+} from "@nakama/db";
+import { AutomationService } from "./automation-service";
+import { TaskService } from "./task-service";
+
+const ORG_ID = "org_test";
+
+async function seed() {
+  const db = createInMemoryDatabaseAdapter();
+  const now = new Date().toISOString();
+  await db.upsertOrganization({
+    id: ORG_ID,
+    name: "Test Org",
+    slug: "test-org",
+    createdAt: now,
+    updatedAt: now,
+  });
+  const defaultProfile = await seedOrgDefaultProfile(db, ORG_ID);
+  const superProfile = await seedOrgSuperBotProfile(db, ORG_ID);
+  return { db, superId: superProfile.id, defaultId: defaultProfile.id };
+}
+
+const automationInput = {
+  name: "a",
+  description: "a",
+  prompt: "do it",
+  trigger: { type: "manual" as const },
+};
+const taskInput = { title: "t", prompt: "do it", status: "backlog" as const };
+
+describe("profile access: binding an automation/task to Super Bot is admin-only", () => {
+  test("member cannot bind an automation to the Super Bot profile", async () => {
+    const { db, superId } = await seed();
+    const service = new AutomationService(db, { getUserTimezone: async () => "UTC" });
+
+    const attempt = service.create(ORG_ID, automationInput as any, superId, {
+      orgRole: "member",
+    });
+
+    await expect(attempt).rejects.toBeInstanceOf(NakamaApiError);
+    await expect(attempt).rejects.toMatchObject({ status: 403 });
+  });
+
+  test("admin can bind an automation to the Super Bot profile", async () => {
+    const { db, superId } = await seed();
+    const service = new AutomationService(db, { getUserTimezone: async () => "UTC" });
+
+    const automation = await service.create(ORG_ID, automationInput as any, superId, {
+      orgRole: "admin",
+    });
+
+    expect(automation.profileId).toBe(superId);
+  });
+
+  test("member cannot bind a task to the Super Bot profile", async () => {
+    const { db, superId } = await seed();
+    const service = new TaskService(db);
+
+    const attempt = service.create(ORG_ID, taskInput as any, superId, { orgRole: "member" });
+
+    await expect(attempt).rejects.toBeInstanceOf(NakamaApiError);
+    await expect(attempt).rejects.toMatchObject({ status: 403 });
+  });
+
+  test("no access context (internal/agent-tool caller) is not gated", async () => {
+    const { db, superId } = await seed();
+    const service = new AutomationService(db, { getUserTimezone: async () => "UTC" });
+
+    // Agent-tool path passes the session's own (already access-checked) profile
+    // with no role context; enforcement is opt-in, so this must still succeed.
+    const automation = await service.create(ORG_ID, automationInput as any, superId);
+
+    expect(automation.profileId).toBe(superId);
+  });
+});

--- a/apps/server/src/services/task-service.ts
+++ b/apps/server/src/services/task-service.ts
@@ -5,10 +5,14 @@ import type {
   TaskStatus,
   UpdateTaskRequest,
 } from "@nakama/core";
-import { createId } from "@nakama/core";
+import { createId, NakamaApiError } from "@nakama/core";
+import { canAccessSuperBotProfile } from "@nakama/core/profiles";
 import type { DatabaseAdapter, StoredTaskRecord } from "@nakama/db";
 import { isValidTaskStatus, validateTaskInput } from "./task-validate";
 import type { TaskRunner } from "./task-runner";
+
+/** Caller role context used to gate access to admin-only profiles (e.g. Super Bot). */
+export type ProfileAccess = Parameters<typeof canAccessSuperBotProfile>[0];
 
 export class TaskService {
   private taskRunner: TaskRunner | null = null;
@@ -37,6 +41,7 @@ export class TaskService {
     orgId: string,
     input: CreateTaskRequest,
     profileIdOverride?: string,
+    access?: ProfileAccess,
   ): Promise<StoredTask> {
     const status = input.status ?? "backlog";
     validateTaskInput({
@@ -48,6 +53,7 @@ export class TaskService {
     const profileId = await this.resolveProfileId(
       orgId,
       profileIdOverride ?? input.profileId,
+      access,
     );
 
     const now = new Date().toISOString();
@@ -72,7 +78,7 @@ export class TaskService {
     id: string,
     orgId: string,
     input: UpdateTaskRequest,
-    options?: { triggerRun?: boolean },
+    options?: { triggerRun?: boolean; access?: ProfileAccess },
   ): Promise<StoredTask> {
     const existing = await this.db.getTask(id);
 
@@ -93,7 +99,7 @@ export class TaskService {
     let profileId = existing.profileId;
 
     if (input.profileId !== undefined) {
-      profileId = await this.resolveProfileId(orgId, input.profileId);
+      profileId = await this.resolveProfileId(orgId, input.profileId, options?.access);
     }
 
     const statusChanged = status !== existing.status;
@@ -203,12 +209,19 @@ export class TaskService {
     });
   }
 
-  private async resolveProfileId(orgId: string, profileId?: string): Promise<string> {
+  private async resolveProfileId(
+    orgId: string,
+    profileId?: string,
+    access?: ProfileAccess,
+  ): Promise<string> {
     const trimmed = profileId?.trim();
 
     if (trimmed) {
       const profile = await this.db.getProfileForOrg(trimmed, orgId);
       if (profile) {
+        if (profile.isSuper && access && !canAccessSuperBotProfile(access)) {
+          throw new NakamaApiError("Super Bot is only available to org admins.", 403);
+        }
         return profile.id;
       }
 


### PR DESCRIPTION
Fixes #107. Two authorization gaps in the same area, one commit each.

**1. A viewer can reach state-changing automation/task routes.**
These routes only checked org context (`requireActiveOrgIdFromContext`), never `orgRole`. So a `viewer`, which is meant to be read-only, could create, update, delete and run automations and tasks. Running one executes an agent, so a viewer could trigger file writes/deletes, send email, fetch arbitrary URLs, and burn LLM cost.

Fix: add the existing `requireNotViewerFromContext` guard to the mutating routes (automations: `POST /draft`, `POST /`, `PUT /:id`, `DELETE /:id`, `POST /:id/run`, `DELETE /:id/runs/:runId`; tasks: `POST /draft-prompt`, `POST /`, `PUT /:id`, `DELETE /:id`, `POST /:id/run`). It runs before any service call, so it's a 403 before any side effect.

Repro on `main`, viewer session via the existing test harness:
```
POST /v1/automations          -> 201, automationService.create called 1x
POST /v1/automations/:id/run  -> 200, agent.runAutomation called 1x
```
Both should be 403.

**2. A caller-supplied `profileId` wasn't role-checked.**
`resolveProfileId` (both services) only checked the profile belongs to the caller's org, not that their role may use it. Super Bot, the `bash`-capable profile, is admin-only per `canAccessSuperBotProfile` and is seeded into every org, so a non-admin passing a Super Bot `profileId` on create could bind to it.

Fix: enforce that same admin-only rule at the binding point, 403 reusing the `createSession` message. Enforcement is opt-in via an access context passed from the HTTP routes, so the agent-tool path is unaffected (it binds the session's own, already-checked profile and has no role context).

**Left alone on purpose:** read routes (`GET` list/detail/runs/messages), and per-user self-service (`/v1/user/context`, run `mark-read`), since those only write the caller's own data.

**Tests:** `rbac-mutations.test.ts` asserts 403 for a viewer on every guarded route and that no service/agent call leaks through, plus an admin allow case. `profile-access.test.ts` covers member binding to Super Bot rejected, admin allowed, and the no-access path left ungated. Full `apps/server` suite: 359 pass, 0 fail.

**Scope:** just the authz enforcement slice of #58, not the Owner/Manager/Member redesign. The third commit (telegram timeout) is unrelated and only there to get CI green, happy to split it out.
