### PR TITLE
Show Thinking…/Working… while the chat waits between stream turns.

### DIFF
--- a/apps/web/src/components/chat/ThinkingState.tsx
+++ b/apps/web/src/components/chat/ThinkingState.tsx
@@ -3,8 +3,13 @@ import { cn } from "@/lib/utils";
 
 interface ThinkingStateProps {
   className?: string;
+  label?: string;
 }
 
-export function ThinkingState({ className }: ThinkingStateProps) {
-  return <span className={cn(styles.shimmer, className)}>Thinking</span>;
+export function ThinkingState({ className, label = "Thinking" }: ThinkingStateProps) {
+  return (
+    <span className={cn(styles.shimmer, className)} role="status" aria-live="polite">
+      {label}
+    </span>
+  );
 }

--- a/apps/web/src/components/chat/assistant-tool-group.shared.ts
+++ b/apps/web/src/components/chat/assistant-tool-group.shared.ts
@@ -79,5 +79,6 @@ function hasThinkingContent(message: ChatListItem): boolean {
 }
 
 function hasAssistantText(message: ChatListItem): boolean {
-  return Boolean(message.content.trim() || (message.streaming && !message.thinkingStreaming));
+  // Empty streaming bubbles are handled by the awaiting-model placeholder, not as text.
+  return Boolean(message.content.trim());
 }

--- a/apps/web/src/components/chat/chat-message-list.tsx
+++ b/apps/web/src/components/chat/chat-message-list.tsx
@@ -26,7 +26,12 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { ThinkingState } from "@/components/chat/ThinkingState";
 import { formatSessionTimestamp, type ChatListItem } from "@/lib/chat-history";
+import {
+  awaitingModelLabel,
+  isAwaitingModelResponse,
+} from "@/lib/chat-stream";
 import { isPastedTextDocument } from "@/lib/pasted-text";
 import { TextAttachmentPreview } from "@/components/chat/text-attachment-preview";
 import { ImageAttachmentPreview } from "@/components/chat/image-attachment-preview";
@@ -71,6 +76,11 @@ export function ChatMessageList({
   contentClassName,
 }: ChatMessageListProps) {
   const turns = groupMessagesIntoTurns(messages);
+  const showAwaitingPlaceholder =
+    streamActive && isAwaitingModelResponse(messages);
+  const awaitingLabel = showAwaitingPlaceholder
+    ? awaitingModelLabel(messages)
+    : null;
 
   return (
     <Conversation className={cn("min-h-0 flex-1", className)}>
@@ -78,7 +88,7 @@ export function ChatMessageList({
         {messages.length === 0 && emptyMessage ? (
           <p className="text-sm text-muted-foreground">{emptyMessage}</p>
         ) : null}
-        {turns.map((turn) =>
+        {turns.map((turn, turnIndex) =>
           turn.kind === "user" ? (
             <ChatMessageRow key={turn.message.id} message={turn.message} />
           ) : (
@@ -91,6 +101,9 @@ export function ChatMessageList({
               branchingMessageId={branchingMessageId}
               actionsDisabled={actionsDisabled}
               streamActive={streamActive}
+              awaitingLabel={
+                turnIndex === turns.length - 1 ? awaitingLabel : null
+              }
               onBranchMessage={onBranchMessage}
               onRetryMessage={onRetryMessage}
             />
@@ -136,6 +149,7 @@ function AssistantTurn({
   branchingMessageId,
   actionsDisabled,
   streamActive,
+  awaitingLabel,
   onBranchMessage,
   onRetryMessage,
 }: {
@@ -146,6 +160,7 @@ function AssistantTurn({
   branchingMessageId?: string | null;
   actionsDisabled?: boolean;
   streamActive: boolean;
+  awaitingLabel?: "Thinking…" | "Working…" | null;
   onBranchMessage?: (message: ChatListItem) => void;
   onRetryMessage?: (message: ChatListItem) => void;
 }) {
@@ -173,6 +188,7 @@ function AssistantTurn({
           modelLabel={modelLabel}
         />
       ))}
+      {awaitingLabel ? <ThinkingState label={awaitingLabel} /> : null}
       {profileId && showArtifacts ? (
         <div className="flex flex-wrap gap-2">
           {artifacts.map((artifact) => {

--- a/apps/web/src/lib/chat-stream-awaiting.test.ts
+++ b/apps/web/src/lib/chat-stream-awaiting.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+import type { ChatListItem } from "@/lib/chat-history";
+import {
+  awaitingModelLabel,
+  buildStreamHandlers,
+  isAwaitingModelResponse,
+} from "./chat-stream";
+
+function assistant(partial: Partial<ChatListItem> & { id: string }): ChatListItem {
+  return {
+    role: "assistant",
+    content: "",
+    ...partial,
+  };
+}
+
+function tool(partial: Partial<ChatListItem> & { id: string; tool: string }): ChatListItem {
+  return {
+    role: "tool",
+    content: partial.tool,
+    toolCallId: partial.id,
+    toolStatus: "done",
+    ...partial,
+  };
+}
+
+describe("isAwaitingModelResponse", () => {
+  test("false when thinking is streaming", () => {
+    expect(
+      isAwaitingModelResponse([
+        { id: "u1", role: "user", content: "hi" },
+        assistant({ id: "a1", streaming: true, thinkingStreaming: true, thinking: "" }),
+      ]),
+    ).toBe(false);
+  });
+
+  test("true when empty streaming assistant waits for first token", () => {
+    expect(
+      isAwaitingModelResponse([
+        { id: "u1", role: "user", content: "hi" },
+        assistant({ id: "a1", streaming: true }),
+      ]),
+    ).toBe(true);
+  });
+
+  test("false when text is streaming", () => {
+    expect(
+      isAwaitingModelResponse([
+        { id: "u1", role: "user", content: "hi" },
+        assistant({ id: "a1", streaming: true, content: "Hello" }),
+      ]),
+    ).toBe(false);
+  });
+
+  test("false while a tool is running", () => {
+    expect(
+      isAwaitingModelResponse([
+        { id: "u1", role: "user", content: "hi" },
+        assistant({ id: "a1", streaming: false, thinking: "plan" }),
+        tool({ id: "t1", tool: "list_profiles", toolStatus: "running" }),
+      ]),
+    ).toBe(false);
+  });
+
+  test("true after tools complete while waiting for next turn", () => {
+    expect(
+      isAwaitingModelResponse([
+        { id: "u1", role: "user", content: "hi" },
+        assistant({ id: "a1", streaming: false, thinking: "plan" }),
+        tool({ id: "t1", tool: "list_profiles", toolStatus: "done" }),
+        tool({ id: "t2", tool: "list_tools", toolStatus: "done" }),
+      ]),
+    ).toBe(true);
+  });
+});
+
+describe("awaitingModelLabel", () => {
+  test("Thinking… before any tools or thinking text", () => {
+    expect(
+      awaitingModelLabel([
+        { id: "u1", role: "user", content: "hi" },
+        assistant({ id: "a1", streaming: true }),
+      ]),
+    ).toBe("Thinking…");
+  });
+
+  test("Working… after tools", () => {
+    expect(
+      awaitingModelLabel([
+        { id: "u1", role: "user", content: "hi" },
+        tool({ id: "t1", tool: "list_profiles", toolStatus: "done" }),
+      ]),
+    ).toBe("Working…");
+  });
+});
+
+describe("buildStreamHandlers onThinking after tools", () => {
+  test("seeds a new streaming assistant when last message is a tool", () => {
+    let messages: ChatListItem[] = [
+      { id: "u1", role: "user", content: "hi" },
+      assistant({ id: "a1", streaming: false, thinking: "plan" }),
+      tool({ id: "t1", tool: "list_profiles", toolStatus: "done" }),
+    ];
+
+    const handlers = buildStreamHandlers((updater) => {
+      messages = typeof updater === "function" ? updater(messages) : updater;
+    });
+
+    handlers.onThinking?.("next thought ");
+
+    const last = messages[messages.length - 1];
+    expect(last?.role).toBe("assistant");
+    expect(last?.streaming).toBe(true);
+    expect(last?.thinkingStreaming).toBe(true);
+    expect(last?.thinking).toBe("next thought ");
+    expect(isAwaitingModelResponse(messages)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/chat-stream.ts
+++ b/apps/web/src/lib/chat-stream.ts
@@ -401,6 +401,71 @@ export function deriveChatStatus(
   return "ready";
 }
 
+/** Messages after the latest user message (current assistant turn). */
+export function latestAssistantTurnMessages(messages: ChatListItem[]): ChatListItem[] {
+  let start = 0;
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index]?.role === "user") {
+      start = index + 1;
+      break;
+    }
+  }
+
+  return messages.slice(start);
+}
+
+/**
+ * True when the SSE turn is still in flight but the transcript has no live
+ * activity (no thinking stream, no running tool, no text tokens yet). Covers
+ * first-token wait and the gap after tools before the next model turn.
+ */
+export function isAwaitingModelResponse(messages: ChatListItem[]): boolean {
+  const turn = latestAssistantTurnMessages(messages);
+
+  if (turn.length === 0) {
+    return false;
+  }
+
+  if (turn.some((message) => message.role === "tool" && message.toolStatus === "running")) {
+    return false;
+  }
+
+  if (turn.some((message) => message.role === "assistant" && message.thinkingStreaming)) {
+    return false;
+  }
+
+  if (
+    turn.some(
+      (message) =>
+        message.role === "assistant" && message.streaming && message.content.trim().length > 0,
+    )
+  ) {
+    return false;
+  }
+
+  if (
+    turn.some(
+      (message) =>
+        message.role === "assistant" && message.streaming && message.content.trim().length === 0,
+    )
+  ) {
+    return true;
+  }
+
+  return turn.some((message) => message.role === "tool" || message.role === "assistant");
+}
+
+export function awaitingModelLabel(messages: ChatListItem[]): "Thinking…" | "Working…" {
+  const turn = latestAssistantTurnMessages(messages);
+  const hasTools = turn.some((message) => message.role === "tool");
+  const hasThinkingText = turn.some(
+    (message) => message.role === "assistant" && Boolean(message.thinking?.trim()),
+  );
+
+  return hasTools || hasThinkingText ? "Working…" : "Thinking…";
+}
+
 export function buildStreamHandlers(
   setMessages: Dispatch<SetStateAction<ChatListItem[]>>,
   options: {
@@ -423,6 +488,16 @@ export function buildStreamHandlers(
           return next;
         }
 
+        // After tools the prior assistant is finalized; seed a new streaming
+        // message so post-tool thinking is not dropped.
+        next.push({
+          id: nanoid(),
+          role: "assistant",
+          content: "",
+          streaming: true,
+          thinking: delta,
+          thinkingStreaming: true,
+        });
         return next;
       });
     },


### PR DESCRIPTION
Keeps the transcript feeling alive during first-token and post-tool gaps, and seeds a streaming assistant so post-tool thinking is not dropped.