### PR TITLE
Fix setup wizard Authentication required on HTTP Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,5 @@ pitch-deck.pdf
 pitch-deck.md
 .commandcode
 design-plans/
-
+tmp-repro-artifacts/
+tmp-repro-setup-auth.mjs

--- a/apps/server/src/http/app.test.ts
+++ b/apps/server/src/http/app.test.ts
@@ -398,6 +398,192 @@ describe("createHonoApp", () => {
     expect(response.status).toBe(201);
   });
 
+  test("setup over HTTP does not set Secure cookies even in production (#112)", async () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+
+    try {
+      const options = createServerOptions();
+      const app = createHonoApp(options);
+      const setupResponse = await app.fetch(
+        new Request("http://localhost:4310/v1/auth/setup", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(buildSetupAuthBody("admin@example.com", { admin: { password: "secret123" } })),
+        }),
+      );
+
+      expect(setupResponse.status).toBe(201);
+      const setCookies = extractSetCookies(setupResponse);
+      expect(setCookies.length).toBeGreaterThan(0);
+      expect(setCookies.every((cookie) => !/;\s*Secure(?:;|$)/i.test(cookie))).toBe(true);
+
+      const meResponse = await app.fetch(
+        new Request("http://localhost:4310/v1/auth/me", {
+          headers: { Cookie: cookieHeaderFromSetCookies(setCookies) },
+        }),
+      );
+      expect(meResponse.status).toBe(200);
+    } finally {
+      if (previousNodeEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = previousNodeEnv;
+      }
+    }
+  });
+
+  test("setup over HTTPS sets Secure cookies in production", async () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+
+    try {
+      const options = createServerOptions();
+      const app = createHonoApp(options);
+      const setupResponse = await app.fetch(
+        new Request("https://nakama.example/v1/auth/setup", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(buildSetupAuthBody("admin@example.com", { admin: { password: "secret123" } })),
+        }),
+      );
+
+      expect(setupResponse.status).toBe(201);
+      const setCookies = extractSetCookies(setupResponse);
+      expect(setCookies.length).toBeGreaterThan(0);
+      expect(setCookies.every((cookie) => /;\s*Secure(?:;|$)/i.test(cookie))).toBe(true);
+    } finally {
+      if (previousNodeEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = previousNodeEnv;
+      }
+    }
+  });
+
+  test("setup over HTTPS sets Secure cookies even when NODE_ENV is not production", async () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "development";
+
+    try {
+      const options = createServerOptions();
+      const app = createHonoApp(options);
+      const setupResponse = await app.fetch(
+        new Request("https://nakama.example/v1/auth/setup", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(buildSetupAuthBody("admin@example.com", { admin: { password: "secret123" } })),
+        }),
+      );
+
+      expect(setupResponse.status).toBe(201);
+      const setCookies = extractSetCookies(setupResponse);
+      expect(setCookies.every((cookie) => /;\s*Secure(?:;|$)/i.test(cookie))).toBe(true);
+    } finally {
+      if (previousNodeEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = previousNodeEnv;
+      }
+    }
+  });
+
+  test("setup behind HTTPS proxy sets Secure cookies via X-Forwarded-Proto", async () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+
+    try {
+      const options = createServerOptions();
+      const app = createHonoApp(options);
+      const setupResponse = await app.fetch(
+        new Request("http://localhost:4310/v1/auth/setup", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Forwarded-Proto": "https",
+          },
+          body: JSON.stringify(buildSetupAuthBody("admin@example.com", { admin: { password: "secret123" } })),
+        }),
+      );
+
+      expect(setupResponse.status).toBe(201);
+      const setCookies = extractSetCookies(setupResponse);
+      expect(setCookies.every((cookie) => /;\s*Secure(?:;|$)/i.test(cookie))).toBe(true);
+    } finally {
+      if (previousNodeEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = previousNodeEnv;
+      }
+    }
+  });
+
+  test("https request URL keeps Secure cookies even if X-Forwarded-Proto is http", async () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+
+    try {
+      const options = createServerOptions();
+      const app = createHonoApp(options);
+      const setupResponse = await app.fetch(
+        new Request("https://nakama.example/v1/auth/setup", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Forwarded-Proto": "http",
+          },
+          body: JSON.stringify(buildSetupAuthBody("admin@example.com", { admin: { password: "secret123" } })),
+        }),
+      );
+
+      expect(setupResponse.status).toBe(201);
+      const setCookies = extractSetCookies(setupResponse);
+      expect(setCookies.every((cookie) => /;\s*Secure(?:;|$)/i.test(cookie))).toBe(true);
+    } finally {
+      if (previousNodeEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = previousNodeEnv;
+      }
+    }
+  });
+
+  test("logout clears both Secure and non-Secure session cookies", async () => {
+    const options = createServerOptions();
+    const app = createHonoApp(options);
+    const setupResponse = await app.fetch(
+      new Request("http://localhost:4310/v1/auth/setup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(buildSetupAuthBody("admin@example.com", { admin: { password: "secret123" } })),
+      }),
+    );
+    expect(setupResponse.status).toBe(201);
+    const session = {
+      cookieHeader: cookieHeaderFromSetCookies(extractSetCookies(setupResponse)),
+      csrfToken: cookieValue(extractSetCookies(setupResponse), "nakama_csrf"),
+    };
+
+    const logoutResponse = await app.fetch(
+      new Request("http://localhost:4310/v1/auth/logout", {
+        method: "POST",
+        headers: {
+          Cookie: session.cookieHeader,
+          "X-CSRF-Token": session.csrfToken,
+        },
+      }),
+    );
+
+    expect(logoutResponse.status).toBe(200);
+    const clearCookies = extractSetCookies(logoutResponse);
+    const sessionClears = clearCookies.filter((cookie) => cookie.startsWith("nakama_session="));
+    const csrfClears = clearCookies.filter((cookie) => cookie.startsWith("nakama_csrf="));
+    expect(sessionClears.some((cookie) => /;\s*Secure(?:;|$)/i.test(cookie))).toBe(true);
+    expect(sessionClears.some((cookie) => !/;\s*Secure(?:;|$)/i.test(cookie))).toBe(true);
+    expect(csrfClears.some((cookie) => /;\s*Secure(?:;|$)/i.test(cookie))).toBe(true);
+    expect(csrfClears.some((cookie) => !/;\s*Secure(?:;|$)/i.test(cookie))).toBe(true);
+  });
+
   test("serves task chat capability probe without auth", async () => {
     const options = createServerOptions();
     const app = createHonoApp(options);

--- a/apps/server/src/http/routes/auth.ts
+++ b/apps/server/src/http/routes/auth.ts
@@ -301,6 +301,7 @@ export function registerAuthRoutes(app: HonoApp, options: ServerOptions): void {
 
     const response = await createBrowserSessionResponse(authService, databaseAdapter, user, {
       activeOrgId: organization.id,
+      request: c.req.raw,
     });
     const authBody = await orgService.buildAuthUserResponse(
       user,
@@ -328,7 +329,9 @@ export function registerAuthRoutes(app: HonoApp, options: ServerOptions): void {
       return errorResponse("Invalid credentials", 401);
     }
 
-    const response = await createBrowserSessionResponse(authService, databaseAdapter, user);
+    const response = await createBrowserSessionResponse(authService, databaseAdapter, user, {
+      request: c.req.raw,
+    });
     const authBody = await orgService.buildAuthUserResponse(
       user,
       response.session.id,
@@ -430,7 +433,7 @@ export function registerAuthRoutes(app: HonoApp, options: ServerOptions): void {
       authService,
       databaseAdapter,
       accepted.user,
-      { activeOrgId: accepted.orgId },
+      { activeOrgId: accepted.orgId, request: c.req.raw },
     );
 
     return json<AcceptOrgInviteResponse>(

--- a/apps/server/src/http/shared.ts
+++ b/apps/server/src/http/shared.ts
@@ -93,8 +93,29 @@ function isMutatingMethod(method: string): boolean {
   return method !== "GET" && method !== "HEAD" && method !== "OPTIONS";
 }
 
-function isSecureCookieRequest(): boolean {
-  return process.env.NODE_ENV === "production";
+/**
+ * Cookies must only carry the Secure flag when the browser is on HTTPS.
+ * NODE_ENV=production alone is not enough — Docker serves HTTP by default and
+ * browsers drop Secure cookies on http:// hosts (#112).
+ *
+ * X-Forwarded-Proto can upgrade http backends behind TLS terminators, but must
+ * never downgrade an https request URL (spoofed/forwarded "http").
+ */
+function isSecureCookieRequest(request: Request): boolean {
+  const forwardedProto = request.headers
+    .get("x-forwarded-proto")
+    ?.split(",")[0]
+    ?.trim()
+    .toLowerCase();
+
+  let urlIsHttps = false;
+  try {
+    urlIsHttps = new URL(request.url).protocol === "https:";
+  } catch {
+    urlIsHttps = false;
+  }
+
+  return urlIsHttps || forwardedProto === "https";
 }
 
 export interface RequestAuthContext {
@@ -225,11 +246,12 @@ function applyBrowserSessionCookies(
   headers: Headers,
   sessionToken: string,
   csrfToken: string,
+  request: Request,
 ): void {
   const cookieBase = {
     path: "/",
     sameSite: "Lax" as const,
-    secure: isSecureCookieRequest(),
+    secure: isSecureCookieRequest(request),
   };
 
   appendSetCookie(
@@ -254,7 +276,7 @@ export async function createBrowserSessionResponse(
   authService: AuthService,
   databaseAdapter: DatabaseAdapter,
   user: StoredUserRecord,
-  options: { activeOrgId?: string | null } = {},
+  options: { activeOrgId?: string | null; request: Request },
 ): Promise<{
   body: { email: string };
   headers: Headers;
@@ -277,7 +299,12 @@ export async function createBrowserSessionResponse(
   await databaseAdapter.createBrowserSession(record);
 
   const headers = new Headers();
-  applyBrowserSessionCookies(headers, session.sessionToken, session.csrfToken);
+  applyBrowserSessionCookies(
+    headers,
+    session.sessionToken,
+    session.csrfToken,
+    options.request,
+  );
 
   return {
     body: { email: user.email },
@@ -290,25 +317,29 @@ export function clearBrowserSessionCookies(headers: Headers): void {
   const cookieBase = {
     path: "/",
     sameSite: "Lax" as const,
-    secure: isSecureCookieRequest(),
   };
 
-  appendSetCookie(
-    headers,
-    buildCookie(SESSION_COOKIE_NAME, "", {
-      ...cookieBase,
-      httpOnly: true,
-      maxAge: 0,
-    }),
-  );
-
-  appendSetCookie(
-    headers,
-    buildCookie(CSRF_COOKIE_NAME, "", {
-      ...cookieBase,
-      maxAge: 0,
-    }),
-  );
+  // Clear both Secure and non-Secure variants so logout still works if the
+  // Secure decision differs between login and logout (proxy header drift).
+  for (const secure of [true, false] as const) {
+    appendSetCookie(
+      headers,
+      buildCookie(SESSION_COOKIE_NAME, "", {
+        ...cookieBase,
+        httpOnly: true,
+        maxAge: 0,
+        secure,
+      }),
+    );
+    appendSetCookie(
+      headers,
+      buildCookie(CSRF_COOKIE_NAME, "", {
+        ...cookieBase,
+        maxAge: 0,
+        secure,
+      }),
+    );
+  }
 }
 
 export async function readJson<T>(request: Request): Promise<T> {


### PR DESCRIPTION
## Summary
- Session cookies no longer force `Secure` solely because `NODE_ENV=production`, which broke the setup wizard on Docker/`http://` (#112).
- `Secure` is set when the request URL is `https:` or `X-Forwarded-Proto: https` (upgrade-only; forwarded `http` cannot downgrade an https URL).
- Logout clears both Secure and non-Secure cookie variants so proto detection drift cannot leave cookies behind.

## Test plan
- [x] `bun test apps/server/src/http/app.test.ts` (includes #112 HTTP production cookie cases)
- [x] Fresh Docker on `http://localhost:PORT/setup`: create account + org → advances past step 2 without “Authentication required”
- [x] Behind TLS-terminating proxy with `X-Forwarded-Proto: https`: setup/login still set Secure cookies

Fixes #112
