### PR TITLE
feat: Confirm-first Super Bot agent factory

### DIFF
--- a/apps/server/src/http/app.test.ts
+++ b/apps/server/src/http/app.test.ts
@@ -365,6 +365,8 @@ describe("createHonoApp", () => {
       ok: true,
       providerConfigured: true,
       userConfigured: false,
+      // /health stays local — never probes Composio reachability
+      composioAvailable: false,
     });
   });
 

--- a/apps/server/src/http/routes/system.ts
+++ b/apps/server/src/http/routes/system.ts
@@ -28,14 +28,19 @@ const DOCS_HTML = `<!doctype html>
 `;
 
 export function registerSystemRoutes(app: HonoApp, options: ServerOptions): void {
-  const { agent, databaseAdapter, systemStatus, composioService } = options;
+  const { agent, databaseAdapter, systemStatus } = options;
   const healthResponseSchema = z.object({
     ok: z.literal(true),
     apiVersion: z.number().int(),
     providerConfigured: z.boolean(),
     userConfigured: z.boolean(),
-    composioConfigured: z.boolean(),
-    composioAvailable: z.boolean(),
+    composioConfigured: z.boolean().openapi({
+      description: "Whether a Composio project API key is saved locally.",
+    }),
+    composioAvailable: z.boolean().openapi({
+      description:
+        "Whether Composio is reachable. Always false on /health (no live probe). Check GET /v1/system/status for the probed value.",
+    }),
   }).openapi("HealthResponse");
   const systemStatusSchema = z.object({ ok: z.boolean() }).passthrough().openapi("SystemStatusResponse");
   const errorSchema = z.object({ error: z.string() }).openapi("ApiErrorResponse");
@@ -141,6 +146,7 @@ export function registerSystemRoutes(app: HonoApp, options: ServerOptions): void
   });
 
   app.openapi(healthRoute, async (c) => {
+    // Local checks only — Composio reachability is on GET /v1/system/status.
     const humanUserCount = (await databaseAdapter?.countHumanUsers()) ?? 0;
     const composioConfigured = await isComposioConfiguredAsync();
     return c.json({
@@ -149,7 +155,7 @@ export function registerSystemRoutes(app: HonoApp, options: ServerOptions): void
       providerConfigured: agent.providerConfigured,
       userConfigured: humanUserCount > 0,
       composioConfigured,
-      composioAvailable: composioConfigured ? await (composioService?.isReachable() ?? false) : false,
+      composioAvailable: false,
     }, 200);
   });
 

--- a/apps/server/src/services/system-status-service.test.ts
+++ b/apps/server/src/services/system-status-service.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   clearAutomationWorkerHeartbeat,
+  saveComposioConfig,
   writeAutomationWorkerHeartbeat,
   type WorkerProcessInfo,
 } from "@nakama/core";
@@ -27,7 +28,12 @@ async function withConfigDir(): Promise<void> {
   process.env.NAKAMA_CONFIG_DIR = configDir;
 }
 
-function createService(automationProcess: WorkerProcessInfo | null) {
+function createService(
+  automationProcess: WorkerProcessInfo | null,
+  extras?: {
+    composioService?: { isReachable: () => Promise<boolean> } | null;
+  },
+) {
   return new SystemStatusService(
     {
       providerConfigured: true,
@@ -53,6 +59,7 @@ function createService(automationProcess: WorkerProcessInfo | null) {
       }),
     } as any,
     null,
+    extras?.composioService as any,
   );
 }
 
@@ -126,5 +133,28 @@ describe("SystemStatusService", () => {
 
     expect(status.automationWorker.ok).toBe(false);
     expect(status.automationWorker.process?.managed).toBe(false);
+  });
+
+  test("probes Composio reachability on system status when configured", async () => {
+    await withConfigDir();
+    await saveComposioConfig({ apiKey: "test-key" });
+
+    let reachabilityCalls = 0;
+    const service = createService(null, {
+      composioService: {
+        isReachable: async () => {
+          reachabilityCalls += 1;
+          return true;
+        },
+      },
+    });
+
+    const status = await service.getStatus();
+
+    expect(reachabilityCalls).toBe(1);
+    expect(status.server).toMatchObject({
+      composioConfigured: true,
+      composioAvailable: true,
+    });
   });
 });

