### PR TITLE
fix: reuse web Composio connections on Telegram

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,16 +135,6 @@ Custom JS tools should resolve relative paths against `context.workspaceRoot` �
 | Tools playground | `POST /v1/tools/:toolId/run` → `apps/server/src/http/routes/tools.ts` → `agent.runToolPlayground()` | Profile: first assignee of tool, else org default — `resolvePlaygroundProfileId()` in `agent-service.ts` |
 | Param suggest | `POST /v1/tools/:toolId/params/suggest` | Same service, no execution |
 
-### Tools playground (web)
-
-| What | Where |
-|---|---|
-| Page route | `/system/playground/:toolId` — `apps/web/src/pages/ToolPlaygroundPage.tsx` |
-| Run UI | `apps/web/src/components/tools/ToolPlaygroundPanel.tsx` |
-| Tools list link | `apps/web/src/components/soul-tools/ToolsTab.tsx` |
-| Path helpers | `toolPlaygroundPath()`, `toolsTabPath()` in `apps/web/src/lib/navigation.ts` |
-| Access | Org admin or platform admin — `canUseToolPlayground()` in `navigation.ts` |
-
 ### Debugging checklist
 
 1. Read the custom tool module in `~/.nakama/tools/` — check how it resolves paths.

--- a/apps/server/src/services/composio-callback-url.test.ts
+++ b/apps/server/src/services/composio-callback-url.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   persistWebPublicUrl,
+  isLoopbackComposioCallbackBaseUrl,
   resolveComposioCallbackBaseUrl,
   resolveRequestClientOrigin,
 } from "./composio-callback-url";
@@ -25,6 +26,12 @@ describe("composio-callback-url", () => {
     });
 
     expect(resolveRequestClientOrigin(request)).toBe("http://localhost:3003");
