### PR TITLE
feat: enhance documentation for org memory and tool execution

### DIFF
--- a/docs/website/content/docs/agent-prompt.mdx
+++ b/docs/website/content/docs/agent-prompt.mdx
@@ -11,6 +11,7 @@ The short version:
 Profile soul/system prompt
 + skills catalog
 + knowledge base catalog
++ org memory summary (non-viewers only)
 + super bot rules, when enabled
 + USER.md context
 + timezone
@@ -43,6 +44,7 @@ After the main profile prompt, Nakama may append:
 
 - Assigned skills catalog
 - Knowledge base catalog
+- Org memory summary for non-viewers — pinned bullets under `## Org Memory`, capped at **2048 bytes** with an overflow hint to use `org_memory_search` when truncated (see [Org memory](/org-memory))
 - Super Bot tool-authoring rules, only for super profiles
 
 ## Chat wrapper

--- a/docs/website/content/docs/backup-restore.mdx
+++ b/docs/website/content/docs/backup-restore.mdx
@@ -14,6 +14,7 @@ Treat export ZIPs as sensitive. They can include:
 - Provider settings and API keys
 - Auth data
 - Org and profile workspaces (soul files, memory, artifacts)
+- Org-level `MEMORY.md` and `memory-archive/` (see [Org memory](/org-memory))
 - Custom tools and skills
 - The local SQLite database when it lives under the Nakama root
 

--- a/docs/website/content/docs/builtin-tools.mdx
+++ b/docs/website/content/docs/builtin-tools.mdx
@@ -26,6 +26,20 @@ For example:
 
 Give each profile the minimum tool set it needs.
 