--- a/apps/server/src/services/system-status-service.ts
+++ b/apps/server/src/services/system-status-service.ts
@@ -148,6 +148,7 @@ export class SystemStatusService {
       providerConfigured: this.agent.providerConfigured,
       userConfigured: humanUserCount > 0,
       composioConfigured,
+      // Live probe — intentional here; /health skips this to stay fast.
       composioAvailable: composioConfigured
         ? await (this.composioService?.isReachable() ?? false)
         : false,

--- a/apps/web/src/components/ProfileAvatar.tsx
+++ b/apps/web/src/components/ProfileAvatar.tsx
@@ -12,12 +12,34 @@ const sizeClasses = {
   lg: "size-16 text-xl",
 } as const;
 
+/** Stable soft fills keyed by profile id so missing images still look distinct. */
+const AVATAR_FALLBACK_COLORS = [
+  "bg-rose-500/20 text-rose-800 dark:text-rose-200",
+  "bg-orange-500/20 text-orange-800 dark:text-orange-200",
+  "bg-amber-500/20 text-amber-900 dark:text-amber-200",
+  "bg-lime-500/20 text-lime-900 dark:text-lime-200",
+  "bg-emerald-500/20 text-emerald-900 dark:text-emerald-200",
+  "bg-teal-500/20 text-teal-900 dark:text-teal-200",
+  "bg-sky-500/20 text-sky-900 dark:text-sky-200",
+  "bg-blue-500/20 text-blue-900 dark:text-blue-200",
+  "bg-indigo-500/20 text-indigo-900 dark:text-indigo-200",
+  "bg-fuchsia-500/20 text-fuchsia-900 dark:text-fuchsia-200",
+] as const;
+
 function profileInitial(profile: ProfileAvatarProfile): string {
   return (
     profile.name?.charAt(0)?.toUpperCase() ??
     profile.id?.charAt(0)?.toUpperCase() ??
     "?"
   );
+}
+
+function avatarFallbackColorClass(seed: string): string {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) {
+    hash = (hash * 31 + seed.charCodeAt(i)) | 0;
+  }
+  return AVATAR_FALLBACK_COLORS[Math.abs(hash) % AVATAR_FALLBACK_COLORS.length];
 }
 
 export function ProfileAvatar({
@@ -49,8 +71,9 @@ export function ProfileAvatar({
     <span
       aria-hidden
       className={cn(
-        "inline-flex shrink-0 items-center justify-center rounded-full bg-muted font-medium text-foreground",
+        "inline-flex shrink-0 items-center justify-center rounded-full font-medium",
         sizeClasses[size],
+        avatarFallbackColorClass(profile.id || profile.name || "?"),
         className,
       )}
     >

--- a/apps/web/src/components/ProfileCreateDialog.tsx
+++ b/apps/web/src/components/ProfileCreateDialog.tsx
@@ -24,6 +24,7 @@ interface ProfileCreateDialogProps {
   tools: ToolSummary[];
   onCreated: (profileId: string) => void;
   onOpenChange: (open: boolean) => void;
+  onAskSuperBot?: () => void;
 }
 
 const defaultCreatePrompt = "You are a helpful assistant.";
@@ -103,6 +104,7 @@ export function ProfileCreateDialog({
   tools,
   onCreated,
   onOpenChange,
+  onAskSuperBot,
 }: ProfileCreateDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -111,6 +113,7 @@ export function ProfileCreateDialog({
           tools={tools}
           onCreated={onCreated}
           onOpenChange={onOpenChange}
+          onAskSuperBot={onAskSuperBot}
         />
       ) : null}
     </Dialog>
@@ -121,10 +124,12 @@ function ProfileCreateDialogContent({
   tools,
   onCreated,
   onOpenChange,
+  onAskSuperBot,
 }: {
   tools: ToolSummary[];
   onCreated: (profileId: string) => void;
   onOpenChange: (open: boolean) => void;
+  onAskSuperBot?: () => void;
 }) {
   const createMutation = useCreateProfileMutation();
   const uploadAvatarMutation = useUploadProfileAvatarMutation();
@@ -254,6 +259,24 @@ function ProfileCreateDialogContent({
           <DialogTitle>Create profile</DialogTitle>
           <DialogDescription>
             Name, profile id, and system prompt for the new bot profile.
+            {onAskSuperBot ? (
+              <>
+                {" "}
+                Or{" "}
+                <button
+                  type="button"
+                  className="text-foreground underline underline-offset-2"
+                  disabled={busy}
+                  onClick={() => {
+                    onOpenChange(false);
+                    onAskSuperBot();
+                  }}
+                >
+                  ask Super Bot
+                </button>{" "}
+                to draft one from chat.
+              </>
+            ) : null}
           </DialogDescription>
         </DialogHeader>
 

--- a/apps/web/src/components/chat/chat-composer.tsx
+++ b/apps/web/src/components/chat/chat-composer.tsx
@@ -11,7 +11,6 @@ import type { ChatStatus } from "ai";
 import type { FileUIPart } from "ai";
 import { ArrowUpIcon, FileTextIcon, PlusIcon, WifiOffIcon, XIcon } from "lucide-react";
 import { useCallback, useMemo, useRef, useState } from "react";
-import { ProfileAvatar } from "@/components/ProfileAvatar";
 import {
   PromptInput,
   PromptInputBody,
@@ -63,6 +62,7 @@ import {
 } from "@/components/chat/ChatMessageQueuePanel";
 import { TextAttachmentPreview } from "@/components/chat/text-attachment-preview";
 import { ImageAttachmentPreview } from "@/components/chat/image-attachment-preview";
+import { ChatProfileSwitcher } from "@/components/chat/chat-profile-switcher";
 import { ChatSkillPicker } from "@/components/chat/chat-skill-picker";
 import { ChatSkillTokenOverlay } from "@/components/chat/chat-skill-token-overlay";
 import { cn } from "@/lib/utils";
@@ -108,6 +108,7 @@ interface ChatComposerFullProps extends ChatComposerBaseProps {
   profiles: ProfileSummary[];
   activeProfile?: ProfileSummary;
   onProfileSwitch: (profileId: string) => void;
+  showProfileSwitch?: boolean;
   showOfflineHint?: boolean;
   providerConfigured?: boolean;
   onNavigateSetup?: () => void;
@@ -460,51 +461,20 @@ function ChatComposerFullFooter({
         aria-label="Composer options"
         className={composerToolbarClass}
       >
-        <PromptInputTools className="gap-1.5">
-          <DropdownMenu>
-            <DropdownMenuTrigger
-              render={
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-sm"
-                  aria-label={
-                    props.activeProfile
-                      ? `Switch profile (${props.activeProfile.name})`
-                      : "Switch profile"
-                  }
-                  title={props.activeProfile?.name ?? "Switch profile"}
-                  className={cn(composerIconButtonClass, "p-0")}
-                />
-              }
-            >
-              {props.activeProfile ? (
-                <ProfileAvatar profile={props.activeProfile} size="sm" className="size-7" />
-              ) : (
-                <span className="text-xs font-medium">?</span>
-              )}
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className="min-w-52 w-auto">
-              {props.profiles.map((profile) => (
-                <DropdownMenuItem
-                  key={profile.id}
-                  disabled={profile.id === props.profileId}
-                  onClick={() => void props.onProfileSwitch(profile.id)}
-                >
-                  <span className="flex min-w-0 items-center gap-2.5">
-                    <ProfileAvatar profile={profile} size="sm" />
-                    <span className="whitespace-nowrap">
-                      {profile.name}
-                      {profile.isSuper ? " (super)" : ""}
-                    </span>
-                  </span>
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </PromptInputTools>
-
-        <span className="hidden h-5 w-px bg-border sm:block" aria-hidden />
+        {props.showProfileSwitch !== false ? (
+          <>
+            <PromptInputTools className="gap-1.5">
+              <ChatProfileSwitcher
+                profileId={props.profileId}
+                profiles={props.profiles}
+                activeProfile={props.activeProfile}
+                onProfileSwitch={props.onProfileSwitch}
+                disabled={busy || disabled}
+              />
+            </PromptInputTools>
+            <span className="hidden h-5 w-px bg-border sm:block" aria-hidden />
+          </>
+        ) : null}
 
         {props.providerConfigured ? (
           <PromptInputSelect

--- a/apps/web/src/components/chat/chat-profile-switcher.tsx
+++ b/apps/web/src/components/chat/chat-profile-switcher.tsx
@@ -1,0 +1,105 @@
+import type { ProfileSummary } from "@nakama/core/contract";
+import { ChevronDownIcon } from "lucide-react";
+import { ProfileAvatar } from "@/components/ProfileAvatar";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { composerIconButtonClass } from "@/lib/chat-stream";
+import { cn } from "@/lib/utils";
+
+function profileLabel(profile: ProfileSummary): string {
+  return profile.isSuper ? `${profile.name} (super)` : profile.name;
+}
+
+export function ChatProfileSwitcher({
+  profileId,
+  profiles,
+  activeProfile,
+  onProfileSwitch,
+  variant = "compact",
+  disabled = false,
+  className,
+}: {
+  profileId: string;
+  profiles: ProfileSummary[];
+  activeProfile?: ProfileSummary;
+  onProfileSwitch: (profileId: string) => void;
+  variant?: "compact" | "prominent";
+  disabled?: boolean;
+  className?: string;
+}) {
+  const switchLabel = activeProfile
+    ? `Switch profile (${activeProfile.name})`
+    : "Switch profile";
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          variant === "prominent" ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={disabled}
+              aria-label={switchLabel}
+              title={activeProfile?.name ?? "Switch profile"}
+              className={cn(
+                "h-7 gap-1.5 rounded-full px-1.5 text-xs font-medium text-foreground hover:bg-muted/60",
+                className,
+              )}
+            />
+          ) : (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              disabled={disabled}
+              aria-label={switchLabel}
+              title={activeProfile?.name ?? "Switch profile"}
+              className={cn(composerIconButtonClass, "p-0", className)}
+            />
+          )
+        }
+      >
+        {variant === "prominent" ? (
+          <>
+            {activeProfile ? (
+              <ProfileAvatar profile={activeProfile} size="xs" className="size-4" />
+            ) : (
+              <span className="inline-flex size-4 items-center justify-center rounded-full bg-background text-[9px] font-medium">
+                ?
+              </span>
+            )}
+            <span className="max-w-[10rem] truncate">
+              {activeProfile ? profileLabel(activeProfile) : "Select profile"}
+            </span>
+            <ChevronDownIcon className="size-3 shrink-0 text-muted-foreground" aria-hidden />
+          </>
+        ) : activeProfile ? (
+          <ProfileAvatar profile={activeProfile} size="sm" className="size-7" />
+        ) : (
+          <span className="text-xs font-medium">?</span>
+        )}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="min-w-52 w-auto">
+        {profiles.map((profile) => (
+          <DropdownMenuItem
+            key={profile.id}
+            disabled={profile.id === profileId}
+            onClick={() => onProfileSwitch(profile.id)}
+          >
+            <span className="flex min-w-0 items-center gap-2.5">
+              <ProfileAvatar profile={profile} size="sm" />
+              <span className="whitespace-nowrap">{profileLabel(profile)}</span>
+            </span>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/web/src/hooks/use-app-navigation.ts
+++ b/apps/web/src/hooks/use-app-navigation.ts
@@ -1,7 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import {
-  buildChatBasePath,
   buildChatPath,
+  buildNewChatPath,
   type RequestedChatSession,
   MAX_URL_CHAT_DRAFT_LENGTH,
   storeChatDraft,
@@ -22,21 +22,20 @@ export function useAppNavigation() {
       navigate(toolPlaygroundPath(toolId));
     },
     navigateToNewChat(profileId?: string | null, options?: { draft?: string }) {
-      const params = new URLSearchParams({ new: "1", _: String(Date.now()) });
-      if (profileId) {
-        params.set("profile", profileId);
-      }
-
       const draft = options?.draft?.trim();
-      if (draft) {
-        if (draft.length <= MAX_URL_CHAT_DRAFT_LENGTH) {
-          params.set("draft", draft);
-        } else {
-          params.set("draftKey", storeChatDraft(draft));
-        }
+      if (!draft) {
+        navigate(buildNewChatPath(profileId));
+        return;
       }
 
-      navigate(`${buildChatBasePath()}?${params.toString()}`);
+      const url = new URL(buildNewChatPath(profileId), "http://nakama.local");
+      if (draft.length <= MAX_URL_CHAT_DRAFT_LENGTH) {
+        url.searchParams.set("draft", draft);
+      } else {
+        url.searchParams.set("draftKey", storeChatDraft(draft));
+      }
+
+      navigate(`${url.pathname}?${url.searchParams.toString()}`);
     },
   };
 }

--- a/apps/web/src/lib/chat-history-route.test.ts
+++ b/apps/web/src/lib/chat-history-route.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   buildChatPath,
+  buildNewChatPath,
   chatProfileIdFromPath,
   parseChatRouteParams,
   readRequestedDraftFromNewChatSearch,
@@ -18,6 +19,15 @@ describe("chat history route helpers", () => {
       sessionId: "s",
     });
     expect(parseChatRouteParams({ profileId: "", sessionId: "s" })).toBeNull();
+  });
+
+  test("buildNewChatPath carries profile so ChatPage remount keeps the selection", () => {
+    const path = buildNewChatPath("gary-vee");
+    const url = new URL(path, "http://nakama.local");
+    expect(url.pathname).toBe("/chat");
+    expect(url.searchParams.get("new")).toBe("1");
+    expect(url.searchParams.get("profile")).toBe("gary-vee");
+    expect(readRequestedProfileFromNewChatSearch(url.search)).toBe("gary-vee");
   });
 
   test("reads the requested profile only for new chat links", () => {

--- a/apps/web/src/lib/chat-history.ts
+++ b/apps/web/src/lib/chat-history.ts
@@ -21,6 +21,20 @@ export function buildChatBasePath(): string {
   return "/chat";
 }
 
+/**
+ * Draft chat URL used when starting a new chat (or switching profiles while on a
+ * session route). `/chat` and `/chat/:profileId/:sessionId` are separate routes,
+ * so navigating between them remounts ChatPage — the profile must travel in the
+ * query string or the remounted page falls back to the default profile.
+ */
+export function buildNewChatPath(profileId?: string | null): string {
+  const params = new URLSearchParams({ new: "1", _: String(Date.now()) });
+  if (profileId) {
+    params.set("profile", profileId);
+  }
+  return `${buildChatBasePath()}?${params.toString()}`;
+}
+
 /** Profile id from `?new=1&profile=…` when opening a new chat (e.g. Super Bot from Tools). */
 export function readRequestedProfileFromNewChatSearch(search: string): string | null {
   const params = new URLSearchParams(search);

--- a/apps/web/src/lib/profiles.ts
+++ b/apps/web/src/lib/profiles.ts
@@ -4,6 +4,13 @@ export function findSuperBotProfile(profiles: ProfileSummary[]): ProfileSummary 
   return profiles.find((profile) => profile.isSuper);
 }
 
+/** Profile id to open for Super Bot chat CTAs, or null when none exists. */
+export function resolveSuperBotChatProfileId(
+  profiles: Array<Pick<ProfileSummary, "id" | "isSuper">>,
+): string | null {
+  return profiles.find((profile) => profile.isSuper)?.id ?? null;
+}
+
 export function findDefaultProfile(profiles: ProfileSummary[]): ProfileSummary | undefined {
   return profiles.find((profile) => profile.isDefault) ?? profiles[0];
 }

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -29,8 +29,7 @@ export function LoginPage() {
   const from = (location.state as { from?: string } | null)?.from;
 
   if (isAuthenticated) {
-    navigate(resolvePostAuthPath(health, from), { replace: true });
-    return null;
+    return <Navigate to={resolvePostAuthPath(health, from)} replace />;
   }
 
   if (health?.userConfigured === false) {

--- a/apps/web/src/pages/chat/chat-page-content.tsx
+++ b/apps/web/src/pages/chat/chat-page-content.tsx
@@ -69,6 +69,7 @@ export function ChatPageContent(state: ChatPageState) {
         activeProfile={activeProfile}
         availableSkills={availableSkills}
         onProfileSwitch={handleProfileSwitch}
+        showProfileSwitch={!isEmptyState}
         showOfflineHint={showOfflineHint}
         providerConfigured={health?.providerConfigured}
         onNavigateSetup={navigateSetup}
@@ -100,8 +101,14 @@ export function ChatPageContent(state: ChatPageState) {
     return (
       <ChatAttachmentPanelProvider key={session?.id ?? "new"}>
         <ChatPageColumn centered>
-          <div className="mx-auto flex w-full max-w-3xl flex-col mb-12">
-            <ChatWelcome profile={activeProfile} />
+          <div className="mx-auto mb-12 flex w-full max-w-3xl flex-col gap-1">
+            <ChatWelcome
+              profile={activeProfile}
+              profileId={profileId}
+              profiles={profiles}
+              onProfileSwitch={handleProfileSwitch}
+              profileSwitchDisabled={busy}
+            />
             {composer}
           </div>
         </ChatPageColumn>

--- a/apps/web/src/pages/chat/chat-page-layout.tsx
+++ b/apps/web/src/pages/chat/chat-page-layout.tsx
@@ -1,4 +1,5 @@
 import type { ProfileSummary } from "@nakama/core/contract";
+import { ChatProfileSwitcher } from "@/components/chat/chat-profile-switcher";
 import { useChatAttachmentPanel } from "@/context/use-chat-attachment-panel";
 import { cn } from "@/lib/utils";
 
@@ -24,18 +25,34 @@ export function ChatPageColumn({
   );
 }
 
-export function ChatWelcome({ profile }: { profile: ProfileSummary | undefined }) {
+export function ChatWelcome({
+  profile,
+  profileId,
+  profiles,
+  onProfileSwitch,
+  profileSwitchDisabled = false,
+}: {
+  profile: ProfileSummary | undefined;
+  profileId: string;
+  profiles: ProfileSummary[];
+  onProfileSwitch: (profileId: string) => void;
+  profileSwitchDisabled?: boolean;
+}) {
   return (
-    <div className="flex items-center gap-4 px-2">
-      <div className="min-w-0 text-left">
-        <h2 className="type-section-title text-xl tracking-tight">
-          Hi, good {new Date().getHours() < 12 ? "morning" : new Date().getHours() < 18 ? "afternoon" : "evening"}!
-        </h2>
-        <p className="type-body mt-1 max-w-sm">
-          {profile?.isSuper
-            ? "Ask anything, attach images, or run tools."
-            : "What can I help you with today?"}
-        </p>
+    <div className="flex flex-col gap-2 px-2">
+      <h2 className="type-section-title text-xl tracking-tight">
+        Hi, good {new Date().getHours() < 12 ? "morning" : new Date().getHours() < 18 ? "afternoon" : "evening"}!
+      </h2>
+      <div className="flex items-center gap-2 self-start">
+        <span className="type-body text-sm text-muted-foreground">Select profile</span>
+        <ChatProfileSwitcher
+          variant="prominent"
+          profileId={profileId}
+          profiles={profiles}
+          activeProfile={profile}
+          onProfileSwitch={onProfileSwitch}
+          disabled={profileSwitchDisabled}
+        />
       </div>
     </div>
   );

--- a/apps/web/src/pages/chat/use-chat-page.ts
+++ b/apps/web/src/pages/chat/use-chat-page.ts
@@ -7,7 +7,7 @@ import type {
 } from "@nakama/core/contract";
 import type { FileUIPart } from "ai";
 import { nanoid } from "nanoid";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import type { RemoteChatSession } from "@nakama/client";
 import type { QueuedComposerMessage } from "@/components/chat/ChatMessageQueuePanel";
@@ -22,6 +22,7 @@ import {
 import {
   buildChatBasePath,
   buildChatPath,
+  buildNewChatPath,
   chatMessagesToListItems,
   isReadOnlySessionChannel,
   parseChatRouteParams,
@@ -67,7 +68,7 @@ export function useChatPage() {
   const params = useParams();
   const location = useLocation();
   const navigate = useNavigate();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const routeSession = useMemo(() => parseChatRouteParams(params), [params]);
   const { health, models } = useAppContext();
   const [profiles, setProfiles] = useState<ProfileSummary[]>([]);
@@ -90,7 +91,6 @@ export function useChatPage() {
   const isSendingRef = useRef(false);
   const skipNextProfileSessionRef = useRef(false);
   const loadedRouteRef = useRef<string | null>(null);
-  const profileSwitchInFlightRef = useRef(false);
   const profileIdRef = useRef(profileId);
 
   useEffect(() => {
@@ -230,8 +230,10 @@ export function useChatPage() {
       setError(null);
       setAgentTodos([]);
       setAgentQuestionnaire(null);
+      // Session routes remount ChatPage on /chat — pass profile in the query so it survives.
+      // The ?new=1 handler then replaces the URL with bare /chat.
       if (location.pathname !== buildChatBasePath()) {
-        navigate(buildChatBasePath(), { replace: true });
+        navigate(buildNewChatPath(nextProfileId), { replace: true });
       }
     },
     [location.pathname, navigate],
@@ -293,19 +295,19 @@ export function useChatPage() {
   );
 
   const handleProfileSwitch = useCallback(
-    async (nextProfileId: string) => {
+    (nextProfileId: string) => {
       if (!nextProfileId || nextProfileId === profileId || busy) {
         return;
       }
-      profileSwitchInFlightRef.current = true;
       setProfileId(nextProfileId);
       enterDraftChat(nextProfileId);
-      profileSwitchInFlightRef.current = false;
     },
     [profileId, busy, enterDraftChat],
   );
 
-  useEffect(() => {
+  // Layout effect so session is cleared before the syncChatUrl effect can
+  // re-push the previous /chat/:profile/:session URL (first-click blink).
+  useLayoutEffect(() => {
     if (searchParams.get("new") !== "1") {
       return;
     }
@@ -314,13 +316,22 @@ export function useChatPage() {
     const draftKey = readRequestedDraftKeyFromNewChatSearch(location.search);
     const storedDraft = draftKey ? consumeStoredChatDraft(draftKey) : null;
     const requestedDraft = inlineDraft ?? storedDraft;
-    setSearchParams({}, { replace: true });
     const targetProfileId = requestedProfile || profileIdRef.current;
-    if (!targetProfileId) {
-      return;
-    }
 
+    if (targetProfileId) {
+      localStorage.removeItem(sessionStorageKey(targetProfileId));
+    }
     skipNextProfileSessionRef.current = true;
+    loadedRouteRef.current = null;
+    messageQueueRef.current = [];
+    isSendingRef.current = false;
+    setQueuedMessages([]);
+    setSession(null);
+    setSessionChannel("web");
+    setMessages([]);
+    setError(null);
+    setAgentTodos([]);
+    setAgentQuestionnaire(null);
 
     if (requestedProfile && requestedProfile !== profileIdRef.current) {
       setProfileId(requestedProfile);
@@ -330,8 +341,8 @@ export function useChatPage() {
       setComposerDraft(requestedDraft);
     }
 
-    enterDraftChat(targetProfileId);
-  }, [searchParams, setSearchParams, enterDraftChat, location.search]);
+    navigate(buildChatBasePath(), { replace: true });
+  }, [searchParams, navigate, location.search]);
 
   useEffect(() => {
     if (!profileId || routeSession) {
@@ -345,7 +356,7 @@ export function useChatPage() {
   }, [profileId, routeSession, enterDraftChat]);
 
   useEffect(() => {
-    if (!routeSession || profileSwitchInFlightRef.current) {
+    if (!routeSession) {
       return;
     }
     const routeKey = `${routeSession.profileId}:${routeSession.sessionId}`;
@@ -358,11 +369,16 @@ export function useChatPage() {
   }, [routeSession, resumeSession]);
 
   useEffect(() => {
-    if (!session || !profileId || profileSwitchInFlightRef.current) {
+    if (!session || !profileId) {
+      return;
+    }
+    // Stale session state must never overwrite an intentional draft /chat URL.
+    // send/resume call syncChatUrl explicitly when a session should be reflected.
+    if (location.pathname === buildChatBasePath()) {
       return;
     }
     syncChatUrl(profileId, session.id);
-  }, [session, profileId, syncChatUrl]);
+  }, [session, profileId, syncChatUrl, location.pathname]);
 
   useEffect(() => {
     void loadProfiles();

--- a/apps/web/src/pages/profiles/profiles-dialogs.tsx
+++ b/apps/web/src/pages/profiles/profiles-dialogs.tsx
@@ -12,6 +12,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
+import { useAppNavigation } from "@/hooks/use-app-navigation";
+import { resolveSuperBotChatProfileId } from "@/lib/profiles";
 import type { ProfilesPageState } from "@/pages/profiles/use-profiles-page";
 
 export function ProfilesDialogs(state: ProfilesPageState) {
@@ -46,7 +48,13 @@ export function ProfilesDialogs(state: ProfilesPageState) {
     unassignMcpMutation,
     unassignSkillMutation,
     handleRemoveAssignmentConfirm,
+    profiles,
   } = state;
+  const { navigateToNewChat } = useAppNavigation();
+  const superBotProfileId = resolveSuperBotChatProfileId(profiles);
+  const onAskSuperBot = superBotProfileId
+    ? () => navigateToNewChat(superBotProfileId)
+    : undefined;
 
   return (
     <>
@@ -55,6 +63,7 @@ export function ProfilesDialogs(state: ProfilesPageState) {
         tools={allTools}
         onOpenChange={handleCreateOpenChange}
         onCreated={(profileId) => setSelectedId(profileId)}
+        onAskSuperBot={onAskSuperBot}
       />
 
       <SkillCreateDialog

--- a/apps/web/src/pages/profiles/profiles-page-layout.tsx
+++ b/apps/web/src/pages/profiles/profiles-page-layout.tsx
@@ -11,6 +11,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { ProfileAvatar } from "@/components/ProfileAvatar";
+import { useAppNavigation } from "@/hooks/use-app-navigation";
+import { resolveSuperBotChatProfileId } from "@/lib/profiles";
 import { cn } from "@/lib/utils";
 import { ProfileConfigTab } from "@/pages/profiles/profile-config-tab";
 import { sectionClass } from "@/pages/profiles/profiles-page.shared";
@@ -45,6 +47,11 @@ export function ProfilesPageLayout(state: ProfilesPageState) {
     setCreateOpen,
     openDeleteDialog,
   } = state;
+  const { navigateToNewChat } = useAppNavigation();
+  const superBotProfileId = resolveSuperBotChatProfileId(profiles);
+  const onAskSuperBot = superBotProfileId
+    ? () => navigateToNewChat(superBotProfileId)
+    : undefined;
 
   if (profilesLoading && profiles.length === 0) {
     return <PageState message="Loading profiles…" />;
@@ -152,6 +159,7 @@ export function ProfilesPageLayout(state: ProfilesPageState) {
                   variant="compact"
                   disabled={busy}
                   onCreate={() => setCreateOpen(true)}
+                  onAskSuperBot={onAskSuperBot}
                 />
               ) : filteredProfiles.length === 0 ? (
                 <EmptyMessage
@@ -182,6 +190,7 @@ export function ProfilesPageLayout(state: ProfilesPageState) {
                     variant="full"
                     disabled={busy}
                     onCreate={() => setCreateOpen(true)}
+                    onAskSuperBot={onAskSuperBot}
                   />
                 </div>
               ) : detailLoading && !detail ? (

--- a/apps/web/src/pages/profiles/profiles-super-bot-cta.test.ts
+++ b/apps/web/src/pages/profiles/profiles-super-bot-cta.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import type { ProfileSummary } from "@nakama/core/contract";
+import { resolveSuperBotChatProfileId } from "@/lib/profiles";
+
+function profile(
+  partial: Pick<ProfileSummary, "id" | "name" | "isSuper" | "isDefault">,
+): ProfileSummary {
+  return {
+    id: partial.id,
+    name: partial.name,
+    isSuper: partial.isSuper,
+    isDefault: partial.isDefault,
+    model: null,
+    hasAvatar: false,
+    soulActive: false,
+    toolCount: 0,
+    mcpServerCount: 0,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+describe("resolveSuperBotChatProfileId", () => {
+  test("returns the super bot profile id when present", () => {
+    expect(
+      resolveSuperBotChatProfileId([
+        profile({ id: "default", name: "Default", isSuper: false, isDefault: true }),
+        profile({ id: "super_bot", name: "Super Bot", isSuper: true, isDefault: false }),
+      ]),
+    ).toBe("super_bot");
+  });
+
+  test("returns null when no super bot exists", () => {
+    expect(
+      resolveSuperBotChatProfileId([
+        profile({ id: "default", name: "Default", isSuper: false, isDefault: true }),
+      ]),
+    ).toBeNull();
+  });
+
+  test("returns null for an empty profile list", () => {
+    expect(resolveSuperBotChatProfileId([])).toBeNull();
+  });
+});

--- a/apps/web/src/pages/profiles/profiles-ui.tsx
+++ b/apps/web/src/pages/profiles/profiles-ui.tsx
@@ -223,10 +223,12 @@ export function ProfilesEmptyState({
   variant,
   disabled,
   onCreate,
+  onAskSuperBot,
 }: {
   variant: "compact" | "full";
   disabled?: boolean;
   onCreate: () => void;
+  onAskSuperBot?: () => void;
 }) {
   const isCompact = variant === "compact";
 
@@ -268,10 +270,23 @@ export function ProfilesEmptyState({
         ) : null}
       </div>
 
-      <Button type="button" size={isCompact ? "sm" : "default"} disabled={disabled} onClick={onCreate}>
-        <PlusIcon className="size-4" aria-hidden />
-        {isCompact ? "Create profile" : "New profile"}
-      </Button>
+      <div className="flex flex-col items-center gap-2">
+        <Button type="button" size={isCompact ? "sm" : "default"} disabled={disabled} onClick={onCreate}>
+          <PlusIcon className="size-4" aria-hidden />
+          {isCompact ? "Create profile" : "New profile"}
+        </Button>
+        {onAskSuperBot ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={disabled}
+            onClick={onAskSuperBot}
+          >
+            Ask Super Bot
+          </Button>
+        ) : null}
+      </div>
 
       {!isCompact ? (
         <ol className="w-full max-w-md space-y-3 border-t border-border pt-6 text-left">

--- a/docs/website/composio.md
+++ b/docs/website/composio.md
@@ -20,7 +20,7 @@ The key is stored in `~/.nakama/composio/config.ini` on the Nakama server.
 ## Setup
 
 1. As an org admin, open **Integrations → Composio** and save your Composio **project API key**.
-2. Confirm `/health` reports `composioConfigured: true` and `composioAvailable: true`.
+2. Confirm `/health` reports `composioConfigured: true`. Reachability (`composioAvailable`) is on `GET /v1/system/status` under `server`.
 3. As an org admin, **enable** a toolkit for the organization.
 4. As any org member, click **Connect your account** and complete OAuth in the browser.
 5. Click **Sync tools** after connecting.

--- a/docs/website/profiles.md
+++ b/docs/website/profiles.md
@@ -30,7 +30,7 @@ If a session or channel config omits a profile id — or names one that does not
 
 Platform admins create extra profiles inside the **active org**. Each new profile gets its own soul directory and starts with `read_file`, `write_file`, `edit_file`, `search_files`, and `knowledge_base_search` when those builtins are available. Default and super-bot profiles also receive bundled skills (memory, automations, skill authoring) when installed on the server. Assign more tools, MCP servers, and skills from the dashboard.
 
-Super Bot can also create profiles from chat. For profile-creation requests, it uses a Super Bot-only bundled skill that guides soul-file generation, keeps `MEMORY.md` empty, and uses the current tool inventory to recommend a small relevant starter set.
+Super Bot can also create profiles from chat using a confirm-first factory. For profile-creation requests, it drafts soul files and a tool plan in chat, waits for your explicit OK, then calls `create_profile`. New profiles keep `MEMORY.md` empty and receive basic file/knowledge tools automatically; extra tools still need an explicit ask. On the Profiles page, use **Ask Super Bot** (empty state or create dialog) when a Super Bot profile exists.
 
 Super Bot can hand coding tasks to a dedicated coding agent via the `coding-delegation` skill and `bash`. See [Coding agent](/coding-agent).
 

--- a/docs/website/skills.md
+++ b/docs/website/skills.md
@@ -131,7 +131,7 @@ Selecting a skill inserts an explicit invocation like:
 
 The composer highlights the selected skill, but the message still sends as plain text so it works with the normal skill matcher.
 
-Nakama also ships bundled skills for system workflows. The `create-profile` bundled skill is assigned only to Super Bot, so profile-authoring instructions load when Super Bot is asked to create a profile without adding those instructions to ordinary profile prompts.
+Nakama also ships bundled skills for system workflows. The `create-profile` bundled skill is assigned only to Super Bot, so profile-authoring instructions load when Super Bot is asked to create a profile without adding those instructions to ordinary profile prompts. That skill runs a confirm-first factory: draft soul files in chat, wait for explicit confirmation, then create.
 
 For more detail, see [Agent prompts](/agent-prompt).
 

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -77,7 +77,11 @@ export interface HealthResponse {
   userConfigured: boolean;
   /** A Composio project API key is saved on this server. */
   composioConfigured: boolean;
-  /** Nakama can reach the Composio API with the saved key. */
+  /**
+   * Whether Nakama can reach the Composio API with the saved key.
+   * Probed only on `GET /v1/system/status` (`server.composioAvailable`).
+   * `GET /health` always returns `false` so liveness stays local and fast.
+   */
   composioAvailable: boolean;
 }
 

--- a/packages/core/src/skills/bundled/create-automation.test.ts
+++ b/packages/core/src/skills/bundled/create-automation.test.ts
@@ -53,6 +53,23 @@ describe("bundled create-profile skill", () => {
       ),
     ).toEqual(["create-profile"]);
   });
+
+  test("body requires draft-and-confirm before create_profile", async () => {
+    const content = await readBundledSkillMarkdown("create-profile");
+    const parsed = parseSkillMarkdown(content, "create-profile/SKILL.md");
+    const body = parsed.body.toLowerCase();
+
+    expect(body).toContain("draft");
+    expect(body).toMatch(/confirm|confirmation|explicit/);
+    expect(body).toContain("create_profile");
+    expect(body).not.toMatch(/otherwise proceed/);
+    expect(body).toContain("memory.md");
+    expect(body).toMatch(/empty/);
+    expect(body).toContain("web_fetch");
+    expect(body).toMatch(/isSuper|is super|super profile/i);
+    expect(body).toMatch(/revise|edit/);
+    expect(body).toMatch(/open|dashboard|profiles/);
+  });
 });
 
 describe("bundled manage-skills skill", () => {

--- a/packages/core/src/skills/bundled/create-profile/SKILL.md
+++ b/packages/core/src/skills/bundled/create-profile/SKILL.md
@@ -4,24 +4,43 @@ description: Create, design, or set up a new bot profile with soul files and app
 include-body-on-match: true
 ---
 
-When the user asks to create a profile, turn the request into a complete profile setup.
+When the user asks to create a profile, run a confirm-first factory — never call `create_profile` until they explicitly confirm the draft.
 
-Clarify only when the profile's purpose, audience, or permissions are materially unclear. Otherwise proceed with a concise, useful interpretation of the request.
+## 1. Clarify only when needed
 
-Create the profile with generated soul files:
+Ask follow-ups only when purpose, audience, or permissions are materially unclear. Otherwise interpret the request concisely and move to the draft.
 
-- `SOUL.md` defines who the profile is, what it values, what it helps with, and its boundaries.
-- `STYLE.md` defines voice, tone, formatting, and communication preferences.
-- `INSTRUCTIONS.md` defines operating rules, tool-use posture, uncertainty handling, and when to ask the user.
-- `MEMORY.md` must be empty. Do not invent continuity facts, preferences, or history for a new profile.
+## 2. Draft in chat first
 
-Use the available-tools context when it is present. Assign the basic tools by default: `read_file`, `write_file`, `edit_file`, `search_files`, and `knowledge_base_search`. Assign the `update-profile-memory` bundled skill for memory writes. Recommend or assign additional tools only when they clearly match the user's requested profile purpose. Do not assign every available tool.
+Post a reviewable draft before any tool call:
 
-When choosing tools:
+- Proposed **name** and optional **id**
+- Full proposed `SOUL.md` (who it is, values, help scope, boundaries)
+- Full proposed `STYLE.md` (voice, tone, formatting)
+- Full proposed `INSTRUCTIONS.md` (operating rules, tool posture, when to ask the user)
+- `MEMORY.md` must be **empty**. Do not invent continuity facts, preferences, or history.
 
-- Prefer small, relevant tool sets.
-- Treat custom tools as optional capabilities that need a clear fit.
-- Avoid powerful or externally visible tools unless the user asked for that capability.
-- Summarize which tools were assigned and why.
+Also include a **tool plan**:
 
-The profile should be ready to use after creation: name, soul files, empty memory, and a practical starter tool set.
+- Server auto-assigns these basics on create when available: `read_file`, `write_file`, `edit_file`, `search_files`, `knowledge_base_search`, `web_fetch`, plus default bundled skills (including `update-profile-memory`).
+- Recommend optional extras from the available-tools context only when they clearly match the requested purpose.
+- Do not assign every available tool. Avoid powerful or externally visible tools unless the user asked for that capability.
+- Extra tools still need an explicit user ask after create (`assign_tool_to_profile`).
+
+Never set `isSuper: true` unless the user explicitly asked for a super profile. Prefer refusing agent-initiated super creation and directing them to the dashboard.
+
+## 3. Wait for explicit confirmation
+
+Always wait for a clear OK (for example “yes, create it”) even when the request looked complete.
+
+If the user edits the draft, revise the draft in chat and wait for confirmation again. Do not call `create_profile` on edit-only messages.
+
+## 4. Create only after OK
+
+After confirmation, call `create_profile` with `name`, optional `id`, and `soulFiles` for `SOUL.md`, `STYLE.md`, `INSTRUCTIONS.md`, and empty `MEMORY.md`.
+
+Then summarize:
+
+- Profile id and name
+- How to open it in the dashboard (Profiles → select the new profile)
+- Which basics were auto-assigned vs any extras still waiting on an explicit assign ask

--- a/packages/db/src/constants.test.ts
+++ b/packages/db/src/constants.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { SUPER_BOT_SYSTEM_PROMPT } from "./constants";
+
+describe("SUPER_BOT_SYSTEM_PROMPT", () => {
+  test("requires draft-and-confirm before create_profile", () => {
+    expect(SUPER_BOT_SYSTEM_PROMPT).toContain("create_profile");
+    expect(SUPER_BOT_SYSTEM_PROMPT.toLowerCase()).toMatch(/draft/);
+    expect(SUPER_BOT_SYSTEM_PROMPT.toLowerCase()).toMatch(/confirm/);
+    expect(SUPER_BOT_SYSTEM_PROMPT).not.toContain(
+      "without confirming intent when the user did not ask for it",
+    );
+  });
+});

--- a/packages/db/src/constants.ts
+++ b/packages/db/src/constants.ts
@@ -59,7 +59,8 @@ export async function run(input) {
 ## Safety
 
 - Explain what you will run before destructive bash commands or file writes when the impact is unclear.
-- Do not create profiles or assign powerful tools without confirming intent when the user did not ask for it.
+- For new profiles: always draft soul files and a tool plan in chat, then wait for explicit confirmation before calling create_profile — even when the request looks complete. Prefer the create-profile skill workflow when it is active.
+- Do not assign powerful tools without confirming intent when the user did not ask for that capability.
 - After creating a tool, do not ask which profile should receive it. Tell the user they can assign it from the dashboard or ask you to assign it to a specific profile.
 - Do not assign tools to profiles unless the user asks. Never assign a newly created tool to all profiles without explicit user approval.
 


### PR DESCRIPTION

<img width="864" height="376" alt="image" src="https://github.com/user-attachments/assets/b88bcf50-4450-49cd-9bef-4a4b83a39632" />

## Summary
- Super Bot `create-profile` skill now drafts SOUL/STYLE/INSTRUCTIONS in chat and waits for explicit confirmation before `create_profile` (closes the workflow gap in #111 on top of existing tooling).
- Align Super Bot system prompt with always-confirm profile creation; Profiles empty state + create dialog add Ask Super Bot CTAs when a super profile exists.
- Docs updated for the confirm-first factory.


Closes #111