+  });
+
+  test("isLoopbackComposioCallbackBaseUrl detects localhost hosts", () => {
+    expect(isLoopbackComposioCallbackBaseUrl("http://127.0.0.1:3003")).toBe(true);
+    expect(isLoopbackComposioCallbackBaseUrl("http://localhost:3003")).toBe(true);
+    expect(isLoopbackComposioCallbackBaseUrl("https://nakama.example.com")).toBe(false);
   });
 
   test("resolveComposioCallbackBaseUrl falls back to env when no request", () => {

--- a/apps/server/src/services/composio-callback-url.ts
+++ b/apps/server/src/services/composio-callback-url.ts
@@ -85,3 +85,19 @@ export function resolveComposioCallbackBaseUrl(options: {
   const webPort = process.env.NAKAMA_WEB_PORT?.trim() || "3003";
   return `http://127.0.0.1:${webPort}`;
 }
+
+/** True when the OAuth callback host is unreachable from a phone (Telegram / WhatsApp). */
+export function isLoopbackComposioCallbackBaseUrl(baseUrl: string): boolean {
+  try {
+    const { hostname } = new URL(baseUrl);
+    return (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "::1" ||
+      hostname === "[::1]" ||
+      hostname.endsWith(".localhost")
+    );
+  } catch {
+    return false;
+  }
+}

--- a/apps/server/src/services/composio-service.test.ts
+++ b/apps/server/src/services/composio-service.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { saveComposioConfig } from "@nakama/core";
+import { LOCAL_CLIENT_USER_ID } from "@nakama/core/local-auth";
 import { createInMemoryDatabaseAdapter } from "@nakama/db";
 import { AuthService } from "./auth-service";
 import { ComposioService } from "./composio-service";
@@ -10,6 +11,7 @@ import type { ComposioApiClient } from "./composio-api-client";
 
 const TEST_API_KEY = "ck_test";
 const USER_ID = "user_admin";
+const ORG_ID = "org_1";
 
 function createMockClient(): ComposioApiClient {
   return {
@@ -50,6 +52,43 @@ function injectMockComposioClient(service: ComposioService, client: ComposioApiC
     };
 }
 
+async function seedOrgWithAdmin(db: ReturnType<typeof createInMemoryDatabaseAdapter>) {
+  const now = "2026-01-01T00:00:00.000Z";
+  await db.upsertOrganization({
+    id: ORG_ID,
+    name: "Org",
+    slug: "org",
+    createdAt: now,
+    updatedAt: now,
+  });
+  await db.createUser({
+    id: USER_ID,
+    email: "admin@example.com",
+    passwordHash: "hash",
+    createdAt: now,
+    updatedAt: now,
+  });
+  await db.createUser({
+    id: LOCAL_CLIENT_USER_ID,
+    email: "local-client@nakama.internal",
+    passwordHash: "hash",
+    createdAt: now,
+    updatedAt: now,
+  });
+  await db.upsertOrgMember({
+    orgId: ORG_ID,
+    userId: LOCAL_CLIENT_USER_ID,
+    role: "admin",
+    createdAt: now,
+  });
+  await db.upsertOrgMember({
+    orgId: ORG_ID,
+    userId: USER_ID,
+    role: "admin",
+    createdAt: "2026-01-01T00:00:01.000Z",
+  });
+}
+
 async function createConfiguredService() {
   const configDir = await mkdtemp(join(tmpdir(), "nakama-composio-service-"));
   const previous = process.env.NAKAMA_CONFIG_DIR;
@@ -78,11 +117,11 @@ describe("ComposioService", () => {
     const { service, restore } = await createConfiguredService();
 
     try {
-      const toolkit = await service.enableToolkit("org_1", { toolkitSlug: "gmail" });
+      const toolkit = await service.enableToolkit(ORG_ID, { toolkitSlug: "gmail" });
       expect(toolkit.toolkitSlug).toBe("gmail");
       expect(toolkit.status).toBe("enabled");
 
-      const listed = await service.listToolkits("org_1", USER_ID);
+      const listed = await service.listToolkits(ORG_ID, USER_ID);
       expect(listed.orgToolkits).toHaveLength(1);
       expect(listed.userConnections).toEqual([]);
     } finally {
@@ -94,16 +133,16 @@ describe("ComposioService", () => {
     const { service, restore } = await createConfiguredService();
 
     try {
-      await service.enableToolkit("org_1", { toolkitSlug: "gmail" });
+      await service.enableToolkit(ORG_ID, { toolkitSlug: "gmail" });
       const response = await service.connectToolkit(
-        "org_1",
+        ORG_ID,
         USER_ID,
         "gmail",
         "http://localhost:4310",
       );
 
       expect(response.redirectUrl).toBe("https://example.com/oauth");
-      const listed = await service.listToolkits("org_1", USER_ID);
+      const listed = await service.listToolkits(ORG_ID, USER_ID);
       expect(listed.orgToolkits[0]?.status).toBe("enabled");
       expect(listed.userConnections[0]?.status).toBe("oauth_in_progress");
     } finally {
@@ -122,7 +161,7 @@ describe("ComposioService", () => {
     });
 
     try {
-      const listed = await service.listToolkits("org_1", USER_ID);
+      const listed = await service.listToolkits(ORG_ID, USER_ID);
       expect(listed.configured).toBe(true);
       expect(listed.composioReachable).toBe(false);
       expect(listed.composioAvailable).toBe(false);
@@ -130,6 +169,67 @@ describe("ComposioService", () => {
       expect(listed.catalog).toEqual([]);
       expect(listed.orgToolkits).toEqual([]);
       expect(listed.userConnections).toEqual([]);
+    } finally {
+      restore();
+    }
+  });
+
+  test("resolveComposioActingUserId maps local client to earliest human admin", async () => {
+    const { db, service, restore } = await createConfiguredService();
+
+    try {
+      await seedOrgWithAdmin(db);
+      expect(await service.resolveComposioActingUserId(ORG_ID, LOCAL_CLIENT_USER_ID)).toBe(USER_ID);
+      expect(await service.resolveComposioActingUserId(ORG_ID, USER_ID)).toBe(USER_ID);
+    } finally {
+      restore();
+    }
+  });
+
+  test("getAssignedToolkitRecords uses admin connections for local client sessions", async () => {
+    const { db, service, restore } = await createConfiguredService();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    try {
+      await seedOrgWithAdmin(db);
+      const toolkit = await service.enableToolkit(ORG_ID, { toolkitSlug: "gmail" });
+      await db.upsertComposioUserConnection({
+        id: "cuc_admin",
+        orgId: ORG_ID,
+        userId: USER_ID,
+        toolkitId: toolkit.id,
+        status: "connected",
+        connectedAccountId: "ca_admin",
+        sessionIdEnc: null,
+        oauthStateHash: null,
+        lastError: null,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await db.upsertProfile({
+        id: "profile_1",
+        orgId: ORG_ID,
+        name: "Bot",
+        model: null,
+        systemPrompt: "",
+        isDefault: true,
+        isSuper: false,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await db.replaceProfileComposioToolkits("profile_1", [
+        { profileId: "profile_1", toolkitId: toolkit.id, allowedActions: null },
+      ]);
+
+      const assigned = await service.getAssignedToolkitRecords(
+        ORG_ID,
+        LOCAL_CLIENT_USER_ID,
+        "profile_1",
+      );
+
+      expect(assigned).toHaveLength(1);
+      expect(assigned[0]?.userConnection?.status).toBe("connected");
+      expect(assigned[0]?.userConnection?.userId).toBe(USER_ID);
     } finally {
       restore();
     }

--- a/apps/server/src/services/composio-service.ts
+++ b/apps/server/src/services/composio-service.ts
@@ -15,6 +15,7 @@ import {
   type ProfileComposioToolkitAssignment,
   type UpdateProfileComposioToolkitsRequest,
 } from "@nakama/core";
+import { LOCAL_CLIENT_USER_ID } from "@nakama/core/local-auth";
 import { normalizeEnableComposioToolkitRequest, normalizeUpdateProfileComposioToolkitsRequest } from "@nakama/core";
 import type {
   DatabaseAdapter,
@@ -87,6 +88,25 @@ export class ComposioService {
 
   reloadConfiguration(): void {
     this.apiClientCache = null;
+  }
+
+  /**
+   * Channel bridges (Telegram / WhatsApp / Discord / CLI) authenticate as the
+   * local client user. Composio OAuth is per human member, so map the local
+   * client onto the earliest human org admin — same convention as the legacy
+   * org-shared connection migration.
+   */
+  async resolveComposioActingUserId(orgId: string, userId: string): Promise<string> {
+    if (userId !== LOCAL_CLIENT_USER_ID) {
+      return userId;
+    }
+
+    const members = await this.databaseAdapter.listOrgMembers(orgId);
+    const humanAdmins = members
+      .filter((member) => member.role === "admin" && member.userId !== LOCAL_CLIENT_USER_ID)
+      .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+
+    return humanAdmins[0]?.userId ?? userId;
   }
 
   private async resolveApiKey(): Promise<string> {
@@ -276,6 +296,7 @@ export class ComposioService {
     toolkitSlug: string,
     callbackBaseUrl: string,
   ): Promise<ComposioConnectResponse> {
+    const actingUserId = await this.resolveComposioActingUserId(orgId, userId);
     const apiClient = await this.requireAvailable();
     const orgToolkit = await this.getOwnedToolkitBySlug(orgId, toolkitSlug);
 
@@ -285,7 +306,7 @@ export class ComposioService {
 
     const now = new Date().toISOString();
     const existingConnection = await this.databaseAdapter.getComposioUserConnection(
-      userId,
+      actingUserId,
       orgToolkit.id,
     );
     const connectionId = existingConnection?.id ?? createId("cuc");
@@ -293,7 +314,7 @@ export class ComposioService {
     const state = Buffer.from(
       JSON.stringify({
         orgId,
-        userId,
+        userId: actingUserId,
         toolkitId: orgToolkit.id,
         connectionId,
         nonce: oauthNonce,
@@ -301,7 +322,7 @@ export class ComposioService {
     ).toString("base64url");
     const callbackUrl = `${callbackBaseUrl.replace(/\/$/, "")}/v1/composio/oauth/callback?state=${encodeURIComponent(state)}`;
     const link = await apiClient.linkToolkitAccount(
-      composioUserId(userId),
+      composioUserId(actingUserId),
       toolkitSlug,
       callbackUrl,
     );
@@ -309,7 +330,7 @@ export class ComposioService {
     const connection: StoredComposioUserConnectionRecord = {
       id: connectionId,
       orgId,
-      userId,
+      userId: actingUserId,
       toolkitId: orgToolkit.id,
       status: "oauth_in_progress",
       connectedAccountId: link.connectedAccountId ?? existingConnection?.connectedAccountId ?? null,
@@ -382,9 +403,13 @@ export class ComposioService {
     userId: string,
     toolkitSlug: string,
   ): Promise<ComposioToolkitSummary> {
+    const actingUserId = await this.resolveComposioActingUserId(orgId, userId);
     const apiClient = await this.requireAvailable();
     const orgToolkit = await this.getOwnedToolkitBySlug(orgId, toolkitSlug);
-    const connection = await this.databaseAdapter.getComposioUserConnection(userId, orgToolkit.id);
+    const connection = await this.databaseAdapter.getComposioUserConnection(
+      actingUserId,
+      orgToolkit.id,
+    );
 
     if (!connection) {
       return toOrgToolkitSummary(orgToolkit);
@@ -399,7 +424,7 @@ export class ComposioService {
     }
 
     await this.databaseAdapter.deleteComposioUserConnection(connection.id);
-    this.invalidateProfileSessionCachesForUser(userId);
+    this.invalidateProfileSessionCachesForUser(actingUserId);
 
     return toOrgToolkitSummary(orgToolkit);
   }
@@ -409,9 +434,13 @@ export class ComposioService {
     userId: string,
     toolkitSlug: string,
   ): Promise<ComposioToolkitSummary> {
+    const actingUserId = await this.resolveComposioActingUserId(orgId, userId);
     const apiClient = await this.requireAvailable();
     const orgToolkit = await this.getOwnedToolkitBySlug(orgId, toolkitSlug);
-    const connection = await this.databaseAdapter.getComposioUserConnection(userId, orgToolkit.id);
+    const connection = await this.databaseAdapter.getComposioUserConnection(
+      actingUserId,
+      orgToolkit.id,
+    );
 
     if (!connection || connection.status !== "connected") {
       throw new NakamaApiError("Connect the toolkit before syncing tools.", 400);
@@ -422,7 +451,7 @@ export class ComposioService {
         ? { [orgToolkit.toolkitSlug]: connection.connectedAccountId }
         : {};
       const session = await apiClient.createProfileSession(
-        composioUserId(userId),
+        composioUserId(actingUserId),
         [orgToolkit.toolkitSlug],
         { [orgToolkit.toolkitSlug]: null },
         connectedAccountsByToolkit,
@@ -443,7 +472,7 @@ export class ComposioService {
 
       await this.databaseAdapter.upsertComposioToolkit(updatedOrgToolkit);
       await this.databaseAdapter.upsertComposioUserConnection(updatedConnection);
-      this.invalidateProfileSessionCachesForUser(userId);
+      this.invalidateProfileSessionCachesForUser(actingUserId);
       return toOrgToolkitSummary(updatedOrgToolkit);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -519,6 +548,7 @@ export class ComposioService {
     userId: string,
     profileId: string,
   ): Promise<ComposioSessionMcpEndpoint | null> {
+    const actingUserId = await this.resolveComposioActingUserId(orgId, userId);
     const apiClient = await this.getApiClient();
 
     if (!apiClient) {
@@ -537,7 +567,7 @@ export class ComposioService {
     const connectedAccountsByToolkit: Record<string, string> = {};
     const userConnections = await this.databaseAdapter.listComposioUserConnectionsForUser(
       orgId,
-      userId,
+      actingUserId,
     );
     const connectionByToolkitId = new Map(
       userConnections.map((connection) => [connection.toolkitId, connection] as const),
@@ -561,7 +591,7 @@ export class ComposioService {
       return null;
     }
 
-    const cacheKey = this.profileSessionCacheKey(orgId, userId, profileId);
+    const cacheKey = this.profileSessionCacheKey(orgId, actingUserId, profileId);
     const fingerprint = this.buildProfileSessionFingerprint(
       enabledToolkits,
       allowedToolsByToolkit,
@@ -573,7 +603,7 @@ export class ComposioService {
     }
 
     const endpoint = await apiClient.createProfileSession(
-      composioUserId(userId),
+      composioUserId(actingUserId),
       enabledToolkits,
       allowedToolsByToolkit,
       connectedAccountsByToolkit,
@@ -629,12 +659,13 @@ export class ComposioService {
       allowedActions: string[] | null;
     }>
   > {
+    const actingUserId = await this.resolveComposioActingUserId(orgId, userId);
     const assignments = await this.databaseAdapter.listProfileComposioToolkits(profileId);
     const orgToolkits = await this.databaseAdapter.listComposioToolkitsForOrg(orgId);
     const toolkitById = new Map(orgToolkits.map((toolkit) => [toolkit.id, toolkit]));
     const userConnections = await this.databaseAdapter.listComposioUserConnectionsForUser(
       orgId,
-      userId,
+      actingUserId,
     );
     const connectionByToolkitId = new Map(
       userConnections.map((connection) => [connection.toolkitId, connection] as const),

--- a/apps/server/src/services/composio-tool-bridge.test.ts
+++ b/apps/server/src/services/composio-tool-bridge.test.ts
@@ -158,13 +158,59 @@ describe("composio-tool-bridge", () => {
 
     const result = await tools[0]?.run(
       { toolkit_slug: "gmail" },
-      { clientOrigin: "http://localhost:3003" },
+      { clientOrigin: "https://nakama.example.com" },
     );
     expect(result).toMatchObject({
       toolkitSlug: "gmail",
       displayName: "Gmail",
       redirectUrl: "https://oauth.example.com/authorize",
     });
+  });
+
+  test("connect tool rejects loopback callback URLs", async () => {
+    const composioService = {
+      isAvailable: async () => true,
+      async getAssignedToolkitRecords() {
+        return [
+          {
+            orgToolkit: {
+              id: "ctk_1",
+              orgId: "org_1",
+              toolkitSlug: "gmail",
+              displayName: "Gmail",
+              status: "enabled",
+              cachedTools: [],
+              lastError: null,
+              createdAt: "2026-01-01T00:00:00.000Z",
+              updatedAt: "2026-01-01T00:00:00.000Z",
+            },
+            userConnection: null,
+            allowedActions: null,
+          },
+        ];
+      },
+      async connectToolkit() {
+        throw new Error("should not be called");
+      },
+    } as unknown as ComposioService;
+
+    const tools = await buildComposioConnectTools(
+      "org_1",
+      "usr_1",
+      "profile_1",
+      composioService,
+    );
+
+    const result = await tools[0]?.run(
+      { toolkit_slug: "gmail" },
+      { clientOrigin: "http://127.0.0.1:3003" },
+    );
+
+    expect(result).toMatchObject({
+      code: "COMPOSIO_POLICY",
+      toolkitSlug: "gmail",
+    });
+    expect(String((result as { error?: string }).error)).toContain("localhost");
   });
 
   test("resolveComposioCallbackBaseUrl prefers clientOrigin from browser", () => {

--- a/apps/server/src/services/composio-tool-bridge.ts
+++ b/apps/server/src/services/composio-tool-bridge.ts
@@ -1,6 +1,9 @@
 import type { ComposioToolErrorResult, ToolContext, ToolDefinition } from "@nakama/core";
 import { emptyObjectSchema } from "@nakama/core";
-import { resolveComposioCallbackBaseUrl } from "./composio-callback-url";
+import {
+  isLoopbackComposioCallbackBaseUrl,
+  resolveComposioCallbackBaseUrl,
+} from "./composio-callback-url";
 import type { ComposioService } from "./composio-service";
 import type { McpClientManager } from "./mcp-client-manager";
 import { sanitizeLlmToolNamePart } from "./mcp-tool-bridge";
@@ -123,6 +126,16 @@ export async function buildComposioConnectTools(
           const callbackBaseUrl = resolveComposioCallbackBaseUrl({
             clientOrigin: context.clientOrigin,
           });
+
+          if (isLoopbackComposioCallbackBaseUrl(callbackBaseUrl)) {
+            return {
+              error:
+                "Cannot start Composio OAuth from this channel: the callback URL is localhost. Set a reachable public web URL (Settings → Web public URL, or NAKAMA_WEB_PUBLIC_URL), restart the Telegram/WhatsApp/Discord bridge, then ask again.",
+              code: "COMPOSIO_POLICY",
+              toolkitSlug,
+            } satisfies ComposioToolErrorResult;
+          }
+
           const { redirectUrl } = await composioService.connectToolkit(
             orgId,
             userId,

--- a/docs/website/composio.md
+++ b/docs/website/composio.md
@@ -44,10 +44,11 @@ If you used org-shared connections before this model, existing connected toolkit
 - **Web chat:** callback URL comes from the browser automatically (`window.location.origin`).
 - **Setup wizard:** silently saves `window.location.origin` during first-time setup (no extra step shown).
 - **Settings:** org admins can view or change the public web URL under Settings.
-- **Telegram / WhatsApp / Discord:** bridges read `web_public_url` from `~/.nakama/config.ini` (or `NAKAMA_WEB_PUBLIC_URL` env override) and pass it on each message so OAuth links open on a reachable host.
+- **Telegram / WhatsApp / Discord / CLI:** these bridges authenticate as the local client user. Composio still uses the **earliest human org admin's** connected accounts (so OAuth completed in the web Integrations UI works on Telegram). Bridges also read `web_public_url` from `~/.nakama/config.ini` (or `NAKAMA_WEB_PUBLIC_URL`) and pass it on each message so new OAuth links open on a reachable host — localhost callbacks are rejected.
 - The OAuth callback (`/v1/composio/oauth/callback`) is public — Composio redirects the browser there without a Nakama login cookie. After success, close the tab and continue in chat.
 - Auth failures return `COMPOSIO_NOT_CONNECTED`; the agent should call `composio__connect_account` and share the link.
 - Automations without a user context do not resolve personal Composio tools.
+- Composio is **org-scoped**: enable toolkits and assign them to a profile in the same org your Telegram `/org` selection uses.
 
 ## Related docs
 


### PR DESCRIPTION
## Summary

Before this change, connecting Gmail (or any Composio toolkit) in the web Integrations UI still left Telegram asking you to connect again. Channel bridges authenticate as the local client user, so they never saw the admin’s OAuth connection.

Telegram / WhatsApp / Discord / CLI now resolve Composio against the earliest human org admin—the same account you connect on the web. Channel-originated OAuth also refuses localhost callback URLs and tells you to set a public web URL instead of generating a dead link.

## Validation

- `bun test` on `composio-service`, `composio-tool-bridge`, and `composio-callback-url` (18 tests, all pass)
- Confirmed against local DB: web connection on `user_admin`, Telegram sessions on `user_local_client`

## Test plan

- [ ] Connect a toolkit in web Integrations (Personal org)
- [ ] In Telegram, `/org` to that same org and ask the agent to use the toolkit — should not ask to reconnect
- [ ] With no `web_public_url`, asking to connect from Telegram should return a clear localhost/policy error instead of a 127.0.0.1 link
