### PR TITLE
feat: organization memory v2 — propose/approve queue + recent-log tier

### DIFF
--- a/apps/server/src/http/routes/org-memory.test.ts
+++ b/apps/server/src/http/routes/org-memory.test.ts
@@ -12,7 +12,7 @@ setupTestConfigDir("nakama-org-memory-routes-test-");
 function createApp() {
   const databaseAdapter = createInMemoryDatabaseAdapter();
   const authService = new AuthService();
-  const orgMemoryService = new OrgMemoryService();
+  const orgMemoryService = new OrgMemoryService(databaseAdapter);
   return {
     databaseAdapter,
     authService,
@@ -237,5 +237,82 @@ describe("org memory routes (v1)", () => {
       }),
     );
     expect(archiveResp.status).toBe(404);
+  });
+
+  test("admin can list, approve, and reject proposals; member cannot list", async () => {
+    const { app, authService, databaseAdapter, orgMemoryService } = createApp();
+    const adminSession = await setupFreshInstallSession(app, databaseAdapter, "admin6@org.com");
+    const orgId = adminSession.orgId!;
+
+    const proposed = await orgMemoryService.propose(orgId, {
+      bullet: "deploy freeze on Fridays",
+      profileId: "profile_a",
+    });
+    expect(proposed.outcome).toBe("created");
+
+    const listResp = await app.fetch(
+      new Request(`${BASE}/v1/orgs/${orgId}/memory/proposals?status=pending`, {
+        headers: adminSession.headers({}, orgId),
+      }),
+    );
+    expect(listResp.status).toBe(200);
+    const listBody = (await listResp.json()) as {
+      proposals: { id: string; bullet: string }[];
+      pendingCount: number;
+    };
+    expect(listBody.pendingCount).toBe(1);
+    expect(listBody.proposals[0]?.bullet).toBe("deploy freeze on Fridays");
+
+    const approveResp = await app.fetch(
+      new Request(`${BASE}/v1/orgs/${orgId}/memory/proposals/${proposed.proposalId}/approve`, {
+        method: "POST",
+        headers: adminSession.headers({ "X-CSRF-Token": adminSession.csrfToken }, orgId),
+        body: JSON.stringify({ pin: false }),
+      }),
+    );
+    expect(approveResp.status).toBe(200);
+    const approveBody = (await approveResp.json()) as { content: string };
+    expect(approveBody.content).toContain("deploy freeze on Fridays");
+
+    const memberResp = await app.fetch(
+      new Request(`${BASE}/v1/orgs/${orgId}/members`, {
+        method: "POST",
+        headers: adminSession.headers({ "X-CSRF-Token": adminSession.csrfToken }, orgId),
+        body: JSON.stringify({
+          email: "member6@org.com",
+          name: "Member Six",
+          role: "member",
+        }),
+      }),
+    );
+    const memberProvisioned = (await memberResp.json()) as { temporaryPassword: string };
+    const memberSession = await loginUserSession(
+      app,
+      "member6@org.com",
+      memberProvisioned.temporaryPassword,
+      orgId,
+    );
+    const memberListResp = await app.fetch(
+      new Request(`${BASE}/v1/orgs/${orgId}/memory/proposals`, {
+        headers: memberSession.headers({}, orgId),
+      }),
+    );
+    expect(memberListResp.status).toBe(403);
+  });
+
+  test("approve proposal from wrong org returns 404", async () => {
+    const { app, databaseAdapter, orgMemoryService } = createApp();
+    const adminSession = await setupFreshInstallSession(app, databaseAdapter, "admin7@org.com");
+    const orgId = adminSession.orgId!;
+    const proposed = await orgMemoryService.propose(orgId, { bullet: "org scoped fact" });
+
+    const otherOrgResp = await app.fetch(
+      new Request(`${BASE}/v1/orgs/org_other/memory/proposals/${proposed.proposalId}/approve`, {
+        method: "POST",
+        headers: adminSession.headers({ "X-CSRF-Token": adminSession.csrfToken }, orgId),
+        body: JSON.stringify({}),
+      }),
+    );
+    expect(otherOrgResp.status).toBe(404);
   });
 });

--- a/apps/server/src/http/routes/org-memory.ts
+++ b/apps/server/src/http/routes/org-memory.ts
@@ -306,4 +306,130 @@ export function registerOrgMemoryRoutes(app: HonoApp, options: ServerOptions): v
     const result = await service.archiveEntries(orgId, body.entries, { reason: body.reason });
     return json<ArchiveOrgMemoryResponse>(result);
   });
+
+  const listOrgMemoryProposalsResponseSchema = z
+    .object({})
+    .passthrough()
+    .openapi("ListOrgMemoryProposalsResponse");
+  const approveOrgMemoryProposalSchema = z
+    .object({ pin: z.boolean().optional() })
+    .openapi("ApproveOrgMemoryProposalRequest");
+  const orgMemoryProposalResponseSchema = z
+    .object({})
+    .passthrough()
+    .openapi("OrgMemoryProposalResponse");
+
+  // GET /v1/orgs/{orgId}/memory/proposals — admin only
+  app.openAPIRegistry.registerPath(
+    createRoute({
+      method: "get",
+      path: "/v1/orgs/{orgId}/memory/proposals",
+      tags: ["Organizations"],
+      summary: "List org memory proposals",
+      operationId: "listOrgMemoryProposals",
+      request: {
+        params: orgIdParam,
+        query: z.object({
+          status: z.enum(["pending", "approved", "rejected"]).optional(),
+        }),
+      },
+      responses: {
+        200: {
+          description: "Proposals",
+          content: { "application/json": { schema: listOrgMemoryProposalsResponseSchema } },
+        },
+        403: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        404: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        500: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+      },
+    }),
+  );
+
+  app.get("/v1/orgs/:orgId/memory/proposals", async (c) => {
+    const auth = requireOrgAdminFromContext(c);
+    const orgId = resolveOrgId(c, auth.activeOrgId ?? "");
+    const service = requireService();
+    const status = c.req.query("status") as "pending" | "approved" | "rejected" | undefined;
+    const proposals = await service.listProposals(orgId, status);
+    const pendingCount = await service.countPendingProposals(orgId);
+    return json({ proposals, pendingCount });
+  });
+
+  // POST /v1/orgs/{orgId}/memory/proposals/{proposalId}/approve — admin only
+  app.openAPIRegistry.registerPath(
+    createRoute({
+      method: "post",
+      path: "/v1/orgs/{orgId}/memory/proposals/{proposalId}/approve",
+      tags: ["Organizations"],
+      summary: "Approve an org memory proposal",
+      operationId: "approveOrgMemoryProposal",
+      request: {
+        params: orgIdParam.extend({
+          proposalId: z.string().openapi({ param: { name: "proposalId", in: "path" } }),
+        }),
+        body: {
+          required: false,
+          content: { "application/json": { schema: approveOrgMemoryProposalSchema } },
+        },
+      },
+      responses: {
+        200: {
+          description: "Approved",
+          content: { "application/json": { schema: orgMemoryProposalResponseSchema } },
+        },
+        400: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        403: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        404: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        500: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+      },
+    }),
+  );
+
+  app.post("/v1/orgs/:orgId/memory/proposals/:proposalId/approve", async (c) => {
+    const auth = requireOrgAdminFromContext(c);
+    const orgId = resolveOrgId(c, auth.activeOrgId ?? "");
+    const proposalId = decodeURIComponent(c.req.param("proposalId"));
+    const service = requireService();
+    const body = await readJson<{ pin?: boolean }>(c.req.raw).catch(() => ({}));
+    const proposal = await service.approveProposal(orgId, proposalId, auth.user.id, {
+      pin: body.pin,
+    });
+    const content = await service.getMemory(orgId);
+    return json({ proposal, content });
+  });
+
+  // POST /v1/orgs/{orgId}/memory/proposals/{proposalId}/reject — admin only
+  app.openAPIRegistry.registerPath(
+    createRoute({
+      method: "post",
+      path: "/v1/orgs/{orgId}/memory/proposals/{proposalId}/reject",
+      tags: ["Organizations"],
+      summary: "Reject an org memory proposal",
+      operationId: "rejectOrgMemoryProposal",
+      request: {
+        params: orgIdParam.extend({
+          proposalId: z.string().openapi({ param: { name: "proposalId", in: "path" } }),
+        }),
+      },
+      responses: {
+        200: {
+          description: "Rejected",
+          content: { "application/json": { schema: orgMemoryProposalResponseSchema } },
+        },
+        400: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        403: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        404: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        500: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+      },
+    }),
+  );
+
+  app.post("/v1/orgs/:orgId/memory/proposals/:proposalId/reject", async (c) => {
+    const auth = requireOrgAdminFromContext(c);
+    const orgId = resolveOrgId(c, auth.activeOrgId ?? "");
+    const proposalId = decodeURIComponent(c.req.param("proposalId"));
+    const service = requireService();
+    const proposal = await service.rejectProposal(orgId, proposalId, auth.user.id);
+    return json({ proposal });
+  });
 }

--- a/apps/server/src/http/routes/org-memory.ts
+++ b/apps/server/src/http/routes/org-memory.ts
@@ -121,7 +121,11 @@ export function registerOrgMemoryRoutes(app: HonoApp, options: ServerOptions): v
     const orgId = resolveOrgId(c, auth.activeOrgId ?? "");
     const service = requireService();
     const body = await readJson<UpdateOrgMemoryRequest>(c.req.raw);
-    await service.setMemory(orgId, body.content);
+    await service.setMemory(orgId, body.content, {
+      actorUserId: auth.user.id,
+      action: "edit",
+      label: "Manual edit",
+    });
     const content = await service.getMemory(orgId);
     return json<OrgMemoryResponse>({ content });
   });
@@ -159,7 +163,14 @@ export function registerOrgMemoryRoutes(app: HonoApp, options: ServerOptions): v
     const orgId = resolveOrgId(c, auth.activeOrgId ?? "");
     const service = requireService();
     const body = await readJson<AddOrgMemoryFactRequest>(c.req.raw);
-    await service.addFact(orgId, body.bullet, { pin: body.pin ?? true });
+    await service.addFact(orgId, body.bullet, {
+      pin: body.pin ?? true,
+      change: {
+        actorUserId: auth.user.id,
+        action: "add_fact",
+        label: `Added fact: ${body.bullet.trim()}`,
+      },
+    });
     const content = await service.getMemory(orgId);
     return json<OrgMemoryResponse>({ content });
   });
@@ -230,7 +241,11 @@ export function registerOrgMemoryRoutes(app: HonoApp, options: ServerOptions): v
     const orgId = resolveOrgId(c, auth.activeOrgId ?? "");
     const service = requireService();
     const body = await readJson<PinOrgMemoryRequest>(c.req.raw);
-    await service.pinFact(orgId, body.bullet);
+    await service.pinFact(orgId, body.bullet, {
+      actorUserId: auth.user.id,
+      action: "pin",
+      label: `Pinned fact: ${body.bullet.trim()}`,
+    });
     const content = await service.getMemory(orgId);
     return json<OrgMemoryResponse>({ content });
   });
@@ -265,7 +280,11 @@ export function registerOrgMemoryRoutes(app: HonoApp, options: ServerOptions): v
     const orgId = resolveOrgId(c, auth.activeOrgId ?? "");
     const service = requireService();
     const body = await readJson<UnpinOrgMemoryRequest>(c.req.raw);
-    await service.unpinFact(orgId, body.bullet);
+    await service.unpinFact(orgId, body.bullet, {
+      actorUserId: auth.user.id,
+      action: "unpin",
+      label: `Unpinned fact: ${body.bullet.trim()}`,
+    });
     const content = await service.getMemory(orgId);
     return json<OrgMemoryResponse>({ content });
   });
@@ -303,8 +322,116 @@ export function registerOrgMemoryRoutes(app: HonoApp, options: ServerOptions): v
     const orgId = resolveOrgId(c, auth.activeOrgId ?? "");
     const service = requireService();
     const body = await readJson<ArchiveOrgMemoryRequest>(c.req.raw);
-    const result = await service.archiveEntries(orgId, body.entries, { reason: body.reason });
+    const result = await service.archiveEntries(orgId, body.entries, {
+      reason: body.reason,
+      change: {
+        actorUserId: auth.user.id,
+        action: "archive",
+        label: `Archived ${body.entries.length} ${body.entries.length === 1 ? "fact" : "facts"}`,
+      },
+    });
     return json<ArchiveOrgMemoryResponse>(result);
+  });
+
+  const listOrgMemoryHistoryResponseSchema = z
+    .object({})
+    .passthrough()
+    .openapi("ListOrgMemoryHistoryResponse");
+  const restoreOrgMemoryHistoryResponseSchema = z
+    .object({})
+    .passthrough()
+    .openapi("RestoreOrgMemoryHistoryResponse");
+
+  // GET /v1/orgs/{orgId}/memory/history — admin only
+  app.openAPIRegistry.registerPath(
+    createRoute({
+      method: "get",
+      path: "/v1/orgs/{orgId}/memory/history",
+      tags: ["Organizations"],
+      summary: "List org memory change history",
+      operationId: "listOrgMemoryHistory",
+      request: { params: orgIdParam },
+      responses: {
+        200: {
+          description: "Change history",
+          content: { "application/json": { schema: listOrgMemoryHistoryResponseSchema } },
+        },
+        403: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        404: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        500: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+      },
+    }),
+  );
+
+  app.get("/v1/orgs/:orgId/memory/history", async (c) => {
+    const auth = requireOrgAdminFromContext(c);
+    const orgId = resolveOrgId(c, auth.activeOrgId ?? "");
+    const service = requireService();
+    const changes = await service.listHistory(orgId);
+    return json({ changes });
+  });
+
+  // POST /v1/orgs/{orgId}/memory/history/undo — admin only
+  app.openAPIRegistry.registerPath(
+    createRoute({
+      method: "post",
+      path: "/v1/orgs/{orgId}/memory/history/undo",
+      tags: ["Organizations"],
+      summary: "Undo the latest org memory change",
+      operationId: "undoOrgMemoryChange",
+      request: { params: orgIdParam },
+      responses: {
+        200: {
+          description: "Restored previous revision",
+          content: { "application/json": { schema: restoreOrgMemoryHistoryResponseSchema } },
+        },
+        403: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        404: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        500: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+      },
+    }),
+  );
+
+  app.post("/v1/orgs/:orgId/memory/history/undo", async (c) => {
+    const auth = requireOrgAdminFromContext(c);
+    const orgId = resolveOrgId(c, auth.activeOrgId ?? "");
+    const service = requireService();
+    const content = await service.undoLastChange(orgId, auth.user.id);
+    return json({ content });
+  });
+
+  // POST /v1/orgs/{orgId}/memory/history/{revisionId}/restore — admin only
+  app.openAPIRegistry.registerPath(
+    createRoute({
+      method: "post",
+      path: "/v1/orgs/{orgId}/memory/history/{revisionId}/restore",
+      tags: ["Organizations"],
+      summary: "Restore org memory to a previous revision",
+      operationId: "restoreOrgMemoryHistory",
+      request: {
+        params: orgIdParam.extend({
+          revisionId: z.string().openapi({ param: { name: "revisionId", in: "path" } }),
+        }),
+      },
+      responses: {
+        200: {
+          description: "Restored revision",
+          content: { "application/json": { schema: restoreOrgMemoryHistoryResponseSchema } },
+        },
+        403: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        404: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        500: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+      },
+    }),
+  );
+
+  app.post("/v1/orgs/:orgId/memory/history/:revisionId/restore", async (c) => {
+    const auth = requireOrgAdminFromContext(c);
+    const orgId = resolveOrgId(c, auth.activeOrgId ?? "");
+    const revisionId = decodeURIComponent(c.req.param("revisionId"));
+    const service = requireService();
+    const content = await service.restoreHistoryRevision(orgId, revisionId, auth.user.id);
+    return json({ content });
   });
 
   const listOrgMemoryProposalsResponseSchema = z

--- a/apps/server/src/http/routes/org-memory.ts
+++ b/apps/server/src/http/routes/org-memory.ts
@@ -337,6 +337,10 @@ export function registerOrgMemoryRoutes(app: HonoApp, options: ServerOptions): v
     .object({})
     .passthrough()
     .openapi("ListOrgMemoryHistoryResponse");
+  const orgMemoryHistoryRevisionResponseSchema = z
+    .object({})
+    .passthrough()
+    .openapi("OrgMemoryHistoryRevisionResponse");
   const restoreOrgMemoryHistoryResponseSchema = z
     .object({})
     .passthrough()
@@ -369,6 +373,40 @@ export function registerOrgMemoryRoutes(app: HonoApp, options: ServerOptions): v
     const service = requireService();
     const changes = await service.listHistory(orgId);
     return json({ changes });
+  });
+
+  // GET /v1/orgs/{orgId}/memory/history/{revisionId} — admin only
+  app.openAPIRegistry.registerPath(
+    createRoute({
+      method: "get",
+      path: "/v1/orgs/{orgId}/memory/history/{revisionId}",
+      tags: ["Organizations"],
+      summary: "Get an org memory history revision",
+      operationId: "getOrgMemoryHistoryRevision",
+      request: {
+        params: orgIdParam.extend({
+          revisionId: z.string().openapi({ param: { name: "revisionId", in: "path" } }),
+        }),
+      },
+      responses: {
+        200: {
+          description: "History revision",
+          content: { "application/json": { schema: orgMemoryHistoryRevisionResponseSchema } },
+        },
+        403: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        404: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        500: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+      },
+    }),
+  );
+
+  app.get("/v1/orgs/:orgId/memory/history/:revisionId", async (c) => {
+    const auth = requireOrgAdminFromContext(c);
+    const orgId = resolveOrgId(c, auth.activeOrgId ?? "");
+    const revisionId = decodeURIComponent(c.req.param("revisionId"));
+    const service = requireService();
+    const revision = await service.getHistoryRevision(orgId, revisionId);
+    return json(revision);
   });
 
   // POST /v1/orgs/{orgId}/memory/history/undo — admin only

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -115,7 +115,7 @@ agent.setTaskRunner(taskRunner);
 const workerManager = new WorkerManagerService(projectRoot);
 
 const orgService = new OrgService(database.adapter, authService);
-const orgMemoryService = new OrgMemoryService();
+const orgMemoryService = new OrgMemoryService(database.adapter);
 
 const systemStatus = new SystemStatusService(
   agent,

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -27,6 +27,9 @@ import { AuthService } from "./services/auth-service";
 import { OrgService } from "./services/org-service";
 import { OrgMemoryService } from "./services/org-memory-service";
 import {
+  mergeOrgMemoryWithApprovedBullet,
+} from "@nakama/agent";
+import {
   createAutomationRunHistoryTools,
   createAutomationTools,
 } from "./tools/automation-tools";
@@ -115,7 +118,17 @@ agent.setTaskRunner(taskRunner);
 const workerManager = new WorkerManagerService(projectRoot);
 
 const orgService = new OrgService(database.adapter, authService);
-const orgMemoryService = new OrgMemoryService(database.adapter);
+const orgMemoryService = new OrgMemoryService(database.adapter, {
+  approvedBulletMerger: {
+    merge(content, bullet, options) {
+      return mergeOrgMemoryWithApprovedBullet(content, bullet, {
+        pin: options.pin,
+        dateUtc: options.dateUtc,
+        provider,
+      });
+    },
+  },
+});
 
 const systemStatus = new SystemStatusService(
   agent,

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -346,7 +346,7 @@ export class AgentService {
 
   private getOrgMemoryService(): OrgMemoryService {
     if (!this.orgMemoryService) {
-      this.orgMemoryService = new OrgMemoryService();
+      this.orgMemoryService = new OrgMemoryService(this.db);
     }
     return this.orgMemoryService;
   }

--- a/apps/server/src/services/org-memory-service.test.ts
+++ b/apps/server/src/services/org-memory-service.test.ts
@@ -159,4 +159,27 @@ describe("OrgMemoryService", () => {
       true,
     );
   });
+
+  test("logs changes and supports undo", async () => {
+    const service = await setup();
+    await service.setMemory("org_a", `${ORG_MEMORY_PREAMBLE}\n\n- first fact\n`, {
+      actorUserId: "admin_user",
+      action: "edit",
+      label: "Initial edit",
+    });
+    await service.setMemory("org_a", `${ORG_MEMORY_PREAMBLE}\n\n- second fact\n`, {
+      actorUserId: "admin_user",
+      action: "edit",
+      label: "Second edit",
+    });
+
+    const history = await service.listHistory("org_a");
+    expect(history).toHaveLength(2);
+    expect(history[0]?.label).toBe("Second edit");
+
+    const restored = await service.undoLastChange("org_a", "admin_user");
+    expect(restored).toContain("- first fact");
+    expect(await service.getMemory("org_a")).toContain("- first fact");
+    expect((await service.listHistory("org_a"))).toHaveLength(3);
+  });
 });

--- a/apps/server/src/services/org-memory-service.test.ts
+++ b/apps/server/src/services/org-memory-service.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 import { ORG_MEMORY_PREAMBLE, parseOrgMemoryContent } from "@nakama/core";
+import { createInMemoryDatabaseAdapter } from "@nakama/db";
 import { OrgMemoryService } from "./org-memory-service";
 
 const originalConfigDir = process.env.NAKAMA_CONFIG_DIR;
@@ -22,10 +23,10 @@ describe("OrgMemoryService", () => {
     }
   });
 
-  async function setup(): Promise<OrgMemoryService> {
+  async function setup(withDb = false): Promise<OrgMemoryService> {
     tempDir = await mkdtemp(path.join(os.tmpdir(), "nakama-org-memory-"));
     process.env.NAKAMA_CONFIG_DIR = tempDir;
-    return new OrgMemoryService();
+    return new OrgMemoryService(withDb ? createInMemoryDatabaseAdapter() : null);
   }
 
   test("getMemory returns the canonical preamble when the file is missing", async () => {
@@ -105,5 +106,57 @@ describe("OrgMemoryService", () => {
     expect(orgB).toBe(`${ORG_MEMORY_PREAMBLE}\n`);
     const orgA = parseOrgMemoryContent(await service.getMemory("org_a"));
     expect(orgA.pinned).toEqual(["org a fact"]);
+  });
+
+  test("propose creates pending row without writing MEMORY.md", async () => {
+    const service = await setup(true);
+    const result = await service.propose("org_a", { bullet: "team standup is 10am UTC" });
+    expect(result.outcome).toBe("created");
+    expect(result.proposalId).toBeTruthy();
+    const memory = parseOrgMemoryContent(await service.getMemory("org_a"));
+    expect(memory.pinned).toEqual([]);
+    expect(memory.sections).toEqual([]);
+    const pending = await service.listProposals("org_a", "pending");
+    expect(pending).toHaveLength(1);
+  });
+
+  test("propose returns already_pending for duplicate bullet", async () => {
+    const service = await setup(true);
+    const first = await service.propose("org_a", { bullet: "shared deploy window" });
+    const second = await service.propose("org_a", { bullet: "shared deploy window" });
+    expect(first.outcome).toBe("created");
+    expect(second.outcome).toBe("already_pending");
+    expect(await service.countPendingProposals("org_a")).toBe(1);
+  });
+
+  test("approve writes to recent-log section by default", async () => {
+    const service = await setup(true);
+    const proposed = await service.propose("org_a", { bullet: "review PRs before lunch" });
+    await service.approveProposal("org_a", proposed.proposalId!, "admin_user");
+    const parsed = parseOrgMemoryContent(await service.getMemory("org_a"));
+    expect(parsed.pinned).toEqual([]);
+    expect(parsed.sections.some((section) => section.bullets.includes("review PRs before lunch"))).toBe(
+      true,
+    );
+  });
+
+  test("approve with pin writes to pinned section and is idempotent", async () => {
+    const service = await setup(true);
+    const proposed = await service.propose("org_a", { bullet: "always pin this" });
+    await service.approveProposal("org_a", proposed.proposalId!, "admin_user", { pin: true });
+    await service.approveProposal("org_a", proposed.proposalId!, "admin_user", { pin: true });
+    const parsed = parseOrgMemoryContent(await service.getMemory("org_a"));
+    expect(parsed.pinned.filter((bullet) => bullet === "always pin this")).toEqual(["always pin this"]);
+  });
+
+  test("search tags pinned and recent-log tiers", async () => {
+    const service = await setup();
+    await service.addFact("org_a", "pinned fact", { pin: true });
+    await service.addRecentLogFact("org_a", "dated fact", "2026-07-31");
+    const result = await service.search("org_a", "fact");
+    expect(result.matches.some((match) => match.tier === "pinned")).toBe(true);
+    expect(result.matches.some((match) => match.tier === "recent-log" && match.date === "2026-07-31")).toBe(
+      true,
+    );
   });
 });

--- a/apps/server/src/services/org-memory-service.test.ts
+++ b/apps/server/src/services/org-memory-service.test.ts
@@ -181,5 +181,10 @@ describe("OrgMemoryService", () => {
     expect(restored).toContain("- first fact");
     expect(await service.getMemory("org_a")).toContain("- first fact");
     expect((await service.listHistory("org_a"))).toHaveLength(3);
+
+    const latest = (await service.listHistory("org_a"))[0]!;
+    const revision = await service.getHistoryRevision("org_a", latest.id);
+    expect(revision.content).toContain("- first fact");
+    expect(revision.change.id).toBe(latest.id);
   });
 });

--- a/apps/server/src/services/org-memory-service.ts
+++ b/apps/server/src/services/org-memory-service.ts
@@ -132,6 +132,16 @@ export class OrgMemoryService {
     return listOrgMemoryHistory(orgId, limit);
   }
 