+## Parallel execution
+
+When the model requests multiple tool calls in one turn, Nakama can run them concurrently — but only when **every** call in the batch is marked `parallelSafe`.
+
+| Parallel-safe builtins | Sequential (default) |
+|------------------------|----------------------|
+| `read_file`, `search_files`, `knowledge_base_search`, `web_search`, `web_fetch`, `sub_agent` | `bash`, write/edit/delete file tools, email, Composio, MCP, session-state tools, and the rest |
+
+If a turn mixes parallel-safe and sequential tools — for example `read_file` and `bash` together — the whole turn runs sequentially.
+
+Custom JavaScript tools under `~/.nakama/tools/` default to sequential. Export `parallelSafe = true` from the module to opt in.
+
+Parallel execution speeds up multi-file research and lets a parent agent delegate several independent `sub_agent` tasks at once. See [`sub_agent`](#sub_agent) below.
+
 ## Default assignments
 
 Nakama includes these builtins:
@@ -283,6 +297,10 @@ Run a one-off shell command in the profile workspace and return stdout, stderr, 
 
 Run a focused **same-profile** sub-agent for delegated work (research, review, planning, debugging). The parent receives a structured result to summarize for the user. This is a Nakama-native in-process agent loop — **not** the external coding-agent path (`bash` + `coding-agent`).
 
+While a sub-agent runs, the chat UI shows a dedicated row with the task title and a **live status label** (for example "Reading SOUL.md", "Searching web · …", "Writing answer…"). When the run completes, the row shows the summary with an expandable full output.
+
+Multiple `sub_agent` calls in one turn can run **in parallel** when the model batches them for independent tasks. Sub-agents still cannot nest — a sub-agent cannot call `sub_agent` again.
+
 | Parameter | Type | Required | Notes |
 |-----------|------|----------|-------|
 | `task` | string | Yes | Clear instruction for the sub-agent |
@@ -300,6 +318,28 @@ Run a focused **same-profile** sub-agent for delegated work (research, review, p
 - Default timeout counts toward the parent web stream budget (10 minute total turn limit)
 
 **Availability:** When assigned to the profile (opt-in; not part of default custom profile assignments).
+
+### `org_memory_search`
+
+Search the organization's shared memory — live pinned bullets and the full archive — for facts relevant to a query. Use when the injected org memory summary is missing detail or when you need historical facts that were archived.
+
+| Parameter | Type | Required | Notes |
+|-----------|------|----------|-------|
+| `query` | string | Yes | Text to search for across org memory bullets |
+
+**Returns:** `{ query, matches }` — each match includes the source file and matching bullet text.
+
+**Availability:** Automatically available on every profile for non-viewer roles. Not assigned from the dashboard. Viewers are denied. See [Org memory](/org-memory).
+
+### `org_memory_list`
+
+Return the organization's current live org memory content (pinned facts).
+
+**Parameters:** None.
+
+**Returns:** `{ content }` — raw markdown of the live org memory file.
+
+**Availability:** Automatically available on every profile for non-viewer roles. Not assigned from the dashboard. Viewers are denied. See [Org memory](/org-memory).
 
 ## Configuration prerequisites
 
@@ -351,6 +391,7 @@ All builtin tool IDs are protected and cannot be deleted from the dashboard.
 
 ## Next steps
 
+- [Org memory](/org-memory) — shared facts, admin UI, and API
 - [Skills](/skills) — bundled system skills and reusable profile procedures
 - [Coding agent](/coding-agent) — hand repo work to Codex, Claude Code, or OpenCode via `bash`
 - [Agent browser](/agent-browser) — interactive browsing via `bash` and the `agent-browser` skill

--- a/docs/website/content/docs/docs.mdx
+++ b/docs/website/content/docs/docs.mdx
@@ -41,6 +41,7 @@ Then open the dashboard, complete the setup wizard, and send your first message.
 ## Concepts
 
 - [Multi-tenancy](/multi-tenancy) — organizations, members, roles, and tenant isolation
+- [Org memory](/org-memory) — shared, admin-curated facts for the whole organization
 - [Profiles](/profiles) — soul files, memory, tools, and model selection
 - [Agent prompts](/agent-prompt) — how Nakama builds the system prompt each turn
 

--- a/docs/website/content/docs/meta.json
+++ b/docs/website/content/docs/meta.json
@@ -16,6 +16,7 @@
     "discord",
     "---Concepts---",
     "multi-tenancy",
+    "org-memory",
     "profiles",
     "agent-prompt",
     "---Extend---",

--- a/docs/website/content/docs/multi-tenancy.mdx
+++ b/docs/website/content/docs/multi-tenancy.mdx
@@ -18,6 +18,7 @@ That organization keeps its own:
 - Skills
 - MCP servers
 - Usage data
+- [Org memory](/org-memory) — shared, admin-curated facts for every profile in the org
 
 ## Why this matters
 
@@ -36,7 +37,7 @@ For example:
 | Platform admin | Whole deployment | Create orgs and manage shared system-level bot resources |
 | Org admin | One organization | Invite members and manage roles |
 | Org member | One organization | Chat with profiles and use the workspace |
-| Org viewer | One organization | Read chat history only |
+| Org viewer | One organization | Read chat history only — no org memory, agent invoke, or mutations |
 
 ## Practical mental model
 
@@ -78,6 +79,7 @@ So the split is:
 
 ## Next steps
 
+- [Org memory](/org-memory) — shared facts injected into every profile
 - [Profiles](/profiles) — how to model bots inside an organization
 - [Builtin tools](/builtin-tools) — how profile capabilities are controlled
 - [Quickstart](/quickstart) — setup flow from zero

--- a/docs/website/content/docs/org-memory.mdx
+++ b/docs/website/content/docs/org-memory.mdx
@@ -1,0 +1,119 @@
+---
+title: "Org Memory"
+description: "Shared, admin-curated facts for an organization — injected into every profile's prompt and distinct from per-profile MEMORY.md."
+---
+
+**Org memory** is shared context for the whole organization.
+
+Every non-viewer agent in the org sees a pinned summary in its system prompt. Org admins curate the facts from **Settings → Org Memory**. Members can read and search; viewers are blocked entirely.
+
+Org memory is separate from [profile memory](/profiles#knowledge-base-and-memory). Profile `MEMORY.md` is per-bot continuity that agents update themselves. Org memory is team-wide facts that admins maintain.
+
+## On disk
+
+Org memory lives at the organization level, alongside profile directories:
+
+```text
+~/.nakama/orgs/{orgId}/MEMORY.md
+~/.nakama/orgs/{orgId}/memory-archive/
+```
+
+Archived bullets move into monthly `.md` files under `memory-archive/` without deleting history.
+
+Platform-admin [data exports](/backup-restore) include org memory as part of the org workspace in the ZIP.
+
+## Format (v1)
+
+v1 is **pinned-only**. Use this structure:
+
+```md
+## Org Memory
+
+## Pinned
+
+- Acme Corp is our primary customer in APAC.
+- Support hours are 9am–6pm SGT, Mon–Fri.
+```
+
+| Rule | Detail |
+|------|--------|
+| Pinned bullets | Lines under `## Pinned` starting with `- ` |
+| Dated sections | `## YYYY-MM-DD` sections are parsed but **not** injected into prompts (reserved for a future recent-log tier) |
+| Empty state | When no pinned bullets exist, nothing is injected |
+
+## Prompt injection
+
+After the profile soul stack and knowledge base catalog, Nakama appends a `## Org Memory` section for every role except **viewer**.
+
+| Limit | Value |
+|-------|-------|
+| Summary injected into prompt | **2048 bytes** max |
+| Live file on save | **8192 bytes** max |
+
+When the summary exceeds the cap, trailing bullets are dropped and the agent sees a hint to call `org_memory_search` for the full history (including archives).
+
+See [Agent prompts](/agent-prompt) for the full assembly order.
+
+## Agent tools
+
+Two org memory tools are **automatically available on every profile**. They are not assigned from the dashboard like other builtins.
+
+| Tool | Purpose |
+|------|---------|
+| `org_memory_search` | Search live pinned bullets and the full archive by query |
+| `org_memory_list` | Return the current live org memory content |
+
+Viewers cannot call these tools. Automations and sub-agents run with member-level org context.
+
+In v1, agents **cannot propose** org facts. Admins add and edit facts through the UI or API. For per-bot continuity the agent manages itself, use the profile `update-profile-memory` skill — see [Profiles](/profiles#knowledge-base-and-memory).
+
+## Admin UI
+
+Org admins manage org memory from **Settings → Org Memory** (`/settings`).
+
+The card shows a preview of the live markdown and an **Edit** dialog for raw content. Keep the `## Org Memory` / `## Pinned` structure when editing.
+
+## Roles and access
+
+| Role | Read | Search | Write (UI/API) | Prompt injection | Agent tools |
+|------|------|--------|----------------|------------------|-------------|
+| **admin** | yes | yes | yes | yes | yes |
+| **member** | yes | yes | no | yes | yes |
+| **viewer** | no | no | no | no | no |
+
+Cross-org requests return **404** — the path `orgId` must match the active organization.
+
+## API reference
+
+All routes require authentication and an active org context (`X-Org-Id` or `active_org_id` cookie).
+
+| Method | Path | Role | Action |
+|--------|------|------|--------|
+| `GET` | `/v1/orgs/{orgId}/memory` | member+ | Read live content |
+| `PUT` | `/v1/orgs/{orgId}/memory` | admin | Replace entire file |
+| `POST` | `/v1/orgs/{orgId}/memory/facts` | admin | Add a pinned bullet |
+| `POST` | `/v1/orgs/{orgId}/memory/search` | member+ | Search live + archive |
+| `POST` | `/v1/orgs/{orgId}/memory/pin` | admin | Pin a bullet |
+| `POST` | `/v1/orgs/{orgId}/memory/unpin` | admin | Unpin a bullet |
+| `POST` | `/v1/orgs/{orgId}/memory/archive` | admin | Move bullets to monthly archive |
+
+Use **Archive** when the pinned list grows large — it keeps the live file within limits while preserving history under `memory-archive/`.
+
+## Org memory vs profile memory
+
+| | **Org memory** | **Profile `MEMORY.md`** |
+|---|---|---|
+| **Scope** | Entire organization | Single profile |
+| **Path** | `~/.nakama/orgs/{orgId}/MEMORY.md` | `~/.nakama/orgs/{orgId}/profiles/{profileId}/MEMORY.md` |
+| **Structure (v1)** | `## Pinned` bullets | Dated `## YYYY-MM-DD` sections |
+| **Who writes** | Org admins (UI/API) | Agent via `update-profile-memory` skill |
+| **Prompt injection** | Appended as `## Org Memory` | In soul stack as continuity |
+| **Active file limit** | 8192 bytes (live); 2048 bytes injected | 4096 bytes soft limit |
+| **Viewer access** | Blocked | Follows normal chat access |
+
+## Next steps
+
+- [Multi-tenancy](/multi-tenancy) — org boundaries and roles
+- [Profiles](/profiles) — per-profile soul files and memory
+- [Agent prompts](/agent-prompt) — how org memory joins the system prompt
+- [Builtin tools](/builtin-tools) — `org_memory_search` and `org_memory_list` reference

--- a/docs/website/content/docs/overview.mdx
+++ b/docs/website/content/docs/overview.mdx
@@ -31,6 +31,7 @@ It keeps one team's data separate from another team's data, including:
 - Skills
 - MCP servers
 - Usage data
+- Org memory — shared facts for the whole organization
 
 ### 2. Profile
 
@@ -45,6 +46,8 @@ Each profile has a role. It defines:
 - Which knowledge base it can search
 
 If two profiles should behave differently, make two profiles.
+
+Org memory holds team-wide facts every profile shares; profile `MEMORY.md` holds per-bot continuity. See [Org memory](/org-memory) and [Profiles](/profiles#knowledge-base-and-memory).
 
 ### 3. Tool access
 

--- a/docs/website/content/docs/profiles.mdx
+++ b/docs/website/content/docs/profiles.mdx
@@ -65,7 +65,8 @@ When a chat runs with a profile, Nakama builds the agent context in this order:
 2. If soul files exist, compose them into the main system prompt
 3. Append the assigned skills catalog
 4. Append the knowledge base catalog
-5. Expose only the tools allowed for that profile
+5. Append org memory summary for non-viewers (see [Org memory](/org-memory))
+6. Expose only the tools allowed for that profile
 
 So a profile is not just a name. It controls both:
 
@@ -141,10 +142,13 @@ Profiles keep their own context on disk under the org-scoped profile directory:
 - **`memory-archive/`** for facts moved out of active memory without deleting them
 - **Artifacts** for persistent reports and generated text saved via the `save-artifact` skill
 
+At the **organization** level (not inside a profile directory), [org memory](/org-memory) stores shared facts every profile in the org sees — admin-curated, distinct from per-profile `MEMORY.md`.
+
 Memory writes and archives use bundled skills (`update-profile-memory`, `archive-profile-memory`) with the profile's file tools — not separate memory builtins. Artifact saves use `save-artifact` with `write_file`. Default and super-bot profiles receive these skills automatically when they are installed on the server.
 
 | Store | Loaded into chat | How agents write |
 |-------|------------------|------------------|
+| Org memory | Yes (appended as `## Org Memory` for non-viewers) | Org admins via Settings or API — see [Org memory](/org-memory) |
 | `MEMORY.md` | Yes (via soul stack) | `update-profile-memory` skill + `read_file` / `edit_file` / `write_file` |
 | `memory-archive/` | No | `archive-profile-memory` skill + file tools |
 | `artifacts/` | No (dashboard, download API, web chat preview) | `save-artifact` skill + `write_file` or `write_docx` |
@@ -152,6 +156,8 @@ Memory writes and archives use bundled skills (`update-profile-memory`, `archive
 | Profile skills | Via skill matcher when relevant | `manage-skills` skill or dashboard |
 
 Active `MEMORY.md` has a **4096-byte** soft limit. When it is full, the agent should archive old bullets before adding new ones.
+
+Org memory has separate limits: **8192 bytes** for the live file and **2048 bytes** for the injected summary. See [Org memory](/org-memory).
 
 This data is isolated per org and per profile. Two orgs never read or write the same directory, even if profile ids happen to match.
 


### PR DESCRIPTION
- Added org memory summary for non-viewers in agent prompts and profiles.
- Updated backup and restore documentation to include org-level memory files.
- Introduced parallel execution details for tool calls in the built-in tools section.
- Enhanced multi-tenancy and overview documentation with references to org memory.
- Improved clarity on org memory's role and usage across various documentation files.