+  async getHistoryRevision(orgId: string, revisionId: string) {
+    const record = await getOrgMemoryHistoryEntry(orgId, revisionId);
+    if (!record) {
+      throw new NakamaApiError("Org memory history revision not found.", 404);
+    }
+
+    const { content, ...change } = record;
+    return { change, content };
+  }
+
   async restoreHistoryRevision(
     orgId: string,
     revisionId: string,

--- a/apps/server/src/services/org-memory-service.ts
+++ b/apps/server/src/services/org-memory-service.ts
@@ -2,14 +2,21 @@ import { join } from "node:path";
 import {
   NakamaApiError,
   ORG_MEMORY_PREAMBLE,
+  applyApprovedOrgMemoryBullet,
+  appendOrgMemoryHistory,
   composeOrgMemorySummary,
+  createOrgMemoryChangeId,
   detectOrgMemoryInjectionWarnings,
   getOrgMemoryArchiveDir,
   getOrgMemoryDir,
   getOrgMemoryFilePath,
+  getOrgMemoryHistoryEntry,
+  listOrgMemoryHistory,
   normalizeOrgMemoryDedupKey,
   parseOrgMemoryContent,
   rebuildOrgMemoryContent,
+  type OrgMemoryChangeAction,
+  type OrgMemoryChangeLogEntry,
 } from "@nakama/core";
 import {
   pathExists,
@@ -61,8 +68,30 @@ export interface ProposeOrgMemoryInput {
   proposedByUserId?: string | null;
 }
 
+export interface OrgMemoryApprovedBulletMerger {
+  merge(
+    content: string,
+    bullet: string,
+    options: { pin: boolean; dateUtc: string },
+  ): Promise<string | null>;
+}
+
+export interface OrgMemoryServiceOptions {
+  approvedBulletMerger?: OrgMemoryApprovedBulletMerger;
+}
+
+export interface OrgMemoryChangeContext {
+  actorUserId?: string | null;
+  action: OrgMemoryChangeAction;
+  label: string;
+  restoredFromId?: string | null;
+}
+
 export class OrgMemoryService {
-  constructor(private readonly database: DatabaseAdapter | null = null) {}
+  constructor(
+    private readonly database: DatabaseAdapter | null = null,
+    private readonly options: OrgMemoryServiceOptions = {},
+  ) {}
 
   /**
    * Read the live org MEMORY.md. Returns the canonical preamble when the file
@@ -70,7 +99,10 @@ export class OrgMemoryService {
    */
   async getMemory(orgId: string): Promise<string> {
     const existing = await readTextIfExists(getOrgMemoryFilePath(orgId));
-    return existing ?? `${ORG_MEMORY_PREAMBLE}\n`;
+    if (!existing || existing.trim().length === 0) {
+      return `${ORG_MEMORY_PREAMBLE}\n`;
+    }
+    return existing;
   }
 
   /** Render the `## Org Memory` section injected into profile system prompts. */
@@ -80,15 +112,52 @@ export class OrgMemoryService {
   }
 
   /** Replace the entire live MEMORY.md content (admin only). */
-  async setMemory(orgId: string, content: string): Promise<void> {
+  async setMemory(
+    orgId: string,
+    content: string,
+    change?: OrgMemoryChangeContext,
+  ): Promise<void> {
     const trimmed = content.trim();
     if (Buffer.byteLength(trimmed, "utf8") > SUMMARY_BYTE_CAP * 4) {
       throw new NakamaApiError("Org memory content exceeds the size limit.", 400);
     }
     const normalized = trimmed.length > 0 ? `${trimmed.replace(/\n+$/, "")}\n` : `${ORG_MEMORY_PREAMBLE}\n`;
-    await writePrivateTextFile(getOrgMemoryFilePath(orgId), normalized, {
-      ensureDir: getOrgMemoryDir(orgId),
+    await this.commitMemory(orgId, normalized, change ?? {
+      action: "edit",
+      label: "Manual edit",
     });
+  }
+
+  async listHistory(orgId: string, limit?: number): Promise<OrgMemoryChangeLogEntry[]> {
+    return listOrgMemoryHistory(orgId, limit);
+  }
+
+  async restoreHistoryRevision(
+    orgId: string,
+    revisionId: string,
+    actorUserId: string,
+  ): Promise<string> {
+    const record = await getOrgMemoryHistoryEntry(orgId, revisionId);
+    if (!record) {
+      throw new NakamaApiError("Org memory history revision not found.", 404);
+    }
+
+    await this.commitMemory(orgId, record.content, {
+      actorUserId,
+      action: "restore",
+      label: `Restored snapshot from ${new Date(record.createdAt).toLocaleString()}`,
+      restoredFromId: revisionId,
+    });
+    return record.content;
+  }
+
+  async undoLastChange(orgId: string, actorUserId: string): Promise<string> {
+    const history = await listOrgMemoryHistory(orgId, 2);
+    if (history.length < 2) {
+      throw new NakamaApiError("No previous org memory revision to restore.", 404);
+    }
+
+    return this.restoreHistoryRevision(orgId, history[1]!.id, actorUserId);
   }
 
   /**
@@ -96,7 +165,11 @@ export class OrgMemoryService {
    * with the canonical preamble if it is missing. Idempotent — adding a
    * bullet that is already pinned is a no-op.
    */
-  async addFact(orgId: string, bullet: string, options: { pin?: boolean } = {}): Promise<void> {
+  async addFact(
+    orgId: string,
+    bullet: string,
+    options: { pin?: boolean; change?: OrgMemoryChangeContext } = {},
+  ): Promise<void> {
     const text = this.normalizeBullet(bullet);
     const content = await this.getMemory(orgId);
     const parsed = parseOrgMemoryContent(content);
@@ -105,35 +178,34 @@ export class OrgMemoryService {
       return;
     }
 
-    parsed.pinned.push(text);
-    await this.writeMemory(orgId, rebuildOrgMemoryContent(parsed));
+    const next = applyApprovedOrgMemoryBullet(content, text, { pin: true });
+    await this.commitMemory(orgId, next, options.change ?? {
+      action: "add_fact",
+      label: `Added fact: ${truncateLabel(text)}`,
+    });
   }
 
-  async addRecentLogFact(orgId: string, bullet: string, dateUtc: string): Promise<void> {
+  async addRecentLogFact(
+    orgId: string,
+    bullet: string,
+    dateUtc: string,
+    change?: OrgMemoryChangeContext,
+  ): Promise<void> {
     const text = this.normalizeBullet(bullet);
     const content = await this.getMemory(orgId);
-    const parsed = parseOrgMemoryContent(content);
-
-    if (this.bulletExistsInMemory(parsed, text)) {
+    const parsedBefore = parseOrgMemoryContent(content);
+    if (this.bulletExistsInMemory(parsedBefore, text)) {
       return;
     }
-
-    let section = parsed.sections.find((entry) => entry.date === dateUtc);
-    if (!section) {
-      section = { date: dateUtc, bullets: [] };
-      parsed.sections.push(section);
-      parsed.sections.sort((a, b) => a.date.localeCompare(b.date));
-    }
-
-    if (!section.bullets.some((existing) => existing.trim() === text)) {
-      section.bullets.push(text);
-    }
-
-    await this.writeMemory(orgId, rebuildOrgMemoryContent(parsed));
+    const next = applyApprovedOrgMemoryBullet(content, text, { pin: false, dateUtc });
+    await this.commitMemory(orgId, next, change ?? {
+      action: "add_fact",
+      label: `Added recent log fact: ${truncateLabel(text)}`,
+    });
   }
 
   /** Pin an existing bullet (move to pinned if dated, or add). */
-  async pinFact(orgId: string, bullet: string): Promise<void> {
+  async pinFact(orgId: string, bullet: string, change?: OrgMemoryChangeContext): Promise<void> {
     const text = this.normalizeBullet(bullet);
     const content = await this.getMemory(orgId);
     const parsed = parseOrgMemoryContent(content);
@@ -150,11 +222,14 @@ export class OrgMemoryService {
     }
 
     parsed.pinned.push(text);
-    await this.writeMemory(orgId, rebuildOrgMemoryContent(parsed));
+    await this.commitMemory(orgId, rebuildOrgMemoryContent(parsed), change ?? {
+      action: "pin",
+      label: `Pinned fact: ${truncateLabel(text)}`,
+    });
   }
 
   /** Remove a bullet from the pinned section. 404 if it is not pinned. */
-  async unpinFact(orgId: string, bullet: string): Promise<void> {
+  async unpinFact(orgId: string, bullet: string, change?: OrgMemoryChangeContext): Promise<void> {
     const text = this.normalizeBullet(bullet);
     const content = await this.getMemory(orgId);
     const parsed = parseOrgMemoryContent(content);
@@ -164,13 +239,16 @@ export class OrgMemoryService {
       throw new NakamaApiError("Pinned fact not found.", 404);
     }
     parsed.pinned.splice(index, 1);
-    await this.writeMemory(orgId, rebuildOrgMemoryContent(parsed));
+    await this.commitMemory(orgId, rebuildOrgMemoryContent(parsed), change ?? {
+      action: "unpin",
+      label: `Unpinned fact: ${truncateLabel(text)}`,
+    });
   }
 
   async archiveEntries(
     orgId: string,
     entries: string[],
-    options: { reason?: string; archivedAt?: Date } = {},
+    options: { reason?: string; archivedAt?: Date; change?: OrgMemoryChangeContext } = {},
   ) {
     const targets = new Set(
       entries.map((e) => e.trim().replace(/^-\s+/, "").trim()).filter(Boolean),
@@ -229,8 +307,9 @@ export class OrgMemoryService {
       sections: parsed.sections,
     });
     await writePrivateTextFile(archivePath, archiveContent, { ensureDir: archiveDir });
-    await writePrivateTextFile(getOrgMemoryFilePath(orgId), activeContent, {
-      ensureDir: getOrgMemoryDir(orgId),
+    await this.commitMemory(orgId, activeContent, options.change ?? {
+      action: "archive",
+      label: `Archived ${archived.length} pinned ${archived.length === 1 ? "fact" : "facts"}`,
     });
 
     return {
@@ -337,11 +416,25 @@ export class OrgMemoryService {
     }
 
     const pin = options.pin ?? false;
-    if (pin) {
-      await this.addFact(orgId, proposal.bullet, { pin: true });
-    } else {
-      await this.addRecentLogFact(orgId, proposal.bullet, utcDateString());
+    const dateUtc = utcDateString();
+    const content = await this.getMemory(orgId);
+
+    let next = applyApprovedOrgMemoryBullet(content, proposal.bullet, { pin, dateUtc });
+    if (this.options.approvedBulletMerger) {
+      const merged = await this.options.approvedBulletMerger.merge(content, proposal.bullet, {
+        pin,
+        dateUtc,
+      });
+      if (merged) {
+        next = merged;
+      }
     }
+
+    await this.commitMemory(orgId, next, {
+      actorUserId: reviewerUserId,
+      action: "approve",
+      label: `Approved proposal: ${truncateLabel(proposal.bullet)}`,
+    });
 
     const reviewedAt = new Date().toISOString();
     await db.updateOrgMemoryProposalStatus(orgId, proposalId, {
@@ -498,13 +591,41 @@ export class OrgMemoryService {
     return this.database;
   }
 
-  private async writeMemory(orgId: string, content: string): Promise<void> {
+  private async commitMemory(
+    orgId: string,
+    content: string,
+    change: OrgMemoryChangeContext,
+  ): Promise<void> {
+    const current = await this.getMemory(orgId);
+    if (current === content) {
+      return;
+    }
+
     await writePrivateTextFile(getOrgMemoryFilePath(orgId), content, {
       ensureDir: getOrgMemoryDir(orgId),
     });
+
+    const entry: OrgMemoryChangeLogEntry = {
+      id: createOrgMemoryChangeId(),
+      orgId,
+      createdAt: new Date().toISOString(),
+      actorUserId: change.actorUserId ?? null,
+      action: change.action,
+      label: change.label,
+      restoredFromId: change.restoredFromId ?? null,
+    };
+    await appendOrgMemoryHistory(orgId, entry, content);
   }
 }
 
 function utcDateString(date = new Date()): string {
   return date.toISOString().slice(0, 10);
+}
+
+function truncateLabel(value: string, maxLength = 80): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= maxLength) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, maxLength - 1).trimEnd()}…`;
 }

--- a/apps/server/src/services/org-memory-service.ts
+++ b/apps/server/src/services/org-memory-service.ts
@@ -3,9 +3,11 @@ import {
   NakamaApiError,
   ORG_MEMORY_PREAMBLE,
   composeOrgMemorySummary,
+  detectOrgMemoryInjectionWarnings,
   getOrgMemoryArchiveDir,
   getOrgMemoryDir,
   getOrgMemoryFilePath,
+  normalizeOrgMemoryDedupKey,
   parseOrgMemoryContent,
   rebuildOrgMemoryContent,
 } from "@nakama/core";
@@ -16,16 +18,22 @@ import {
   readTextIfExists,
   writePrivateTextFile,
 } from "@nakama/core/fs";
+import type { DatabaseAdapter, StoredOrgMemoryProposal } from "@nakama/db";
 
 const SUMMARY_BYTE_CAP = 2048;
+const MAX_PROPOSAL_BULLET_LENGTH = 500;
 
 export interface OrgMemoryContent {
   content: string;
 }
 
+export type OrgMemorySearchTier = "pinned" | "recent-log" | "archive";
+
 export interface OrgMemorySearchMatch {
   source: "live" | string;
   bullet: string;
+  tier: OrgMemorySearchTier;
+  date?: string;
 }
 
 export interface OrgMemorySearchResult {
@@ -33,7 +41,29 @@ export interface OrgMemorySearchResult {
   matches: OrgMemorySearchMatch[];
 }
 
+export type ProposeOrgMemoryOutcome =
+  | "created"
+  | "already_pending"
+  | "already_pinned"
+  | "already_in_recent_log";
+
+export interface ProposeOrgMemoryResult {
+  outcome: ProposeOrgMemoryOutcome;
+  proposalId?: string;
+  message: string;
+  warnings?: string[];
+}
+
+export interface ProposeOrgMemoryInput {
+  bullet: string;
+  profileId?: string | null;
+  sessionId?: string | null;
+  proposedByUserId?: string | null;
+}
+
 export class OrgMemoryService {
+  constructor(private readonly database: DatabaseAdapter | null = null) {}
+
   /**
    * Read the live org MEMORY.md. Returns the canonical preamble when the file
    * does not yet exist (so callers always get a usable string).
@@ -79,15 +109,46 @@ export class OrgMemoryService {
     await this.writeMemory(orgId, rebuildOrgMemoryContent(parsed));
   }
 
-  /** Pin an existing bullet (move to pinned if dated, or add). 404 if not found and not adding. */
+  async addRecentLogFact(orgId: string, bullet: string, dateUtc: string): Promise<void> {
+    const text = this.normalizeBullet(bullet);
+    const content = await this.getMemory(orgId);
+    const parsed = parseOrgMemoryContent(content);
+
+    if (this.bulletExistsInMemory(parsed, text)) {
+      return;
+    }
+
+    let section = parsed.sections.find((entry) => entry.date === dateUtc);
+    if (!section) {
+      section = { date: dateUtc, bullets: [] };
+      parsed.sections.push(section);
+      parsed.sections.sort((a, b) => a.date.localeCompare(b.date));
+    }
+
+    if (!section.bullets.some((existing) => existing.trim() === text)) {
+      section.bullets.push(text);
+    }
+
+    await this.writeMemory(orgId, rebuildOrgMemoryContent(parsed));
+  }
+
+  /** Pin an existing bullet (move to pinned if dated, or add). */
   async pinFact(orgId: string, bullet: string): Promise<void> {
     const text = this.normalizeBullet(bullet);
     const content = await this.getMemory(orgId);
     const parsed = parseOrgMemoryContent(content);
 
     if (parsed.pinned.some((existing) => existing.trim() === text)) {
-      return; // already pinned
+      return;
     }
+
+    for (const section of parsed.sections) {
+      const index = section.bullets.findIndex((existing) => existing.trim() === text);
+      if (index !== -1) {
+        section.bullets.splice(index, 1);
+      }
+    }
+
     parsed.pinned.push(text);
     await this.writeMemory(orgId, rebuildOrgMemoryContent(parsed));
   }
@@ -106,12 +167,6 @@ export class OrgMemoryService {
     await this.writeMemory(orgId, rebuildOrgMemoryContent(parsed));
   }
 
-  /**
-   * Archive pinned bullets out of the live file into memory-archive/YYYY-MM.md.
-   * Uses the org (pinned-aware) parser rather than the profile dated-section
-   * parser, since org memory v1 is pinned-only. Throws if an entry is not
-   * pinned or no entries match.
-   */
   async archiveEntries(
     orgId: string,
     entries: string[],
@@ -153,9 +208,7 @@ export class OrgMemoryService {
     const yearMonth = `${archivedAt.getFullYear()}-${String(archivedAt.getMonth() + 1).padStart(2, "0")}`;
     const archiveDir = getOrgMemoryArchiveDir(orgId);
     const archivePath = join(archiveDir, `${yearMonth}.md`);
-    const appendLines = [
-      `<!-- archived: ${archivedAt.toISOString()} -->`,
-    ];
+    const appendLines = [`<!-- archived: ${archivedAt.toISOString()} -->`];
     if (options.reason?.trim()) {
       appendLines.push(`<!-- reason: ${options.reason.trim().replace(/-->/g, "")} -->`);
     }
@@ -170,7 +223,11 @@ export class OrgMemoryService {
       ? `${(await readText(archivePath)).replace(/\n+$/, "")}\n\n${append}`
       : `# Archived Org Memory\n\n---\n\n${append}`;
 
-    const activeContent = rebuildOrgMemoryContent({ preamble: parsed.preamble, pinned: kept });
+    const activeContent = rebuildOrgMemoryContent({
+      preamble: parsed.preamble,
+      pinned: kept,
+      sections: parsed.sections,
+    });
     await writePrivateTextFile(archivePath, archiveContent, { ensureDir: archiveDir });
     await writePrivateTextFile(getOrgMemoryFilePath(orgId), activeContent, {
       ensureDir: getOrgMemoryDir(orgId),
@@ -180,6 +237,158 @@ export class OrgMemoryService {
       archived: archived.length,
       activeBytes: Buffer.byteLength(activeContent, "utf8"),
       archivePath,
+    };
+  }
+
+  async listProposals(
+    orgId: string,
+    status?: StoredOrgMemoryProposal["status"],
+  ): Promise<StoredOrgMemoryProposal[]> {
+    return this.requireDatabase().listOrgMemoryProposals(orgId, status);
+  }
+
+  async countPendingProposals(orgId: string): Promise<number> {
+    return this.requireDatabase().countOrgMemoryProposals(orgId, "pending");
+  }
+
+  async getProposal(orgId: string, proposalId: string): Promise<StoredOrgMemoryProposal> {
+    const proposal = await this.requireDatabase().getOrgMemoryProposal(orgId, proposalId);
+    if (!proposal) {
+      throw new NakamaApiError("Org memory proposal not found.", 404);
+    }
+    return proposal;
+  }
+
+  async propose(orgId: string, input: ProposeOrgMemoryInput): Promise<ProposeOrgMemoryResult> {
+    const text = this.normalizeProposalBullet(input.bullet);
+    const warnings = detectOrgMemoryInjectionWarnings(text);
+    const content = await this.getMemory(orgId);
+    const parsed = parseOrgMemoryContent(content);
+    const dedupKey = normalizeOrgMemoryDedupKey(text);
+    const db = this.requireDatabase();
+
+    if (parsed.pinned.some((bullet) => normalizeOrgMemoryDedupKey(bullet) === dedupKey)) {
+      return {
+        outcome: "already_pinned",
+        message: "This is already in org memory (pinned).",
+      };
+    }
+
+    if (
+      parsed.sections.some((section) =>
+        section.bullets.some((bullet) => normalizeOrgMemoryDedupKey(bullet) === dedupKey),
+      )
+    ) {
+      return {
+        outcome: "already_in_recent_log",
+        message: "This is already in org memory (recent log).",
+      };
+    }
+
+    const pending = await db.getPendingOrgMemoryProposalByBullet(orgId, text);
+    if (pending) {
+      return {
+        outcome: "already_pending",
+        proposalId: pending.id,
+        message: "This fact is already awaiting admin approval.",
+        warnings: warnings.length > 0 ? warnings : undefined,
+      };
+    }
+
+    const now = new Date().toISOString();
+    const proposal: StoredOrgMemoryProposal = {
+      id: `prop_${crypto.randomUUID().replace(/-/g, "")}`,
+      orgId,
+      profileId: input.profileId ?? null,
+      sessionId: input.sessionId ?? null,
+      proposedByUserId: input.proposedByUserId ?? null,
+      bullet: text,
+      status: "pending",
+      pinned: false,
+      reviewerUserId: null,
+      reviewedAt: null,
+      createdAt: now,
+    };
+    await db.createOrgMemoryProposal(proposal);
+
+    return {
+      outcome: "created",
+      proposalId: proposal.id,
+      message: `Recorded for admin review (proposal ${proposal.id}).`,
+      warnings: warnings.length > 0 ? warnings : undefined,
+    };
+  }
+
+  async approveProposal(
+    orgId: string,
+    proposalId: string,
+    reviewerUserId: string,
+    options: { pin?: boolean } = {},
+  ): Promise<StoredOrgMemoryProposal> {
+    const db = this.requireDatabase();
+    const proposal = await this.getProposal(orgId, proposalId);
+
+    if (proposal.status === "approved") {
+      return proposal;
+    }
+
+    if (proposal.status !== "pending") {
+      throw new NakamaApiError("Only pending proposals can be approved.", 400);
+    }
+
+    const pin = options.pin ?? false;
+    if (pin) {
+      await this.addFact(orgId, proposal.bullet, { pin: true });
+    } else {
+      await this.addRecentLogFact(orgId, proposal.bullet, utcDateString());
+    }
+
+    const reviewedAt = new Date().toISOString();
+    await db.updateOrgMemoryProposalStatus(orgId, proposalId, {
+      status: "approved",
+      reviewerUserId,
+      reviewedAt,
+      pinned: pin,
+    });
+
+    return {
+      ...proposal,
+      status: "approved",
+      reviewerUserId,
+      reviewedAt,
+      pinned: pin,
+    };
+  }
+
+  async rejectProposal(
+    orgId: string,
+    proposalId: string,
+    reviewerUserId: string,
+  ): Promise<StoredOrgMemoryProposal> {
+    const db = this.requireDatabase();
+    const proposal = await this.getProposal(orgId, proposalId);
+
+    if (proposal.status === "rejected") {
+      return proposal;
+    }
+
+    if (proposal.status !== "pending") {
+      throw new NakamaApiError("Only pending proposals can be rejected.", 400);
+    }
+
+    const reviewedAt = new Date().toISOString();
+    await db.updateOrgMemoryProposalStatus(orgId, proposalId, {
+      status: "rejected",
+      reviewerUserId,
+      reviewedAt,
+      pinned: false,
+    });
+
+    return {
+      ...proposal,
+      status: "rejected",
+      reviewerUserId,
+      reviewedAt,
     };
   }
 
@@ -194,9 +403,22 @@ export class OrgMemoryService {
 
     const live = await readTextIfExists(getOrgMemoryFilePath(orgId));
     if (live) {
-      for (const bullet of this.collectBullets(live)) {
+      const parsed = parseOrgMemoryContent(live);
+      for (const bullet of parsed.pinned) {
         if (bullet.toLowerCase().includes(normalizedQuery)) {
-          matches.push({ source: "live", bullet });
+          matches.push({ source: "live", bullet, tier: "pinned" });
+        }
+      }
+      for (const section of parsed.sections) {
+        for (const bullet of section.bullets) {
+          if (bullet.toLowerCase().includes(normalizedQuery)) {
+            matches.push({
+              source: "live",
+              bullet,
+              tier: "recent-log",
+              date: section.date,
+            });
+          }
         }
       }
     }
@@ -210,9 +432,9 @@ export class OrgMemoryService {
         .sort();
       for (const filename of files) {
         const archiveContent = await readText(join(archiveDir, filename));
-        for (const bullet of this.collectBullets(archiveContent)) {
+        for (const bullet of this.collectArchiveBullets(archiveContent)) {
           if (bullet.toLowerCase().includes(normalizedQuery)) {
-            matches.push({ source: filename, bullet });
+            matches.push({ source: filename, bullet, tier: "archive" });
           }
         }
       }
@@ -221,7 +443,20 @@ export class OrgMemoryService {
     return { query, matches };
   }
 
-  private collectBullets(content: string): string[] {
+  private bulletExistsInMemory(
+    parsed: ReturnType<typeof parseOrgMemoryContent>,
+    text: string,
+  ): boolean {
+    const dedupKey = normalizeOrgMemoryDedupKey(text);
+    if (parsed.pinned.some((bullet) => normalizeOrgMemoryDedupKey(bullet) === dedupKey)) {
+      return true;
+    }
+    return parsed.sections.some((section) =>
+      section.bullets.some((bullet) => normalizeOrgMemoryDedupKey(bullet) === dedupKey),
+    );
+  }
+
+  private collectArchiveBullets(content: string): string[] {
     const bullets: string[] = [];
     for (const line of content.split("\n")) {
       if (line.startsWith("- ")) {
@@ -239,9 +474,37 @@ export class OrgMemoryService {
     return text;
   }
 
+  private normalizeProposalBullet(bullet: string): string {
+    const text = this.normalizeBullet(bullet);
+    if (text.length > MAX_PROPOSAL_BULLET_LENGTH) {
+      throw new NakamaApiError(
+        `Memory bullet exceeds the ${MAX_PROPOSAL_BULLET_LENGTH} character limit.`,
+        400,
+      );
+    }
+    if (text.includes("\n\n")) {
+      throw new NakamaApiError("Memory bullet must not contain multiple blank lines.", 400);
+    }
+    if (/^##\s/m.test(text)) {
+      throw new NakamaApiError("Memory bullet must not contain markdown headings.", 400);
+    }
+    return text;
+  }
+
+  private requireDatabase(): DatabaseAdapter {
+    if (!this.database) {
+      throw new NakamaApiError("Org memory proposals are not configured.", 500);
+    }
+    return this.database;
+  }
+
   private async writeMemory(orgId: string, content: string): Promise<void> {
     await writePrivateTextFile(getOrgMemoryFilePath(orgId), content, {
       ensureDir: getOrgMemoryDir(orgId),
     });
   }
+}
+
+function utcDateString(date = new Date()): string {
+  return date.toISOString().slice(0, 10);
 }

--- a/apps/server/src/tools/org-memory-tools.test.ts
+++ b/apps/server/src/tools/org-memory-tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { ToolContext } from "@nakama/core";
+import { createInMemoryDatabaseAdapter } from "@nakama/db";
 import { OrgMemoryService } from "../services/org-memory-service";
 import { createOrgMemoryTools } from "./org-memory-tools";
 
@@ -13,7 +14,10 @@ describe("org memory tools", () => {
     const spy = spyOnSearch(service, "org_a", "Bun");
     const [searchTool] = createOrgMemoryTools(service);
     const result = await searchTool.run({ query: "Bun" }, context("org_a", "member"));
-    expect(result).toEqual({ query: "Bun", matches: [{ source: "live", bullet: "we use Bun" }] });
+    expect(result).toEqual({
+      query: "Bun",
+      matches: [{ source: "live", bullet: "we use Bun", tier: "pinned" }],
+    });
     expect(spy.orgId).toBe("org_a");
     expect(spy.query).toBe("Bun");
   });
@@ -56,6 +60,24 @@ describe("org memory tools", () => {
     const result = await listTool.run({}, context("org_a", "member"));
     expect(result).toHaveProperty("content");
   });
+
+  test("propose_org_memory as member creates a proposal", async () => {
+    const service = new OrgMemoryService(createInMemoryDatabaseAdapter());
+    const proposeTool = createOrgMemoryTools(service)[2];
+    const result = await proposeTool.run(
+      { bullet: "standups are at 10am UTC" },
+      { ...context("org_a", "member"), profileId: "profile_1", sessionId: "session_1", userId: "user_1" },
+    );
+    expect(result.outcome).toBe("created");
+  });
+
+  test("propose_org_memory as viewer throws", async () => {
+    const service = new OrgMemoryService(createInMemoryDatabaseAdapter());
+    const proposeTool = createOrgMemoryTools(service)[2];
+    await expect(
+      proposeTool.run({ bullet: "fact" }, context("org_a", "viewer")),
+    ).rejects.toThrow("Viewers cannot access org memory.");
+  });
 });
 
 function spyOnSearch(
@@ -67,7 +89,7 @@ function spyOnSearch(
   service.search = (async (orgId: string, query: string) => {
     captured.orgId = orgId;
     captured.query = query;
-    return { query, matches: [{ source: "live", bullet: "we use Bun" }] };
+    return { query, matches: [{ source: "live", bullet: "we use Bun", tier: "pinned" as const }] };
   }) as OrgMemoryService["search"];
   void expectedOrgId;
   void expectedQuery;

--- a/apps/server/src/tools/org-memory-tools.ts
+++ b/apps/server/src/tools/org-memory-tools.ts
@@ -40,16 +40,12 @@ function readString(input: unknown, key: string): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
-/**
- * Build the org-memory tools bound to a service instance. v1 ships only the
- * search tool; the propose tool is deferred to v2.
- */
 export function createOrgMemoryTools(service: OrgMemoryService): ToolDefinition[] {
   return [
     {
       name: "org_memory_search",
       description:
-        "Search the organization's shared memory (pinned facts plus the full archive) for facts relevant to the query. Use this when the injected org memory summary is missing detail or when you need the full history.",
+        "Search the organization's shared memory (pinned facts, recent dated log, and archives) for facts relevant to the query. Use this when the injected org memory summary is missing detail or when you need the full history.",
       parameters: {
         type: "object",
         properties: {
@@ -73,12 +69,42 @@ export function createOrgMemoryTools(service: OrgMemoryService): ToolDefinition[
     {
       name: "org_memory_list",
       description:
-        "List the organization's pinned facts (the live org memory). Returns the current pinned bullets.",
+        "List the organization's live org memory markdown (pinned and recent-log sections). Returns the current MEMORY.md content.",
       parameters: emptyObjectSchema(),
       async run(_input, context: ToolContext) {
         const { orgId } = requireOrgMemoryAccess(context);
         const content = await service.getMemory(orgId);
         return { content };
+      },
+    },
+    {
+      name: "propose_org_memory",
+      description:
+        "Propose a durable org-wide fact (team conventions, policies, shared context) for admin approval. Never propose secrets, credentials, API keys, tokens, or PII. Facts require admin approval before appearing in org memory. Do not re-propose if the tool reports the fact is already pending, pinned, or in the recent log.",
+      parameters: {
+        type: "object",
+        properties: {
+          bullet: {
+            type: "string",
+            description: "A single concise org-wide fact to propose for admin review.",
+          },
+        },
+        required: ["bullet"],
+        additionalProperties: false,
+      },
+      parallelSafe: false,
+      async run(input, context: ToolContext) {
+        const { orgId } = requireOrgMemoryAccess(context);
+        const bullet = readString(input, "bullet");
+        if (!bullet) {
+          throw new Error("bullet is required.");
+        }
+        return service.propose(orgId, {
+          bullet,
+          profileId: context.profileId ?? null,
+          sessionId: context.sessionId ?? null,
+          proposedByUserId: context.userId ?? null,
+        });
       },
     },
   ];

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -14,6 +14,7 @@ import { ChatPage } from "@/pages/ChatPage";
 import { HistoryPage } from "@/pages/HistoryPage";
 import { IntegrationsPage } from "@/pages/IntegrationsPage";
 import { LoginPage } from "@/pages/LoginPage";
+import { NotificationsPage } from "@/pages/NotificationsPage";
 import { ProfilesPage } from "@/pages/ProfilesPage";
 import { SettingsPage } from "@/pages/SettingsPage";
 import { SetupWizardPage } from "@/pages/SetupWizardPage";
@@ -58,6 +59,7 @@ function AppShell() {
                   <Route path="/automations" element={<AutomationsPage />} />
                   <Route path="/tasks" element={<TasksPage />} />
                   <Route path="/integrations" element={<IntegrationsPage />} />
+                  <Route path="/notifications" element={<NotificationsPage />} />
                   <Route path="/settings" element={<SettingsPage />} />
                   <Route path="*" element={<Navigate to="/chat" replace />} />
                 </Route>

--- a/apps/web/src/components/ProfileRail.tsx
+++ b/apps/web/src/components/ProfileRail.tsx
@@ -1,4 +1,5 @@
 import { useLocation, useNavigate } from "react-router-dom";
+import { SidebarNotifications } from "@/components/SidebarNotifications";
 import { SidebarUserMenu } from "@/components/SidebarUserMenu";
 import { ProfileAdminPlusButton } from "@/components/ProfileAdminPlusButton";
 import { ProfileAvatar } from "@/components/ProfileAvatar";
@@ -125,7 +126,8 @@ export function ProfileRail() {
         ) : null}
       </div>
 
-      <div className="flex shrink-0 flex-col items-center">
+      <div className="flex shrink-0 flex-col items-center gap-1">
+        <SidebarNotifications />
         <SidebarUserMenu />
       </div>
     </div>

--- a/apps/web/src/components/SidebarNotifications.tsx
+++ b/apps/web/src/components/SidebarNotifications.tsx
@@ -28,17 +28,21 @@ export function SidebarNotifications() {
       }
       className="relative flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-sidebar-accent/55 hover:text-foreground"
     >
-      <BellIcon className="size-4" strokeWidth={1.75} aria-hidden />
-      {showBadge ? (
-        <span
-          className="absolute right-0 top-0 inline-flex h-[18px] min-w-[18px] translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border-2 border-sidebar bg-primary px-1 text-[10px] font-bold leading-none tabular-nums text-primary-foreground"
-          aria-hidden
-        >
-          {badgeLabel}
-        </span>
-      ) : null}
+      <span className="relative shrink-0">
+        <BellIcon className="size-4" strokeWidth={1.75} aria-hidden />
+        {showBadge ? (
+          <span
+            className="absolute -right-1 -top-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full border-2 border-sidebar bg-primary px-0.5 text-[9px] font-bold leading-none tabular-nums text-primary-foreground"
+            aria-hidden
+          >
+            {badgeLabel}
+          </span>
+        ) : null}
+      </span>
     </button>
   );
+
+  const isEmpty = !isLoading && items.length === 0;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -56,37 +60,38 @@ export function SidebarNotifications() {
       </Tooltip>
 
       <PopoverContent side="right" align="end" sideOffset={8} className="w-72 p-1">
-        <div className="border-b border-border px-1.5 py-1.5">
-          <p className="text-sm font-medium leading-tight text-foreground">Notifications</p>
-          <p className="text-[11px] leading-tight text-muted-foreground">
-            Automation runs and org memory proposals
-          </p>
-        </div>
+        {isEmpty ? (
+          <p className="px-2 py-3 text-center text-xs text-muted-foreground">All caught up</p>
+        ) : (
+          <>
+            <div className="border-b border-border px-1.5 py-1.5">
+              <p className="text-sm font-medium leading-tight text-foreground">Notifications</p>
+              <p className="text-[11px] leading-tight text-muted-foreground">
+                Automation runs and org memory proposals
+              </p>
+            </div>
 
-        <div className="max-h-72 overflow-y-auto">
-          {isLoading ? (
-            <p className="px-1.5 py-2 text-xs text-muted-foreground">Loading…</p>
-          ) : (
-            <NotificationList
-              items={items}
-              compact
-              onNavigate={() => setOpen(false)}
-              emptyMessage="You're all caught up."
-            />
-          )}
-        </div>
+            <div className="max-h-72 overflow-y-auto">
+              {isLoading ? (
+                <p className="px-1.5 py-2 text-xs text-muted-foreground">Loading…</p>
+              ) : (
+                <NotificationList items={items} compact onNavigate={() => setOpen(false)} />
+              )}
+            </div>
 
-        <div className="border-t border-border px-1.5 py-1">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-7 w-full justify-center text-xs"
-            render={<Link to={PAGE_PATHS.notifications} onClick={() => setOpen(false)} />}
-          >
-            View all
-          </Button>
-        </div>
+            <div className="border-t border-border px-1.5 py-1">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 w-full justify-center text-xs"
+                render={<Link to={PAGE_PATHS.notifications} onClick={() => setOpen(false)} />}
+              >
+                View all
+              </Button>
+            </div>
+          </>
+        )}
       </PopoverContent>
     </Popover>
   );

--- a/apps/web/src/components/SidebarNotifications.tsx
+++ b/apps/web/src/components/SidebarNotifications.tsx
@@ -64,7 +64,7 @@ export function SidebarNotifications() {
           <p className="px-2 py-3 text-center text-xs text-muted-foreground">All caught up</p>
         ) : (
           <>
-            <div className="border-b border-border px-1.5 py-1.5">
+            <div className="px-1.5 py-1.5">
               <p className="text-sm font-medium leading-tight text-foreground">Notifications</p>
               <p className="text-[11px] leading-tight text-muted-foreground">
                 Automation runs and org memory proposals
@@ -79,7 +79,7 @@ export function SidebarNotifications() {
               )}
             </div>
 
-            <div className="border-t border-border px-1.5 py-1">
+            <div className="px-1.5 pb-1 pt-0.5">
               <Button
                 type="button"
                 variant="ghost"

--- a/apps/web/src/components/SidebarNotifications.tsx
+++ b/apps/web/src/components/SidebarNotifications.tsx
@@ -1,0 +1,93 @@
+import { BellIcon } from "lucide-react";
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { NotificationList } from "@/components/notifications/notification-list";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useNotifications } from "@/hooks/use-notifications";
+import { PAGE_PATHS } from "@/lib/navigation";
+
+export function SidebarNotifications() {
+  const [open, setOpen] = useState(false);
+  const { items, totalCount, isLoading } = useNotifications();
+  const showBadge = totalCount > 0;
+  const badgeLabel = totalCount > 99 ? "99+" : String(totalCount);
+
+  const trigger = (
+    <button
+      type="button"
+      aria-label={
+        showBadge
+          ? `Notifications, ${totalCount} unread`
+          : "Notifications"
+      }
+      className="relative flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-sidebar-accent/55 hover:text-foreground"
+    >
+      <BellIcon className="size-4" strokeWidth={1.75} aria-hidden />
+      {showBadge ? (
+        <span
+          className="absolute right-0 top-0 inline-flex h-[18px] min-w-[18px] translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border-2 border-sidebar bg-primary px-1 text-[10px] font-bold leading-none tabular-nums text-primary-foreground"
+          aria-hidden
+        >
+          {badgeLabel}
+        </span>
+      ) : null}
+    </button>
+  );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <span className="inline-flex">
+              <PopoverTrigger render={trigger} />
+            </span>
+          }
+        />
+        <TooltipContent side="right" sideOffset={8}>
+          {showBadge ? `Notifications (${totalCount})` : "Notifications"}
+        </TooltipContent>
+      </Tooltip>
+
+      <PopoverContent side="right" align="end" sideOffset={8} className="w-72 p-1">
+        <div className="border-b border-border px-1.5 py-1.5">
+          <p className="text-sm font-medium leading-tight text-foreground">Notifications</p>
+          <p className="text-[11px] leading-tight text-muted-foreground">
+            Automation runs and org memory proposals
+          </p>
+        </div>
+
+        <div className="max-h-72 overflow-y-auto">
+          {isLoading ? (
+            <p className="px-1.5 py-2 text-xs text-muted-foreground">Loading…</p>
+          ) : (
+            <NotificationList
+              items={items}
+              compact
+              onNavigate={() => setOpen(false)}
+              emptyMessage="You're all caught up."
+            />
+          )}
+        </div>
+
+        <div className="border-t border-border px-1.5 py-1">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 w-full justify-center text-xs"
+            render={<Link to={PAGE_PATHS.notifications} onClick={() => setOpen(false)} />}
+          >
+            View all
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/notifications/notification-list.tsx
+++ b/apps/web/src/components/notifications/notification-list.tsx
@@ -38,8 +38,8 @@ export function NotificationListItem({
       to={item.href}
       onClick={onNavigate}
       className={cn(
-        "flex gap-2 rounded-md transition-colors hover:bg-muted/60",
-        compact ? "px-1.5 py-1.5" : "border border-border px-3 py-3",
+        "flex rounded-md transition-colors hover:bg-muted/60",
+        compact ? "gap-2.5 px-2 py-2" : "gap-2 border border-border px-3 py-3",
       )}
     >
       <NotificationIcon kind={item.kind} size={compact ? "sm" : "md"} />
@@ -72,7 +72,7 @@ export function NotificationListItem({
         <p
           className={cn(
             "text-muted-foreground",
-            compact ? "mt-0.5 line-clamp-2 text-xs leading-snug" : "mt-1.5 text-sm leading-relaxed",
+            compact ? "mt-1 line-clamp-2 text-xs leading-snug" : "mt-1.5 text-sm leading-relaxed",
           )}
         >
           {item.description}
@@ -98,7 +98,7 @@ export function NotificationList({
   }
 
   return (
-    <div className={cn(compact ? "space-y-0" : "space-y-2")}>
+    <div className={cn(compact ? "space-y-1 py-0.5" : "space-y-2")}>
       {items.map((item) => (
         <NotificationListItem
           key={item.id}

--- a/apps/web/src/components/notifications/notification-list.tsx
+++ b/apps/web/src/components/notifications/notification-list.tsx
@@ -1,0 +1,112 @@
+import { BrainIcon, WorkflowIcon } from "lucide-react";
+import { Link } from "react-router-dom";
+import type { NotificationItem } from "@/hooks/use-notifications";
+import { formatSessionRelativeTime } from "@/lib/chat-history";
+import { cn } from "@/lib/utils";
+
+function NotificationIcon({
+  kind,
+  size = "md",
+}: {
+  kind: NotificationItem["kind"];
+  size?: "sm" | "md";
+}) {
+  const Icon = kind === "automation-run" ? WorkflowIcon : BrainIcon;
+  return (
+    <span
+      className={cn(
+        "flex shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground",
+        size === "sm" ? "size-7" : "size-9",
+      )}
+    >
+      <Icon className={size === "sm" ? "size-3.5" : "size-4"} aria-hidden />
+    </span>
+  );
+}
+
+export function NotificationListItem({
+  item,
+  compact = false,
+  onNavigate,
+}: {
+  item: NotificationItem;
+  compact?: boolean;
+  onNavigate?: () => void;
+}) {
+  return (
+    <Link
+      to={item.href}
+      onClick={onNavigate}
+      className={cn(
+        "flex gap-2 rounded-md transition-colors hover:bg-muted/60",
+        compact ? "px-1.5 py-1.5" : "border border-border px-3 py-3",
+      )}
+    >
+      <NotificationIcon kind={item.kind} size={compact ? "sm" : "md"} />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <p className="truncate text-sm font-medium leading-tight text-foreground">{item.title}</p>
+            {!compact && item.kindLabel ? (
+              <p className="mt-0.5 text-[11px] font-medium uppercase tracking-[0.06em] text-muted-foreground">
+                {item.kindLabel}
+              </p>
+            ) : null}
+          </div>
+          <div className="flex shrink-0 flex-col items-end gap-1">
+            {item.count > 1 ? (
+              <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-semibold tabular-nums text-primary-foreground">
+                {item.count > 99 ? "99+" : item.count}
+              </span>
+            ) : null}
+            {item.createdAt ? (
+              <time
+                dateTime={item.createdAt}
+                className="text-[11px] tabular-nums text-muted-foreground"
+              >
+                {formatSessionRelativeTime(item.createdAt)}
+              </time>
+            ) : null}
+          </div>
+        </div>
+        <p
+          className={cn(
+            "text-muted-foreground",
+            compact ? "mt-0.5 line-clamp-2 text-xs leading-snug" : "mt-1.5 text-sm leading-relaxed",
+          )}
+        >
+          {item.description}
+        </p>
+      </div>
+    </Link>
+  );
+}
+
+export function NotificationList({
+  items,
+  compact = false,
+  onNavigate,
+  emptyMessage = "You're all caught up.",
+}: {
+  items: NotificationItem[];
+  compact?: boolean;
+  onNavigate?: () => void;
+  emptyMessage?: string;
+}) {
+  if (items.length === 0) {
+    return <p className="text-sm text-muted-foreground">{emptyMessage}</p>;
+  }
+
+  return (
+    <div className={cn(compact ? "space-y-0" : "space-y-2")}>
+      {items.map((item) => (
+        <NotificationListItem
+          key={item.id}
+          item={item}
+          compact={compact}
+          onNavigate={onNavigate}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/notifications/notification-list.tsx
+++ b/apps/web/src/components/notifications/notification-list.tsx
@@ -38,7 +38,7 @@ export function NotificationListItem({
       to={item.href}
       onClick={onNavigate}
       className={cn(
-        "flex rounded-md transition-colors hover:bg-muted/60",
+        "flex min-w-0 overflow-hidden rounded-md transition-colors hover:bg-muted/60",
         compact ? "gap-2.5 px-2 py-2" : "gap-2.5 px-2 py-2.5",
       )}
     >
@@ -66,8 +66,10 @@ export function NotificationListItem({
         </div>
         <p
           className={cn(
-            "text-muted-foreground",
-            compact ? "mt-1 line-clamp-2 text-xs leading-snug" : "mt-1.5 text-sm leading-relaxed",
+            "min-w-0 break-all text-muted-foreground",
+            compact
+              ? "mt-1 line-clamp-2 text-xs leading-snug"
+              : "mt-1.5 whitespace-pre-wrap text-sm leading-relaxed",
           )}
         >
           {item.description}

--- a/apps/web/src/components/notifications/notification-list.tsx
+++ b/apps/web/src/components/notifications/notification-list.tsx
@@ -39,7 +39,7 @@ export function NotificationListItem({
       onClick={onNavigate}
       className={cn(
         "flex rounded-md transition-colors hover:bg-muted/60",
-        compact ? "gap-2.5 px-2 py-2" : "gap-2 border border-border px-3 py-3",
+        compact ? "gap-2.5 px-2 py-2" : "gap-2.5 px-2 py-2.5",
       )}
     >
       <NotificationIcon kind={item.kind} size={compact ? "sm" : "md"} />
@@ -47,11 +47,6 @@ export function NotificationListItem({
         <div className="flex items-start justify-between gap-2">
           <div className="min-w-0">
             <p className="truncate text-sm font-medium leading-tight text-foreground">{item.title}</p>
-            {!compact && item.kindLabel ? (
-              <p className="mt-0.5 text-[11px] font-medium uppercase tracking-[0.06em] text-muted-foreground">
-                {item.kindLabel}
-              </p>
-            ) : null}
           </div>
           <div className="flex shrink-0 flex-col items-end gap-1">
             {item.count > 1 ? (

--- a/apps/web/src/components/settings/OrgMembersCard.tsx
+++ b/apps/web/src/components/settings/OrgMembersCard.tsx
@@ -5,7 +5,6 @@ import { useAuth } from "@/context/use-auth";
 import {
   OrgMemberAddDialog,
   OrgMemberEditDialog,
-  OrgMemberInviteDialog,
   OrgMemberRemoveDialog,
   type OrgMemberAddCredentials,
 } from "@/components/settings/org-member-dialogs";
@@ -301,11 +300,27 @@ export function OrgMembersCard() {
         <CardContent className="divide-y divide-border p-0">
           <OrgMembersCardHeader
             orgId={activeOrg.id}
-            onInvite={() => {
-              dispatch({ type: "reset-invite" });
-              dispatch({ type: "clear-secrets" });
-              dispatch({ type: "patch", values: { inviteOpen: true } });
+            inviteOpen={state.inviteOpen}
+            inviteEmail={state.inviteEmail}
+            inviteRole={state.inviteRole}
+            inviteFormError={state.formError}
+            invitePending={inviteMutation.isPending}
+            onInviteOpenChange={(open) => {
+              dispatch({ type: "patch", values: { inviteOpen: open } });
+              if (open) {
+                dispatch({ type: "reset-invite" });
+                dispatch({ type: "clear-secrets" });
+              } else {
+                dispatch({ type: "reset-invite" });
+              }
             }}
+            onInviteEmailChange={(value) =>
+              dispatch({ type: "patch", values: { inviteEmail: value } })
+            }
+            onInviteRoleChange={(value) =>
+              dispatch({ type: "patch", values: { inviteRole: value } })
+            }
+            onInviteSubmit={handleInviteSubmit}
             onAddMember={() => {
               dispatch({ type: "reset-add" });
               dispatch({ type: "clear-secrets" });
@@ -321,7 +336,7 @@ export function OrgMembersCard() {
             />
           ) : null}
 
-          <div className="px-4 py-3">
+          <div>
             <OrgMembersTable
               members={members}
               currentUserEmail={user?.email}
@@ -334,34 +349,13 @@ export function OrgMembersCard() {
             />
 
             {statusLine ? (
-              <p className="mt-3 text-sm text-destructive" role="alert">
+              <p className="px-4 pb-3 pt-2 text-sm text-destructive" role="alert">
                 {statusLine}
               </p>
             ) : null}
           </div>
         </CardContent>
       </Card>
-
-      <OrgMemberInviteDialog
-        open={state.inviteOpen}
-        inviteEmail={state.inviteEmail}
-        inviteRole={state.inviteRole}
-        formError={state.formError}
-        pending={inviteMutation.isPending}
-        onOpenChange={(open) => {
-          dispatch({ type: "patch", values: { inviteOpen: open } });
-          if (!open) {
-            dispatch({ type: "reset-invite" });
-          }
-        }}
-        onInviteEmailChange={(value) =>
-          dispatch({ type: "patch", values: { inviteEmail: value } })
-        }
-        onInviteRoleChange={(value) =>
-          dispatch({ type: "patch", values: { inviteRole: value } })
-        }
-        onSubmit={handleInviteSubmit}
-      />
 
       <OrgMemberAddDialog
         open={state.addOpen}

--- a/apps/web/src/components/settings/OrgMemoryCard.tsx
+++ b/apps/web/src/components/settings/OrgMemoryCard.tsx
@@ -108,7 +108,7 @@ function OrgMemoryPinnedContent({ pinned }: { pinned: string[] }) {
             <ul className="space-y-1.5">
               {details.map((detail, index) => (
                 <li
-                  key={`${index}-${detail.slice(0, 24)}`}
+                  key={detail}
                   className={cn(
                     "text-sm leading-relaxed",
                     index === details.length - 1

--- a/apps/web/src/components/settings/OrgMemoryCard.tsx
+++ b/apps/web/src/components/settings/OrgMemoryCard.tsx
@@ -1,6 +1,7 @@
 import { PencilIcon } from "lucide-react";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { MessageResponse } from "@/components/ai-elements/message";
+import { OrgMemoryProposalsPanel } from "@/components/settings/OrgMemoryProposalsPanel";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import {
@@ -15,10 +16,13 @@ import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
 import { useAuth } from "@/context/use-auth";
 import { useOrgMemory, useUpdateOrgMemory } from "@/hooks/use-org-memory";
+import { useOrgMemoryProposals } from "@/hooks/use-org-memory-proposals";
 import { formatError } from "@/lib/client";
 import { toast } from "@/lib/toast";
 
 const MAX_BODY_BYTES = 256_000;
+
+type OrgMemoryTab = "live" | "proposals";
 
 const orgMemoryPreviewMarkdownClassName =
   "max-w-none text-sm [&_h1]:mt-2 [&_h1]:mb-1 [&_h1]:text-sm [&_h1]:font-semibold [&_h2]:mt-3 [&_h2]:mb-1.5 [&_h2]:text-xs [&_h2]:font-medium [&_h2]:uppercase [&_h2]:tracking-wide [&_h2]:text-muted-foreground [&_h3]:mt-2 [&_h3]:mb-1 [&_h3]:text-sm [&_h3]:font-medium [&_h4]:mt-2 [&_h4]:mb-1 [&_h4]:text-xs [&_h4]:font-medium";
@@ -29,7 +33,10 @@ export function OrgMemoryCard() {
   const isAdmin = activeOrg?.role === "admin";
 
   const { data, isLoading, error: loadError } = useOrgMemory(isAdmin ? orgId : null);
+  const { data: proposalsData } = useOrgMemoryProposals(isAdmin ? orgId : null, "pending");
   const updateMutation = useUpdateOrgMemory(orgId ?? "");
+
+  const [activeTab, setActiveTab] = useState<OrgMemoryTab>("live");
 
   const [draft, setDraft] = useState("");
   const [editOpen, setEditOpen] = useState(false);
@@ -39,6 +46,7 @@ export function OrgMemoryCard() {
   const previewRef = useRef<HTMLDivElement>(null);
 
   const liveContent = data?.content ?? "";
+  const pendingCount = proposalsData?.pendingCount ?? 0;
   const draftBytes = new TextEncoder().encode(draft).byteLength;
 
   useEffect(() => {
@@ -98,19 +106,50 @@ export function OrgMemoryCard() {
         <CardContent className="divide-y divide-border p-0">
           <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
             <div className="min-w-0 space-y-0.5">
-              <p className="text-sm font-medium text-foreground">Org Memory</p>
+              <div className="flex items-center gap-2">
+                <p className="text-sm font-medium text-foreground">Org Memory</p>
+                {pendingCount > 0 ? (
+                  <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-primary px-1.5 py-0.5 text-[0.65rem] font-semibold text-primary-foreground">
+                    {pendingCount > 99 ? "99+" : pendingCount}
+                  </span>
+                ) : null}
+              </div>
               <p className="text-xs text-muted-foreground">
-                Shared, admin-curated facts injected into every profile in this organization.
+                Shared org facts injected into every profile. Review agent proposals before they go live.
               </p>
             </div>
-            <Button type="button" size="sm" variant="outline" onClick={openEdit}>
-              <PencilIcon className="size-3.5" aria-hidden />
-              Edit
+            {activeTab === "live" ? (
+              <Button type="button" size="sm" variant="outline" onClick={openEdit}>
+                <PencilIcon className="size-3.5" aria-hidden />
+                Edit
+              </Button>
+            ) : null}
+          </div>
+
+          <div className="flex gap-2 px-4 pb-2">
+            <Button
+              type="button"
+              size="sm"
+              variant={activeTab === "live" ? "default" : "ghost"}
+              onClick={() => setActiveTab("live")}
+            >
+              Live memory
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant={activeTab === "proposals" ? "default" : "ghost"}
+              onClick={() => setActiveTab("proposals")}
+            >
+              Proposals
+              {pendingCount > 0 ? ` (${pendingCount})` : ""}
             </Button>
           </div>
 
           <div className="px-4 py-3">
-            {isLoading ? (
+            {activeTab === "proposals" ? (
+              orgId ? <OrgMemoryProposalsPanel orgId={orgId} /> : null
+            ) : isLoading ? (
               <p className="text-xs text-muted-foreground">Loading…</p>
             ) : liveContent.trim() ? (
               <div className="space-y-2">

--- a/apps/web/src/components/settings/OrgMemoryCard.tsx
+++ b/apps/web/src/components/settings/OrgMemoryCard.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, type ReactNode } from "react";
 import { useSearchParams } from "react-router-dom";
 import { parseOrgMemoryContent } from "@nakama/core/soul/org-memory";
 import { OrgMemoryProposalsPanel } from "@/components/settings/OrgMemoryProposalsPanel";
+import { OrgMemoryHistoryPanel } from "@/components/settings/OrgMemoryHistoryPanel";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import {
@@ -25,7 +26,7 @@ import { cn } from "@/lib/utils";
 
 const MAX_BODY_BYTES = 256_000;
 
-type OrgMemoryTab = "live" | "proposals";
+type OrgMemoryTab = "live" | "proposals" | "history";
 
 function formatUpdatedLabel(timestampMs: number): string {
   if (!timestampMs) {
@@ -235,11 +236,16 @@ export function OrgMemoryCard() {
                 </span>
               ) : null}
             </OrgMemoryTabButton>
+            <OrgMemoryTabButton active={activeTab === "history"} onClick={() => setActiveTab("history")}>
+              History
+            </OrgMemoryTabButton>
           </div>
         </div>
 
         {activeTab === "proposals" ? (
           orgId ? <OrgMemoryProposalsPanel orgId={orgId} /> : null
+        ) : activeTab === "history" ? (
+          orgId ? <OrgMemoryHistoryPanel orgId={orgId} /> : null
         ) : (
           <div className="px-4 py-3">
             {isLoading ? (

--- a/apps/web/src/components/settings/OrgMemoryCard.tsx
+++ b/apps/web/src/components/settings/OrgMemoryCard.tsx
@@ -1,9 +1,9 @@
-import { PencilIcon } from "lucide-react";
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
-import { MessageResponse } from "@/components/ai-elements/message";
+import { PencilIcon, PinIcon } from "lucide-react";
+import { useState, type ReactNode } from "react";
+import { parseOrgMemoryContent } from "@nakama/core/soul/org-memory";
 import { OrgMemoryProposalsPanel } from "@/components/settings/OrgMemoryProposalsPanel";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
+import { Card } from "@/components/ui/card";
 import {
   Dialog,
   DialogContent,
@@ -19,20 +19,119 @@ import { useOrgMemory, useUpdateOrgMemory } from "@/hooks/use-org-memory";
 import { useOrgMemoryProposals } from "@/hooks/use-org-memory-proposals";
 import { formatError } from "@/lib/client";
 import { toast } from "@/lib/toast";
+import { cn } from "@/lib/utils";
 
 const MAX_BODY_BYTES = 256_000;
 
 type OrgMemoryTab = "live" | "proposals";
 
-const orgMemoryPreviewMarkdownClassName =
-  "max-w-none text-sm [&_h1]:mt-2 [&_h1]:mb-1 [&_h1]:text-sm [&_h1]:font-semibold [&_h2]:mt-3 [&_h2]:mb-1.5 [&_h2]:text-xs [&_h2]:font-medium [&_h2]:uppercase [&_h2]:tracking-wide [&_h2]:text-muted-foreground [&_h3]:mt-2 [&_h3]:mb-1 [&_h3]:text-sm [&_h3]:font-medium [&_h4]:mt-2 [&_h4]:mb-1 [&_h4]:text-xs [&_h4]:font-medium";
+function formatUpdatedLabel(timestampMs: number): string {
+  if (!timestampMs) {
+    return "—";
+  }
+
+  const deltaMs = Date.now() - timestampMs;
+  const seconds = Math.max(0, Math.round(deltaMs / 1000));
+
+  if (seconds < 60) {
+    return "just now";
+  }
+
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m ago`;
+  }
+
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) {
+    return `${hours}h ago`;
+  }
+
+  return new Date(timestampMs).toLocaleDateString();
+}
+
+function OrgMemoryTabButton({
+  active,
+  children,
+  onClick,
+}: {
+  active: boolean;
+  children: ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "-mb-px border-b-2 px-0 py-2.5 text-sm transition-colors",
+        active
+          ? "border-foreground font-semibold text-foreground"
+          : "border-transparent font-normal text-muted-foreground hover:text-foreground",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function OrgMemoryPinnedContent({ pinned }: { pinned: string[] }) {
+  if (pinned.length === 0) {
+    return <p className="text-sm text-muted-foreground">No pinned facts yet.</p>;
+  }
+
+  const [lead, ...details] = pinned;
+
+  return (
+    <div className="flex gap-3">
+      <div className="flex flex-col items-center self-stretch">
+        <div
+          className="flex size-7 shrink-0 items-center justify-center rounded-full bg-foreground text-background"
+          aria-hidden
+        >
+          <PinIcon className="size-3.5" strokeWidth={2.25} />
+        </div>
+        <div className="mt-2 w-px flex-1 bg-border" />
+      </div>
+
+      <div className="min-w-0 flex-1 space-y-3 pb-1">
+        <p className="text-[0.65rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+          PINNED
+        </p>
+
+        <div className="space-y-3">
+          <p className="text-sm leading-relaxed text-foreground">{lead}</p>
+
+          {details.length > 0 ? (
+            <ul className="space-y-1.5">
+              {details.map((detail, index) => (
+                <li
+                  key={`${index}-${detail.slice(0, 24)}`}
+                  className={cn(
+                    "text-sm leading-relaxed",
+                    index === details.length - 1
+                      ? "font-mono text-xs text-muted-foreground/80"
+                      : "text-muted-foreground",
+                  )}
+                >
+                  <span className="mr-1.5 select-none" aria-hidden>→</span>
+                  {detail}
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export function OrgMemoryCard() {
   const { activeOrg } = useAuth();
   const orgId = activeOrg?.id ?? null;
   const isAdmin = activeOrg?.role === "admin";
 
-  const { data, isLoading, error: loadError } = useOrgMemory(isAdmin ? orgId : null);
+  const { data, isLoading, error: loadError, dataUpdatedAt } = useOrgMemory(isAdmin ? orgId : null);
   const { data: proposalsData } = useOrgMemoryProposals(isAdmin ? orgId : null, "pending");
   const updateMutation = useUpdateOrgMemory(orgId ?? "");
 
@@ -41,35 +140,12 @@ export function OrgMemoryCard() {
   const [draft, setDraft] = useState("");
   const [editOpen, setEditOpen] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
-  const [previewExpanded, setPreviewExpanded] = useState(false);
-  const [previewTruncated, setPreviewTruncated] = useState(false);
-  const previewRef = useRef<HTMLDivElement>(null);
 
   const liveContent = data?.content ?? "";
+  const parsedLive = parseOrgMemoryContent(liveContent);
+  const pinnedFacts = parsedLive.pinned;
   const pendingCount = proposalsData?.pendingCount ?? 0;
   const draftBytes = new TextEncoder().encode(draft).byteLength;
-
-  useEffect(() => {
-    setPreviewExpanded(false);
-  }, [liveContent]);
-
-  useLayoutEffect(() => {
-    const element = previewRef.current;
-    if (!element || previewExpanded) {
-      return;
-    }
-
-    const checkTruncation = () => {
-      setPreviewTruncated(element.scrollHeight > element.clientHeight + 1);
-    };
-
-    checkTruncation();
-
-    const observer = new ResizeObserver(checkTruncation);
-    observer.observe(element);
-
-    return () => observer.disconnect();
-  }, [liveContent, previewExpanded]);
 
   if (!isAdmin) {
     return null;
@@ -99,99 +175,70 @@ export function OrgMemoryCard() {
   const statusLine = formError ?? (loadError ? formatError(loadError) : null);
   const busy = updateMutation.isPending;
   const dirty = draft !== liveContent;
+  const showPinnedFooter = activeTab === "live" && !isLoading && pinnedFacts.length > 0;
 
   return (
     <>
-      <Card className="w-full shadow-none">
-        <CardContent className="divide-y divide-border p-0">
-          <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
+      <Card className="w-full overflow-hidden shadow-none">
+        <div className="border-b border-border px-4 py-3">
+          <div className="flex flex-wrap items-start justify-between gap-2">
             <div className="min-w-0 space-y-0.5">
-              <div className="flex items-center gap-2">
-                <p className="text-sm font-medium text-foreground">Org Memory</p>
-                {pendingCount > 0 ? (
-                  <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-primary px-1.5 py-0.5 text-[0.65rem] font-semibold text-primary-foreground">
-                    {pendingCount > 99 ? "99+" : pendingCount}
-                  </span>
-                ) : null}
-              </div>
-              <p className="text-xs text-muted-foreground">
-                Shared org facts injected into every profile. Review agent proposals before they go live.
+              <p className="text-sm font-medium text-foreground">Org Memory</p>
+              <p className="max-w-prose text-xs leading-relaxed text-muted-foreground">
+                Shared org facts injected into every profile. Review agent proposals before they go
+                live.
               </p>
             </div>
-            {activeTab === "live" ? (
-              <Button type="button" size="sm" variant="outline" onClick={openEdit}>
-                <PencilIcon className="size-3.5" aria-hidden />
-                Edit
-              </Button>
-            ) : null}
-          </div>
-
-          <div className="flex gap-2 px-4 pb-2">
-            <Button
-              type="button"
-              size="sm"
-              variant={activeTab === "live" ? "default" : "ghost"}
-              onClick={() => setActiveTab("live")}
-            >
-              Live memory
+            <Button type="button" size="sm" variant="outline" className="shrink-0" onClick={openEdit}>
+              <PencilIcon className="size-3.5" aria-hidden />
+              Edit
             </Button>
-            <Button
-              type="button"
-              size="sm"
-              variant={activeTab === "proposals" ? "default" : "ghost"}
+          </div>
+        </div>
+
+        <div className="border-b border-border px-4">
+          <div className="flex gap-5">
+            <OrgMemoryTabButton active={activeTab === "live"} onClick={() => setActiveTab("live")}>
+              Live memory
+            </OrgMemoryTabButton>
+            <OrgMemoryTabButton
+              active={activeTab === "proposals"}
               onClick={() => setActiveTab("proposals")}
             >
               Proposals
-              {pendingCount > 0 ? ` (${pendingCount})` : ""}
-            </Button>
+              {pendingCount > 0 ? (
+                <span className="ml-1 text-xs font-normal text-muted-foreground">
+                  ({pendingCount > 99 ? "99+" : pendingCount})
+                </span>
+              ) : null}
+            </OrgMemoryTabButton>
           </div>
+        </div>
 
-          <div className="px-4 py-3">
-            {activeTab === "proposals" ? (
-              orgId ? <OrgMemoryProposalsPanel orgId={orgId} /> : null
-            ) : isLoading ? (
-              <p className="text-xs text-muted-foreground">Loading…</p>
-            ) : liveContent.trim() ? (
-              <div className="space-y-2">
-                <div
-                  ref={previewRef}
-                  className={previewExpanded ? "relative" : "relative max-h-48 overflow-hidden"}
-                >
-                  <MessageResponse className={orgMemoryPreviewMarkdownClassName}>
-                    {liveContent}
-                  </MessageResponse>
-                  {!previewExpanded ? (
-                    <div
-                      className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-card to-transparent"
-                      aria-hidden
-                    />
-                  ) : null}
-                </div>
-                {previewTruncated || previewExpanded ? (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="h-7 px-0 text-xs text-muted-foreground hover:text-foreground"
-                    onClick={() => setPreviewExpanded((expanded) => !expanded)}
-                  >
-                    {previewExpanded ? "See less" : "See more"}
-                  </Button>
-                ) : null}
-              </div>
-            ) : (
-              <p className="text-xs text-muted-foreground">No pinned facts yet.</p>
-            )}
+        <div className="px-4 py-3">
+          {activeTab === "proposals" ? (
+            orgId ? <OrgMemoryProposalsPanel orgId={orgId} /> : null
+          ) : isLoading ? (
+            <p className="text-sm text-muted-foreground">Loading…</p>
+          ) : (
+            <OrgMemoryPinnedContent pinned={pinnedFacts} />
+          )}
+        </div>
+
+        {showPinnedFooter ? (
+          <div className="flex items-center justify-between border-t border-border px-4 py-2 text-xs text-muted-foreground">
+            <span>Pinned</span>
+            <span>Updated {formatUpdatedLabel(dataUpdatedAt)}</span>
           </div>
+        ) : null}
 
-          {statusLine ? (
-            <div className="px-4 py-2">
-              <p className="text-sm text-destructive" role="alert">
-                {statusLine}
-              </p>
-            </div>
-          ) : null}
-        </CardContent>
+        {statusLine ? (
+          <div className="border-t border-border px-4 py-2">
+            <p className="text-sm text-destructive" role="alert">
+              {statusLine}
+            </p>
+          </div>
+        ) : null}
       </Card>
 
       <Dialog

--- a/apps/web/src/components/settings/OrgMemoryCard.tsx
+++ b/apps/web/src/components/settings/OrgMemoryCard.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useAuth } from "@/context/use-auth";
 import { useOrgMemory, useUpdateOrgMemory } from "@/hooks/use-org-memory";
 import { useOrgMemoryProposals } from "@/hooks/use-org-memory-proposals";
@@ -189,18 +190,32 @@ export function OrgMemoryCard() {
     <>
       <Card className="w-full overflow-hidden shadow-none">
         <div className="border-b border-border px-4 py-3">
-          <div className="flex flex-wrap items-start justify-between gap-2">
-            <div className="min-w-0 space-y-0.5">
+          <div className="flex items-center justify-between gap-3">
+            <div className="min-w-0 flex-1 space-y-0.5">
               <p className="text-sm font-medium text-foreground">Org Memory</p>
               <p className="max-w-prose text-xs leading-relaxed text-muted-foreground">
-                Shared org facts injected into every profile. Review agent proposals before they go
-                live.
+                Shared facts for every agent. Review proposals before they go live.
               </p>
             </div>
-            <Button type="button" size="sm" variant="outline" className="shrink-0" onClick={openEdit}>
-              <PencilIcon className="size-3.5" aria-hidden />
-              Edit
-            </Button>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    type="button"
+                    size="icon-sm"
+                    variant="outline"
+                    className="shrink-0"
+                    aria-label="Edit org memory"
+                    onClick={openEdit}
+                  >
+                    <PencilIcon className="size-3.5" aria-hidden />
+                  </Button>
+                }
+              />
+              <TooltipContent side="top" sideOffset={8}>
+                Edit
+              </TooltipContent>
+            </Tooltip>
           </div>
         </div>
 
@@ -223,15 +238,17 @@ export function OrgMemoryCard() {
           </div>
         </div>
 
-        <div className="px-4 py-3">
-          {activeTab === "proposals" ? (
-            orgId ? <OrgMemoryProposalsPanel orgId={orgId} /> : null
-          ) : isLoading ? (
-            <p className="text-sm text-muted-foreground">Loading…</p>
-          ) : (
-            <OrgMemoryPinnedContent pinned={pinnedFacts} />
-          )}
-        </div>
+        {activeTab === "proposals" ? (
+          orgId ? <OrgMemoryProposalsPanel orgId={orgId} /> : null
+        ) : (
+          <div className="px-4 py-3">
+            {isLoading ? (
+              <p className="text-sm text-muted-foreground">Loading…</p>
+            ) : (
+              <OrgMemoryPinnedContent pinned={pinnedFacts} />
+            )}
+          </div>
+        )}
 
         {showPinnedFooter ? (
           <div className="flex items-center justify-between border-t border-border px-4 py-2 text-xs text-muted-foreground">

--- a/apps/web/src/components/settings/OrgMemoryCard.tsx
+++ b/apps/web/src/components/settings/OrgMemoryCard.tsx
@@ -1,5 +1,6 @@
 import { PencilIcon, PinIcon } from "lucide-react";
-import { useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
+import { useSearchParams } from "react-router-dom";
 import { parseOrgMemoryContent } from "@nakama/core/soul/org-memory";
 import { OrgMemoryProposalsPanel } from "@/components/settings/OrgMemoryProposalsPanel";
 import { Button } from "@/components/ui/button";
@@ -128,6 +129,7 @@ function OrgMemoryPinnedContent({ pinned }: { pinned: string[] }) {
 
 export function OrgMemoryCard() {
   const { activeOrg } = useAuth();
+  const [searchParams] = useSearchParams();
   const orgId = activeOrg?.id ?? null;
   const isAdmin = activeOrg?.role === "admin";
 
@@ -136,6 +138,12 @@ export function OrgMemoryCard() {
   const updateMutation = useUpdateOrgMemory(orgId ?? "");
 
   const [activeTab, setActiveTab] = useState<OrgMemoryTab>("live");
+
+  useEffect(() => {
+    if (searchParams.get("orgMemory") === "proposals") {
+      setActiveTab("proposals");
+    }
+  }, [searchParams]);
 
   const [draft, setDraft] = useState("");
   const [editOpen, setEditOpen] = useState(false);

--- a/apps/web/src/components/settings/OrgMemoryHistoryPanel.tsx
+++ b/apps/web/src/components/settings/OrgMemoryHistoryPanel.tsx
@@ -1,9 +1,19 @@
+import { useState } from "react";
 import type { OrgMemoryChangeLogEntry } from "@nakama/core/contract";
-import { HistoryIcon } from "lucide-react";
+import { EyeIcon, HistoryIcon, RotateCcwIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   useOrgMemoryHistory,
+  useOrgMemoryHistoryRevision,
   useRestoreOrgMemoryHistory,
   useUndoOrgMemoryChange,
 } from "@/hooks/use-org-memory-history";
@@ -52,6 +62,62 @@ function formatActionLabel(action: OrgMemoryChangeLogEntry["action"]): string {
   }
 }
 
+function HistoryRevisionDialog({
+  orgId,
+  change,
+  actorLabel,
+  open,
+  onOpenChange,
+}: {
+  orgId: string;
+  change: OrgMemoryChangeLogEntry;
+  actorLabel: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { data, isLoading, error } = useOrgMemoryHistoryRevision(orgId, open ? change.id : null);
+  const absoluteTime = formatSessionTimestamp(change.createdAt);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[min(90dvh,85vh)] w-[calc(100%-1.5rem)] flex-col gap-4 overflow-hidden p-4 sm:max-w-3xl sm:gap-6 sm:p-6">
+        <DialogHeader className="pr-8">
+          <DialogTitle>Memory snapshot</DialogTitle>
+          <DialogDescription className="break-all">{change.label}</DialogDescription>
+        </DialogHeader>
+
+        <div className="min-w-0 space-y-1 text-xs text-muted-foreground">
+          <p>
+            <span className="font-medium text-foreground/80">{formatActionLabel(change.action)}</span>
+            {" · "}
+            <time dateTime={change.createdAt} title={absoluteTime}>
+              {absoluteTime}
+            </time>
+            {actorLabel ? <> · {actorLabel}</> : null}
+          </p>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-hidden rounded-lg border border-border bg-muted/30">
+          {isLoading ? (
+            <div className="flex items-center gap-2 px-3 py-4 text-sm text-muted-foreground">
+              <Spinner />
+              Loading snapshot…
+            </div>
+          ) : error ? (
+            <p className="px-3 py-4 text-sm text-destructive" role="alert">
+              {formatError(error)}
+            </p>
+          ) : (
+            <pre className="max-h-[min(52dvh,28rem)] overflow-y-auto px-3 py-3 font-mono text-xs leading-relaxed break-all whitespace-pre-wrap text-foreground">
+              {data?.content ?? ""}
+            </pre>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 function HistoryTimelineItem({
   change,
   orgId,
@@ -65,6 +131,7 @@ function HistoryTimelineItem({
   isCurrent: boolean;
   isLast: boolean;
 }) {
+  const [viewOpen, setViewOpen] = useState(false);
   const restoreMutation = useRestoreOrgMemoryHistory(orgId);
   const busy = restoreMutation.isPending;
 
@@ -81,60 +148,102 @@ function HistoryTimelineItem({
   const absoluteTime = formatSessionTimestamp(change.createdAt);
 
   return (
-    <div className="flex gap-3">
-      <div className="flex flex-col items-center self-stretch">
-        <div
-          className={cn(
-            "flex size-7 shrink-0 items-center justify-center rounded-full border",
-            isCurrent
-              ? "border-foreground bg-foreground text-background"
-              : "border-border bg-muted text-muted-foreground",
-          )}
-          aria-hidden
-        >
-          <HistoryIcon className="size-3.5" strokeWidth={2.25} />
+    <>
+      <div className="flex gap-3">
+        <div className="flex flex-col items-center self-stretch">
+          <div
+            className={cn(
+              "flex size-7 shrink-0 items-center justify-center rounded-full border",
+              isCurrent
+                ? "border-foreground bg-foreground text-background"
+                : "border-border bg-muted text-muted-foreground",
+            )}
+            aria-hidden
+          >
+            <HistoryIcon className="size-3.5" strokeWidth={2.25} />
+          </div>
+          {!isLast ? <div className="mt-2 w-px flex-1 bg-border" /> : null}
         </div>
-        {!isLast ? <div className="mt-2 w-px flex-1 bg-border" /> : null}
-      </div>
 
-      <div className={cn("min-w-0 flex-1", !isLast && "pb-4")}>
-        <div className="flex flex-wrap items-start justify-between gap-2">
-          <div className="min-w-0 flex-1 space-y-1">
-            <div className="flex flex-wrap items-center gap-2">
-              <span className="text-[0.65rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-                {formatActionLabel(change.action)}
-              </span>
-              {isCurrent ? (
-                <span className="rounded-full bg-muted px-2 py-0.5 text-[0.65rem] font-medium text-foreground">
-                  Current
+        <div className={cn("min-w-0 flex-1 overflow-hidden", !isLast && "pb-4")}>
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0 flex-1 space-y-1 overflow-hidden">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-[0.65rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                  {formatActionLabel(change.action)}
                 </span>
+                {isCurrent ? (
+                  <span className="rounded-full bg-muted px-2 py-0.5 text-[0.65rem] font-medium text-foreground">
+                    Current
+                  </span>
+                ) : null}
+              </div>
+              <p className="break-all text-sm leading-relaxed text-foreground">{change.label}</p>
+              <p className="text-xs text-muted-foreground">
+                <time dateTime={change.createdAt} title={absoluteTime}>
+                  {relativeTime}
+                </time>
+                {actorLabel ? <> · {actorLabel}</> : null}
+              </p>
+            </div>
+
+            <div className="flex shrink-0 gap-1">
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      type="button"
+                      size="icon-sm"
+                      variant="outline"
+                      aria-label="View snapshot"
+                      onClick={() => setViewOpen(true)}
+                    >
+                      <EyeIcon className="size-3.5" aria-hidden />
+                    </Button>
+                  }
+                />
+                <TooltipContent side="top" sideOffset={8}>
+                  View
+                </TooltipContent>
+              </Tooltip>
+              {!isCurrent ? (
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <Button
+                        type="button"
+                        size="icon-sm"
+                        variant="outline"
+                        aria-label="Revert to this snapshot"
+                        disabled={busy}
+                        onClick={() => void handleRevert()}
+                      >
+                        {busy ? (
+                          <Spinner className="size-3.5" />
+                        ) : (
+                          <RotateCcwIcon className="size-3.5" aria-hidden />
+                        )}
+                      </Button>
+                    }
+                  />
+                  <TooltipContent side="top" sideOffset={8}>
+                    Revert
+                  </TooltipContent>
+                </Tooltip>
               ) : null}
             </div>
-            <p className="text-sm leading-relaxed text-foreground">{change.label}</p>
-            <p className="text-xs text-muted-foreground">
-              <time dateTime={change.createdAt} title={absoluteTime}>
-                {relativeTime}
-              </time>
-              {actorLabel ? <> · {actorLabel}</> : null}
-            </p>
           </div>
-
-          {!isCurrent ? (
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              className="shrink-0"
-              disabled={busy}
-              onClick={() => void handleRevert()}
-            >
-              {busy ? <Spinner className="mr-2" /> : null}
-              Revert
-            </Button>
-          ) : null}
         </div>
       </div>
-    </div>
+
+      <HistoryRevisionDialog
+        orgId={orgId}
+        change={change}
+        actorLabel={actorLabel}
+        open={viewOpen}
+        onOpenChange={setViewOpen}
+      />
+    </>
   );
 }
 
@@ -168,10 +277,10 @@ export function OrgMemoryHistoryPanel({ orgId }: { orgId: string }) {
   }
 
   return (
-    <div>
+    <div className="min-w-0">
       <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-2">
         <p className="text-xs text-muted-foreground">
-          Timeline of every change. Revert to any earlier snapshot.
+          Timeline of every change. View snapshots or revert to an earlier revision.
         </p>
         <Button
           type="button"
@@ -188,7 +297,7 @@ export function OrgMemoryHistoryPanel({ orgId }: { orgId: string }) {
       {changes.length === 0 ? (
         <p className="px-4 py-3 text-xs text-muted-foreground">No changes logged yet.</p>
       ) : (
-        <div className="px-4 py-3">
+        <div className="min-w-0 px-4 py-3">
           {changes.map((change, index) => (
             <HistoryTimelineItem
               key={change.id}

--- a/apps/web/src/components/settings/OrgMemoryHistoryPanel.tsx
+++ b/apps/web/src/components/settings/OrgMemoryHistoryPanel.tsx
@@ -1,0 +1,170 @@
+import type { OrgMemoryChangeLogEntry } from "@nakama/core/contract";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  useOrgMemoryHistory,
+  useRestoreOrgMemoryHistory,
+  useUndoOrgMemoryChange,
+} from "@/hooks/use-org-memory-history";
+import { useOrgMembers } from "@/hooks/use-org-members";
+import { formatSessionRelativeTime, formatSessionTimestamp } from "@/lib/chat-history";
+import { formatError } from "@/lib/client";
+import { toast } from "@/lib/toast";
+
+function shortenId(value: string): string {
+  return value.length > 16 ? `${value.slice(0, 12)}…` : value;
+}
+
+function resolveActorLabel(userId: string | null, members: { userId: string; name?: string | null; email: string }[]): string | null {
+  if (!userId) {
+    return null;
+  }
+  const member = members.find((entry) => entry.userId === userId);
+  if (!member) {
+    return shortenId(userId);
+  }
+  return member.name?.trim() || member.email;
+}
+
+function formatActionLabel(action: OrgMemoryChangeLogEntry["action"]): string {
+  switch (action) {
+    case "edit":
+      return "Edit";
+    case "approve":
+      return "Approved";
+    case "add_fact":
+      return "Added";
+    case "pin":
+      return "Pinned";
+    case "unpin":
+      return "Unpinned";
+    case "archive":
+      return "Archived";
+    case "restore":
+      return "Restored";
+    default:
+      return action;
+  }
+}
+
+function HistoryRow({
+  change,
+  orgId,
+  actorLabel,
+  canUndo,
+}: {
+  change: OrgMemoryChangeLogEntry;
+  orgId: string;
+  actorLabel: string | null;
+  canUndo: boolean;
+}) {
+  const restoreMutation = useRestoreOrgMemoryHistory(orgId);
+  const busy = restoreMutation.isPending;
+
+  async function handleRestore() {
+    try {
+      await restoreMutation.mutateAsync(change.id);
+      toast("Org memory restored.");
+    } catch (err) {
+      toast(formatError(err));
+    }
+  }
+
+  const relativeTime = formatSessionRelativeTime(change.createdAt);
+  const absoluteTime = formatSessionTimestamp(change.createdAt);
+
+  return (
+    <div className="flex flex-wrap items-start gap-2 py-2 pl-4 pr-4">
+      <div className="min-w-0 flex-1 space-y-1">
+        <p className="text-sm text-foreground">{change.label}</p>
+        <p className="text-xs text-muted-foreground">
+          <span className="font-medium text-foreground/80">{formatActionLabel(change.action)}</span>
+          {" · "}
+          <time dateTime={change.createdAt} title={absoluteTime}>
+            {relativeTime}
+          </time>
+          {actorLabel ? <> · {actorLabel}</> : null}
+        </p>
+      </div>
+      {canUndo ? (
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="shrink-0"
+          disabled={busy}
+          onClick={() => void handleRestore()}
+        >
+          {busy ? <Spinner className="mr-2" /> : null}
+          Restore
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+export function OrgMemoryHistoryPanel({ orgId }: { orgId: string }) {
+  const { data, isLoading, error } = useOrgMemoryHistory(orgId);
+  const undoMutation = useUndoOrgMemoryChange(orgId);
+  const { data: membersData } = useOrgMembers(orgId);
+  const changes = data?.changes ?? [];
+  const members = membersData?.members ?? [];
+  const canUndo = changes.length >= 2;
+
+  async function handleUndo() {
+    try {
+      await undoMutation.mutateAsync();
+      toast("Latest org memory change undone.");
+    } catch (err) {
+      toast(formatError(err));
+    }
+  }
+
+  if (isLoading) {
+    return <p className="px-4 py-2 text-xs text-muted-foreground">Loading history…</p>;
+  }
+
+  if (error) {
+    return (
+      <p className="px-4 py-2 text-sm text-destructive" role="alert">
+        {formatError(error)}
+      </p>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-2">
+        <p className="text-xs text-muted-foreground">
+          Snapshots of every change. Restore any revision or undo the latest change.
+        </p>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          disabled={!canUndo || undoMutation.isPending}
+          onClick={() => void handleUndo()}
+        >
+          {undoMutation.isPending ? <Spinner className="mr-2" /> : null}
+          Undo latest
+        </Button>
+      </div>
+
+      {changes.length === 0 ? (
+        <p className="px-4 py-2 text-xs text-muted-foreground">No changes logged yet.</p>
+      ) : (
+        <div className="divide-y divide-border">
+          {changes.map((change, index) => (
+            <HistoryRow
+              key={change.id}
+              change={change}
+              orgId={orgId}
+              actorLabel={resolveActorLabel(change.actorUserId, members)}
+              canUndo={index > 0}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/OrgMemoryHistoryPanel.tsx
+++ b/apps/web/src/components/settings/OrgMemoryHistoryPanel.tsx
@@ -1,4 +1,5 @@
 import type { OrgMemoryChangeLogEntry } from "@nakama/core/contract";
+import { HistoryIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import {
@@ -10,12 +11,16 @@ import { useOrgMembers } from "@/hooks/use-org-members";
 import { formatSessionRelativeTime, formatSessionTimestamp } from "@/lib/chat-history";
 import { formatError } from "@/lib/client";
 import { toast } from "@/lib/toast";
+import { cn } from "@/lib/utils";
 
 function shortenId(value: string): string {
   return value.length > 16 ? `${value.slice(0, 12)}…` : value;
 }
 
-function resolveActorLabel(userId: string | null, members: { userId: string; name?: string | null; email: string }[]): string | null {
+function resolveActorLabel(
+  userId: string | null,
+  members: { userId: string; name?: string | null; email: string }[],
+): string | null {
   if (!userId) {
     return null;
   }
@@ -47,24 +52,26 @@ function formatActionLabel(action: OrgMemoryChangeLogEntry["action"]): string {
   }
 }
 
-function HistoryRow({
+function HistoryTimelineItem({
   change,
   orgId,
   actorLabel,
-  canUndo,
+  isCurrent,
+  isLast,
 }: {
   change: OrgMemoryChangeLogEntry;
   orgId: string;
   actorLabel: string | null;
-  canUndo: boolean;
+  isCurrent: boolean;
+  isLast: boolean;
 }) {
   const restoreMutation = useRestoreOrgMemoryHistory(orgId);
   const busy = restoreMutation.isPending;
 
-  async function handleRestore() {
+  async function handleRevert() {
     try {
       await restoreMutation.mutateAsync(change.id);
-      toast("Org memory restored.");
+      toast("Org memory reverted.");
     } catch (err) {
       toast(formatError(err));
     }
@@ -74,31 +81,59 @@ function HistoryRow({
   const absoluteTime = formatSessionTimestamp(change.createdAt);
 
   return (
-    <div className="flex flex-wrap items-start gap-2 py-2 pl-4 pr-4">
-      <div className="min-w-0 flex-1 space-y-1">
-        <p className="text-sm text-foreground">{change.label}</p>
-        <p className="text-xs text-muted-foreground">
-          <span className="font-medium text-foreground/80">{formatActionLabel(change.action)}</span>
-          {" · "}
-          <time dateTime={change.createdAt} title={absoluteTime}>
-            {relativeTime}
-          </time>
-          {actorLabel ? <> · {actorLabel}</> : null}
-        </p>
-      </div>
-      {canUndo ? (
-        <Button
-          type="button"
-          size="sm"
-          variant="outline"
-          className="shrink-0"
-          disabled={busy}
-          onClick={() => void handleRestore()}
+    <div className="flex gap-3">
+      <div className="flex flex-col items-center self-stretch">
+        <div
+          className={cn(
+            "flex size-7 shrink-0 items-center justify-center rounded-full border",
+            isCurrent
+              ? "border-foreground bg-foreground text-background"
+              : "border-border bg-muted text-muted-foreground",
+          )}
+          aria-hidden
         >
-          {busy ? <Spinner className="mr-2" /> : null}
-          Restore
-        </Button>
-      ) : null}
+          <HistoryIcon className="size-3.5" strokeWidth={2.25} />
+        </div>
+        {!isLast ? <div className="mt-2 w-px flex-1 bg-border" /> : null}
+      </div>
+
+      <div className={cn("min-w-0 flex-1", !isLast && "pb-4")}>
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <div className="min-w-0 flex-1 space-y-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-[0.65rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                {formatActionLabel(change.action)}
+              </span>
+              {isCurrent ? (
+                <span className="rounded-full bg-muted px-2 py-0.5 text-[0.65rem] font-medium text-foreground">
+                  Current
+                </span>
+              ) : null}
+            </div>
+            <p className="text-sm leading-relaxed text-foreground">{change.label}</p>
+            <p className="text-xs text-muted-foreground">
+              <time dateTime={change.createdAt} title={absoluteTime}>
+                {relativeTime}
+              </time>
+              {actorLabel ? <> · {actorLabel}</> : null}
+            </p>
+          </div>
+
+          {!isCurrent ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="shrink-0"
+              disabled={busy}
+              onClick={() => void handleRevert()}
+            >
+              {busy ? <Spinner className="mr-2" /> : null}
+              Revert
+            </Button>
+          ) : null}
+        </div>
+      </div>
     </div>
   );
 }
@@ -136,7 +171,7 @@ export function OrgMemoryHistoryPanel({ orgId }: { orgId: string }) {
     <div>
       <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-2">
         <p className="text-xs text-muted-foreground">
-          Snapshots of every change. Restore any revision or undo the latest change.
+          Timeline of every change. Revert to any earlier snapshot.
         </p>
         <Button
           type="button"
@@ -151,16 +186,17 @@ export function OrgMemoryHistoryPanel({ orgId }: { orgId: string }) {
       </div>
 
       {changes.length === 0 ? (
-        <p className="px-4 py-2 text-xs text-muted-foreground">No changes logged yet.</p>
+        <p className="px-4 py-3 text-xs text-muted-foreground">No changes logged yet.</p>
       ) : (
-        <div className="divide-y divide-border">
+        <div className="px-4 py-3">
           {changes.map((change, index) => (
-            <HistoryRow
+            <HistoryTimelineItem
               key={change.id}
               change={change}
               orgId={orgId}
               actorLabel={resolveActorLabel(change.actorUserId, members)}
-              canUndo={index > 0}
+              isCurrent={index === 0}
+              isLast={index === changes.length - 1}
             />
           ))}
         </div>

--- a/apps/web/src/components/settings/OrgMemoryProposalsPanel.tsx
+++ b/apps/web/src/components/settings/OrgMemoryProposalsPanel.tsx
@@ -1,0 +1,141 @@
+import { useState } from "react";
+import type { OrgMemoryProposal } from "@nakama/core/contract";
+import { detectOrgMemoryInjectionWarnings } from "@nakama/core";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { Switch } from "@/components/ui/switch";
+import {
+  useApproveOrgMemoryProposal,
+  useOrgMemoryProposals,
+  useRejectOrgMemoryProposal,
+} from "@/hooks/use-org-memory-proposals";
+import { formatError } from "@/lib/client";
+import { toast } from "@/lib/toast";
+
+function formatTimestamp(value: string | null): string {
+  if (!value) {
+    return "—";
+  }
+  try {
+    return new Date(value).toLocaleString();
+  } catch {
+    return value;
+  }
+}
+
+function ProposalRow({
+  proposal,
+  orgId,
+}: {
+  proposal: OrgMemoryProposal;
+  orgId: string;
+}) {
+  const [pinOnApprove, setPinOnApprove] = useState(false);
+  const approveMutation = useApproveOrgMemoryProposal(orgId);
+  const rejectMutation = useRejectOrgMemoryProposal(orgId);
+  const warnings = detectOrgMemoryInjectionWarnings(proposal.bullet);
+  const busy = approveMutation.isPending || rejectMutation.isPending;
+
+  async function handleApprove() {
+    try {
+      await approveMutation.mutateAsync({
+        proposalId: proposal.id,
+        request: { pin: pinOnApprove },
+      });
+      toast(pinOnApprove ? "Proposal approved and pinned." : "Proposal approved.");
+    } catch (err) {
+      toast(formatError(err));
+    }
+  }
+
+  async function handleReject() {
+    try {
+      await rejectMutation.mutateAsync(proposal.id);
+      toast("Proposal rejected.");
+    } catch (err) {
+      toast(formatError(err));
+    }
+  }
+
+  return (
+    <div className="space-y-3 rounded-md border border-border p-3">
+      <p className="text-sm text-foreground">{proposal.bullet}</p>
+      {warnings.length > 0 ? (
+        <p className="text-xs text-amber-600 dark:text-amber-400">
+          Warning: {warnings.join(" ")}
+        </p>
+      ) : null}
+      <dl className="grid gap-1 text-xs text-muted-foreground">
+        <div>
+          <dt className="inline">Proposed </dt>
+          <dd className="inline">{formatTimestamp(proposal.createdAt)}</dd>
+        </div>
+        {proposal.profileId ? (
+          <div>
+            <dt className="inline">Profile </dt>
+            <dd className="inline font-mono">{proposal.profileId}</dd>
+          </div>
+        ) : null}
+        {proposal.proposedByUserId ? (
+          <div>
+            <dt className="inline">User </dt>
+            <dd className="inline font-mono">{proposal.proposedByUserId}</dd>
+          </div>
+        ) : null}
+      </dl>
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="flex items-center gap-2">
+          <Switch
+            id={`pin-${proposal.id}`}
+            checked={pinOnApprove}
+            disabled={busy}
+            onCheckedChange={setPinOnApprove}
+            aria-label="Pin on approve"
+          />
+          <label htmlFor={`pin-${proposal.id}`} className="text-xs text-muted-foreground">
+            Pin on approve
+          </label>
+        </div>
+        <div className="ml-auto flex gap-2">
+          <Button type="button" size="sm" variant="outline" disabled={busy} onClick={() => void handleReject()}>
+            {rejectMutation.isPending ? <Spinner className="mr-2" /> : null}
+            Reject
+          </Button>
+          <Button type="button" size="sm" disabled={busy} onClick={() => void handleApprove()}>
+            {approveMutation.isPending ? <Spinner className="mr-2" /> : null}
+            Approve
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function OrgMemoryProposalsPanel({ orgId }: { orgId: string }) {
+  const { data, isLoading, error } = useOrgMemoryProposals(orgId, "pending");
+  const proposals = data?.proposals ?? [];
+
+  if (isLoading) {
+    return <p className="text-xs text-muted-foreground">Loading proposals…</p>;
+  }
+
+  if (error) {
+    return (
+      <p className="text-sm text-destructive" role="alert">
+        {formatError(error)}
+      </p>
+    );
+  }
+
+  if (proposals.length === 0) {
+    return <p className="text-xs text-muted-foreground">No pending proposals.</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      {proposals.map((proposal) => (
+        <ProposalRow key={proposal.id} proposal={proposal} orgId={orgId} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/OrgMemoryProposalsPanel.tsx
+++ b/apps/web/src/components/settings/OrgMemoryProposalsPanel.tsx
@@ -1,40 +1,167 @@
-import { useState } from "react";
-import type { OrgMemoryProposal } from "@nakama/core/contract";
-import { detectOrgMemoryInjectionWarnings } from "@nakama/core/soul/org-memory";
+import { useState, type ReactNode } from "react";
+import type { OrgMemoryProposal, OrgMemberSummary, ProfileSummary } from "@nakama/core/contract";
+import {
+  detectOrgMemoryInjectionWarnings,
+} from "@nakama/core/soul/org-memory";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
+import { useProfilesQuery } from "@/hooks/use-app-queries";
 import {
   useApproveOrgMemoryProposal,
   useOrgMemoryProposals,
   useRejectOrgMemoryProposal,
 } from "@/hooks/use-org-memory-proposals";
+import { useOrgMembers } from "@/hooks/use-org-members";
+import { formatSessionRelativeTime, formatSessionTimestamp } from "@/lib/chat-history";
 import { formatError } from "@/lib/client";
 import { toast } from "@/lib/toast";
 
-function formatTimestamp(value: string | null): string {
-  if (!value) {
-    return "—";
-  }
-  try {
-    return new Date(value).toLocaleString();
-  } catch {
-    return value;
-  }
+function shortenId(value: string): string {
+  return value.length > 16 ? `${value.slice(0, 12)}…` : value;
 }
 
-function ProposalRow({
+function resolveProfileLabel(
+  profileId: string | null,
+  profiles: ProfileSummary[],
+): string | null {
+  if (!profileId) {
+    return null;
+  }
+  return profiles.find((profile) => profile.id === profileId)?.name ?? shortenId(profileId);
+}
+
+interface ProposerInfo {
+  name: string;
+  email?: string;
+}
+
+function resolveProposer(
+  userId: string | null,
+  members: OrgMemberSummary[],
+): ProposerInfo | null {
+  if (!userId) {
+    return null;
+  }
+  const member = members.find((entry) => entry.userId === userId);
+  if (!member) {
+    return { name: shortenId(userId) };
+  }
+  const name = member.name?.trim() || member.email;
+  return {
+    name,
+    email: member.name?.trim() ? member.email : undefined,
+  };
+}
+
+function ProposalMetadataTableRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <tr className="border-b border-border last:border-b-0">
+      <th
+        scope="row"
+        className="w-[4.5rem] border-r border-border px-2 py-1 align-top text-left font-normal text-muted-foreground"
+      >
+        {label}
+      </th>
+      <td className="px-2 py-1 align-top text-foreground">{children}</td>
+    </tr>
+  );
+}
+
+function ProposalMetadata({
+  proposal,
+  profileLabel,
+  proposer,
+  variant = "compact",
+}: {
+  proposal: OrgMemoryProposal;
+  profileLabel: string | null;
+  proposer: ProposerInfo | null;
+  variant?: "compact" | "detail";
+}) {
+  const relativeTime = formatSessionRelativeTime(proposal.createdAt);
+  const absoluteTime = formatSessionTimestamp(proposal.createdAt);
+
+  if (variant === "compact") {
+    return (
+      <p className="text-xs text-muted-foreground">
+        <time dateTime={proposal.createdAt} title={absoluteTime}>
+          {relativeTime}
+        </time>
+        {profileLabel ? <> · {profileLabel}</> : null}
+        {proposer ? <> · {proposer.name}</> : null}
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-md border border-border">
+      <table className="w-full border-collapse text-xs">
+        <tbody>
+          {proposer ? (
+            <ProposalMetadataTableRow label="By">
+              <span className="min-w-0">
+                <span className="text-foreground">{proposer.name}</span>
+                {proposer.email ? (
+                  <span className="text-muted-foreground"> · {proposer.email}</span>
+                ) : null}
+              </span>
+            </ProposalMetadataTableRow>
+          ) : null}
+          <ProposalMetadataTableRow label="When">
+            <time dateTime={proposal.createdAt} title={absoluteTime}>
+              {relativeTime}
+            </time>
+          </ProposalMetadataTableRow>
+          {profileLabel ? (
+            <ProposalMetadataTableRow label="Agent">{profileLabel}</ProposalMetadataTableRow>
+          ) : null}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ProposalReviewDialog({
   proposal,
   orgId,
+  profileLabel,
+  proposer,
+  open,
+  onOpenChange,
 }: {
   proposal: OrgMemoryProposal;
   orgId: string;
+  profileLabel: string | null;
+  proposer: ProposerInfo | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
 }) {
   const [pinOnApprove, setPinOnApprove] = useState(false);
   const approveMutation = useApproveOrgMemoryProposal(orgId);
   const rejectMutation = useRejectOrgMemoryProposal(orgId);
   const warnings = detectOrgMemoryInjectionWarnings(proposal.bullet);
   const busy = approveMutation.isPending || rejectMutation.isPending;
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) {
+      setPinOnApprove(false);
+    }
+    onOpenChange(nextOpen);
+  }
 
   async function handleApprove() {
     try {
@@ -43,6 +170,7 @@ function ProposalRow({
         request: { pin: pinOnApprove },
       });
       toast(pinOnApprove ? "Proposal approved and pinned." : "Proposal approved.");
+      handleOpenChange(false);
     } catch (err) {
       toast(formatError(err));
     }
@@ -52,51 +180,66 @@ function ProposalRow({
     try {
       await rejectMutation.mutateAsync(proposal.id);
       toast("Proposal rejected.");
+      handleOpenChange(false);
     } catch (err) {
       toast(formatError(err));
     }
   }
 
   return (
-    <div className="space-y-3 rounded-md border border-border p-3">
-      <p className="text-sm text-foreground">{proposal.bullet}</p>
-      {warnings.length > 0 ? (
-        <p className="text-xs text-amber-600 dark:text-amber-400">
-          Warning: {warnings.join(" ")}
-        </p>
-      ) : null}
-      <dl className="grid gap-1 text-xs text-muted-foreground">
-        <div>
-          <dt className="inline">Proposed </dt>
-          <dd className="inline">{formatTimestamp(proposal.createdAt)}</dd>
-        </div>
-        {proposal.profileId ? (
-          <div>
-            <dt className="inline">Profile </dt>
-            <dd className="inline font-mono">{proposal.profileId}</dd>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="gap-4 p-4 sm:max-w-md sm:p-6">
+        <DialogHeader className="pr-8">
+          <DialogTitle>Approve for org memory?</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <p className="text-xs text-black dark:text-white">Content:</p>
+            <p className="border-l-2 border-primary/40 bg-muted/50 px-3 py-2 font-mono text-xs leading-relaxed text-foreground">
+              {proposal.bullet}
+            </p>
           </div>
-        ) : null}
-        {proposal.proposedByUserId ? (
-          <div>
-            <dt className="inline">User </dt>
-            <dd className="inline font-mono">{proposal.proposedByUserId}</dd>
+
+          <div className="space-y-1.5">
+            <p className="text-xs text-black dark:text-white">Metadata:</p>
+            <ProposalMetadata
+              proposal={proposal}
+              profileLabel={profileLabel}
+              proposer={proposer}
+              variant="detail"
+            />
           </div>
-        ) : null}
-      </dl>
-      <div className="flex flex-wrap items-center gap-3">
-        <div className="flex items-center gap-2">
-          <Switch
-            id={`pin-${proposal.id}`}
-            checked={pinOnApprove}
-            disabled={busy}
-            onCheckedChange={setPinOnApprove}
-            aria-label="Pin on approve"
-          />
-          <label htmlFor={`pin-${proposal.id}`} className="text-xs text-muted-foreground">
-            Pin on approve
-          </label>
+
+          {warnings.length > 0 ? (
+            <p className="text-xs text-amber-600 dark:text-amber-400">
+              {warnings.join(" ")}
+            </p>
+          ) : null}
+
+          <div className="space-y-1.5">
+            <p className="text-xs text-black dark:text-white">Pin for all agents?</p>
+            <div className="flex items-start gap-2">
+              <Switch
+                id={`pin-dialog-${proposal.id}`}
+                size="sm"
+                checked={pinOnApprove}
+                disabled={busy}
+                onCheckedChange={setPinOnApprove}
+                aria-label="Yes / No"
+                className="mt-0.5"
+              />
+              <label
+                htmlFor={`pin-dialog-${proposal.id}`}
+                className="pt-0.5 text-sm font-base text-foreground"
+              >
+                Yes / No
+              </label>
+            </div>
+          </div>
         </div>
-        <div className="ml-auto flex gap-2">
+
+        <DialogFooter className="mx-0 mb-0 gap-2 border-t-0 bg-transparent p-0 pt-2 sm:justify-end">
           <Button type="button" size="sm" variant="outline" disabled={busy} onClick={() => void handleReject()}>
             {rejectMutation.isPending ? <Spinner className="mr-2" /> : null}
             Reject
@@ -105,15 +248,65 @@ function ProposalRow({
             {approveMutation.isPending ? <Spinner className="mr-2" /> : null}
             Approve
           </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ProposalRow({
+  proposal,
+  orgId,
+  profileLabel,
+  proposer,
+}: {
+  proposal: OrgMemoryProposal;
+  orgId: string;
+  profileLabel: string | null;
+  proposer: ProposerInfo | null;
+}) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const warnings = detectOrgMemoryInjectionWarnings(proposal.bullet);
+
+  return (
+    <>
+      <div className="flex flex-wrap items-start gap-3 rounded-md border border-border p-3">
+        <div className="min-w-0 flex-1 space-y-1">
+          <p className="text-sm text-foreground">{proposal.bullet}</p>
+          {warnings.length > 0 ? (
+            <p className="text-xs text-amber-600 dark:text-amber-400">
+              Warning: {warnings.join(" ")}
+            </p>
+          ) : null}
+          <ProposalMetadata
+            proposal={proposal}
+            profileLabel={profileLabel}
+            proposer={proposer}
+          />
         </div>
+        <Button type="button" size="sm" variant="outline" className="shrink-0" onClick={() => setDialogOpen(true)}>
+          Review
+        </Button>
       </div>
-    </div>
+
+      <ProposalReviewDialog
+        proposal={proposal}
+        orgId={orgId}
+        profileLabel={profileLabel}
+        proposer={proposer}
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+      />
+    </>
   );
 }
 
 export function OrgMemoryProposalsPanel({ orgId }: { orgId: string }) {
   const { data, isLoading, error } = useOrgMemoryProposals(orgId, "pending");
+  const { data: profiles = [] } = useProfilesQuery();
+  const { data: membersData } = useOrgMembers(orgId);
   const proposals = data?.proposals ?? [];
+  const members = membersData?.members ?? [];
 
   if (isLoading) {
     return <p className="text-xs text-muted-foreground">Loading proposals…</p>;
@@ -134,7 +327,13 @@ export function OrgMemoryProposalsPanel({ orgId }: { orgId: string }) {
   return (
     <div className="space-y-3">
       {proposals.map((proposal) => (
-        <ProposalRow key={proposal.id} proposal={proposal} orgId={orgId} />
+        <ProposalRow
+          key={proposal.id}
+          proposal={proposal}
+          orgId={orgId}
+          profileLabel={resolveProfileLabel(proposal.profileId, profiles)}
+          proposer={resolveProposer(proposal.proposedByUserId, members)}
+        />
       ))}
     </div>
   );

--- a/apps/web/src/components/settings/OrgMemoryProposalsPanel.tsx
+++ b/apps/web/src/components/settings/OrgMemoryProposalsPanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import type { OrgMemoryProposal } from "@nakama/core/contract";
-import { detectOrgMemoryInjectionWarnings } from "@nakama/core";
+import { detectOrgMemoryInjectionWarnings } from "@nakama/core/soul/org-memory";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";

--- a/apps/web/src/components/settings/OrgMemoryProposalsPanel.tsx
+++ b/apps/web/src/components/settings/OrgMemoryProposalsPanel.tsx
@@ -270,7 +270,7 @@ function ProposalRow({
 
   return (
     <>
-      <div className="flex flex-wrap items-start gap-3 rounded-md border border-border p-3">
+      <div className="flex flex-wrap items-start gap-2 py-2 pl-4 pr-4">
         <div className="min-w-0 flex-1 space-y-1">
           <p className="text-sm text-foreground">{proposal.bullet}</p>
           {warnings.length > 0 ? (
@@ -309,23 +309,23 @@ export function OrgMemoryProposalsPanel({ orgId }: { orgId: string }) {
   const members = membersData?.members ?? [];
 
   if (isLoading) {
-    return <p className="text-xs text-muted-foreground">Loading proposals…</p>;
+    return <p className="px-4 py-2 text-xs text-muted-foreground">Loading proposals…</p>;
   }
 
   if (error) {
     return (
-      <p className="text-sm text-destructive" role="alert">
+      <p className="px-4 py-2 text-sm text-destructive" role="alert">
         {formatError(error)}
       </p>
     );
   }
 
   if (proposals.length === 0) {
-    return <p className="text-xs text-muted-foreground">No pending proposals.</p>;
+    return <p className="px-4 py-2 text-xs text-muted-foreground">No pending proposals.</p>;
   }
 
   return (
-    <div className="space-y-3">
+    <div className="divide-y divide-border">
       {proposals.map((proposal) => (
         <ProposalRow
           key={proposal.id}

--- a/apps/web/src/components/settings/OrgMemoryProposalsPanel.tsx
+++ b/apps/web/src/components/settings/OrgMemoryProposalsPanel.tsx
@@ -188,15 +188,15 @@ function ProposalReviewDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="gap-4 p-4 sm:max-w-md sm:p-6">
+      <DialogContent className="gap-4 overflow-hidden p-4 sm:max-w-md sm:p-6">
         <DialogHeader className="pr-8">
           <DialogTitle>Approve for org memory?</DialogTitle>
         </DialogHeader>
 
-        <div className="space-y-4">
-          <div className="space-y-1.5">
+        <div className="min-w-0 space-y-4">
+          <div className="min-w-0 space-y-1.5">
             <p className="text-xs text-black dark:text-white">Content:</p>
-            <p className="border-l-2 border-primary/40 bg-muted/50 px-3 py-2 font-mono text-xs leading-relaxed text-foreground">
+            <p className="max-w-full min-w-0 border-l-2 border-primary/40 bg-muted/50 px-3 py-2 font-mono text-xs leading-relaxed break-all whitespace-pre-wrap text-foreground">
               {proposal.bullet}
             </p>
           </div>
@@ -270,11 +270,13 @@ function ProposalRow({
 
   return (
     <>
-      <div className="flex flex-wrap items-start gap-2 py-2 pl-4 pr-4">
-        <div className="min-w-0 flex-1 space-y-1">
-          <p className="text-sm text-foreground">{proposal.bullet}</p>
+      <div className="flex items-start gap-2 overflow-hidden py-2 pl-4 pr-4">
+        <div className="min-w-0 flex-1 overflow-hidden space-y-1">
+          <p className="max-w-full min-w-0 break-all text-sm leading-relaxed whitespace-pre-wrap text-foreground">
+            {proposal.bullet}
+          </p>
           {warnings.length > 0 ? (
-            <p className="text-xs text-amber-600 dark:text-amber-400">
+            <p className="break-all text-xs text-amber-600 dark:text-amber-400">
               Warning: {warnings.join(" ")}
             </p>
           ) : null}
@@ -325,7 +327,7 @@ export function OrgMemoryProposalsPanel({ orgId }: { orgId: string }) {
   }
 
   return (
-    <div className="divide-y divide-border">
+    <div className="min-w-0 divide-y divide-border">
       {proposals.map((proposal) => (
         <ProposalRow
           key={proposal.id}

--- a/apps/web/src/components/settings/org-member-dialogs.tsx
+++ b/apps/web/src/components/settings/org-member-dialogs.tsx
@@ -1,5 +1,7 @@
 import type { OrgMemberSummary, OrgRole } from "@nakama/core/contract";
+import { useQuery } from "@tanstack/react-query";
 import { CopyIcon } from "lucide-react";
+import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -12,6 +14,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
 import { OrgMemberRoleSelect } from "@/components/settings/org-member-role-select";
+import { emailSettingsQueryOptions } from "@/hooks/use-email-settings";
 
 export type OrgMemberAddCredentials = {
   email: string;
@@ -39,12 +42,29 @@ export function OrgMemberInviteDialog({
   onInviteRoleChange: (role: OrgRole) => void;
   onSubmit: (event: React.FormEvent) => void;
 }) {
+  const { data: emailSettings, isLoading: emailSettingsLoading } = useQuery(emailSettingsQueryOptions);
+  const emailConfigured = emailSettings?.configured === true;
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Invite member</DialogTitle>
+          <DialogDescription>
+            Send an invite by email. The recipient gets a link to join this organization.
+          </DialogDescription>
         </DialogHeader>
+        {!emailSettingsLoading && !emailConfigured ? (
+          <p className="rounded-md border border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
+            Configure the shared email mailbox before you can invite members by email.{" "}
+            <Link
+              to="/system?tab=tools"
+              className="font-medium text-foreground underline-offset-4 hover:underline"
+            >
+              Configure in System → Tools
+            </Link>
+          </p>
+        ) : null}
         <form onSubmit={onSubmit} className="space-y-4">
           <div>
             <label htmlFor="invite-email" className="mb-1 block text-sm font-medium">

--- a/apps/web/src/components/settings/org-member-dialogs.tsx
+++ b/apps/web/src/components/settings/org-member-dialogs.tsx
@@ -1,6 +1,6 @@
 import type { OrgMemberSummary, OrgRole } from "@nakama/core/contract";
 import { useQuery } from "@tanstack/react-query";
-import { CopyIcon } from "lucide-react";
+import { CopyIcon, MailIcon } from "lucide-react";
 import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import {
@@ -12,7 +12,9 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Spinner } from "@/components/ui/spinner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { OrgMemberRoleSelect } from "@/components/settings/org-member-role-select";
 import { emailSettingsQueryOptions } from "@/hooks/use-email-settings";
 
@@ -20,6 +22,137 @@ export type OrgMemberAddCredentials = {
   email: string;
   temporaryPassword: string;
 };
+
+function OrgMemberInviteForm({
+  inviteEmail,
+  inviteRole,
+  formError,
+  pending,
+  onInviteEmailChange,
+  onInviteRoleChange,
+  onSubmit,
+}: {
+  inviteEmail: string;
+  inviteRole: OrgRole;
+  formError: string | null;
+  pending: boolean;
+  onInviteEmailChange: (value: string) => void;
+  onInviteRoleChange: (role: OrgRole) => void;
+  onSubmit: (event: React.FormEvent) => void;
+}) {
+  const { data: emailSettings, isLoading: emailSettingsLoading } = useQuery(emailSettingsQueryOptions);
+  const emailConfigured = emailSettings?.configured === true;
+
+  return (
+    <>
+      {!emailSettingsLoading && !emailConfigured ? (
+        <p className="rounded-md border border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
+          Configure the shared email mailbox before you can invite members by email.{" "}
+          <Link
+            to="/system?tab=tools"
+            className="font-medium text-foreground underline-offset-4 hover:underline"
+          >
+            Configure in System → Tools
+          </Link>
+        </p>
+      ) : null}
+      <form onSubmit={onSubmit} className="space-y-4">
+        <div>
+          <label htmlFor="invite-email" className="mb-1 block text-sm font-medium">
+            Email
+          </label>
+          <Input
+            id="invite-email"
+            type="email"
+            value={inviteEmail}
+            onChange={(event) => onInviteEmailChange(event.target.value)}
+            placeholder="colleague@example.com"
+            required
+          />
+        </div>
+        <div>
+          <label htmlFor="invite-role" className="mb-1 block text-sm font-medium">
+            Role
+          </label>
+          <OrgMemberRoleSelect value={inviteRole} onChange={onInviteRoleChange} />
+        </div>
+        {formError ? <p className="text-sm text-destructive">{formError}</p> : null}
+        <Button type="submit" size="sm" className="w-full sm:w-auto" disabled={pending}>
+          {pending ? "Sending…" : "Send invite"}
+        </Button>
+      </form>
+    </>
+  );
+}
+
+export function OrgMemberInvitePopover({
+  open,
+  inviteEmail,
+  inviteRole,
+  formError,
+  pending,
+  onOpenChange,
+  onInviteEmailChange,
+  onInviteRoleChange,
+  onSubmit,
+}: {
+  open: boolean;
+  inviteEmail: string;
+  inviteRole: OrgRole;
+  formError: string | null;
+  pending: boolean;
+  onOpenChange: (open: boolean) => void;
+  onInviteEmailChange: (value: string) => void;
+  onInviteRoleChange: (role: OrgRole) => void;
+  onSubmit: (event: React.FormEvent) => void;
+}) {
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <span className="inline-flex">
+              <PopoverTrigger
+                render={
+                  <Button
+                    type="button"
+                    size="icon-sm"
+                    variant="outline"
+                    aria-label="Invite by email"
+                  >
+                    <MailIcon className="size-3.5" aria-hidden />
+                  </Button>
+                }
+              />
+            </span>
+          }
+        />
+        <TooltipContent side="top" sideOffset={8}>
+          Invite by email
+        </TooltipContent>
+      </Tooltip>
+      <PopoverContent align="end" sideOffset={4} className="w-80 overflow-hidden p-0">
+        <div className="space-y-1 border-b border-border px-4 py-3">
+          <p className="text-sm font-medium text-foreground">Invite member</p>
+          <p className="text-xs text-muted-foreground">
+            Send an invite by email. The recipient gets a link to join this organization.
+          </p>
+        </div>
+        <div className="space-y-4 p-4">
+          <OrgMemberInviteForm
+          inviteEmail={inviteEmail}
+          inviteRole={inviteRole}
+          formError={formError}
+          pending={pending}
+          onInviteEmailChange={onInviteEmailChange}
+          onInviteRoleChange={onInviteRoleChange}
+          onSubmit={onSubmit}
+        />
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
 
 export function OrgMemberInviteDialog({
   open,
@@ -42,9 +175,6 @@ export function OrgMemberInviteDialog({
   onInviteRoleChange: (role: OrgRole) => void;
   onSubmit: (event: React.FormEvent) => void;
 }) {
-  const { data: emailSettings, isLoading: emailSettingsLoading } = useQuery(emailSettingsQueryOptions);
-  const emailConfigured = emailSettings?.configured === true;
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
@@ -54,44 +184,15 @@ export function OrgMemberInviteDialog({
             Send an invite by email. The recipient gets a link to join this organization.
           </DialogDescription>
         </DialogHeader>
-        {!emailSettingsLoading && !emailConfigured ? (
-          <p className="rounded-md border border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
-            Configure the shared email mailbox before you can invite members by email.{" "}
-            <Link
-              to="/system?tab=tools"
-              className="font-medium text-foreground underline-offset-4 hover:underline"
-            >
-              Configure in System → Tools
-            </Link>
-          </p>
-        ) : null}
-        <form onSubmit={onSubmit} className="space-y-4">
-          <div>
-            <label htmlFor="invite-email" className="mb-1 block text-sm font-medium">
-              Email
-            </label>
-            <Input
-              id="invite-email"
-              type="email"
-              value={inviteEmail}
-              onChange={(event) => onInviteEmailChange(event.target.value)}
-              placeholder="colleague@example.com"
-              required
-            />
-          </div>
-          <div>
-            <label htmlFor="invite-role" className="mb-1 block text-sm font-medium">
-              Role
-            </label>
-            <OrgMemberRoleSelect value={inviteRole} onChange={onInviteRoleChange} />
-          </div>
-          {formError ? <p className="text-sm text-destructive">{formError}</p> : null}
-          <DialogFooter>
-            <Button type="submit" disabled={pending}>
-              {pending ? "Sending…" : "Send invite"}
-            </Button>
-          </DialogFooter>
-        </form>
+        <OrgMemberInviteForm
+          inviteEmail={inviteEmail}
+          inviteRole={inviteRole}
+          formError={formError}
+          pending={pending}
+          onInviteEmailChange={onInviteEmailChange}
+          onInviteRoleChange={onInviteRoleChange}
+          onSubmit={onSubmit}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/apps/web/src/components/settings/org-members-card-header.tsx
+++ b/apps/web/src/components/settings/org-members-card-header.tsx
@@ -1,14 +1,33 @@
 import { useState } from "react";
-import { CheckIcon, CopyIcon, PlusIcon, UserPlusIcon } from "lucide-react";
+import type { OrgRole } from "@nakama/core/contract";
+import { CheckIcon, CopyIcon, UserPlusIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { OrgMemberInvitePopover } from "@/components/settings/org-member-dialogs";
 
 export function OrgMembersCardHeader({
   orgId,
-  onInvite,
+  inviteOpen,
+  inviteEmail,
+  inviteRole,
+  inviteFormError,
+  invitePending,
+  onInviteOpenChange,
+  onInviteEmailChange,
+  onInviteRoleChange,
+  onInviteSubmit,
   onAddMember,
 }: {
   orgId: string;
-  onInvite: () => void;
+  inviteOpen: boolean;
+  inviteEmail: string;
+  inviteRole: OrgRole;
+  inviteFormError: string | null;
+  invitePending: boolean;
+  onInviteOpenChange: (open: boolean) => void;
+  onInviteEmailChange: (value: string) => void;
+  onInviteRoleChange: (role: OrgRole) => void;
+  onInviteSubmit: (event: React.FormEvent) => void;
   onAddMember: () => void;
 }) {
   const [copiedOrgId, setCopiedOrgId] = useState(false);
@@ -24,39 +43,57 @@ export function OrgMembersCardHeader({
   }
 
   return (
-    <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
-      <div className="min-w-0 space-y-0.5">
-        <p className="text-sm font-medium text-foreground">Organization</p>
-        <div className="flex items-center gap-1.5 pt-0.5">
-          <span className="text-xs text-muted-foreground">Org ID</span>
-          <code className="max-w-[14rem] truncate rounded border border-border bg-muted/30 px-1.5 py-0.5 font-mono text-[11px] text-foreground sm:max-w-xs">
-            {orgId}
-          </code>
-          <Button
-            type="button"
-            size="icon-sm"
-            variant="ghost"
-            className="size-7 shrink-0"
-            aria-label={copiedOrgId ? "Copied org ID" : "Copy org ID"}
-            onClick={() => void handleCopyOrgId()}
-          >
-            {copiedOrgId ? (
-              <CheckIcon className="size-3.5 text-emerald-600 dark:text-emerald-400" aria-hidden />
-            ) : (
-              <CopyIcon className="size-3.5" aria-hidden />
-            )}
-          </Button>
-        </div>
+    <div className="flex flex-wrap items-center justify-between gap-2 px-4 py-2">
+      <div className="flex min-w-0 items-center gap-2">
+        <span className="shrink-0 text-sm font-medium leading-none text-foreground">Organization</span>
+        <code className="inline-flex h-7 max-w-[14rem] items-center truncate rounded border border-border bg-muted/30 px-1.5 font-mono text-[11px] leading-none text-foreground sm:max-w-xs">
+          {orgId}
+        </code>
+        <Button
+          type="button"
+          size="icon-sm"
+          variant="ghost"
+          className="size-7 shrink-0"
+          aria-label={copiedOrgId ? "Copied org ID" : "Copy org ID"}
+          onClick={() => void handleCopyOrgId()}
+        >
+          {copiedOrgId ? (
+            <CheckIcon className="size-3.5 text-emerald-600 dark:text-emerald-400" aria-hidden />
+          ) : (
+            <CopyIcon className="size-3.5" aria-hidden />
+          )}
+        </Button>
       </div>
-      <div className="flex items-center gap-2">
-        <Button type="button" size="sm" variant="outline" onClick={onInvite}>
-          <PlusIcon className="size-3.5" aria-hidden="true" />
-          Invite
-        </Button>
-        <Button type="button" size="sm" onClick={onAddMember}>
-          <UserPlusIcon className="size-3.5" aria-hidden="true" />
-          Add member
-        </Button>
+      <div className="flex items-center gap-1">
+        <OrgMemberInvitePopover
+          open={inviteOpen}
+          inviteEmail={inviteEmail}
+          inviteRole={inviteRole}
+          formError={inviteFormError}
+          pending={invitePending}
+          onOpenChange={onInviteOpenChange}
+          onInviteEmailChange={onInviteEmailChange}
+          onInviteRoleChange={onInviteRoleChange}
+          onSubmit={onInviteSubmit}
+        />
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                type="button"
+                size="icon-sm"
+                variant="outline"
+                aria-label="Add member"
+                onClick={onAddMember}
+              >
+                <UserPlusIcon className="size-3.5" aria-hidden />
+              </Button>
+            }
+          />
+          <TooltipContent side="top" sideOffset={8}>
+            Add member
+          </TooltipContent>
+        </Tooltip>
       </div>
     </div>
   );

--- a/apps/web/src/components/settings/org-members-table.tsx
+++ b/apps/web/src/components/settings/org-members-table.tsx
@@ -25,7 +25,7 @@ export function OrgMembersTable({
 }) {
   if (isLoading) {
     return (
-      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+      <div className="flex items-center gap-2 px-4 py-2 text-sm text-muted-foreground">
         <Spinner />
         Loading members…
       </div>
@@ -33,29 +33,42 @@ export function OrgMembersTable({
   }
 
   if (members.length === 0) {
-    return <p className="text-sm text-muted-foreground">No members yet.</p>;
+    return <p className="px-4 py-2 text-sm text-muted-foreground">No members yet.</p>;
   }
 
+  const headerMemberClass =
+    "border-b border-r border-border py-2 pl-4 pr-2 font-medium";
+  const headerRoleClass =
+    "border-b border-r border-border px-2 py-2 font-medium";
+  const headerActionsClass =
+    "border-b border-border py-2 pl-2 pr-4 font-medium";
+  const memberCellClass =
+    "border-b border-r border-border py-1.5 pl-4 pr-2";
+  const roleCellClass =
+    "border-b border-r border-border px-2 py-1.5";
+  const actionsCellClass =
+    "border-b border-border py-1.5 pl-2 pr-4";
+
   return (
-    <div className="overflow-x-auto rounded-lg border border-border">
-      <table className="w-full min-w-[28rem] text-left text-sm">
-        <thead className="border-b border-border bg-muted/30 text-xs text-muted-foreground">
+    <div className="overflow-x-auto">
+      <table className="w-full min-w-[28rem] border-collapse text-left text-sm">
+        <thead className="text-xs text-muted-foreground">
           <tr>
-            <th className="px-3 py-2 font-medium">Member</th>
-            <th className="px-3 py-2 font-medium">Role</th>
-            <th className="px-3 py-2 font-medium">
+            <th className={headerMemberClass}>Member</th>
+            <th className={headerRoleClass}>Role</th>
+            <th className={headerActionsClass}>
               <span className="sr-only">Actions</span>
             </th>
           </tr>
         </thead>
-        <tbody className="divide-y divide-border">
+        <tbody>
           {members.map((member) => {
             const isSelf = member.email === currentUserEmail;
             const displayName = member.name?.trim() || member.email;
 
             return (
-              <tr key={member.userId}>
-                <td className="px-3 py-2">
+              <tr key={member.userId} className="last:[&>td]:border-b-0">
+                <td className={memberCellClass}>
                   <div className="min-w-0">
                     <p className="truncate font-medium text-foreground">
                       {displayName}
@@ -70,14 +83,14 @@ export function OrgMembersTable({
                     ) : null}
                   </div>
                 </td>
-                <td className="px-3 py-2">
+                <td className={roleCellClass}>
                   <OrgMemberRoleSelect
                     value={member.role}
                     disabled={updatePending}
                     onChange={(role) => onRoleChange(member.userId, role)}
                   />
                 </td>
-                <td className="px-3 py-2">
+                <td className={actionsCellClass}>
                   <div className="flex items-center justify-end gap-1">
                     <Button
                       type="button"

--- a/apps/web/src/components/system/OrganizationPanel.tsx
+++ b/apps/web/src/components/system/OrganizationPanel.tsx
@@ -1,0 +1,11 @@
+import { OrgMembersCard } from "@/components/settings/OrgMembersCard";
+import { OrgMemoryCard } from "@/components/settings/OrgMemoryCard";
+
+export function OrganizationPanel() {
+  return (
+    <div className="min-w-0 space-y-8 p-4 sm:p-5">
+      <OrgMembersCard />
+      <OrgMemoryCard />
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/switch.tsx
+++ b/apps/web/src/components/ui/switch.tsx
@@ -6,8 +6,24 @@ type SwitchProps = {
   disabled?: boolean;
   id?: string;
   className?: string;
+  size?: "default" | "sm";
   "aria-label"?: string;
 };
+
+const switchSizes = {
+  default: {
+    track: "h-6 w-11",
+    thumb: "size-5",
+    on: "translate-x-5",
+    off: "translate-x-0.5",
+  },
+  sm: {
+    track: "h-5 w-9",
+    thumb: "size-4",
+    on: "translate-x-4",
+    off: "translate-x-0.5",
+  },
+} as const;
 
 function Switch({
   checked,
@@ -15,8 +31,11 @@ function Switch({
   disabled,
   id,
   className,
+  size = "default",
   "aria-label": ariaLabel,
 }: SwitchProps) {
+  const dimensions = switchSizes[size];
+
   return (
     <button
       type="button"
@@ -27,7 +46,8 @@ function Switch({
       disabled={disabled}
       onClick={() => onCheckedChange(!checked)}
       className={cn(
-        "relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50",
+        "relative inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50",
+        dimensions.track,
         checked ? "bg-primary" : "bg-muted",
         className,
       )}
@@ -35,8 +55,9 @@ function Switch({
       <span
         aria-hidden="true"
         className={cn(
-          "pointer-events-none block size-5 rounded-full bg-background shadow-sm transition-transform",
-          checked ? "translate-x-5" : "translate-x-0.5",
+          "pointer-events-none block rounded-full bg-background shadow-sm transition-transform",
+          dimensions.thumb,
+          checked ? dimensions.on : dimensions.off,
         )}
       />
     </button>

--- a/apps/web/src/hooks/use-notifications.ts
+++ b/apps/web/src/hooks/use-notifications.ts
@@ -1,0 +1,101 @@
+import { useMemo } from "react";
+import { useAuth } from "@/context/use-auth";
+import { useAutomationsQuery } from "@/hooks/use-automations";
+import { useOrgMemoryProposals } from "@/hooks/use-org-memory-proposals";
+import { PAGE_PATHS } from "@/lib/navigation";
+
+export type NotificationKind = "automation-run" | "org-memory-proposal";
+
+export interface NotificationItem {
+  id: string;
+  kind: NotificationKind;
+  kindLabel: string;
+  title: string;
+  description: string;
+  href: string;
+  count: number;
+  createdAt?: string;
+}
+
+export function useNotifications(): {
+  items: NotificationItem[];
+  automationItems: NotificationItem[];
+  orgMemoryItems: NotificationItem[];
+  totalCount: number;
+  isLoading: boolean;
+} {
+  const { activeOrg, isAuthenticated, isLoading: authLoading } = useAuth();
+  const isOrgAdmin = activeOrg?.role === "admin";
+  const orgId = activeOrg?.id ?? null;
+
+  const { data: automationsData, isLoading: automationsLoading } = useAutomationsQuery();
+  const { data: proposalsData, isLoading: proposalsLoading } = useOrgMemoryProposals(
+    isOrgAdmin ? orgId : null,
+    "pending",
+    { refetchInterval: 30_000 },
+  );
+
+  const { items, automationItems, orgMemoryItems } = useMemo(() => {
+    const automationItems: NotificationItem[] = [];
+    const orgMemoryItems: NotificationItem[] = [];
+
+    const automations = automationsData?.automations ?? [];
+    const unreadByAutomationId = automationsData?.unread?.byAutomationId ?? {};
+
+    for (const automation of automations) {
+      const count = unreadByAutomationId[automation.id] ?? 0;
+      if (count <= 0) {
+        continue;
+      }
+
+      automationItems.push({
+        id: `automation-${automation.id}`,
+        kind: "automation-run",
+        kindLabel: "Automation",
+        title: automation.name,
+        description:
+          count === 1 ? "1 unread automation run" : `${count} unread automation runs`,
+        href: `${PAGE_PATHS.automations}?automation=${encodeURIComponent(automation.id)}`,
+        count,
+        createdAt: automation.lastRunAt ?? undefined,
+      });
+    }
+
+    for (const proposal of proposalsData?.proposals ?? []) {
+      orgMemoryItems.push({
+        id: `org-memory-${proposal.id}`,
+        kind: "org-memory-proposal",
+        kindLabel: "Org memory",
+        title: "Memory proposal awaiting review",
+        description: proposal.bullet,
+        href: `${PAGE_PATHS.soul}?tab=organization&orgMemory=proposals`,
+        count: 1,
+        createdAt: proposal.createdAt,
+      });
+    }
+
+    return {
+      items: [...automationItems, ...orgMemoryItems],
+      automationItems,
+      orgMemoryItems,
+    };
+  }, [automationsData, proposalsData?.proposals]);
+
+  const totalCount = items.reduce((sum, item) => sum + item.count, 0);
+  const isLoading =
+    authLoading ||
+    !isAuthenticated ||
+    automationsLoading ||
+    (isOrgAdmin && proposalsLoading);
+
+  return { items, automationItems, orgMemoryItems, totalCount, isLoading };
+}
+
+/** @deprecated Use useNotifications */
+export const useSidebarNotifications = useNotifications;
+
+/** @deprecated Use NotificationItem */
+export type SidebarNotificationItem = NotificationItem;
+
+/** @deprecated Use NotificationKind */
+export type SidebarNotificationKind = NotificationKind;

--- a/apps/web/src/hooks/use-org-memory-history.ts
+++ b/apps/web/src/hooks/use-org-memory-history.ts
@@ -20,6 +20,14 @@ export function useOrgMemoryHistory(orgId: string | null) {
   });
 }
 
+export function useOrgMemoryHistoryRevision(orgId: string, revisionId: string | null) {
+  return useQuery({
+    queryKey: queryKeys.orgMemoryHistoryRevision(orgId, revisionId ?? ""),
+    queryFn: () => client.getOrgMemoryHistoryRevision(orgId, revisionId!),
+    enabled: Boolean(orgId && revisionId),
+  });
+}
+
 export function useRestoreOrgMemoryHistory(orgId: string) {
   const queryClient = useQueryClient();
   return useMutation({

--- a/apps/web/src/hooks/use-org-memory-history.ts
+++ b/apps/web/src/hooks/use-org-memory-history.ts
@@ -1,0 +1,37 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { client } from "@/lib/client";
+import { queryKeys } from "@/lib/query-keys";
+
+function invalidateOrgMemoryQueries(
+  queryClient: ReturnType<typeof useQueryClient>,
+  orgId: string,
+) {
+  return Promise.all([
+    queryClient.invalidateQueries({ queryKey: queryKeys.orgMemory(orgId) }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.orgMemoryHistory(orgId) }),
+  ]);
+}
+
+export function useOrgMemoryHistory(orgId: string | null) {
+  return useQuery({
+    queryKey: queryKeys.orgMemoryHistory(orgId ?? ""),
+    queryFn: () => client.listOrgMemoryHistory(orgId ?? ""),
+    enabled: Boolean(orgId),
+  });
+}
+
+export function useRestoreOrgMemoryHistory(orgId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (revisionId: string) => client.restoreOrgMemoryHistory(orgId, revisionId),
+    onSuccess: () => invalidateOrgMemoryQueries(queryClient, orgId),
+  });
+}
+
+export function useUndoOrgMemoryChange(orgId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => client.undoOrgMemoryChange(orgId),
+    onSuccess: () => invalidateOrgMemoryQueries(queryClient, orgId),
+  });
+}

--- a/apps/web/src/hooks/use-org-memory-proposals.ts
+++ b/apps/web/src/hooks/use-org-memory-proposals.ts
@@ -23,6 +23,7 @@ function invalidateProposalQueries(
   return Promise.all([
     queryClient.invalidateQueries({ queryKey: ["orgMemoryProposals", orgId] }),
     queryClient.invalidateQueries({ queryKey: queryKeys.orgMemory(orgId) }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.orgMemoryHistory(orgId) }),
   ]);
 }
 

--- a/apps/web/src/hooks/use-org-memory-proposals.ts
+++ b/apps/web/src/hooks/use-org-memory-proposals.ts
@@ -3,11 +3,16 @@ import type { ApproveOrgMemoryProposalRequest } from "@nakama/core/contract";
 import { client } from "@/lib/client";
 import { queryKeys } from "@/lib/query-keys";
 
-export function useOrgMemoryProposals(orgId: string | null, status: "pending" | "approved" | "rejected" = "pending") {
+export function useOrgMemoryProposals(
+  orgId: string | null,
+  status: "pending" | "approved" | "rejected" = "pending",
+  options?: { refetchInterval?: number },
+) {
   return useQuery({
     queryKey: queryKeys.orgMemoryProposals(orgId ?? "", status),
     queryFn: () => client.listOrgMemoryProposals(orgId ?? "", status),
     enabled: Boolean(orgId),
+    refetchInterval: options?.refetchInterval,
   });
 }
 

--- a/apps/web/src/hooks/use-org-memory-proposals.ts
+++ b/apps/web/src/hooks/use-org-memory-proposals.ts
@@ -1,0 +1,44 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { ApproveOrgMemoryProposalRequest } from "@nakama/core/contract";
+import { client } from "@/lib/client";
+import { queryKeys } from "@/lib/query-keys";
+
+export function useOrgMemoryProposals(orgId: string | null, status: "pending" | "approved" | "rejected" = "pending") {
+  return useQuery({
+    queryKey: queryKeys.orgMemoryProposals(orgId ?? "", status),
+    queryFn: () => client.listOrgMemoryProposals(orgId ?? "", status),
+    enabled: Boolean(orgId),
+  });
+}
+
+function invalidateProposalQueries(
+  queryClient: ReturnType<typeof useQueryClient>,
+  orgId: string,
+) {
+  return Promise.all([
+    queryClient.invalidateQueries({ queryKey: ["orgMemoryProposals", orgId] }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.orgMemory(orgId) }),
+  ]);
+}
+
+export function useApproveOrgMemoryProposal(orgId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      proposalId,
+      request = {},
+    }: {
+      proposalId: string;
+      request?: ApproveOrgMemoryProposalRequest;
+    }) => client.approveOrgMemoryProposal(orgId, proposalId, request),
+    onSuccess: () => invalidateProposalQueries(queryClient, orgId),
+  });
+}
+
+export function useRejectOrgMemoryProposal(orgId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (proposalId: string) => client.rejectOrgMemoryProposal(orgId, proposalId),
+    onSuccess: () => invalidateProposalQueries(queryClient, orgId),
+  });
+}

--- a/apps/web/src/hooks/use-org-memory.ts
+++ b/apps/web/src/hooks/use-org-memory.ts
@@ -15,7 +15,10 @@ function invalidateOrgMemory(
   queryClient: ReturnType<typeof useQueryClient>,
   orgId: string,
 ) {
-  return queryClient.invalidateQueries({ queryKey: queryKeys.orgMemory(orgId) });
+  return Promise.all([
+    queryClient.invalidateQueries({ queryKey: queryKeys.orgMemory(orgId) }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.orgMemoryHistory(orgId) }),
+  ]);
 }
 
 export function useUpdateOrgMemory(orgId: string) {

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -1,5 +1,6 @@
 import type { LucideIcon } from "lucide-react";
 import {
+  BellIcon,
   CircleFadingPlusIcon,
   CircleUserRoundIcon,
   BrainIcon,
@@ -18,7 +19,8 @@ export type PageId =
   | "automations"
   | "tasks"
   | "integrations"
-  | "settings";
+  | "settings"
+  | "notifications";
 
 export interface NavItem {
   id: PageId;
@@ -95,6 +97,14 @@ export const NAV_GROUPS: NavGroup[] = [
 
 export const NAV_ITEMS: NavItem[] = NAV_GROUPS.flatMap((group) => group.items);
 
+export const STANDALONE_PAGES: Partial<Record<PageId, NavItem>> = {
+  notifications: {
+    id: "notifications",
+    label: "Notifications",
+    description: "Automation runs and org memory proposals",
+  },
+};
+
 export const NAV_ITEM_ICONS: Record<PageId, LucideIcon> = {
   chat: CircleFadingPlusIcon,
   history: ClockIcon,
@@ -104,6 +114,7 @@ export const NAV_ITEM_ICONS: Record<PageId, LucideIcon> = {
   tasks: KanbanIcon,
   integrations: CableIcon,
   settings: CogIcon,
+  notifications: BellIcon,
 };
 
 export const SETUP_PATH = "/setup";
@@ -178,6 +189,7 @@ export const PAGE_PATHS: Record<PageId, string> = {
   tasks: "/tasks",
   integrations: "/integrations",
   settings: "/settings",
+  notifications: "/notifications",
 };
 
 export function pathForPage(pageId: PageId): string {
@@ -200,7 +212,7 @@ export function navHrefForPage(
 }
 
 export function findNavItem(pageId: PageId): NavItem | undefined {
-  return NAV_ITEMS.find((item) => item.id === pageId);
+  return NAV_ITEMS.find((item) => item.id === pageId) ?? STANDALONE_PAGES[pageId];
 }
 
 export function pageIdFromPath(pathname: string): PageId | null {

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -90,4 +90,6 @@ export const queryKeys = {
   workerLogs: ["workerLogs"] as const,
   orgMembers: (orgId: string) => ["orgMembers", orgId] as const,
   orgMemory: (orgId: string) => ["orgMemory", orgId] as const,
+  orgMemoryProposals: (orgId: string, status?: string) =>
+    ["orgMemoryProposals", orgId, status ?? "all"] as const,
 } as const;

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -91,6 +91,8 @@ export const queryKeys = {
   orgMembers: (orgId: string) => ["orgMembers", orgId] as const,
   orgMemory: (orgId: string) => ["orgMemory", orgId] as const,
   orgMemoryHistory: (orgId: string) => ["orgMemoryHistory", orgId] as const,
+  orgMemoryHistoryRevision: (orgId: string, revisionId: string) =>
+    ["orgMemoryHistoryRevision", orgId, revisionId] as const,
   orgMemoryProposals: (orgId: string, status?: string) =>
     ["orgMemoryProposals", orgId, status ?? "all"] as const,
 } as const;

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -90,6 +90,7 @@ export const queryKeys = {
   workerLogs: ["workerLogs"] as const,
   orgMembers: (orgId: string) => ["orgMembers", orgId] as const,
   orgMemory: (orgId: string) => ["orgMemory", orgId] as const,
+  orgMemoryHistory: (orgId: string) => ["orgMemoryHistory", orgId] as const,
   orgMemoryProposals: (orgId: string, status?: string) =>
     ["orgMemoryProposals", orgId, status ?? "all"] as const,
 } as const;

--- a/apps/web/src/pages/NotificationsPage.tsx
+++ b/apps/web/src/pages/NotificationsPage.tsx
@@ -14,7 +14,7 @@ export function NotificationsPage() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-3xl">
+    <div className="mx-auto w-full min-w-0 max-w-3xl">
       {totalCount === 0 ? (
         <p className="py-6 text-center text-sm text-muted-foreground">All caught up</p>
       ) : (

--- a/apps/web/src/pages/NotificationsPage.tsx
+++ b/apps/web/src/pages/NotificationsPage.tsx
@@ -1,0 +1,87 @@
+import type { ReactNode } from "react";
+import { Card } from "@/components/ui/card";
+import { Spinner } from "@/components/ui/spinner";
+import { NotificationList } from "@/components/notifications/notification-list";
+import { useNotifications } from "@/hooks/use-notifications";
+
+function NotificationSection({
+  title,
+  description,
+  count,
+  children,
+}: {
+  title: string;
+  description: string;
+  count: number;
+  children: ReactNode;
+}) {
+  if (count === 0) {
+    return null;
+  }
+
+  return (
+    <section className="space-y-3">
+      <div>
+        <h2 className="text-sm font-medium text-foreground">
+          {title}
+          <span className="ml-2 text-xs font-normal text-muted-foreground">({count})</span>
+        </h2>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+export function NotificationsPage() {
+  const { automationItems, orgMemoryItems, totalCount, isLoading } = useNotifications();
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-48 items-center justify-center text-sm text-muted-foreground">
+        <Spinner className="size-5" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-4">
+      <Card className="overflow-hidden shadow-none">
+        <div className="border-b border-border px-4 py-3">
+          <p className="text-sm text-muted-foreground">
+            {totalCount === 0
+              ? "No unread notifications right now."
+              : `${totalCount} unread notification${totalCount === 1 ? "" : "s"}`}
+          </p>
+        </div>
+
+        <div className="space-y-6 px-4 py-4">
+          {totalCount === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              Automation runs and org memory proposals will show up here when they need your
+              attention.
+            </p>
+          ) : (
+            <>
+              <NotificationSection
+                title="Automation runs"
+                description="Unread results from scheduled or manual automation runs."
+                count={automationItems.length}
+              >
+                <NotificationList items={automationItems} />
+              </NotificationSection>
+
+              <NotificationSection
+                title="Org memory proposals"
+                description="Facts proposed by agents that need admin approval."
+                count={orgMemoryItems.length}
+              >
+                <NotificationList items={orgMemoryItems} />
+              </NotificationSection>
+            </>
+          )}
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/pages/NotificationsPage.tsx
+++ b/apps/web/src/pages/NotificationsPage.tsx
@@ -1,40 +1,9 @@
-import type { ReactNode } from "react";
-import { Card } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
 import { NotificationList } from "@/components/notifications/notification-list";
 import { useNotifications } from "@/hooks/use-notifications";
 
-function NotificationSection({
-  title,
-  description,
-  count,
-  children,
-}: {
-  title: string;
-  description: string;
-  count: number;
-  children: ReactNode;
-}) {
-  if (count === 0) {
-    return null;
-  }
-
-  return (
-    <section className="space-y-3">
-      <div>
-        <h2 className="text-sm font-medium text-foreground">
-          {title}
-          <span className="ml-2 text-xs font-normal text-muted-foreground">({count})</span>
-        </h2>
-        <p className="text-xs text-muted-foreground">{description}</p>
-      </div>
-      {children}
-    </section>
-  );
-}
-
 export function NotificationsPage() {
-  const { automationItems, orgMemoryItems, totalCount, isLoading } = useNotifications();
+  const { items, totalCount, isLoading } = useNotifications();
 
   if (isLoading) {
     return (
@@ -45,43 +14,12 @@ export function NotificationsPage() {
   }
 
   return (
-    <div className="mx-auto flex w-full max-w-3xl flex-col gap-4">
-      <Card className="overflow-hidden shadow-none">
-        <div className="border-b border-border px-4 py-3">
-          <p className="text-sm text-muted-foreground">
-            {totalCount === 0
-              ? "No unread notifications right now."
-              : `${totalCount} unread notification${totalCount === 1 ? "" : "s"}`}
-          </p>
-        </div>
-
-        <div className="space-y-6 px-4 py-4">
-          {totalCount === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              Automation runs and org memory proposals will show up here when they need your
-              attention.
-            </p>
-          ) : (
-            <>
-              <NotificationSection
-                title="Automation runs"
-                description="Unread results from scheduled or manual automation runs."
-                count={automationItems.length}
-              >
-                <NotificationList items={automationItems} />
-              </NotificationSection>
-
-              <NotificationSection
-                title="Org memory proposals"
-                description="Facts proposed by agents that need admin approval."
-                count={orgMemoryItems.length}
-              >
-                <NotificationList items={orgMemoryItems} />
-              </NotificationSection>
-            </>
-          )}
-        </div>
-      </Card>
+    <div className="mx-auto w-full max-w-3xl">
+      {totalCount === 0 ? (
+        <p className="py-6 text-center text-sm text-muted-foreground">All caught up</p>
+      ) : (
+        <NotificationList items={items} />
+      )}
     </div>
   );
 }

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -1,7 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 import { ProviderSettingsCard } from "@/components/settings/ProviderSettingsCard";
-import { OrgMembersCard } from "@/components/settings/OrgMembersCard";
-import { OrgMemoryCard } from "@/components/settings/OrgMemoryCard";
 import { VisionSettingsCard } from "@/components/settings/VisionSettingsCard";
 import { TranscriptionSettingsCard } from "@/components/settings/TranscriptionSettingsCard";
 import { WebPublicUrlSettingsRow } from "@/components/settings/WebPublicUrlSettingsRow";
@@ -51,10 +49,6 @@ export function SettingsPage() {
 
   return (
     <div className="mx-auto max-w-3xl space-y-8">
-      <OrgMembersCard />
-
-      <OrgMemoryCard />
-
       <Card className="w-full shadow-none">
         <CardContent className="divide-y divide-border p-0">
           <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">

--- a/apps/web/src/pages/SystemPage.test.ts
+++ b/apps/web/src/pages/SystemPage.test.ts
@@ -5,16 +5,23 @@ describe("SystemPage tab access", () => {
   test("shows status to all system users and data portability only to platform admins", () => {
     expect(visibleSystemTabs(true).map((tab) => tab.id)).toEqual([
       "status",
+      "organization",
       "tools",
       "mcp",
       "data",
     ]);
-    expect(visibleSystemTabs(false).map((tab) => tab.id)).toEqual(["status", "tools"]);
+    expect(visibleSystemTabs(false).map((tab) => tab.id)).toEqual([
+      "status",
+      "organization",
+      "tools",
+    ]);
   });
 
   test("resolves status for all system users and forces non-platform users off admin tabs", () => {
     expect(resolveSystemTab("status", true)).toBe("status");
     expect(resolveSystemTab("status", false)).toBe("status");
+    expect(resolveSystemTab("organization", true)).toBe("organization");
+    expect(resolveSystemTab("organization", false)).toBe("organization");
     expect(resolveSystemTab("data", true)).toBe("data");
     expect(resolveSystemTab("data", false)).toBe("tools");
     expect(resolveSystemTab("unknown", true)).toBe("tools");

--- a/apps/web/src/pages/SystemPage.tsx
+++ b/apps/web/src/pages/SystemPage.tsx
@@ -4,6 +4,7 @@ import { Navigate, useSearchParams } from "react-router-dom";
 import { McpTab } from "@/components/soul-tools/McpTab";
 import { ToolsTab } from "@/components/soul-tools/ToolsTab";
 import { DataPortabilityPanel } from "@/components/system/DataPortabilityPanel";
+import { OrganizationPanel } from "@/components/system/OrganizationPanel";
 import { Spinner } from "@/components/ui/spinner";
 import { useAuth } from "@/context/use-auth";
 import { canAccessSystemPage } from "@/lib/navigation";
@@ -76,6 +77,8 @@ export function SystemPage() {
       >
         {tab === "status" ? (
           <StatusPage embedded />
+        ) : tab === "organization" ? (
+          <OrganizationPanel />
         ) : tab === "tools" ? (
           <ToolsTab embedded />
         ) : tab === "mcp" ? (

--- a/apps/web/src/pages/automations/use-automations-page.ts
+++ b/apps/web/src/pages/automations/use-automations-page.ts
@@ -3,6 +3,7 @@ import type {
   StoredAutomation,
 } from "@nakama/core/contract";
 import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import {
   useAutomationRunsQuery,
   useAutomationsQuery,
@@ -36,6 +37,7 @@ export function useAutomationsPage() {
     automationsData?.unread?.byAutomationId ?? EMPTY_UNREAD_BY_AUTOMATION_ID;
   const { data: profiles = [] } = useProfilesQuery();
   const superBotProfile = findSuperBotProfile(profiles);
+  const [searchParams] = useSearchParams();
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const {
     data: runs = [],
@@ -95,10 +97,19 @@ export function useAutomationsPage() {
       return;
     }
 
+    const automationFromUrl = searchParams.get("automation");
+    if (
+      automationFromUrl &&
+      automations.some((automation) => automation.id === automationFromUrl)
+    ) {
+      setSelectedId(automationFromUrl);
+      return;
+    }
+
     if (!selectedId || !automations.some((automation) => automation.id === selectedId)) {
       setSelectedId(automations[0]!.id);
     }
-  }, [automations, selectedId]);
+  }, [automations, selectedId, searchParams]);
 
   useEffect(() => {
     if (!selectedId || !runsLoaded) {

--- a/apps/web/src/pages/system-page.shared.ts
+++ b/apps/web/src/pages/system-page.shared.ts
@@ -1,5 +1,6 @@
 import {
   BlocksIcon,
+  Building2Icon,
   CircleGaugeIcon,
   DatabaseBackupIcon,
   PlugIcon,
@@ -7,6 +8,7 @@ import {
 
 export const SYSTEM_TABS = [
   { id: "status" as const, label: "Status", icon: CircleGaugeIcon },
+  { id: "organization" as const, label: "Organization", icon: Building2Icon },
   { id: "tools" as const, label: "Tools", icon: BlocksIcon },
   { id: "mcp" as const, label: "MCP", icon: PlugIcon },
   { id: "data" as const, label: "Data", icon: DatabaseBackupIcon },
@@ -17,6 +19,10 @@ export type SystemTabId = (typeof SYSTEM_TABS)[number]["id"];
 export function resolveSystemTab(value: string | null, isPlatformAdmin: boolean): SystemTabId {
   if (value === "status") {
     return "status";
+  }
+
+  if (value === "organization") {
+    return "organization";
   }
 
   if (!isPlatformAdmin) {
@@ -31,7 +37,11 @@ export function resolveSystemTab(value: string | null, isPlatformAdmin: boolean)
 }
 
 export function visibleSystemTabs(isPlatformAdmin: boolean) {
-  return isPlatformAdmin
-    ? SYSTEM_TABS
-    : SYSTEM_TABS.filter((item) => item.id === "status" || item.id === "tools");
+  if (isPlatformAdmin) {
+    return SYSTEM_TABS;
+  }
+
+  return SYSTEM_TABS.filter(
+    (item) => item.id === "status" || item.id === "organization" || item.id === "tools",
+  );
 }

--- a/docs/website/content/docs/backup-restore.mdx
+++ b/docs/website/content/docs/backup-restore.mdx
@@ -14,7 +14,7 @@ Treat export ZIPs as sensitive. They can include:
 - Provider settings and API keys
 - Auth data
 - Org and profile workspaces (soul files, memory, artifacts)
-- Org-level `MEMORY.md` and `memory-archive/` (see [Org memory](/org-memory))
+- Org-level `MEMORY.md`, `memory-archive/`, and `memory-history/` (see [Org memory](/org-memory))
 - Custom tools and skills
 - The local SQLite database when it lives under the Nakama root
 

--- a/docs/website/content/docs/org-memory.mdx
+++ b/docs/website/content/docs/org-memory.mdx
@@ -112,6 +112,7 @@ Org admins can also manage memory via the REST API (`X-Org-Id` required):
 | `GET` | `/v1/orgs/{orgId}/memory` | Read live memory |
 | `PUT` | `/v1/orgs/{orgId}/memory` | Replace live memory |
 | `GET` | `/v1/orgs/{orgId}/memory/history` | List change snapshots (newest first) |
+| `GET` | `/v1/orgs/{orgId}/memory/history/{revisionId}` | Read a single snapshot |
 | `POST` | `/v1/orgs/{orgId}/memory/history/undo` | Undo the latest change |
 | `POST` | `/v1/orgs/{orgId}/memory/history/{revisionId}/restore` | Restore a specific snapshot |
 | `GET` | `/v1/orgs/{orgId}/memory/proposals` | List proposals |

--- a/docs/website/content/docs/org-memory.mdx
+++ b/docs/website/content/docs/org-memory.mdx
@@ -5,7 +5,7 @@ description: "Shared, admin-curated facts for an organization — injected into 
 
 **Org memory** is shared context for the whole organization.
 
-Every non-viewer agent in the org sees a pinned summary in its system prompt. Org admins curate the facts from **Settings → Org Memory**. Members can read and search; viewers are blocked entirely.
+Every non-viewer agent in the org sees a summary of pinned facts plus recent log entries in its system prompt. Org admins curate facts from **Settings → Org Memory** and review agent proposals on the **Proposals** tab. Members can read and search; viewers are blocked entirely.
 
 Org memory is separate from [profile memory](/profiles#knowledge-base-and-memory). Profile `MEMORY.md` is per-bot continuity that agents update themselves. Org memory is team-wide facts that admins maintain.
 
@@ -22,9 +22,9 @@ Archived bullets move into monthly `.md` files under `memory-archive/` without d
 
 Platform-admin [data exports](/backup-restore) include org memory as part of the org workspace in the ZIP.
 
-## Format (v1)
+## Format
 
-v1 is **pinned-only**. Use this structure:
+Use this structure:
 
 ```md
 ## Org Memory
@@ -32,14 +32,17 @@ v1 is **pinned-only**. Use this structure:
 ## Pinned
 
 - Acme Corp is our primary customer in APAC.
+
+## 2026-07-31
+
 - Support hours are 9am–6pm SGT, Mon–Fri.
 ```
 
 | Rule | Detail |
 |------|--------|
-| Pinned bullets | Lines under `## Pinned` starting with `- ` |
-| Dated sections | `## YYYY-MM-DD` sections are parsed but **not** injected into prompts (reserved for a future recent-log tier) |
-| Empty state | When no pinned bullets exist, nothing is injected |
+| Pinned bullets | Always-in-prompt facts under `## Pinned` |
+| Recent log | `## YYYY-MM-DD` dated sections below pinned; up to **20** most recent bullets are injected after pinned facts |
+| Empty state | When no pinned or recent bullets exist, nothing is injected |
 
 ## Prompt injection
 
@@ -60,18 +63,23 @@ Two org memory tools are **automatically available on every profile**. They are 
 
 | Tool | Purpose |
 |------|---------|
-| `org_memory_search` | Search live pinned bullets and the full archive by query |
+| `org_memory_search` | Search pinned, recent-log, and archived bullets |
 | `org_memory_list` | Return the current live org memory content |
+| `propose_org_memory` | Propose an org-wide fact for admin approval (member+) |
 
 Viewers cannot call these tools. Automations and sub-agents run with member-level org context.
 
-In v1, agents **cannot propose** org facts. Admins add and edit facts through the UI or API. For per-bot continuity the agent manages itself, use the profile `update-profile-memory` skill — see [Profiles](/profiles#knowledge-base-and-memory).
+Agents propose durable org facts via `propose_org_memory`; proposals land in a staging queue until an admin approves or rejects them in **Settings → Org Memory → Proposals**. Admins can still add facts directly via the UI or `POST /memory/facts` (bypasses the queue). Do not propose secrets, credentials, or PII.
+
+Proposal rows live in the SQLite database and are **not** included in workspace ZIP exports yet.
 
 ## Admin UI
 
 Org admins manage org memory from **Settings → Org Memory** (`/settings`).
 
-The card shows a preview of the live markdown and an **Edit** dialog for raw content. Keep the `## Org Memory` / `## Pinned` structure when editing.
+The card has **Live memory** and **Proposals** tabs. Live memory shows a preview and **Edit** dialog for raw markdown. Proposals lists pending agent suggestions with approve/reject actions and an optional **Pin on approve** toggle. A badge shows the pending count.
+
+For per-bot continuity the agent manages itself, use the profile `update-profile-memory` skill — see [Profiles](/profiles#knowledge-base-and-memory).
 
 ## Roles and access
 
@@ -96,6 +104,9 @@ All routes require authentication and an active org context (`X-Org-Id` or `acti
 | `POST` | `/v1/orgs/{orgId}/memory/pin` | admin | Pin a bullet |
 | `POST` | `/v1/orgs/{orgId}/memory/unpin` | admin | Unpin a bullet |
 | `POST` | `/v1/orgs/{orgId}/memory/archive` | admin | Move bullets to monthly archive |
+| `GET` | `/v1/orgs/{orgId}/memory/proposals` | admin | List proposals (`?status=pending`) |
+| `POST` | `/v1/orgs/{orgId}/memory/proposals/{id}/approve` | admin | Approve (optional `{ pin: true }`) |
+| `POST` | `/v1/orgs/{orgId}/memory/proposals/{id}/reject` | admin | Reject |
 
 Use **Archive** when the pinned list grows large — it keeps the live file within limits while preserving history under `memory-archive/`.
 
@@ -105,8 +116,8 @@ Use **Archive** when the pinned list grows large — it keeps the live file with
 |---|---|---|
 | **Scope** | Entire organization | Single profile |
 | **Path** | `~/.nakama/orgs/{orgId}/MEMORY.md` | `~/.nakama/orgs/{orgId}/profiles/{profileId}/MEMORY.md` |
-| **Structure (v1)** | `## Pinned` bullets | Dated `## YYYY-MM-DD` sections |
-| **Who writes** | Org admins (UI/API) | Agent via `update-profile-memory` skill |
+| **Structure** | `## Pinned` + dated `## YYYY-MM-DD` sections | Dated `## YYYY-MM-DD` sections |
+| **Who writes** | Org admins (UI/API); agents propose via `propose_org_memory` | Agent via `update-profile-memory` skill |
 | **Prompt injection** | Appended as `## Org Memory` | In soul stack as continuity |
 | **Active file limit** | 8192 bytes (live); 2048 bytes injected | 4096 bytes soft limit |
 | **Viewer access** | Blocked | Follows normal chat access |

--- a/docs/website/content/docs/org-memory.mdx
+++ b/docs/website/content/docs/org-memory.mdx
@@ -16,9 +16,12 @@ Org memory lives at the organization level, alongside profile directories:
 ```text
 ~/.nakama/orgs/{orgId}/MEMORY.md
 ~/.nakama/orgs/{orgId}/memory-archive/
+~/.nakama/orgs/{orgId}/memory-history/
 ```
 
 Archived bullets move into monthly `.md` files under `memory-archive/` without deleting history.
+
+**Change history** snapshots live under `memory-history/` — one JSON metadata file and one markdown snapshot per revision (up to **50** entries, oldest pruned automatically). This is separate from `memory-archive/`, which stores bullets removed from the live pinned list.
 
 Platform-admin [data exports](/backup-restore) include org memory as part of the org workspace in the ZIP.
 
@@ -71,17 +74,51 @@ Viewers cannot call these tools. Automations and sub-agents run with member-leve
 
 Agents propose durable org facts via `propose_org_memory`; proposals land in a staging queue until an admin approves or rejects them in **Settings → Org Memory → Proposals**. Admins can still add facts directly from the UI (bypasses the queue). Do not propose secrets, credentials, or PII.
 
+When an admin approves a proposal, Nakama merges the new fact into live memory:
+
+1. **LLM merge** (when a provider is configured) — the server asks the model to update `MEMORY.md`, replace superseded facts, and keep unrelated bullets intact.
+2. **Mechanical fallback** — if the LLM call fails or no provider is available, Nakama appends the fact to pinned or the recent log and removes near-duplicate bullets using token overlap.
+
+Use **Pin on approve** in the review dialog when the fact should always appear in the injected summary.
+
 Proposal rows live in the SQLite database and are **not** included in workspace ZIP exports yet.
 
 ## Admin UI
 
 Org admins manage org memory from **Settings → Org Memory** (`/settings`).
 
-The card has **Live memory** and **Proposals** tabs. Live memory shows a preview and **Edit** dialog for raw markdown. Proposals lists pending agent suggestions with approve/reject actions and an optional **Pin on approve** toggle. A badge shows the pending count.
+The card has three tabs:
+
+| Tab | Purpose |
+|-----|---------|
+| **Live memory** | Preview pinned facts and open the **Edit** dialog for raw markdown |
+| **Proposals** | Review pending agent suggestions — approve, reject, optional **Pin on approve** |
+| **History** | Browse change snapshots, **Undo latest**, or **Restore** any older revision |
+
+A badge on **Proposals** shows the pending count.
+
+Every write logs a snapshot (manual edits, approvals, pin/unpin, archive, and restores). **Undo latest** rolls back to the previous revision. **Restore** on an older row replays that snapshot as the new live memory (and logs the restore as a new history entry).
 
 Use **Archive** when the pinned list grows large — it keeps the live file within limits while preserving history under `memory-archive/`.
 
 For per-bot continuity the agent manages itself, use the profile `update-profile-memory` skill — see [Profiles](/profiles#knowledge-base-and-memory).
+
+## HTTP API (admin)
+
+Org admins can also manage memory via the REST API (`X-Org-Id` required):
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/v1/orgs/{orgId}/memory` | Read live memory |
+| `PUT` | `/v1/orgs/{orgId}/memory` | Replace live memory |
+| `GET` | `/v1/orgs/{orgId}/memory/history` | List change snapshots (newest first) |
+| `POST` | `/v1/orgs/{orgId}/memory/history/undo` | Undo the latest change |
+| `POST` | `/v1/orgs/{orgId}/memory/history/{revisionId}/restore` | Restore a specific snapshot |
+| `GET` | `/v1/orgs/{orgId}/memory/proposals` | List proposals |
+| `POST` | `/v1/orgs/{orgId}/memory/proposals/{id}/approve` | Approve a proposal |
+| `POST` | `/v1/orgs/{orgId}/memory/proposals/{id}/reject` | Reject a proposal |
+
+Members can read and search; viewers are blocked on all org memory routes.
 
 ## Roles and access
 

--- a/docs/website/content/docs/org-memory.mdx
+++ b/docs/website/content/docs/org-memory.mdx
@@ -59,7 +59,7 @@ See [Agent prompts](/agent-prompt) for the full assembly order.
 
 ## Agent tools
 
-Two org memory tools are **automatically available on every profile**. They are not assigned from the dashboard like other builtins.
+Three org memory tools are **automatically available on every profile**. They are not assigned from the dashboard like other builtins.
 
 | Tool | Purpose |
 |------|---------|
@@ -69,7 +69,7 @@ Two org memory tools are **automatically available on every profile**. They are 
 
 Viewers cannot call these tools. Automations and sub-agents run with member-level org context.
 
-Agents propose durable org facts via `propose_org_memory`; proposals land in a staging queue until an admin approves or rejects them in **Settings → Org Memory → Proposals**. Admins can still add facts directly via the UI or `POST /memory/facts` (bypasses the queue). Do not propose secrets, credentials, or PII.
+Agents propose durable org facts via `propose_org_memory`; proposals land in a staging queue until an admin approves or rejects them in **Settings → Org Memory → Proposals**. Admins can still add facts directly from the UI (bypasses the queue). Do not propose secrets, credentials, or PII.
 
 Proposal rows live in the SQLite database and are **not** included in workspace ZIP exports yet.
 
@@ -78,6 +78,8 @@ Proposal rows live in the SQLite database and are **not** included in workspace 
 Org admins manage org memory from **Settings → Org Memory** (`/settings`).
 
 The card has **Live memory** and **Proposals** tabs. Live memory shows a preview and **Edit** dialog for raw markdown. Proposals lists pending agent suggestions with approve/reject actions and an optional **Pin on approve** toggle. A badge shows the pending count.
+
+Use **Archive** when the pinned list grows large — it keeps the live file within limits while preserving history under `memory-archive/`.
 
 For per-bot continuity the agent manages itself, use the profile `update-profile-memory` skill — see [Profiles](/profiles#knowledge-base-and-memory).
 
@@ -90,25 +92,6 @@ For per-bot continuity the agent manages itself, use the profile `update-profile
 | **viewer** | no | no | no | no | no |
 
 Cross-org requests return **404** — the path `orgId` must match the active organization.
-
-## API reference
-
-All routes require authentication and an active org context (`X-Org-Id` or `active_org_id` cookie).
-
-| Method | Path | Role | Action |
-|--------|------|------|--------|
-| `GET` | `/v1/orgs/{orgId}/memory` | member+ | Read live content |
-| `PUT` | `/v1/orgs/{orgId}/memory` | admin | Replace entire file |
-| `POST` | `/v1/orgs/{orgId}/memory/facts` | admin | Add a pinned bullet |
-| `POST` | `/v1/orgs/{orgId}/memory/search` | member+ | Search live + archive |
-| `POST` | `/v1/orgs/{orgId}/memory/pin` | admin | Pin a bullet |
-| `POST` | `/v1/orgs/{orgId}/memory/unpin` | admin | Unpin a bullet |
-| `POST` | `/v1/orgs/{orgId}/memory/archive` | admin | Move bullets to monthly archive |
-| `GET` | `/v1/orgs/{orgId}/memory/proposals` | admin | List proposals (`?status=pending`) |
-| `POST` | `/v1/orgs/{orgId}/memory/proposals/{id}/approve` | admin | Approve (optional `{ pin: true }`) |
-| `POST` | `/v1/orgs/{orgId}/memory/proposals/{id}/reject` | admin | Reject |
-
-Use **Archive** when the pinned list grows large — it keeps the live file within limits while preserving history under `memory-archive/`.
 
 ## Org memory vs profile memory
 
@@ -127,4 +110,4 @@ Use **Archive** when the pinned list grows large — it keeps the live file with
 - [Multi-tenancy](/multi-tenancy) — org boundaries and roles
 - [Profiles](/profiles) — per-profile soul files and memory
 - [Agent prompts](/agent-prompt) — how org memory joins the system prompt
-- [Builtin tools](/builtin-tools) — `org_memory_search` and `org_memory_list` reference
+- [Builtin tools](/builtin-tools) — `org_memory_search`, `org_memory_list`, and `propose_org_memory`

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -71,3 +71,8 @@ export {
   generateSessionTitleFromMessages,
   normalizeSessionTitle,
 } from "./session-title";
+export {
+  mergeOrgMemoryWithApprovedBullet,
+  mergeOrgMemoryWithApprovedBulletFallback,
+} from "./org-memory-merge";
+export type { MergeOrgMemoryWithApprovedBulletOptions } from "./org-memory-merge";

--- a/packages/agent/src/org-memory-merge.test.ts
+++ b/packages/agent/src/org-memory-merge.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { ORG_MEMORY_PREAMBLE, type ProviderClient } from "@nakama/core";
+import {
+  mergeOrgMemoryWithApprovedBullet,
+  mergeOrgMemoryWithApprovedBulletFallback,
+} from "./org-memory-merge";
+
+describe("mergeOrgMemoryWithApprovedBullet", () => {
+  test("returns null without provider", async () => {
+    const result = await mergeOrgMemoryWithApprovedBullet(
+      `${ORG_MEMORY_PREAMBLE}\n`,
+      "Team standups are at 10am UTC",
+      { pin: true },
+    );
+    expect(result).toBeNull();
+  });
+
+  test("returns normalized provider output when valid", async () => {
+    const provider: ProviderClient = {
+      async generateText() {
+        return {
+          content: `${ORG_MEMORY_PREAMBLE}\n\n- Team standups are at 10am UTC\n`,
+        };
+      },
+      async generateChat() {
+        throw new Error("not used");
+      },
+      async streamChat() {
+        throw new Error("not used");
+      },
+    };
+
+    const result = await mergeOrgMemoryWithApprovedBullet(
+      `${ORG_MEMORY_PREAMBLE}\n\n- Team standups are at 9am UTC\n`,
+      "Team standups are at 10am UTC",
+      { pin: true, provider },
+    );
+
+    expect(result).toBe("## Org Memory\n\n## Pinned\n\n- Team standups are at 10am UTC\n");
+  });
+
+  test("returns null when provider output omits the approved bullet", async () => {
+    const provider: ProviderClient = {
+      async generateText() {
+        return {
+          content: `${ORG_MEMORY_PREAMBLE}\n\n- unrelated fact\n`,
+        };
+      },
+      async generateChat() {
+        throw new Error("not used");
+      },
+      async streamChat() {
+        throw new Error("not used");
+      },
+    };
+
+    const result = await mergeOrgMemoryWithApprovedBullet(
+      `${ORG_MEMORY_PREAMBLE}\n`,
+      "Team standups are at 10am UTC",
+      { pin: true, provider },
+    );
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("mergeOrgMemoryWithApprovedBulletFallback", () => {
+  test("replaces superseded facts mechanically", () => {
+    const result = mergeOrgMemoryWithApprovedBulletFallback(
+      `${ORG_MEMORY_PREAMBLE}\n\n- Team standups are at 9am UTC\n`,
+      "Team standups are at 10am UTC",
+      { pin: true },
+    );
+
+    expect(result).toContain("- Team standups are at 10am UTC");
+    expect(result).not.toContain("9am UTC");
+  });
+});

--- a/packages/agent/src/org-memory-merge.ts
+++ b/packages/agent/src/org-memory-merge.ts
@@ -1,0 +1,112 @@
+import {
+  applyApprovedOrgMemoryBullet,
+  normalizeOrgMemoryDedupKey,
+  parseOrgMemoryContent,
+  rebuildOrgMemoryContent,
+  type ProviderClient,
+} from "@nakama/core";
+
+const ORG_MEMORY_MERGE_SYSTEM = [
+  "You maintain an organization's shared MEMORY.md file.",
+  "Given the current file and one newly approved fact, return the updated MEMORY.md.",
+  "",
+  "Rules:",
+  "- Keep the structure: `## Org Memory`, optional `## Pinned`, and dated `## YYYY-MM-DD` sections.",
+  "- Place the new fact in the pinned section when pin=true, otherwise under today's dated section.",
+  "- Replace stale facts that the new fact supersedes instead of keeping contradictory duplicates.",
+  "- Preserve unrelated facts verbatim.",
+  "- Return only the markdown file content. No commentary or code fences.",
+].join("\n");
+
+export interface MergeOrgMemoryWithApprovedBulletOptions {
+  pin?: boolean;
+  dateUtc?: string;
+  provider?: ProviderClient;
+}
+
+function buildOrgMemoryMergePrompt(
+  content: string,
+  bullet: string,
+  options: { pin: boolean; dateUtc: string },
+): string {
+  return [
+    "Current MEMORY.md:",
+    content.trim().length > 0 ? content.trim() : "## Org Memory\n\n## Pinned",
+    "",
+    `New approved fact: ${bullet.trim()}`,
+    `Destination: ${options.pin ? "pinned" : `recent log (${options.dateUtc})`}`,
+    `Today's UTC date section (when not pinned): ${options.dateUtc}`,
+  ].join("\n");
+}
+
+function normalizeMergedOrgMemoryContent(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const withoutFences = trimmed
+    .replace(/^```(?:markdown|md)?\s*/i, "")
+    .replace(/\s*```$/, "")
+    .trim();
+
+  if (!withoutFences.includes("## Org Memory")) {
+    return null;
+  }
+
+  return rebuildOrgMemoryContent(parseOrgMemoryContent(withoutFences));
+}
+
+function mergedContentIncludesBullet(content: string, bullet: string): boolean {
+  const parsed = parseOrgMemoryContent(content);
+  const dedupKey = normalizeOrgMemoryDedupKey(bullet);
+  return (
+    parsed.pinned.some((entry) => normalizeOrgMemoryDedupKey(entry) === dedupKey) ||
+    parsed.sections.some((section) =>
+      section.bullets.some((entry) => normalizeOrgMemoryDedupKey(entry) === dedupKey),
+    )
+  );
+}
+
+export async function mergeOrgMemoryWithApprovedBullet(
+  content: string,
+  bullet: string,
+  options: MergeOrgMemoryWithApprovedBulletOptions = {},
+): Promise<string | null> {
+  const pin = options.pin ?? false;
+  const dateUtc = options.dateUtc ?? new Date().toISOString().slice(0, 10);
+  const provider = options.provider;
+
+  if (!provider) {
+    return null;
+  }
+
+  try {
+    const result = await provider.generateText({
+      system: ORG_MEMORY_MERGE_SYSTEM,
+      prompt: buildOrgMemoryMergePrompt(content, bullet, { pin, dateUtc }),
+      format: "text",
+    });
+
+    const merged = normalizeMergedOrgMemoryContent(result.content);
+    if (!merged || !mergedContentIncludesBullet(merged, bullet)) {
+      return null;
+    }
+
+    return merged;
+  } catch (error) {
+    console.error("Failed to merge org memory with provider:", error);
+    return null;
+  }
+}
+
+export function mergeOrgMemoryWithApprovedBulletFallback(
+  content: string,
+  bullet: string,
+  options: MergeOrgMemoryWithApprovedBulletOptions = {},
+): string {
+  return applyApprovedOrgMemoryBullet(content, bullet, {
+    pin: options.pin,
+    dateUtc: options.dateUtc,
+  });
+}

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -163,6 +163,9 @@ import type {
   ArchiveOrgMemoryResponse,
   PinOrgMemoryRequest,
   UnpinOrgMemoryRequest,
+  ListOrgMemoryProposalsResponse,
+  ApproveOrgMemoryProposalRequest,
+  OrgMemoryProposalResponse,
   StoredTask,
   TaskRunRecord,
   WorkerLogsResponse,
@@ -1694,6 +1697,45 @@ export class NakamaClient {
       {
         method: "POST",
         body: JSON.stringify(request),
+        headers: { "X-Org-Id": orgId },
+      },
+    );
+  }
+
+  async listOrgMemoryProposals(
+    orgId: string,
+    status?: "pending" | "approved" | "rejected",
+  ): Promise<ListOrgMemoryProposalsResponse> {
+    const query = status ? `?status=${encodeURIComponent(status)}` : "";
+    return this.request<ListOrgMemoryProposalsResponse>(
+      `/v1/orgs/${encodeURIComponent(orgId)}/memory/proposals${query}`,
+      { headers: { "X-Org-Id": orgId } },
+    );
+  }
+
+  async approveOrgMemoryProposal(
+    orgId: string,
+    proposalId: string,
+    request: ApproveOrgMemoryProposalRequest = {},
+  ): Promise<OrgMemoryProposalResponse> {
+    return this.request<OrgMemoryProposalResponse>(
+      `/v1/orgs/${encodeURIComponent(orgId)}/memory/proposals/${encodeURIComponent(proposalId)}/approve`,
+      {
+        method: "POST",
+        body: JSON.stringify(request),
+        headers: { "X-Org-Id": orgId },
+      },
+    );
+  }
+
+  async rejectOrgMemoryProposal(
+    orgId: string,
+    proposalId: string,
+  ): Promise<OrgMemoryProposalResponse> {
+    return this.request<OrgMemoryProposalResponse>(
+      `/v1/orgs/${encodeURIComponent(orgId)}/memory/proposals/${encodeURIComponent(proposalId)}/reject`,
+      {
+        method: "POST",
         headers: { "X-Org-Id": orgId },
       },
     );

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -166,6 +166,8 @@ import type {
   ListOrgMemoryProposalsResponse,
   ApproveOrgMemoryProposalRequest,
   OrgMemoryProposalResponse,
+  ListOrgMemoryHistoryResponse,
+  RestoreOrgMemoryHistoryResponse,
   StoredTask,
   TaskRunRecord,
   WorkerLogsResponse,
@@ -1697,6 +1699,36 @@ export class NakamaClient {
       {
         method: "POST",
         body: JSON.stringify(request),
+        headers: { "X-Org-Id": orgId },
+      },
+    );
+  }
+
+  async listOrgMemoryHistory(orgId: string): Promise<ListOrgMemoryHistoryResponse> {
+    return this.request<ListOrgMemoryHistoryResponse>(
+      `/v1/orgs/${encodeURIComponent(orgId)}/memory/history`,
+      { headers: { "X-Org-Id": orgId } },
+    );
+  }
+
+  async restoreOrgMemoryHistory(
+    orgId: string,
+    revisionId: string,
+  ): Promise<RestoreOrgMemoryHistoryResponse> {
+    return this.request<RestoreOrgMemoryHistoryResponse>(
+      `/v1/orgs/${encodeURIComponent(orgId)}/memory/history/${encodeURIComponent(revisionId)}/restore`,
+      {
+        method: "POST",
+        headers: { "X-Org-Id": orgId },
+      },
+    );
+  }
+
+  async undoOrgMemoryChange(orgId: string): Promise<RestoreOrgMemoryHistoryResponse> {
+    return this.request<RestoreOrgMemoryHistoryResponse>(
+      `/v1/orgs/${encodeURIComponent(orgId)}/memory/history/undo`,
+      {
+        method: "POST",
         headers: { "X-Org-Id": orgId },
       },
     );

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -168,6 +168,7 @@ import type {
   OrgMemoryProposalResponse,
   ListOrgMemoryHistoryResponse,
   RestoreOrgMemoryHistoryResponse,
+  OrgMemoryHistoryRevisionResponse,
   StoredTask,
   TaskRunRecord,
   WorkerLogsResponse,
@@ -1707,6 +1708,16 @@ export class NakamaClient {
   async listOrgMemoryHistory(orgId: string): Promise<ListOrgMemoryHistoryResponse> {
     return this.request<ListOrgMemoryHistoryResponse>(
       `/v1/orgs/${encodeURIComponent(orgId)}/memory/history`,
+      { headers: { "X-Org-Id": orgId } },
+    );
+  }
+
+  async getOrgMemoryHistoryRevision(
+    orgId: string,
+    revisionId: string,
+  ): Promise<OrgMemoryHistoryRevisionResponse> {
+    return this.request<OrgMemoryHistoryRevisionResponse>(
+      `/v1/orgs/${encodeURIComponent(orgId)}/memory/history/${encodeURIComponent(revisionId)}`,
       { headers: { "X-Org-Id": orgId } },
     );
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,7 @@
     "./whatsapp-config": "./src/whatsapp-config.ts",
     "./whatsapp-worker": "./src/whatsapp-worker.ts",
     "./skills/bundled-names": "./src/skills/bundled-names.ts",
+    "./soul/org-memory": "./src/soul/org-memory.ts",
     "./tools/protected": "./src/tools/protected.ts",
     "./tools/email": "./src/tools/email.ts",
     "./mcp/preinstalled": "./src/mcp/preinstalled.ts"

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -386,6 +386,8 @@ export interface OrgMemorySearchRequest {
 export interface OrgMemorySearchMatchEntry {
   source: string;
   bullet: string;
+  tier?: "pinned" | "recent-log" | "archive";
+  date?: string;
 }
 
 export interface OrgMemorySearchResponse {
@@ -410,6 +412,36 @@ export interface PinOrgMemoryRequest {
 
 export interface UnpinOrgMemoryRequest {
   bullet: string;
+}
+
+export type OrgMemoryProposalStatus = "pending" | "approved" | "rejected";
+
+export interface OrgMemoryProposal {
+  id: string;
+  orgId: string;
+  profileId: string | null;
+  sessionId: string | null;
+  proposedByUserId: string | null;
+  bullet: string;
+  status: OrgMemoryProposalStatus;
+  pinned: boolean;
+  reviewerUserId: string | null;
+  reviewedAt: string | null;
+  createdAt: string;
+}
+
+export interface ListOrgMemoryProposalsResponse {
+  proposals: OrgMemoryProposal[];
+  pendingCount: number;
+}
+
+export interface ApproveOrgMemoryProposalRequest {
+  pin?: boolean;
+}
+
+export interface OrgMemoryProposalResponse {
+  proposal: OrgMemoryProposal;
+  content?: string;
 }
 
 export interface InviteOrgMemberRequest {

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -441,6 +441,11 @@ export interface RestoreOrgMemoryHistoryResponse {
   content: string;
 }
 
+export interface OrgMemoryHistoryRevisionResponse {
+  change: OrgMemoryChangeLogEntry;
+  content: string;
+}
+
 export type OrgMemoryProposalStatus = "pending" | "approved" | "rejected";
 
 export interface OrgMemoryProposal {

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -414,6 +414,33 @@ export interface UnpinOrgMemoryRequest {
   bullet: string;
 }
 
+export type OrgMemoryChangeAction =
+  | "edit"
+  | "approve"
+  | "add_fact"
+  | "pin"
+  | "unpin"
+  | "archive"
+  | "restore";
+
+export interface OrgMemoryChangeLogEntry {
+  id: string;
+  orgId: string;
+  createdAt: string;
+  actorUserId: string | null;
+  action: OrgMemoryChangeAction;
+  label: string;
+  restoredFromId?: string | null;
+}
+
+export interface ListOrgMemoryHistoryResponse {
+  changes: OrgMemoryChangeLogEntry[];
+}
+
+export interface RestoreOrgMemoryHistoryResponse {
+  content: string;
+}
+
 export type OrgMemoryProposalStatus = "pending" | "approved" | "rejected";
 
 export interface OrgMemoryProposal {

--- a/packages/core/src/soul/index.ts
+++ b/packages/core/src/soul/index.ts
@@ -6,4 +6,5 @@ export * from "./init";
 export * from "./save";
 export * from "./templates";
 export * from "./org-memory";
+export * from "./org-memory-history";
 export * from "./memory-archive";

--- a/packages/core/src/soul/org-memory-history.test.ts
+++ b/packages/core/src/soul/org-memory-history.test.ts
@@ -1,0 +1,97 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  appendOrgMemoryHistory,
+  createOrgMemoryChangeId,
+  getOrgMemoryHistoryEntry,
+  listOrgMemoryHistory,
+  ORG_MEMORY_HISTORY_MAX_ENTRIES,
+} from "./org-memory-history";
+
+const originalConfigDir = process.env.NAKAMA_CONFIG_DIR;
+
+describe("org memory history", () => {
+  let tempDir = "";
+
+  afterEach(async () => {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = "";
+    }
+    if (originalConfigDir === undefined) {
+      delete process.env.NAKAMA_CONFIG_DIR;
+    } else {
+      process.env.NAKAMA_CONFIG_DIR = originalConfigDir;
+    }
+  });
+
+  async function setupOrg(orgId = "org_a"): Promise<string> {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "nakama-org-memory-history-"));
+    process.env.NAKAMA_CONFIG_DIR = tempDir;
+    return orgId;
+  }
+
+  test("appends and lists history entries newest first", async () => {
+    const orgId = await setupOrg();
+    const firstId = createOrgMemoryChangeId();
+    const secondId = createOrgMemoryChangeId();
+
+    await appendOrgMemoryHistory(
+      orgId,
+      {
+        id: firstId,
+        orgId,
+        createdAt: "2026-07-31T08:00:00.000Z",
+        actorUserId: "user_a",
+        action: "edit",
+        label: "First edit",
+      },
+      "## Org Memory\n\n## Pinned\n\n- first\n",
+    );
+    await appendOrgMemoryHistory(
+      orgId,
+      {
+        id: secondId,
+        orgId,
+        createdAt: "2026-07-31T09:00:00.000Z",
+        actorUserId: "user_a",
+        action: "approve",
+        label: "Approved proposal",
+      },
+      "## Org Memory\n\n## Pinned\n\n- second\n",
+    );
+
+    const changes = await listOrgMemoryHistory(orgId);
+    expect(changes.map((entry) => entry.id)).toEqual([secondId, firstId]);
+    await expect(getOrgMemoryHistoryEntry(orgId, secondId)).resolves.toMatchObject({
+      label: "Approved proposal",
+      content: "## Org Memory\n\n## Pinned\n\n- second\n",
+    });
+  });
+
+  test("prunes history beyond the configured max entries", async () => {
+    const orgId = await setupOrg();
+
+    for (let index = 0; index < ORG_MEMORY_HISTORY_MAX_ENTRIES + 3; index += 1) {
+      const id = createOrgMemoryChangeId();
+      await appendOrgMemoryHistory(
+        orgId,
+        {
+          id,
+          orgId,
+          createdAt: `2026-07-31T10:${String(index).padStart(2, "0")}:00.000Z`,
+          actorUserId: null,
+          action: "edit",
+          label: `Edit ${index}`,
+        },
+        `content-${index}\n`,
+      );
+    }
+
+    const changes = await listOrgMemoryHistory(orgId);
+    expect(changes).toHaveLength(ORG_MEMORY_HISTORY_MAX_ENTRIES);
+    expect(changes[0]?.label).toBe(`Edit ${ORG_MEMORY_HISTORY_MAX_ENTRIES + 2}`);
+  });
+});

--- a/packages/core/src/soul/org-memory-history.ts
+++ b/packages/core/src/soul/org-memory-history.ts
@@ -1,0 +1,120 @@
+import { join } from "node:path";
+import { pathExists, readDirectoryEntries, readText, writePrivateTextFile } from "../fs";
+import { getOrgMemoryHistoryDir } from "./resolve";
+
+export const ORG_MEMORY_HISTORY_MAX_ENTRIES = 50;
+
+export type OrgMemoryChangeAction =
+  | "edit"
+  | "approve"
+  | "add_fact"
+  | "pin"
+  | "unpin"
+  | "archive"
+  | "restore";
+
+export interface OrgMemoryChangeLogEntry {
+  id: string;
+  orgId: string;
+  createdAt: string;
+  actorUserId: string | null;
+  action: OrgMemoryChangeAction;
+  label: string;
+  restoredFromId?: string | null;
+}
+
+export interface OrgMemoryChangeLogRecord extends OrgMemoryChangeLogEntry {
+  content: string;
+}
+
+function historyMetaPath(orgId: string, id: string): string {
+  return join(getOrgMemoryHistoryDir(orgId), `${id}.json`);
+}
+
+function historyContentPath(orgId: string, id: string): string {
+  return join(getOrgMemoryHistoryDir(orgId), `${id}.md`);
+}
+
+export function createOrgMemoryChangeId(): string {
+  return `omh_${crypto.randomUUID().replace(/-/g, "")}`;
+}
+
+export async function appendOrgMemoryHistory(
+  orgId: string,
+  entry: OrgMemoryChangeLogEntry,
+  content: string,
+): Promise<void> {
+  const historyDir = getOrgMemoryHistoryDir(orgId);
+  await writePrivateTextFile(historyMetaPath(orgId, entry.id), `${JSON.stringify(entry, null, 2)}\n`, {
+    ensureDir: historyDir,
+  });
+  await writePrivateTextFile(historyContentPath(orgId, entry.id), content, {
+    ensureDir: historyDir,
+  });
+  await pruneOrgMemoryHistory(orgId, ORG_MEMORY_HISTORY_MAX_ENTRIES);
+}
+
+export async function listOrgMemoryHistory(
+  orgId: string,
+  limit = ORG_MEMORY_HISTORY_MAX_ENTRIES,
+): Promise<OrgMemoryChangeLogEntry[]> {
+  const historyDir = getOrgMemoryHistoryDir(orgId);
+  if (!(await pathExists(historyDir))) {
+    return [];
+  }
+
+  const entries = await readDirectoryEntries(historyDir);
+  const ids = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+    .map((entry) => entry.name.replace(/\.json$/, ""))
+    .sort((left, right) => right.localeCompare(left));
+
+  const records: OrgMemoryChangeLogEntry[] = [];
+  for (const id of ids) {
+    if (records.length >= limit) {
+      break;
+    }
+    const raw = await readText(historyMetaPath(orgId, id));
+    records.push(JSON.parse(raw) as OrgMemoryChangeLogEntry);
+  }
+
+  records.sort((left, right) => right.createdAt.localeCompare(left.createdAt));
+  return records.slice(0, limit);
+}
+
+export async function getOrgMemoryHistoryEntry(
+  orgId: string,
+  revisionId: string,
+): Promise<OrgMemoryChangeLogRecord | null> {
+  const metaPath = historyMetaPath(orgId, revisionId);
+  const contentPath = historyContentPath(orgId, revisionId);
+  if (!(await pathExists(metaPath)) || !(await pathExists(contentPath))) {
+    return null;
+  }
+
+  const entry = JSON.parse(await readText(metaPath)) as OrgMemoryChangeLogEntry;
+  const content = await readText(contentPath);
+  return { ...entry, content };
+}
+
+export async function pruneOrgMemoryHistory(
+  orgId: string,
+  maxEntries: number,
+): Promise<void> {
+  const historyDir = getOrgMemoryHistoryDir(orgId);
+  if (!(await pathExists(historyDir))) {
+    return;
+  }
+
+  const entries = await listOrgMemoryHistory(orgId, Number.MAX_SAFE_INTEGER);
+  const stale = entries.slice(maxEntries);
+  if (stale.length === 0) {
+    return;
+  }
+
+  const { unlink } = await import("node:fs/promises");
+  for (const entry of stale) {
+    await unlink(historyMetaPath(orgId, entry.id)).catch(() => undefined);
+    await unlink(historyContentPath(orgId, entry.id)).catch(() => undefined);
+  }
+}

--- a/packages/core/src/soul/org-memory.test.ts
+++ b/packages/core/src/soul/org-memory.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
   appendOrgMemorySection,
+  applyApprovedOrgMemoryBullet,
   composeOrgMemorySummary,
   ORG_MEMORY_PREAMBLE,
   parseOrgMemoryContent,
@@ -31,7 +32,25 @@ describe("org memory parse/rebuild", () => {
 
   test("rebuild adds the preamble when missing", () => {
     const rebuilt = rebuildOrgMemoryContent({ preamble: "", pinned: ["a fact"], sections: [] });
-    expect(rebuilt).toBe(`${ORG_MEMORY_PREAMBLE}\n\n## Pinned\n\n- a fact\n`);
+    expect(rebuilt).toBe("## Org Memory\n\n## Pinned\n\n- a fact\n");
+  });
+
+  test("rebuild does not duplicate the pinned header", () => {
+    const rebuilt = rebuildOrgMemoryContent(
+      parseOrgMemoryContent("## Pinned\n\n- fact\n"),
+    );
+    expect(rebuilt).toBe("## Org Memory\n\n## Pinned\n\n- fact\n");
+    expect((rebuilt.match(/^## Pinned$/gm) ?? []).length).toBe(1);
+  });
+
+  test("applyApprovedOrgMemoryBullet replaces superseded pinned facts", () => {
+    const live = `${ORG_MEMORY_PREAMBLE}\n\n- Team standups are at 9am UTC\n`;
+    const next = applyApprovedOrgMemoryBullet(live, "Team standups are at 10am UTC", {
+      pin: true,
+    });
+    const parsed = parseOrgMemoryContent(next);
+    expect(parsed.pinned).toEqual(["Team standups are at 10am UTC"]);
+    expect((next.match(/^## Pinned$/gm) ?? []).length).toBe(1);
   });
 
   test("empty/missing MEMORY.md yields empty summary (no throw)", () => {

--- a/packages/core/src/soul/org-memory.test.ts
+++ b/packages/core/src/soul/org-memory.test.ts
@@ -13,6 +13,7 @@ describe("org memory parse/rebuild", () => {
     const parsed = parseOrgMemoryContent(content);
     expect(parsed.preamble).toBe("## Org Memory");
     expect(parsed.pinned).toEqual(["deploys ship on Tuesdays", "prefer Bun over Node"]);
+    expect(parsed.sections).toEqual([]);
   });
 
   test("round-trips parse -> rebuild -> equal", () => {
@@ -21,8 +22,14 @@ describe("org memory parse/rebuild", () => {
     expect(rebuilt).toBe(content);
   });
 
+  test("round-trips pinned and dated sections", () => {
+    const content = `${ORG_MEMORY_PREAMBLE}\n\n- pinned fact\n\n## 2026-07-25\n\n- dated fact\n`;
+    const rebuilt = rebuildOrgMemoryContent(parseOrgMemoryContent(content));
+    expect(rebuilt).toBe(content);
+  });
+
   test("rebuild adds the preamble when missing", () => {
-    const rebuilt = rebuildOrgMemoryContent({ preamble: "", pinned: ["a fact"] });
+    const rebuilt = rebuildOrgMemoryContent({ preamble: "", pinned: ["a fact"], sections: [] });
     expect(rebuilt).toBe(`${ORG_MEMORY_PREAMBLE}\n\n## Pinned\n\n- a fact\n`);
   });
 
@@ -31,12 +38,14 @@ describe("org memory parse/rebuild", () => {
     expect(composeOrgMemorySummary(ORG_MEMORY_PREAMBLE)).toBe("");
   });
 
-  test("ignores v2 dated sections for v1 summary", () => {
+  test("includes dated sections in summary", () => {
     const content = `${ORG_MEMORY_PREAMBLE}\n\n- pinned fact\n\n## 2026-07-25\n\n- dated fact\n`;
     const parsed = parseOrgMemoryContent(content);
     expect(parsed.pinned).toEqual(["pinned fact"]);
-    expect(composeOrgMemorySummary(content)).toContain("- pinned fact");
-    expect(composeOrgMemorySummary(content)).not.toContain("- dated fact");
+    expect(parsed.sections).toEqual([{ date: "2026-07-25", bullets: ["dated fact"] }]);
+    const summary = composeOrgMemorySummary(content);
+    expect(summary).toContain("- pinned fact");
+    expect(summary).toContain("- dated fact");
   });
 });
 
@@ -49,13 +58,21 @@ describe("composeOrgMemorySummary", () => {
     expect(summary).toContain("- fact two");
   });
 
+  test("includes recent log bullets up to recentLogLimit", () => {
+    const dated = Array.from({ length: 25 }, (_, i) => `## 2026-07-${String(i + 1).padStart(2, "0")}\n\n- fact ${i}`);
+    const content = `${ORG_MEMORY_PREAMBLE}\n\n- pinned\n\n${dated.join("\n\n")}\n`;
+    const summary = composeOrgMemorySummary(content, { recentLogLimit: 20, byteCap: 4096 });
+    expect(summary).toContain("- pinned");
+    const recentMatches = summary.match(/^- fact \d+$/gm) ?? [];
+    expect(recentMatches.length).toBeLessThanOrEqual(20);
+  });
+
   test("truncates at byte cap and appends overflow hint", () => {
     const bullets = Array.from({ length: 50 }, (_, i) => `fact number ${i} with some text`);
     const content = `${ORG_MEMORY_PREAMBLE}\n\n${bullets.map((b) => `- ${b}`).join("\n")}\n`;
     const summary = composeOrgMemorySummary(content, { byteCap: 256 });
     expect(Buffer.byteLength(summary, "utf8")).toBeLessThanOrEqual(512);
     expect(summary).toContain("org_memory_search");
-    // Not all bullets fit
     expect(summary).not.toContain("fact number 49");
   });
 

--- a/packages/core/src/soul/org-memory.test.ts
+++ b/packages/core/src/soul/org-memory.test.ts
@@ -4,6 +4,7 @@ import {
   composeOrgMemorySummary,
   ORG_MEMORY_PREAMBLE,
   parseOrgMemoryContent,
+  previewOrgMemoryAfterApprove,
   rebuildOrgMemoryContent,
 } from "./org-memory";
 
@@ -36,6 +37,8 @@ describe("org memory parse/rebuild", () => {
   test("empty/missing MEMORY.md yields empty summary (no throw)", () => {
     expect(composeOrgMemorySummary("")).toBe("");
     expect(composeOrgMemorySummary(ORG_MEMORY_PREAMBLE)).toBe("");
+    expect(composeOrgMemorySummary(null)).toBe("");
+    expect(parseOrgMemoryContent(undefined).pinned).toEqual([]);
   });
 
   test("includes dated sections in summary", () => {
@@ -118,5 +121,28 @@ describe("appendOrgMemorySection", () => {
   test("does not append an empty summary (no empty header)", () => {
     expect(appendOrgMemorySection(base, "", "member")).toBe(base);
     expect(appendOrgMemorySection(base, "   \n  ", "member")).toBe(base);
+  });
+});
+
+describe("previewOrgMemoryAfterApprove", () => {
+  const live = `${ORG_MEMORY_PREAMBLE}\n\n- existing pinned fact\n`;
+
+  test("recent-log approve preview includes bullet in prompt injection", () => {
+    const preview = previewOrgMemoryAfterApprove(live, "team standups are at 10am UTC", {
+      pin: false,
+      dateUtc: "2026-07-31",
+    });
+    expect(preview.destination).toBe("recent-log");
+    expect(preview.destinationLabel).toBe("## 2026-07-31");
+    expect(preview.memoryLine).toBe("- team standups are at 10am UTC");
+    expect(preview.promptInjection).toContain("- existing pinned fact");
+    expect(preview.promptInjection).toContain("- team standups are at 10am UTC");
+  });
+
+  test("pinned approve preview places bullet after existing pinned facts", () => {
+    const preview = previewOrgMemoryAfterApprove(live, "new pinned fact", { pin: true });
+    expect(preview.destination).toBe("pinned");
+    expect(preview.destinationLabel).toBe("## Pinned");
+    expect(preview.promptInjection).toContain("- new pinned fact");
   });
 });

--- a/packages/core/src/soul/org-memory.ts
+++ b/packages/core/src/soul/org-memory.ts
@@ -1,10 +1,12 @@
 /**
- * Pure parse/summary helpers for org `MEMORY.md` (v1: pinned-only).
+ * Pure parse/summary helpers for org `MEMORY.md`.
  *
  * No disk I/O lives here — callers hand in the file content and write the
  * rebuilt string back out themselves. This keeps the helpers trivially
  * testable and lets the service layer own all filesystem access.
  */
+
+import type { MemorySection } from "./memory-archive";
 
 export const ORG_MEMORY_PREAMBLE = `## Org Memory
 
@@ -13,25 +15,64 @@ export const ORG_MEMORY_PREAMBLE = `## Org Memory
 export interface ParsedOrgMemory {
   preamble: string;
   pinned: string[];
+  sections: MemorySection[];
+}
+
+export function normalizeOrgMemoryDedupKey(bullet: string): string {
+  return bullet.trim().replace(/^-\s+/, "").trim().toLowerCase();
+}
+
+export function detectOrgMemoryInjectionWarnings(bullet: string): string[] {
+  const warnings: string[] = [];
+  if (/ignore (all )?previous/i.test(bullet)) {
+    warnings.push("Contains instruction-like phrasing.");
+  }
+  if (/^system:/im.test(bullet)) {
+    warnings.push("Contains a system-style prefix.");
+  }
+  if (/^##\s/m.test(bullet)) {
+    warnings.push("Contains markdown headings.");
+  }
+  if (/<\/?[a-z][\s\S]*>/i.test(bullet)) {
+    warnings.push("Contains HTML-like markup.");
+  }
+  return warnings;
 }
 
 export function parseOrgMemoryContent(content: string): ParsedOrgMemory {
   const lines = content.split("\n");
   const preambleLines: string[] = [];
   const pinned: string[] = [];
-  let phase: "preamble" | "pinned" = "preamble";
+  const sections: MemorySection[] = [];
+  let phase: "preamble" | "pinned" | "dated" = "preamble";
+  let currentDate: string | null = null;
+  let currentBullets: string[] = [];
+
+  const flushSection = () => {
+    if (currentDate) {
+      sections.push({ date: currentDate, bullets: currentBullets });
+    }
+    currentDate = null;
+    currentBullets = [];
+  };
 
   for (const line of lines) {
     if (line.match(/^## Pinned$/)) {
+      if (phase === "dated") {
+        flushSection();
+      }
       phase = "pinned";
       continue;
     }
 
-    // A dated section (## YYYY-MM-DD) belongs to the v2 recent-log tier; for
-    // v1 we stop collecting pinned bullets once we hit one and treat the
-    // rest as preamble-equivalent (ignored for summary purposes).
-    if (line.match(/^## \d{4}-\d{2}-\d{2}$/)) {
-      phase = "preamble";
+    const dateMatch = line.match(/^## (\d{4}-\d{2}-\d{2})$/);
+    if (dateMatch) {
+      if (phase === "dated") {
+        flushSection();
+      }
+      phase = "dated";
+      currentDate = dateMatch[1];
+      currentBullets = [];
       continue;
     }
 
@@ -41,13 +82,22 @@ export function parseOrgMemoryContent(content: string): ParsedOrgMemory {
     }
 
     if (line.startsWith("- ")) {
-      pinned.push(line.slice(2));
+      if (phase === "pinned") {
+        pinned.push(line.slice(2));
+      } else if (phase === "dated") {
+        currentBullets.push(line.slice(2));
+      }
     }
+  }
+
+  if (phase === "dated") {
+    flushSection();
   }
 
   return {
     preamble: preambleLines.join("\n").replace(/\n+$/, ""),
     pinned,
+    sections,
   };
 }
 
@@ -68,13 +118,48 @@ export function rebuildOrgMemoryContent(parsed: ParsedOrgMemory): string {
     }
   }
 
+  for (const section of parsed.sections) {
+    if (section.bullets.length === 0) {
+      continue;
+    }
+    parts.push("", `## ${section.date}`, "");
+    for (const bullet of section.bullets) {
+      parts.push(`- ${bullet}`);
+    }
+  }
+
   const content = parts.join("\n").replace(/\n+$/, "");
   return content.length > 0 ? `${content}\n` : content;
+}
+
+export function collectRecentLogBullets(
+  sections: MemorySection[],
+  limit: number,
+): string[] {
+  if (limit <= 0) {
+    return [];
+  }
+
+  const sorted = [...sections].sort((a, b) => b.date.localeCompare(a.date));
+  const collected: string[] = [];
+
+  for (const section of sorted) {
+    for (let index = section.bullets.length - 1; index >= 0; index -= 1) {
+      collected.push(section.bullets[index]);
+      if (collected.length >= limit) {
+        return collected;
+      }
+    }
+  }
+
+  return collected;
 }
 
 export interface OrgMemorySummaryOptions {
   /** Hard byte cap on the rendered summary. Defaults to 2048. */
   byteCap?: number;
+  /** Most recent log bullets to include after pinned. Defaults to 20. */
+  recentLogLimit?: number;
   /** Hint shown when the summary is truncated. */
   overflowHint?: string;
 }
@@ -102,19 +187,25 @@ export function appendOrgMemorySection(
 
 /**
  * Render the `## Org Memory` section string injected into a profile's system
- * prompt. v1: pinned bullets only. When the rendered section exceeds
- * `byteCap`, bullets are dropped from the end and an overflow hint is appended
- * pointing the agent at the `org_memory_search` tool.
+ * prompt. Includes pinned bullets first, then the N most recent log bullets.
+ * When the rendered section exceeds `byteCap`, bullets are dropped from the
+ * end and an overflow hint is appended pointing the agent at
+ * `org_memory_search`.
  */
 export function composeOrgMemorySummary(
   content: string,
   options: OrgMemorySummaryOptions = {},
 ): string {
-  const { byteCap = 2048, overflowHint = "Use the org_memory_search tool for the full history." } =
-    options;
+  const {
+    byteCap = 2048,
+    recentLogLimit = 20,
+    overflowHint = "Use the org_memory_search tool for the full history.",
+  } = options;
   const parsed = parseOrgMemoryContent(content);
+  const recentBullets = collectRecentLogBullets(parsed.sections, recentLogLimit);
+  const bullets = [...parsed.pinned, ...recentBullets];
 
-  if (parsed.pinned.length === 0) {
+  if (bullets.length === 0) {
     return "";
   }
 
@@ -124,7 +215,7 @@ export function composeOrgMemorySummary(
   let bytes = Buffer.byteLength(lines.join("\n") + "\n", "utf8");
   let included = 0;
 
-  for (const bullet of parsed.pinned) {
+  for (const bullet of bullets) {
     const candidate = `- ${bullet}`;
     const candidateBytes = Buffer.byteLength(candidate + "\n", "utf8");
     if (bytes + candidateBytes > byteCap) {
@@ -136,12 +227,10 @@ export function composeOrgMemorySummary(
   }
 
   if (included === 0) {
-    // Even one bullet doesn't fit; emit header + hint so the agent knows to
-    // use the tool rather than silently dropping everything.
     return `${header}\n\n- ${overflowHint}\n`;
   }
 
-  if (included < parsed.pinned.length) {
+  if (included < bullets.length) {
     lines.push("", `- ${overflowHint}`);
   }
 

--- a/packages/core/src/soul/org-memory.ts
+++ b/packages/core/src/soul/org-memory.ts
@@ -8,7 +8,9 @@
 
 import type { MemorySection } from "./memory-archive";
 
-export const ORG_MEMORY_PREAMBLE = `## Org Memory
+export const ORG_MEMORY_HEADER = "## Org Memory";
+
+export const ORG_MEMORY_PREAMBLE = `${ORG_MEMORY_HEADER}
 
 ## Pinned`;
 
@@ -98,31 +100,59 @@ export function parseOrgMemoryContent(content?: string | null): ParsedOrgMemory 
     flushSection();
   }
 
-  return {
+  return normalizeParsedOrgMemory({
     preamble: preambleLines.join("\n").replace(/\n+$/, ""),
     pinned,
     sections,
+  });
+}
+
+function stripPinnedHeaderFromPreamble(preamble: string): string {
+  return preamble
+    .split("\n")
+    .filter((line) => !/^## Pinned\s*$/.test(line.trim()))
+    .join("\n")
+    .replace(/\n+$/, "")
+    .trim();
+}
+
+/** Normalize malformed MEMORY.md content before rebuild or merge. */
+export function normalizeParsedOrgMemory(parsed: ParsedOrgMemory): ParsedOrgMemory {
+  const preambleLines: string[] = [];
+  const rescuedPinned: string[] = [];
+
+  for (const line of parsed.preamble.split("\n")) {
+    if (line.startsWith("- ")) {
+      rescuedPinned.push(line.slice(2));
+      continue;
+    }
+    preambleLines.push(line);
+  }
+
+  return {
+    preamble: stripPinnedHeaderFromPreamble(preambleLines.join("\n")),
+    pinned: [...parsed.pinned, ...rescuedPinned],
+    sections: parsed.sections,
   };
 }
 
 export function rebuildOrgMemoryContent(parsed: ParsedOrgMemory): string {
+  const normalized = normalizeParsedOrgMemory(parsed);
   const parts: string[] = [];
 
-  const preamble = parsed.preamble.trim();
-  if (preamble) {
-    parts.push(preamble);
-  } else {
-    parts.push(ORG_MEMORY_PREAMBLE);
-  }
+  const preamble = normalized.preamble.trim();
+  parts.push(preamble.length > 0 ? preamble : ORG_MEMORY_HEADER);
 
-  if (parsed.pinned.length > 0) {
+  if (normalized.pinned.length > 0) {
     parts.push("", "## Pinned", "");
-    for (const bullet of parsed.pinned) {
+    for (const bullet of normalized.pinned) {
       parts.push(`- ${bullet}`);
     }
+  } else if (normalized.sections.length === 0) {
+    parts.push("", "## Pinned", "");
   }
 
-  for (const section of parsed.sections) {
+  for (const section of normalized.sections) {
     if (section.bullets.length === 0) {
       continue;
     }
@@ -134,6 +164,107 @@ export function rebuildOrgMemoryContent(parsed: ParsedOrgMemory): string {
 
   const content = parts.join("\n").replace(/\n+$/, "");
   return content.length > 0 ? `${content}\n` : content;
+}
+
+const ORG_MEMORY_SUPERSEDE_STOP_WORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "at",
+  "for",
+  "in",
+  "is",
+  "of",
+  "on",
+  "or",
+  "our",
+  "team",
+  "the",
+  "to",
+  "we",
+]);
+
+function significantOrgMemoryTokens(bullet: string): string[] {
+  return bullet
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .split(/\s+/)
+    .filter((token) => token.length > 1 && !ORG_MEMORY_SUPERSEDE_STOP_WORDS.has(token));
+}
+
+function orgMemorySupersessionScore(existingBullet: string, newBullet: string): number {
+  const existingTokens = significantOrgMemoryTokens(existingBullet);
+  const newTokens = significantOrgMemoryTokens(newBullet);
+  if (existingTokens.length < 2 || newTokens.length < 2) {
+    return 0;
+  }
+
+  const shared = newTokens.filter((token) => existingTokens.includes(token));
+  return shared.length / Math.min(existingTokens.length, newTokens.length);
+}
+
+function removeOrgMemoryBullet(
+  parsed: ParsedOrgMemory,
+  predicate: (bullet: string) => boolean,
+): void {
+  parsed.pinned = parsed.pinned.filter((bullet) => !predicate(bullet));
+  for (const section of parsed.sections) {
+    section.bullets = section.bullets.filter((bullet) => !predicate(bullet));
+  }
+}
+
+function removeSupersededOrgMemoryBullets(parsed: ParsedOrgMemory, newBullet: string): void {
+  const newKey = normalizeOrgMemoryDedupKey(newBullet);
+  removeOrgMemoryBullet(parsed, (bullet) => {
+    if (normalizeOrgMemoryDedupKey(bullet) === newKey) {
+      return false;
+    }
+    return orgMemorySupersessionScore(bullet, newBullet) >= 0.65;
+  });
+}
+
+export interface ApplyApprovedOrgMemoryBulletOptions {
+  pin?: boolean;
+  dateUtc?: string;
+}
+
+/** Apply an approved proposal bullet to live org memory content. */
+export function applyApprovedOrgMemoryBullet(
+  content: string | null | undefined,
+  bullet: string,
+  options: ApplyApprovedOrgMemoryBulletOptions = {},
+): string {
+  const pin = options.pin ?? false;
+  const dateUtc = options.dateUtc ?? new Date().toISOString().slice(0, 10);
+  const text = bullet.trim().replace(/^-\s+/, "").trim();
+  const parsed = normalizeParsedOrgMemory(parseOrgMemoryContent(content ?? ""));
+  const dedupKey = normalizeOrgMemoryDedupKey(text);
+
+  removeOrgMemoryBullet(parsed, (entry) => normalizeOrgMemoryDedupKey(entry) === dedupKey);
+  removeSupersededOrgMemoryBullets(parsed, text);
+
+  const alreadyPresent =
+    parsed.pinned.some((entry) => normalizeOrgMemoryDedupKey(entry) === dedupKey) ||
+    parsed.sections.some((section) =>
+      section.bullets.some((entry) => normalizeOrgMemoryDedupKey(entry) === dedupKey),
+    );
+
+  if (!alreadyPresent) {
+    if (pin) {
+      parsed.pinned.push(text);
+    } else {
+      let section = parsed.sections.find((entry) => entry.date === dateUtc);
+      if (!section) {
+        section = { date: dateUtc, bullets: [] };
+        parsed.sections.push(section);
+        parsed.sections.sort((a, b) => a.date.localeCompare(b.date));
+      }
+      section.bullets.push(text);
+    }
+  }
+
+  return rebuildOrgMemoryContent(parsed);
 }
 
 export function collectRecentLogBullets(
@@ -212,30 +343,7 @@ export function previewOrgMemoryAfterApprove(
   const pin = options.pin ?? false;
   const dateUtc = options.dateUtc ?? new Date().toISOString().slice(0, 10);
   const text = bullet.trim().replace(/^-\s+/, "").trim();
-  const parsed = parseOrgMemoryContent(liveContent ?? "");
-  const dedupKey = normalizeOrgMemoryDedupKey(text);
-
-  const alreadyPresent =
-    parsed.pinned.some((entry) => normalizeOrgMemoryDedupKey(entry) === dedupKey) ||
-    parsed.sections.some((section) =>
-      section.bullets.some((entry) => normalizeOrgMemoryDedupKey(entry) === dedupKey),
-    );
-
-  if (!alreadyPresent) {
-    if (pin) {
-      parsed.pinned.push(text);
-    } else {
-      let section = parsed.sections.find((entry) => entry.date === dateUtc);
-      if (!section) {
-        section = { date: dateUtc, bullets: [] };
-        parsed.sections.push(section);
-        parsed.sections.sort((a, b) => a.date.localeCompare(b.date));
-      }
-      section.bullets.push(text);
-    }
-  }
-
-  const rebuilt = rebuildOrgMemoryContent(parsed);
+  const rebuilt = applyApprovedOrgMemoryBullet(liveContent, bullet, { pin, dateUtc });
   const promptInjection = composeOrgMemorySummary(rebuilt, {
     byteCap: options.byteCap ?? 2048,
     recentLogLimit: options.recentLogLimit ?? 20,

--- a/packages/core/src/soul/org-memory.ts
+++ b/packages/core/src/soul/org-memory.ts
@@ -39,8 +39,12 @@ export function detectOrgMemoryInjectionWarnings(bullet: string): string[] {
   return warnings;
 }
 
-export function parseOrgMemoryContent(content: string): ParsedOrgMemory {
-  const lines = content.split("\n");
+function utf8ByteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+export function parseOrgMemoryContent(content?: string | null): ParsedOrgMemory {
+  const lines = (content ?? "").split("\n");
   const preambleLines: string[] = [];
   const pinned: string[] = [];
   const sections: MemorySection[] = [];
@@ -192,8 +196,61 @@ export function appendOrgMemorySection(
  * end and an overflow hint is appended pointing the agent at
  * `org_memory_search`.
  */
+export interface OrgMemoryApprovePreview {
+  destination: "pinned" | "recent-log";
+  destinationLabel: string;
+  memoryLine: string;
+  promptInjection: string;
+}
+
+/** Simulate approveProposal writes for admin UI previews. */
+export function previewOrgMemoryAfterApprove(
+  liveContent: string | null | undefined,
+  bullet: string,
+  options: { pin?: boolean; byteCap?: number; recentLogLimit?: number; dateUtc?: string } = {},
+): OrgMemoryApprovePreview {
+  const pin = options.pin ?? false;
+  const dateUtc = options.dateUtc ?? new Date().toISOString().slice(0, 10);
+  const text = bullet.trim().replace(/^-\s+/, "").trim();
+  const parsed = parseOrgMemoryContent(liveContent ?? "");
+  const dedupKey = normalizeOrgMemoryDedupKey(text);
+
+  const alreadyPresent =
+    parsed.pinned.some((entry) => normalizeOrgMemoryDedupKey(entry) === dedupKey) ||
+    parsed.sections.some((section) =>
+      section.bullets.some((entry) => normalizeOrgMemoryDedupKey(entry) === dedupKey),
+    );
+
+  if (!alreadyPresent) {
+    if (pin) {
+      parsed.pinned.push(text);
+    } else {
+      let section = parsed.sections.find((entry) => entry.date === dateUtc);
+      if (!section) {
+        section = { date: dateUtc, bullets: [] };
+        parsed.sections.push(section);
+        parsed.sections.sort((a, b) => a.date.localeCompare(b.date));
+      }
+      section.bullets.push(text);
+    }
+  }
+
+  const rebuilt = rebuildOrgMemoryContent(parsed);
+  const promptInjection = composeOrgMemorySummary(rebuilt, {
+    byteCap: options.byteCap ?? 2048,
+    recentLogLimit: options.recentLogLimit ?? 20,
+  });
+
+  return {
+    destination: pin ? "pinned" : "recent-log",
+    destinationLabel: pin ? "## Pinned" : `## ${dateUtc}`,
+    memoryLine: `- ${text}`,
+    promptInjection,
+  };
+}
+
 export function composeOrgMemorySummary(
-  content: string,
+  content?: string | null,
   options: OrgMemorySummaryOptions = {},
 ): string {
   const {
@@ -212,12 +269,12 @@ export function composeOrgMemorySummary(
   const header = "## Org Memory";
   const lines: string[] = [header, ""];
 
-  let bytes = Buffer.byteLength(lines.join("\n") + "\n", "utf8");
+  let bytes = utf8ByteLength(`${lines.join("\n")}\n`);
   let included = 0;
 
   for (const bullet of bullets) {
     const candidate = `- ${bullet}`;
-    const candidateBytes = Buffer.byteLength(candidate + "\n", "utf8");
+    const candidateBytes = utf8ByteLength(`${candidate}\n`);
     if (bytes + candidateBytes > byteCap) {
       break;
     }

--- a/packages/core/src/soul/resolve.ts
+++ b/packages/core/src/soul/resolve.ts
@@ -31,6 +31,11 @@ export function getOrgMemoryArchiveDir(orgId: string): string {
   return join(getOrgMemoryDir(orgId), "memory-archive");
 }
 
+/** Org memory change history dir: ~/.nakama/orgs/{orgId}/memory-history/ */
+export function getOrgMemoryHistoryDir(orgId: string): string {
+  return join(getOrgMemoryDir(orgId), "memory-history");
+}
+
 /** Org memory archive file for a given year-month: ~/.nakama/orgs/{orgId}/memory-archive/YYYY-MM.md */
 export function getOrgMemoryArchiveFilePath(orgId: string, yearMonth: string): string {
   return join(getOrgMemoryArchiveDir(orgId), `${yearMonth}.md`);

--- a/packages/db/sql/schema.sql
+++ b/packages/db/sql/schema.sql
@@ -286,6 +286,23 @@ CREATE TABLE IF NOT EXISTS org_invites (
 
 CREATE UNIQUE INDEX IF NOT EXISTS org_invites_token_hash_unique ON org_invites (token_hash);
 
+CREATE TABLE IF NOT EXISTS org_memory_proposals (
+  id TEXT PRIMARY KEY NOT NULL,
+  org_id TEXT NOT NULL,
+  profile_id TEXT,
+  session_id TEXT,
+  proposed_by_user_id TEXT,
+  bullet TEXT NOT NULL,
+  status TEXT NOT NULL,
+  pinned INTEGER NOT NULL DEFAULT 0,
+  reviewer_user_id TEXT,
+  reviewed_at TEXT,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY (org_id) REFERENCES organizations (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS org_memory_proposals_org_status ON org_memory_proposals (org_id, status);
+
 CREATE TABLE IF NOT EXISTS channel_org_mappings (
   channel TEXT NOT NULL,
   channel_user_id TEXT NOT NULL,

--- a/packages/db/src/adapters/in-memory.ts
+++ b/packages/db/src/adapters/in-memory.ts
@@ -13,6 +13,8 @@ import type {
   StoredSkillRecord,
   StoredOrgMemberRecord,
   StoredOrgInviteRecord,
+  StoredOrgMemoryProposal,
+  OrgMemoryProposalStatus,
   StoredArtifactShareRecord,
   StoredOrganizationRecord,
   StoredUserOrganizationRecord,
@@ -63,6 +65,7 @@ export function createInMemoryDatabaseAdapter(): DatabaseAdapter {
   const orgMembers = new Map<string, StoredOrgMemberRecord>();
   const orgInvites = new Map<string, StoredOrgInviteRecord>();
   const orgInvitesByTokenHash = new Map<string, StoredOrgInviteRecord>();
+  const orgMemoryProposals = new Map<string, StoredOrgMemoryProposal>();
   const artifactShares = new Map<string, StoredArtifactShareRecord>();
   const artifactSharesByTokenHash = new Map<string, StoredArtifactShareRecord>();
   let llmUsageStats: StoredLlmUsageStatsRecord | null = null;
@@ -276,6 +279,58 @@ export function createInMemoryDatabaseAdapter(): DatabaseAdapter {
       const updated = { ...invite, acceptedAt };
       orgInvites.set(id, updated);
       orgInvitesByTokenHash.set(updated.tokenHash, updated);
+    },
+
+    async createOrgMemoryProposal(record) {
+      orgMemoryProposals.set(record.id, record);
+    },
+
+    async listOrgMemoryProposals(orgId, status) {
+      const proposals = [...orgMemoryProposals.values()].filter((proposal) => proposal.orgId === orgId);
+      const filtered = status ? proposals.filter((proposal) => proposal.status === status) : proposals;
+      return filtered.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    },
+
+    async getOrgMemoryProposal(orgId, id) {
+      const proposal = orgMemoryProposals.get(id);
+      if (!proposal || proposal.orgId !== orgId) {
+        return null;
+      }
+      return proposal;
+    },
+
+    async getPendingOrgMemoryProposalByBullet(orgId, bullet) {
+      for (const proposal of orgMemoryProposals.values()) {
+        if (proposal.orgId === orgId && proposal.bullet === bullet && proposal.status === "pending") {
+          return proposal;
+        }
+      }
+      return null;
+    },
+
+    async updateOrgMemoryProposalStatus(orgId, id, update) {
+      const proposal = orgMemoryProposals.get(id);
+      if (!proposal || proposal.orgId !== orgId) {
+        return false;
+      }
+      orgMemoryProposals.set(id, {
+        ...proposal,
+        status: update.status,
+        reviewerUserId: update.reviewerUserId,
+        reviewedAt: update.reviewedAt,
+        pinned: update.pinned ?? proposal.pinned,
+      });
+      return true;
+    },
+
+    async countOrgMemoryProposals(orgId, status) {
+      let count = 0;
+      for (const proposal of orgMemoryProposals.values()) {
+        if (proposal.orgId === orgId && proposal.status === status) {
+          count += 1;
+        }
+      }
+      return count;
     },
 
     async createArtifactShare(record) {

--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -16,6 +16,8 @@ import type {
   StoredSkillRecord,
   StoredOrgMemberRecord,
   StoredOrgInviteRecord,
+  StoredOrgMemoryProposal,
+  OrgMemoryProposalStatus,
   StoredArtifactShareRecord,
   StoredOrganizationRecord,
   StoredUserOrganizationRecord,
@@ -298,6 +300,20 @@ interface OrgInviteRow {
   expires_at: string;
   accepted_at: string | null;
   revoked_at: string | null;
+  created_at: string;
+}
+
+interface OrgMemoryProposalRow {
+  id: string;
+  org_id: string;
+  profile_id: string | null;
+  session_id: string | null;
+  proposed_by_user_id: string | null;
+  bullet: string;
+  status: string;
+  pinned: number;
+  reviewer_user_id: string | null;
+  reviewed_at: string | null;
   created_at: string;
 }
 
@@ -1072,6 +1088,54 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
     SET accepted_at = ?
     WHERE id = ?
   `);
+  const createOrgMemoryProposalStmt = db.prepare(`
+    INSERT INTO org_memory_proposals (
+      id, org_id, profile_id, session_id, proposed_by_user_id,
+      bullet, status, pinned, reviewer_user_id, reviewed_at, created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const listOrgMemoryProposalsStmt = db.prepare(`
+    SELECT
+      id, org_id, profile_id, session_id, proposed_by_user_id,
+      bullet, status, pinned, reviewer_user_id, reviewed_at, created_at
+    FROM org_memory_proposals
+    WHERE org_id = ? AND status = ?
+    ORDER BY created_at DESC
+  `);
+  const listAllOrgMemoryProposalsStmt = db.prepare(`
+    SELECT
+      id, org_id, profile_id, session_id, proposed_by_user_id,
+      bullet, status, pinned, reviewer_user_id, reviewed_at, created_at
+    FROM org_memory_proposals
+    WHERE org_id = ?
+    ORDER BY created_at DESC
+  `);
+  const getOrgMemoryProposalStmt = db.prepare(`
+    SELECT
+      id, org_id, profile_id, session_id, proposed_by_user_id,
+      bullet, status, pinned, reviewer_user_id, reviewed_at, created_at
+    FROM org_memory_proposals
+    WHERE org_id = ? AND id = ?
+    LIMIT 1
+  `);
+  const getPendingOrgMemoryProposalByBulletStmt = db.prepare(`
+    SELECT
+      id, org_id, profile_id, session_id, proposed_by_user_id,
+      bullet, status, pinned, reviewer_user_id, reviewed_at, created_at
+    FROM org_memory_proposals
+    WHERE org_id = ? AND bullet = ? AND status = 'pending'
+    LIMIT 1
+  `);
+  const updateOrgMemoryProposalStatusStmt = db.prepare(`
+    UPDATE org_memory_proposals
+    SET status = ?, reviewer_user_id = ?, reviewed_at = ?, pinned = ?
+    WHERE org_id = ? AND id = ?
+  `);
+  const countOrgMemoryProposalsStmt = db.prepare(`
+    SELECT COUNT(*) AS count
+    FROM org_memory_proposals
+    WHERE org_id = ? AND status = ?
+  `);
   const createArtifactShareStmt = db.prepare(`
     INSERT INTO artifact_shares (
       id, org_id, profile_id, source_path, filename, mime_type, size_bytes,
@@ -1374,6 +1438,60 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
 
     async markOrgInviteAccepted(id, acceptedAt) {
       markOrgInviteAcceptedStmt.run(acceptedAt, id);
+    },
+
+    async createOrgMemoryProposal(record) {
+      createOrgMemoryProposalStmt.run(
+        record.id,
+        record.orgId,
+        record.profileId,
+        record.sessionId,
+        record.proposedByUserId,
+        record.bullet,
+        record.status,
+        record.pinned ? 1 : 0,
+        record.reviewerUserId,
+        record.reviewedAt,
+        record.createdAt,
+      );
+    },
+
+    async listOrgMemoryProposals(orgId, status) {
+      const rows = (
+        status
+          ? listOrgMemoryProposalsStmt.all(orgId, status)
+          : listAllOrgMemoryProposalsStmt.all(orgId)
+      ) as OrgMemoryProposalRow[];
+      return rows.map(toOrgMemoryProposalRecord);
+    },
+
+    async getOrgMemoryProposal(orgId, id) {
+      const row = getOrgMemoryProposalStmt.get(orgId, id) as OrgMemoryProposalRow | null;
+      return row ? toOrgMemoryProposalRecord(row) : null;
+    },
+
+    async getPendingOrgMemoryProposalByBullet(orgId, bullet) {
+      const row = getPendingOrgMemoryProposalByBulletStmt.get(orgId, bullet) as
+        | OrgMemoryProposalRow
+        | null;
+      return row ? toOrgMemoryProposalRecord(row) : null;
+    },
+
+    async updateOrgMemoryProposalStatus(orgId, id, update) {
+      const result = updateOrgMemoryProposalStatusStmt.run(
+        update.status,
+        update.reviewerUserId,
+        update.reviewedAt,
+        update.pinned ? 1 : 0,
+        orgId,
+        id,
+      );
+      return result.changes > 0;
+    },
+
+    async countOrgMemoryProposals(orgId, status) {
+      const row = countOrgMemoryProposalsStmt.get(orgId, status) as { count: number };
+      return row.count;
     },
 
     async createArtifactShare(record) {
@@ -2616,6 +2734,22 @@ function toOrgInviteRecord(row: OrgInviteRow): StoredOrgInviteRecord {
     expiresAt: row.expires_at,
     acceptedAt: row.accepted_at,
     revokedAt: row.revoked_at,
+    createdAt: row.created_at,
+  };
+}
+
+function toOrgMemoryProposalRecord(row: OrgMemoryProposalRow): StoredOrgMemoryProposal {
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    profileId: row.profile_id,
+    sessionId: row.session_id,
+    proposedByUserId: row.proposed_by_user_id,
+    bullet: row.bullet,
+    status: row.status as OrgMemoryProposalStatus,
+    pinned: Boolean(row.pinned),
+    reviewerUserId: row.reviewer_user_id,
+    reviewedAt: row.reviewed_at,
     createdAt: row.created_at,
   };
 }

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -15,6 +15,7 @@ export function migrateDatabase(db: Database): void {
   migrateSkillsTables(db);
   migrateUsersTable(db);
   migrateOrgTables(db);
+  migrateOrgMemoryProposalsTable(db);
   migrateTenantOrgScope(db);
   migrateProfileOrgColumns(db);
   migrateBrowserSessionsTable(db);
@@ -314,6 +315,26 @@ function migrateOrgTables(db: Database): void {
   if (!columnNames.has("user_context")) {
     db.exec(`ALTER TABLE org_members ADD COLUMN user_context TEXT;`);
   }
+}
+
+function migrateOrgMemoryProposalsTable(db: Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS org_memory_proposals (
+      id TEXT PRIMARY KEY NOT NULL,
+      org_id TEXT NOT NULL,
+      profile_id TEXT,
+      session_id TEXT,
+      proposed_by_user_id TEXT,
+      bullet TEXT NOT NULL,
+      status TEXT NOT NULL,
+      pinned INTEGER NOT NULL DEFAULT 0,
+      reviewer_user_id TEXT,
+      reviewed_at TEXT,
+      created_at TEXT NOT NULL,
+      FOREIGN KEY (org_id) REFERENCES organizations (id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS org_memory_proposals_org_status ON org_memory_proposals (org_id, status);
+  `);
 }
 
 const TENANT_ORG_ID_TABLES = [

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -336,6 +336,22 @@ export interface StoredOrgInviteRecord {
   createdAt: string;
 }
 
+export type OrgMemoryProposalStatus = "pending" | "approved" | "rejected";
+
+export interface StoredOrgMemoryProposal {
+  id: string;
+  orgId: string;
+  profileId: string | null;
+  sessionId: string | null;
+  proposedByUserId: string | null;
+  bullet: string;
+  status: OrgMemoryProposalStatus;
+  pinned: boolean;
+  reviewerUserId: string | null;
+  reviewedAt: string | null;
+  createdAt: string;
+}
+
 export interface StoredArtifactShareRecord {
   id: string;
   orgId: string;
@@ -409,6 +425,28 @@ export interface DatabaseAdapter {
   getOrgInviteByTokenHash(tokenHash: string): Promise<StoredOrgInviteRecord | null>;
   getPendingOrgInvite(orgId: string, email: string): Promise<StoredOrgInviteRecord | null>;
   markOrgInviteAccepted(id: string, acceptedAt: string): Promise<void>;
+
+  createOrgMemoryProposal(record: StoredOrgMemoryProposal): Promise<void>;
+  listOrgMemoryProposals(
+    orgId: string,
+    status?: OrgMemoryProposalStatus,
+  ): Promise<StoredOrgMemoryProposal[]>;
+  getOrgMemoryProposal(orgId: string, id: string): Promise<StoredOrgMemoryProposal | null>;
+  getPendingOrgMemoryProposalByBullet(
+    orgId: string,
+    bullet: string,
+  ): Promise<StoredOrgMemoryProposal | null>;
+  updateOrgMemoryProposalStatus(
+    orgId: string,
+    id: string,
+    update: {
+      status: OrgMemoryProposalStatus;
+      reviewerUserId: string;
+      reviewedAt: string;
+      pinned?: boolean;
+    },
+  ): Promise<boolean>;
+  countOrgMemoryProposals(orgId: string, status: OrgMemoryProposalStatus): Promise<number>;
 
   createArtifactShare(record: StoredArtifactShareRecord): Promise<void>;
   updateArtifactShareSnapshot(


### PR DESCRIPTION
## Summary

- Adds a hybrid write model for org memory: agents propose facts via `propose_org_memory`; admins approve or reject from Settings → Org Memory → Proposals before they become authoritative.
- Introduces a recent-log tier (`## YYYY-MM-DD` sections below `## Pinned`); prompt injection includes pinned bullets plus the 20 most recent log entries within the existing 2048-byte cap.
- Persists proposals in SQLite (`org_memory_proposals`), with server-side dedup for pending duplicates and tier-aware `org_memory_search` results.

Closes #135.

## Test plan

- [x] `bun test packages/core/src/soul/org-memory.test.ts`
- [x] `bun test apps/server/src/services/org-memory-service.test.ts`
- [x] `bun test apps/server/src/http/routes/org-memory.test.ts`
- [x] `bun test apps/server/src/tools/org-memory-tools.test.ts`
- [ ] Manual: agent proposes a fact in chat → admin sees it on Proposals tab → approve → bullet appears in live memory and next chat summary
- [ ] Manual: reject proposal; verify pending badge decrements