### PR TITLE
Implement skill write approval feature

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,7 @@ Path: `~/.nakama/orgs/{orgId}/profiles/{profileId}/` (`getProfileSoulDir`). Load
 | `coding-agent` | Codex / Claude Code / OpenCode via `bash` |
 | `agent-browser` | Opt-in browser CLI; needs host install — `docs/website/agent-browser.md` |
 | `create-profile` | Super Bot only, confirm-first — `apps/server/src/tools/super-bot-tools.ts` |
-| `skill_manage` | Interactive web/cli with `manage-skills` — create/patch/delete profile skills + auto-assign (`apps/server/src/tools/skill-manage-tool.ts`). When present, file tools refuse `skills/*/SKILL.md` (`forbidProfileSkillMarkdownWrites`). Not injected for automations or Telegram/WhatsApp/Discord. |
+| `skill_manage` | Interactive web/cli with `manage-skills` — create/patch/delete profile skills + auto-assign (`apps/server/src/tools/skill-manage-tool.ts`). When org/profile **write approval** is enabled, mutations stage as proposals for org-admin review instead of writing immediately. When present, file tools refuse `skills/*/SKILL.md` (`forbidProfileSkillMarkdownWrites`). Not injected for automations or Telegram/WhatsApp/Discord. |
 | Composio | Org toolkits + per-user OAuth — `docs/website/composio.md` |
 
 **Channel artifacts (Telegram/Discord):** `packages/core/src/channel-artifacts.ts`, `channel-artifact-delivery.ts`; handlers in `apps/platform/{telegram,discord}/src/channel-artifact-flow.ts`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,9 @@ Always build context with `buildToolExecutionContext()` (`packages/core/src/tool
 | Tool loop | `packages/agent/src/tool-loop.ts` → `executeToolCall()`; parallel batching in `packages/agent/src/chat.ts` when every call in the turn is `parallelSafe` |
 
 **Parallel tool calls:** Built-in read/search/fetch tools (`read_file`, `search_files`, `knowledge_base_search`, `web_search`, `web_fetch`) set `parallelSafe: true` on `ToolDefinition`. Mutating, shell, delegation, and session-state tools stay sequential. Custom JS tools default to sequential; export `parallelSafe: true` from the module to opt in. When a turn mixes parallel-safe and sequential tools, the whole turn runs sequentially.
+
+| Flow | Entry |
+|---|---|
 | Playground | `POST /v1/tools/:toolId/run` → `runToolPlayground()` (`resolvePlaygroundProfileId`) |
 | Param suggest | `POST /v1/tools/:toolId/params/suggest` |
 

--- a/apps/server/src/http/app.ts
+++ b/apps/server/src/http/app.ts
@@ -21,6 +21,7 @@ import { registerTaskRoutes } from "./routes/tasks";
 import { registerPlatformOrgRoutes } from "./routes/platform-orgs";
 import { registerOrgMemberRoutes } from "./routes/org-members";
 import { registerOrgMemoryRoutes } from "./routes/org-memory";
+import { registerSkillProposalRoutes } from "./routes/skill-proposals";
 import { registerCodingAgentRoutes } from "./routes/coding-agents";
 import { registerInternalAutomationRoutes } from "./routes/internal-automations";
 import { registerNotificationDestinationRoutes } from "./routes/notification-destinations";
@@ -109,6 +110,7 @@ export function createHonoApp(options: ServerOptions) {
   registerDataPortabilityRoutes(app, options);
   registerOrgMemberRoutes(app, options);
   registerOrgMemoryRoutes(app, options);
+  registerSkillProposalRoutes(app, options);
   registerCodingAgentRoutes(app, options);
 
   app.get("/openapi.json", (c) => {

--- a/apps/server/src/http/coding-harness-install-stream.ts
+++ b/apps/server/src/http/coding-harness-install-stream.ts
@@ -3,6 +3,8 @@ import type { AgentBrowserInstallEvent, CodingHarnessInstallEvent } from "@nakam
 
 const INSTALL_STREAM_TIMEOUT_MS = 120_000;
 
+type InstallStreamErrorEvent = { type: "error"; error: string };
+
 export function streamInstallEvents<TEvent extends { type: string }>(
   executor: (send: (event: TEvent) => void) => Promise<void>,
   options: {
@@ -33,7 +35,7 @@ export function streamInstallEvents<TEvent extends { type: string }>(
         send({
           type: "error",
           error: timeoutMessage,
-        } as TEvent);
+        } as Extract<TEvent, InstallStreamErrorEvent>);
         clearInterval(keepalive);
         controller.close();
       }, INSTALL_STREAM_TIMEOUT_MS);
@@ -44,7 +46,7 @@ export function streamInstallEvents<TEvent extends { type: string }>(
         send({
           type: "error",
           error: formatServerError(error),
-        } as TEvent);
+        } as Extract<TEvent, InstallStreamErrorEvent>);
       } finally {
         clearTimeout(timeoutId);
         clearInterval(keepalive);

--- a/apps/server/src/http/context.ts
+++ b/apps/server/src/http/context.ts
@@ -7,6 +7,7 @@ import type { WorkerManagerService } from "../services/worker-manager-service";
 import type { AuthService } from "../services/auth-service";
 import type { OrgService } from "../services/org-service";
 import type { OrgMemoryService } from "../services/org-memory-service";
+import type { SkillProposalService } from "../services/skill-proposal-service";
 import type { ComposioService } from "../services/composio-service";
 import type { DatabaseAdapter } from "@nakama/db";
 
@@ -21,6 +22,7 @@ export interface ServerOptions {
   authService?: AuthService | null;
   orgService?: OrgService | null;
   orgMemoryService?: OrgMemoryService | null;
+  skillProposalService?: SkillProposalService | null;
   databaseAdapter?: DatabaseAdapter | null;
   webDistDir?: string | null;
 }

--- a/apps/server/src/http/platform-orgs.test.ts
+++ b/apps/server/src/http/platform-orgs.test.ts
@@ -53,6 +53,7 @@ describe("platform org routes", () => {
         id: expect.stringMatching(/^org_/),
         name: "Acme Corp",
         slug: "acme-corp",
+        skillsWriteApproval: false,
         createdAt: expect.any(String),
         updatedAt: expect.any(String),
       },

--- a/apps/server/src/http/routes/profiles-skills-write-approval.test.ts
+++ b/apps/server/src/http/routes/profiles-skills-write-approval.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import { createHonoApp } from "../app";
+import { AuthService } from "../../services/auth-service";
+import { OrgService } from "../../services/org-service";
+import { ProfileService } from "../../services/profile-service";
+import { createInMemoryDatabaseAdapter } from "@nakama/db";
+import { setupFreshInstallSession, loginUserSession } from "../test-session-helpers";
+import { setupTestConfigDir } from "../../test-config-dir";
+
+setupTestConfigDir("nakama-profiles-skills-write-approval-test-");
+
+function createApp() {
+  const databaseAdapter = createInMemoryDatabaseAdapter();
+  const authService = new AuthService();
+  const profileService = new ProfileService(databaseAdapter);
+  return {
+    databaseAdapter,
+    authService,
+    profileService,
+    app: createHonoApp({
+      agent: {
+        updateProfile: (orgId: string, profileId: string, body: unknown) =>
+          profileService.updateProfile(orgId, profileId, body as Parameters<ProfileService["updateProfile"]>[2]),
+      } as never,
+      automationService: {} as never,
+      taskService: {} as never,
+      systemStatus: { getStatus: async () => ({ ok: true }) } as never,
+      workerManager: {} as never,
+      mcpService: {} as never,
+      authService,
+      orgService: new OrgService(databaseAdapter, authService),
+      databaseAdapter,
+      webDistDir: null,
+    }),
+  };
+}
+
+const BASE = "http://localhost:4310";
+
+describe("profile skillsWriteApproval auth", () => {
+  test("org admin can patch skillsWriteApproval only; other fields forbidden", async () => {
+    const { app, databaseAdapter } = createApp();
+    const platformSession = await setupFreshInstallSession(app, databaseAdapter, "platform@org.com");
+    const orgId = platformSession.orgId!;
+
+    const inviteResp = await app.fetch(
+      new Request(`${BASE}/v1/orgs/${orgId}/members`, {
+        method: "POST",
+        headers: platformSession.headers({ "X-CSRF-Token": platformSession.csrfToken }, orgId),
+        body: JSON.stringify({
+          email: "orgadmin@org.com",
+          name: "Org Admin",
+          role: "admin",
+        }),
+      }),
+    );
+    const invited = (await inviteResp.json()) as { temporaryPassword: string };
+    const orgAdminSession = await loginUserSession(
+      app,
+      "orgadmin@org.com",
+      invited.temporaryPassword,
+      orgId,
+    );
+
+    const profileId = (await databaseAdapter.listProfilesForOrg(orgId))[0]!.id;
+
+    const okResp = await app.fetch(
+      new Request(`${BASE}/v1/profiles/${profileId}`, {
+        method: "PUT",
+        headers: orgAdminSession.headers({ "X-CSRF-Token": orgAdminSession.csrfToken }, orgId),
+        body: JSON.stringify({ skillsWriteApproval: true }),
+      }),
+    );
+    expect(okResp.status).toBe(200);
+    const okBody = (await okResp.json()) as { profile: { skillsWriteApproval: boolean | null } };
+    expect(okBody.profile.skillsWriteApproval).toBe(true);
+
+    const forbiddenResp = await app.fetch(
+      new Request(`${BASE}/v1/profiles/${profileId}`, {
+        method: "PUT",
+        headers: orgAdminSession.headers({ "X-CSRF-Token": orgAdminSession.csrfToken }, orgId),
+        body: JSON.stringify({ name: "Renamed", skillsWriteApproval: false }),
+      }),
+    );
+    expect(forbiddenResp.status).toBe(403);
+  });
+});

--- a/apps/server/src/http/routes/profiles.ts
+++ b/apps/server/src/http/routes/profiles.ts
@@ -17,11 +17,23 @@ import type {
   UploadKnowledgeBaseRequest,
   UploadKnowledgeBaseResponse,
 } from "@nakama/core";
+import { NakamaApiError } from "@nakama/core";
 import { filterProfilesForChatAccess } from "@nakama/core/profiles";
 import { json, readJson, getRequestAuth } from "../shared";
-import { requirePlatformAdminFromContext, requireActiveOrgIdFromContext } from "../org-guards";
+import {
+  requirePlatformAdminFromContext,
+  requireActiveOrgIdFromContext,
+  requireOrgAdmin,
+} from "../org-guards";
 import type { HonoApp } from "../types";
 import type { ServerOptions } from "../context";
+
+function isSkillsWriteApprovalOnlyUpdate(body: UpdateProfileRequest): boolean {
+  const keys = Object.keys(body).filter(
+    (key) => body[key as keyof UpdateProfileRequest] !== undefined,
+  );
+  return keys.length === 1 && keys[0] === "skillsWriteApproval";
+}
 
 export function registerProfileRoutes(app: HonoApp, options: ServerOptions): void {
   const { agent } = options;
@@ -444,10 +456,18 @@ export function registerProfileRoutes(app: HonoApp, options: ServerOptions): voi
   });
 
   app.put("/v1/profiles/:profileId", async (c) => {
-    requirePlatformAdminFromContext(c);
+    const auth = getRequestAuth(c);
     const orgId = requireActiveOrgIdFromContext(c);
     const profileId = decodeURIComponent(c.req.param("profileId"));
     const body = await readJson<UpdateProfileRequest>(c.req.raw);
+
+    if (!auth.isPlatformAdmin) {
+      requireOrgAdmin(auth);
+      if (!isSkillsWriteApprovalOnlyUpdate(body)) {
+        throw new NakamaApiError("Forbidden", 403);
+      }
+    }
+
     return json<ProfileResponse>(await agent.updateProfile(orgId, profileId, body));
   });
 

--- a/apps/server/src/http/routes/skill-proposals.test.ts
+++ b/apps/server/src/http/routes/skill-proposals.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "bun:test";
+import { createHonoApp } from "../app";
+import { AuthService } from "../../services/auth-service";
+import { OrgService } from "../../services/org-service";
+import { SkillProposalService } from "../../services/skill-proposal-service";
+import { SkillsService } from "../../services/skills-service";
+import { createInMemoryDatabaseAdapter } from "@nakama/db";
+import { setupFreshInstallSession, loginUserSession } from "../test-session-helpers";
+import { setupTestConfigDir } from "../../test-config-dir";
+
+setupTestConfigDir("nakama-skill-proposals-routes-test-");
+
+const sampleSkillMarkdown = `---
+name: deploy-notes
+description: Notes about deploy process.
+---
+
+Run the deploy checklist before shipping.
+`;
+
+function createApp() {
+  const databaseAdapter = createInMemoryDatabaseAdapter();
+  const authService = new AuthService();
+  const skillsService = new SkillsService(databaseAdapter);
+  const skillProposalService = new SkillProposalService(databaseAdapter, skillsService);
+  return {
+    databaseAdapter,
+    authService,
+    skillsService,
+    skillProposalService,
+    app: createHonoApp({
+      agent: {
+        listProfiles: async () => ({ profiles: [{ id: "default" }] }),
+      } as any,
+      automationService: {} as any,
+      taskService: {} as any,
+      systemStatus: { getStatus: async () => ({ ok: true }) } as any,
+      workerManager: {} as any,
+      mcpService: {} as any,
+      authService,
+      orgService: new OrgService(databaseAdapter, authService),
+      skillProposalService,
+      databaseAdapter,
+      webDistDir: null,
+    }),
+  };
+}
+
+const BASE = "http://localhost:4310";
+
+describe("skill proposal routes (v1)", () => {
+  test("admin can list, approve, and reject proposals; member cannot list", async () => {
+    const { app, authService, databaseAdapter, skillProposalService } = createApp();
+    const adminSession = await setupFreshInstallSession(app, databaseAdapter, "admin@org.com");
+    const orgId = adminSession.orgId!;
+    const profiles = await databaseAdapter.listProfilesForOrg(orgId);
+    const profileId = profiles[0]!.id;
+
+    const staged = await skillProposalService.stageProposal({
+      orgId,
+      profileId,
+      action: "create",
+      content: sampleSkillMarkdown,
+    });
+    expect(staged.outcome).toBe("created");
+
+    const listResp = await app.fetch(
+      new Request(`${BASE}/v1/orgs/${orgId}/skill-proposals?status=pending&profileId=${profileId}`, {
+        headers: adminSession.headers({}, orgId),
+      }),
+    );
+    expect(listResp.status).toBe(200);
+    const listBody = (await listResp.json()) as {
+      proposals: { id: string; skillName: string }[];
+      pendingCount: number;
+    };
+    expect(listBody.pendingCount).toBe(1);
+    expect(listBody.proposals[0]?.skillName).toBe("deploy-notes");
+
+    const approveResp = await app.fetch(
+      new Request(
+        `${BASE}/v1/orgs/${orgId}/skill-proposals/${staged.proposalId}/approve`,
+        {
+          method: "POST",
+          headers: adminSession.headers({ "X-CSRF-Token": adminSession.csrfToken }, orgId),
+        },
+      ),
+    );
+    expect(approveResp.status).toBe(200);
+    const approveBody = (await approveResp.json()) as { proposal: { status: string } };
+    expect(approveBody.proposal.status).toBe("approved");
+
+    const memberResp = await app.fetch(
+      new Request(`${BASE}/v1/orgs/${orgId}/members`, {
+        method: "POST",
+        headers: adminSession.headers({ "X-CSRF-Token": adminSession.csrfToken }, orgId),
+        body: JSON.stringify({
+          email: "member@org.com",
+          name: "Member",
+          role: "member",
+        }),
+      }),
+    );
+    const memberProvisioned = (await memberResp.json()) as { temporaryPassword: string };
+    const memberSession = await loginUserSession(
+      app,
+      "member@org.com",
+      memberProvisioned.temporaryPassword,
+      orgId,
+    );
+    const memberListResp = await app.fetch(
+      new Request(`${BASE}/v1/orgs/${orgId}/skill-proposals`, {
+        headers: memberSession.headers({}, orgId),
+      }),
+    );
+    expect(memberListResp.status).toBe(403);
+  });
+
+  test("admin can reject a pending proposal", async () => {
+    const { app, databaseAdapter, skillProposalService } = createApp();
+    const adminSession = await setupFreshInstallSession(app, databaseAdapter, "admin2@org.com");
+    const orgId = adminSession.orgId!;
+    const profileId = (await databaseAdapter.listProfilesForOrg(orgId))[0]!.id;
+
+    const staged = await skillProposalService.stageProposal({
+      orgId,
+      profileId,
+      action: "create",
+      content: sampleSkillMarkdown,
+    });
+
+    const rejectResp = await app.fetch(
+      new Request(
+        `${BASE}/v1/orgs/${orgId}/skill-proposals/${staged.proposalId}/reject`,
+        {
+          method: "POST",
+          headers: adminSession.headers({ "X-CSRF-Token": adminSession.csrfToken }, orgId),
+        },
+      ),
+    );
+    expect(rejectResp.status).toBe(200);
+    const rejectBody = (await rejectResp.json()) as { proposal: { status: string } };
+    expect(rejectBody.proposal.status).toBe("rejected");
+  });
+
+  test("approve proposal from wrong org returns 404 (AE6)", async () => {
+    const { app, databaseAdapter, skillProposalService } = createApp();
+    const adminSession = await setupFreshInstallSession(app, databaseAdapter, "admin3@org.com");
+    const orgId = adminSession.orgId!;
+    const profileId = (await databaseAdapter.listProfilesForOrg(orgId))[0]!.id;
+
+    const staged = await skillProposalService.stageProposal({
+      orgId,
+      profileId,
+      action: "create",
+      content: sampleSkillMarkdown,
+    });
+
+    const otherOrgResp = await app.fetch(
+      new Request(
+        `${BASE}/v1/orgs/org_other/skill-proposals/${staged.proposalId}/approve`,
+        {
+          method: "POST",
+          headers: adminSession.headers({ "X-CSRF-Token": adminSession.csrfToken }, orgId),
+        },
+      ),
+    );
+    expect(otherOrgResp.status).toBe(404);
+  });
+});

--- a/apps/server/src/http/routes/skill-proposals.ts
+++ b/apps/server/src/http/routes/skill-proposals.ts
@@ -1,0 +1,152 @@
+import { createRoute, z } from "@hono/zod-openapi";
+import { NakamaApiError } from "@nakama/core";
+import type {
+  ListSkillProposalsResponse,
+  SkillProposalResponse,
+} from "@nakama/core/contract";
+import type { HonoApp } from "../types";
+import type { ServerOptions } from "../context";
+import { json } from "../shared";
+import { requireOrgAdminFromContext } from "../org-guards";
+import { SkillProposalService, toSkillProposal } from "../../services/skill-proposal-service";
+
+export function registerSkillProposalRoutes(app: HonoApp, options: ServerOptions): void {
+  const skillProposalService = options.skillProposalService;
+  const errorSchema = z.object({ error: z.string() }).openapi("ApiErrorResponse");
+  const orgIdParam = z.object({
+    orgId: z.string().openapi({ param: { name: "orgId", in: "path" } }),
+  });
+  const listSkillProposalsResponseSchema = z
+    .object({})
+    .passthrough()
+    .openapi("ListSkillProposalsResponse");
+  const skillProposalResponseSchema = z
+    .object({})
+    .passthrough()
+    .openapi("SkillProposalResponse");
+
+  function resolveOrgId(c: { req: { param: (n: string) => string } }, authOrgId: string): string {
+    const orgId = decodeURIComponent(c.req.param("orgId"));
+    if (authOrgId !== orgId) {
+      throw new NakamaApiError("Not found", 404);
+    }
+    return orgId;
+  }
+
+  function requireService(): SkillProposalService {
+    if (!skillProposalService) {
+      throw new NakamaApiError("Skill proposal service not configured", 500);
+    }
+    return skillProposalService;
+  }
+
+  app.openAPIRegistry.registerPath(
+    createRoute({
+      method: "get",
+      path: "/v1/orgs/{orgId}/skill-proposals",
+      tags: ["Organizations"],
+      summary: "List skill proposals",
+      operationId: "listSkillProposals",
+      request: {
+        params: orgIdParam,
+        query: z.object({
+          status: z.enum(["pending", "approved", "rejected"]).optional(),
+          profileId: z.string().optional(),
+        }),
+      },
+      responses: {
+        200: {
+          description: "Skill proposals",
+          content: { "application/json": { schema: listSkillProposalsResponseSchema } },
+        },
+        403: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        404: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        500: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+      },
+    }),
+  );
+
+  app.get("/v1/orgs/:orgId/skill-proposals", async (c) => {
+    const auth = requireOrgAdminFromContext(c);
+    const orgId = resolveOrgId(c, auth.activeOrgId ?? "");
+    const service = requireService();
+    const status = c.req.query("status") as "pending" | "approved" | "rejected" | undefined;
+    const profileId = c.req.query("profileId");
+    const result = await service.listProposals(orgId, {
+      status,
+      profileId: profileId || undefined,
+    });
+    return json<ListSkillProposalsResponse>({
+      proposals: result.proposals.map(toSkillProposal),
+      pendingCount: result.pendingCount,
+    });
+  });
+
+  app.openAPIRegistry.registerPath(
+    createRoute({
+      method: "post",
+      path: "/v1/orgs/{orgId}/skill-proposals/{proposalId}/approve",
+      tags: ["Organizations"],
+      summary: "Approve a skill proposal",
+      operationId: "approveSkillProposal",
+      request: {
+        params: orgIdParam.extend({
+          proposalId: z.string().openapi({ param: { name: "proposalId", in: "path" } }),
+        }),
+      },
+      responses: {
+        200: {
+          description: "Approved",
+          content: { "application/json": { schema: skillProposalResponseSchema } },
+        },
+        400: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        403: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        404: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        500: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+      },
+    }),
+  );
+
+  app.post("/v1/orgs/:orgId/skill-proposals/:proposalId/approve", async (c) => {
+    const auth = requireOrgAdminFromContext(c);
+    const orgId = resolveOrgId(c, auth.activeOrgId ?? "");
+    const proposalId = decodeURIComponent(c.req.param("proposalId"));
+    const service = requireService();
+    const proposal = await service.approveProposal(orgId, proposalId, auth.user.id);
+    return json<SkillProposalResponse>({ proposal: toSkillProposal(proposal) });
+  });
+
+  app.openAPIRegistry.registerPath(
+    createRoute({
+      method: "post",
+      path: "/v1/orgs/{orgId}/skill-proposals/{proposalId}/reject",
+      tags: ["Organizations"],
+      summary: "Reject a skill proposal",
+      operationId: "rejectSkillProposal",
+      request: {
+        params: orgIdParam.extend({
+          proposalId: z.string().openapi({ param: { name: "proposalId", in: "path" } }),
+        }),
+      },
+      responses: {
+        200: {
+          description: "Rejected",
+          content: { "application/json": { schema: skillProposalResponseSchema } },
+        },
+        400: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        403: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        404: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        500: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+      },
+    }),
+  );
+
+  app.post("/v1/orgs/:orgId/skill-proposals/:proposalId/reject", async (c) => {
+    const auth = requireOrgAdminFromContext(c);
+    const orgId = resolveOrgId(c, auth.activeOrgId ?? "");
+    const proposalId = decodeURIComponent(c.req.param("proposalId"));
+    const service = requireService();
+    const proposal = await service.rejectProposal(orgId, proposalId, auth.user.id);
+    return json<SkillProposalResponse>({ proposal: toSkillProposal(proposal) });
+  });
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -26,6 +26,7 @@ import { SkillsService } from "./services/skills-service";
 import { AuthService } from "./services/auth-service";
 import { OrgService } from "./services/org-service";
 import { OrgMemoryService } from "./services/org-memory-service";
+import { SkillProposalService } from "./services/skill-proposal-service";
 import {
   mergeOrgMemoryWithApprovedBullet,
 } from "@nakama/agent";
@@ -129,6 +130,8 @@ const orgMemoryService = new OrgMemoryService(database.adapter, {
     },
   },
 });
+const skillProposalService = new SkillProposalService(database.adapter, skillsService);
+agent.setSkillProposalService(skillProposalService);
 
 const systemStatus = new SystemStatusService(
   agent,
@@ -152,6 +155,7 @@ const app = createHonoApp({
   authService,
   orgService,
   orgMemoryService,
+  skillProposalService,
   databaseAdapter: database.adapter,
   webDistDir,
 });

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -243,6 +243,7 @@ import type { McpService } from "./mcp-service";
 import { OrgMemoryService } from "./org-memory-service";
 import { ProfileService } from "./profile-service";
 import type { SkillsService } from "./skills-service";
+import type { SkillProposalService } from "./skill-proposal-service";
 import { SessionTitleService } from "./session-title-service";
 import { SuperBotSessionState } from "./super-bot-session-state";
 import { resolveProfileStoredTools } from "./tool-resolver";
@@ -304,6 +305,7 @@ export class AgentService {
   private mcpService: McpService | null = null;
   private composioService: ComposioService | null = null;
   private skillsService: SkillsService | null = null;
+  private skillProposalService: SkillProposalService | null = null;
   private orgMemoryService: OrgMemoryService | null = null;
   private readonly sessions = new Map<string, StoredSession>();
   private readonly sessionTitleService: SessionTitleService;
@@ -392,6 +394,10 @@ export class AgentService {
   setSkillsService(service: SkillsService): void {
     this.skillsService = service;
     this.sessions.clear();
+  }
+
+  setSkillProposalService(service: SkillProposalService): void {
+    this.skillProposalService = service;
   }
 
   getMcpService(): McpService {
@@ -2547,7 +2553,13 @@ export class AgentService {
       if (includeSkillManageTools) {
         const assignedSkills = await this.skillsService.listSkillsForProfile(profile.id);
         if (assignedSkills.some((skill) => skill.name === "manage-skills")) {
-          resolved = [...resolved, ...createSkillManageTools(this.skillsService)];
+          resolved = [
+            ...resolved,
+            ...createSkillManageTools({
+              skillsService: this.skillsService,
+              skillProposalService: this.skillProposalService,
+            }),
+          ];
         }
       }
     }

--- a/apps/server/src/services/org-service.ts
+++ b/apps/server/src/services/org-service.ts
@@ -15,6 +15,7 @@ import type {
   AuthUserResponse,
   ListUserOrgsResponse,
   UpdateOrgMemberRequest,
+  UpdateOrganizationRequest,
   UserOrgSummary,
 } from "@nakama/core/contract";
 import {
@@ -50,15 +51,16 @@ export class OrgService {
 
   async updateOrganization(
     orgId: string,
-    request: { name: string },
+    request: UpdateOrganizationRequest,
   ): Promise<OrganizationSummary> {
     const org = await this.databaseAdapter.getOrganizationById(orgId);
     if (!org) {
       throw new NakamaApiError("Not found", 404);
     }
 
-    const name = request.name.trim();
-    if (!name) {
+    const name =
+      request.name !== undefined ? request.name.trim() : org.name;
+    if (request.name !== undefined && !name) {
       throw new NakamaApiError("Organization name is required.", 400);
     }
 
@@ -66,6 +68,10 @@ export class OrgService {
     const updated: StoredOrganizationRecord = {
       ...org,
       name,
+      skillsWriteApproval:
+        request.skillsWriteApproval !== undefined
+          ? request.skillsWriteApproval
+          : org.skillsWriteApproval ?? false,
       updatedAt: now,
     };
 
@@ -740,6 +746,7 @@ function toOrganizationSummary(record: StoredOrganizationRecord): OrganizationSu
     id: record.id,
     name: record.name,
     slug: record.slug,
+    skillsWriteApproval: record.skillsWriteApproval ?? false,
     createdAt: record.createdAt,
     updatedAt: record.updatedAt,
   };

--- a/apps/server/src/services/profile-service.ts
+++ b/apps/server/src/services/profile-service.ts
@@ -150,6 +150,10 @@ export class ProfileService {
       name: request.name?.trim() ?? profile.name,
       systemPrompt: request.systemPrompt?.trim() ?? profile.systemPrompt,
       model: request.model === undefined ? profile.model : request.model,
+      skillsWriteApproval:
+        request.skillsWriteApproval === undefined
+          ? profile.skillsWriteApproval
+          : request.skillsWriteApproval,
       updatedAt: now,
     });
 
@@ -528,6 +532,7 @@ export class ProfileService {
       model: profile.model,
       isSuper: profile.isSuper,
       isDefault: profile.isDefault ?? false,
+      skillsWriteApproval: profile.skillsWriteApproval ?? null,
       toolCount: tools.length,
       mcpServerCount: mcpServers.length,
       soulActive: soulStack !== null,

--- a/apps/server/src/services/skill-proposal-service.test.ts
+++ b/apps/server/src/services/skill-proposal-service.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { NakamaApiError } from "@nakama/core";
+import {
+  createInMemoryDatabaseAdapter,
+  seedOrgDefaultProfile,
+  type DatabaseAdapter,
+} from "@nakama/db";
+import { SkillProposalService } from "./skill-proposal-service";
+import { SkillsService } from "./skills-service";
+
+const ORG_ID = "org_test";
+
+const sampleSkillMarkdown = `---
+name: deploy-notes
+description: Notes about deploy process.
+---
+
+Run the deploy checklist before shipping.
+`;
+
+async function seedOrg(
+  db: DatabaseAdapter,
+  options: {
+    orgSkillsWriteApproval?: boolean;
+    profileSkillsWriteApproval?: boolean | null;
+  } = {},
+) {
+  const now = new Date().toISOString();
+  await db.upsertOrganization({
+    id: ORG_ID,
+    name: "Test Org",
+    slug: "test-org",
+    skillsWriteApproval: options.orgSkillsWriteApproval ?? false,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const profile = await seedOrgDefaultProfile(db, ORG_ID);
+  if (options.profileSkillsWriteApproval !== undefined) {
+    await db.upsertProfile({
+      ...profile,
+      skillsWriteApproval: options.profileSkillsWriteApproval,
+      updatedAt: now,
+    });
+  }
+  return profile;
+}
+
+describe("SkillProposalService", () => {
+  let configDir: string;
+
+  beforeEach(async () => {
+    configDir = await mkdtemp(join(tmpdir(), "nakama-skill-proposals-"));
+    process.env.NAKAMA_CONFIG_DIR = configDir;
+  });
+
+  afterEach(() => {
+    delete process.env.NAKAMA_CONFIG_DIR;
+  });
+
+  test("isWriteApprovalRequired respects org default and profile override (AE7)", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const profile = await seedOrg(db, {
+      orgSkillsWriteApproval: true,
+      profileSkillsWriteApproval: false,
+    });
+    const service = new SkillProposalService(db);
+
+    expect(await service.isWriteApprovalRequired(ORG_ID, profile.id)).toBe(false);
+  });
+
+  test("stage create inserts pending row without writing skill to disk", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const profile = await seedOrg(db);
+    const skills = new SkillsService(db);
+    const service = new SkillProposalService(db, skills);
+
+    const result = await service.stageProposal({
+      orgId: ORG_ID,
+      profileId: profile.id,
+      action: "create",
+      content: sampleSkillMarkdown,
+    });
+
+    expect(result.outcome).toBe("created");
+    expect(result.proposalId).toBeTruthy();
+
+    const listed = await skills.listSkills();
+    expect(listed.skills.some((skill) => skill.name === "deploy-notes")).toBe(false);
+
+    const { proposals } = await service.listProposals(ORG_ID, { profileId: profile.id });
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0]?.status).toBe("pending");
+    expect(proposals[0]?.action).toBe("create");
+  });
+
+  test("duplicate pending create returns already_pending (AE3)", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const profile = await seedOrg(db);
+    const service = new SkillProposalService(db, new SkillsService(db));
+
+    const first = await service.stageProposal({
+      orgId: ORG_ID,
+      profileId: profile.id,
+      action: "create",
+      content: sampleSkillMarkdown,
+    });
+    const second = await service.stageProposal({
+      orgId: ORG_ID,
+      profileId: profile.id,
+      action: "create",
+      content: sampleSkillMarkdown,
+    });
+
+    expect(first.outcome).toBe("created");
+    expect(second.outcome).toBe("already_pending");
+    expect(second.proposalId).toBe(first.proposalId);
+
+    const { proposals } = await service.listProposals(ORG_ID, { profileId: profile.id });
+    expect(proposals).toHaveLength(1);
+  });
+
+  test("approve create applies skill via SkillsService", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const profile = await seedOrg(db);
+    const skills = new SkillsService(db);
+    const service = new SkillProposalService(db, skills);
+
+    const staged = await service.stageProposal({
+      orgId: ORG_ID,
+      profileId: profile.id,
+      action: "create",
+      content: sampleSkillMarkdown,
+    });
+
+    const approved = await service.approveProposal(
+      ORG_ID,
+      staged.proposalId!,
+      "admin_user",
+    );
+    expect(approved.status).toBe("approved");
+
+    const listed = await skills.listSkills();
+    expect(listed.skills.some((skill) => skill.name === "deploy-notes")).toBe(true);
+
+    const again = await service.approveProposal(ORG_ID, staged.proposalId!, "admin_user");
+    expect(again.status).toBe("approved");
+  });
+
+  test("reject leaves disk unchanged", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const profile = await seedOrg(db);
+    const skills = new SkillsService(db);
+    const service = new SkillProposalService(db, skills);
+
+    const staged = await service.stageProposal({
+      orgId: ORG_ID,
+      profileId: profile.id,
+      action: "create",
+      content: sampleSkillMarkdown,
+    });
+
+    const rejected = await service.rejectProposal(
+      ORG_ID,
+      staged.proposalId!,
+      "admin_user",
+    );
+    expect(rejected.status).toBe("rejected");
+
+    const listed = await skills.listSkills();
+    expect(listed.skills.some((skill) => skill.name === "deploy-notes")).toBe(false);
+  });
+
+  test("stage patch requires an existing profile-owned skill", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const profile = await seedOrg(db);
+    const skills = new SkillsService(db);
+    const service = new SkillProposalService(db, skills);
+
+    await skills.createSkill(ORG_ID, {
+      name: "deploy-notes",
+      description: "Notes about deploy process.",
+      body: "Run the deploy checklist before shipping.",
+      profileId: profile.id,
+    });
+
+    const result = await service.stageProposal({
+      orgId: ORG_ID,
+      profileId: profile.id,
+      action: "patch",
+      skillName: "deploy-notes",
+      oldString: "deploy checklist",
+      newString: "release checklist",
+    });
+
+    expect(result.outcome).toBe("created");
+  });
+
+  test("approve patch applies old_string/new_string", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const profile = await seedOrg(db);
+    const skills = new SkillsService(db);
+    const service = new SkillProposalService(db, skills);
+
+    const created = await skills.createSkill(ORG_ID, {
+      name: "deploy-notes",
+      description: "Notes about deploy process.",
+      body: "Run the deploy checklist before shipping.",
+      profileId: profile.id,
+    });
+
+    const staged = await service.stageProposal({
+      orgId: ORG_ID,
+      profileId: profile.id,
+      action: "patch",
+      skillName: "deploy-notes",
+      oldString: "deploy checklist",
+      newString: "release checklist",
+    });
+
+    await service.approveProposal(ORG_ID, staged.proposalId!, "admin_user");
+
+    const detail = await skills.getSkill(created.skill.id);
+    expect(detail.skill.body).toContain("release checklist");
+    expect(detail.skill.body).not.toContain("deploy checklist");
+  });
+
+  test("cross-org proposal id returns 404 on approve (AE6)", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const profile = await seedOrg(db);
+    const service = new SkillProposalService(db, new SkillsService(db));
+
+    const staged = await service.stageProposal({
+      orgId: ORG_ID,
+      profileId: profile.id,
+      action: "create",
+      content: sampleSkillMarkdown,
+    });
+
+    await expect(
+      service.approveProposal("org_other", staged.proposalId!, "admin_user"),
+    ).rejects.toBeInstanceOf(NakamaApiError);
+    await expect(
+      service.approveProposal("org_other", staged.proposalId!, "admin_user"),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});

--- a/apps/server/src/services/skill-proposal-service.test.ts
+++ b/apps/server/src/services/skill-proposal-service.test.ts
@@ -227,6 +227,42 @@ describe("SkillProposalService", () => {
     expect(detail.skill.body).not.toContain("deploy checklist");
   });
 
+  test("stage delete blocks when another pending proposal exists for the skill", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const profile = await seedOrg(db);
+    const skills = new SkillsService(db);
+    const service = new SkillProposalService(db, skills);
+
+    const created = await skills.createSkill(ORG_ID, {
+      name: "deploy-notes",
+      description: "Notes about deploy process.",
+      body: "Run the deploy checklist before shipping.",
+      profileId: profile.id,
+    });
+
+    const patchStaged = await service.stageProposal({
+      orgId: ORG_ID,
+      profileId: profile.id,
+      action: "patch",
+      skillName: "deploy-notes",
+      oldString: "deploy checklist",
+      newString: "release checklist",
+    });
+    expect(patchStaged.outcome).toBe("created");
+
+    const deleteStaged = await service.stageProposal({
+      orgId: ORG_ID,
+      profileId: profile.id,
+      action: "delete",
+      skillName: "deploy-notes",
+    });
+    expect(deleteStaged.outcome).toBe("already_pending");
+    expect(deleteStaged.proposalId).toBe(patchStaged.proposalId);
+
+    const detail = await skills.getSkill(created.skill.id);
+    expect(detail.skill.body).toContain("deploy checklist");
+  });
+
   test("cross-org proposal id returns 404 on approve (AE6)", async () => {
     const db = createInMemoryDatabaseAdapter();
     const profile = await seedOrg(db);

--- a/apps/server/src/services/skill-proposal-service.ts
+++ b/apps/server/src/services/skill-proposal-service.ts
@@ -1,0 +1,450 @@
+import {
+  NakamaApiError,
+  detectOrgMemoryInjectionWarnings,
+  isGlobalSkillSourcePath,
+  isPathWithinProfileSkillsDir,
+  parseRawProfileSkillContent,
+  resolveSkillWriteApprovalRequired,
+} from "@nakama/core";
+import {
+  assertNotBundledSkillName,
+  assertValidSkillName,
+} from "@nakama/core/skills/write";
+import type { DatabaseAdapter, StoredSkillProposal, SkillProposalAction } from "@nakama/db";
+import type { SkillProposal } from "@nakama/core/contract";
+import type { SkillsService } from "./skills-service";
+
+export function toSkillProposal(
+  record: StoredSkillProposal & { warnings?: string[] },
+): SkillProposal {
+  const { warnings, ...proposal } = record;
+  return warnings?.length ? { ...proposal, warnings } : proposal;
+}
+
+export const MAX_SKILL_PATCH_FIELD_LENGTH = 500;
+export const MAX_SKILL_PROPOSAL_CONTENT_BYTES = 64 * 1024;
+
+export type StageSkillProposalOutcome = "created" | "already_pending";
+
+export interface StageSkillProposalInput {
+  orgId: string;
+  profileId: string;
+  action: SkillProposalAction;
+  skillName?: string;
+  content?: string;
+  oldString?: string;
+  newString?: string;
+  sessionId?: string | null;
+  proposedByUserId?: string | null;
+}
+
+export interface StageSkillProposalResult {
+  outcome: StageSkillProposalOutcome;
+  proposalId?: string;
+  message: string;
+  warnings?: string[];
+}
+
+export class SkillProposalService {
+  constructor(
+    private readonly database: DatabaseAdapter | null = null,
+    private readonly skillsService: SkillsService | null = null,
+  ) {}
+
+  async isWriteApprovalRequired(orgId: string, profileId: string): Promise<boolean> {
+    const db = this.requireDatabase();
+    const org = await db.getOrganizationById(orgId);
+    if (!org) {
+      throw new NakamaApiError("Organization not found.", 404);
+    }
+    const profile = await db.getProfileForOrg(profileId, orgId);
+    if (!profile) {
+      throw new NakamaApiError("Profile not found.", 404);
+    }
+    return resolveSkillWriteApprovalRequired({
+      orgSkillsWriteApproval: org.skillsWriteApproval ?? false,
+      profileSkillsWriteApproval: profile.skillsWriteApproval ?? null,
+    });
+  }
+
+  async stageProposal(input: StageSkillProposalInput): Promise<StageSkillProposalResult> {
+    const db = this.requireDatabase();
+    const profile = await db.getProfileForOrg(input.profileId, input.orgId);
+    if (!profile) {
+      throw new NakamaApiError("Profile not found.", 404);
+    }
+
+    if (input.action === "create") {
+      return this.stageCreate(input);
+    }
+    if (input.action === "patch") {
+      return this.stagePatch(input);
+    }
+    return this.stageDelete(input);
+  }
+
+  async listProposals(
+    orgId: string,
+    options: { status?: StoredSkillProposal["status"]; profileId?: string } = {},
+  ): Promise<{ proposals: StoredSkillProposal[]; pendingCount: number }> {
+    const db = this.requireDatabase();
+    const proposals = await db.listSkillProposals(orgId, options);
+    const pendingCount = await db.countPendingSkillProposals(orgId, options.profileId);
+    return { proposals: proposals.map((proposal) => this.withWarnings(proposal)), pendingCount };
+  }
+
+  async approveProposal(
+    orgId: string,
+    proposalId: string,
+    reviewerUserId: string,
+  ): Promise<StoredSkillProposal> {
+    const db = this.requireDatabase();
+    const skills = this.requireSkillsService();
+    const proposal = await this.getProposal(orgId, proposalId);
+
+    if (proposal.status === "approved") {
+      return proposal;
+    }
+    if (proposal.status !== "pending") {
+      throw new NakamaApiError("Only pending proposals can be approved.", 400);
+    }
+
+    if (proposal.action === "create") {
+      const content = proposal.content;
+      if (!content?.trim()) {
+        throw new NakamaApiError("Create proposal is missing content.", 400);
+      }
+      parseRawProfileSkillContent(content, orgId, proposal.profileId);
+      await skills.createAndAssignRawSkillToProfile(orgId, proposal.profileId, content);
+    } else if (proposal.action === "patch") {
+      const oldString = proposal.patchOldString;
+      const newString = proposal.patchNewString;
+      if (oldString === null || oldString === "" || newString === null) {
+        throw new NakamaApiError("Patch proposal is missing patch fields.", 400);
+      }
+      await skills.patchAssignedProfileSkill(
+        orgId,
+        proposal.profileId,
+        proposal.skillName,
+        oldString,
+        newString,
+      );
+    } else {
+      await skills.deleteAssignedProfileSkill(orgId, proposal.profileId, proposal.skillName);
+    }
+
+    const reviewedAt = new Date().toISOString();
+    await db.updateSkillProposalStatus(orgId, proposalId, {
+      status: "approved",
+      reviewerUserId,
+      reviewedAt,
+    });
+
+    return {
+      ...proposal,
+      status: "approved",
+      reviewerUserId,
+      reviewedAt,
+    };
+  }
+
+  async rejectProposal(
+    orgId: string,
+    proposalId: string,
+    reviewerUserId: string,
+  ): Promise<StoredSkillProposal> {
+    const db = this.requireDatabase();
+    const proposal = await this.getProposal(orgId, proposalId);
+
+    if (proposal.status === "rejected") {
+      return proposal;
+    }
+    if (proposal.status !== "pending") {
+      throw new NakamaApiError("Only pending proposals can be rejected.", 400);
+    }
+
+    const reviewedAt = new Date().toISOString();
+    await db.updateSkillProposalStatus(orgId, proposalId, {
+      status: "rejected",
+      reviewerUserId,
+      reviewedAt,
+    });
+
+    return {
+      ...proposal,
+      status: "rejected",
+      reviewerUserId,
+      reviewedAt,
+    };
+  }
+
+  async countPending(orgId: string, profileId?: string): Promise<number> {
+    return this.requireDatabase().countPendingSkillProposals(orgId, profileId);
+  }
+
+  private async stageCreate(input: StageSkillProposalInput): Promise<StageSkillProposalResult> {
+    const content = input.content;
+    if (!content?.trim()) {
+      throw new NakamaApiError("content is required for create.", 400);
+    }
+    this.assertContentSize(content);
+
+    const { name } = parseRawProfileSkillContent(content, input.orgId, input.profileId);
+    assertNotBundledSkillName(name);
+
+    const db = this.requireDatabase();
+    const existingByName = await db.getSkillByName(name);
+    if (
+      existingByName &&
+      !isPathWithinProfileSkillsDir(input.orgId, input.profileId, existingByName.sourcePath)
+    ) {
+      throw new NakamaApiError(
+        `Skill "${name}" already exists globally or in another profile and cannot be created here.`,
+        400,
+      );
+    }
+
+    const pending = await db.getPendingSkillProposalForCreate(
+      input.orgId,
+      input.profileId,
+      name,
+    );
+    if (pending) {
+      return {
+        outcome: "already_pending",
+        proposalId: pending.id,
+        message: `A create proposal for skill "${name}" is already pending admin approval.`,
+        warnings: this.warningsForContent(content),
+      };
+    }
+
+    const proposal = await this.insertProposal({
+      ...input,
+      action: "create",
+      skillName: name,
+      content,
+      patchOldString: null,
+      patchNewString: null,
+    });
+
+    return {
+      outcome: "created",
+      proposalId: proposal.id,
+      message: `Staged create for skill "${name}" (proposal ${proposal.id}). An org admin must approve before it goes live.`,
+      warnings: this.warningsForContent(content),
+    };
+  }
+
+  private async stagePatch(input: StageSkillProposalInput): Promise<StageSkillProposalResult> {
+    const name = this.readSkillName(input);
+    assertNotBundledSkillName(name);
+    await this.assertProfileOwnedSkill(input.orgId, input.profileId, name);
+
+    const oldString = input.oldString;
+    const newString = input.newString;
+    if (oldString === undefined || oldString === "") {
+      throw new NakamaApiError("old_string is required for patch.", 400);
+    }
+    if (newString === undefined) {
+      throw new NakamaApiError("new_string is required for patch.", 400);
+    }
+    this.assertPatchFieldSize(oldString);
+    this.assertPatchFieldSize(newString);
+
+    const db = this.requireDatabase();
+    const pending = await db.getPendingSkillProposalForPatch(
+      input.orgId,
+      input.profileId,
+      name,
+      oldString,
+      newString,
+    );
+    if (pending) {
+      return {
+        outcome: "already_pending",
+        proposalId: pending.id,
+        message: `An identical patch proposal for "${name}" is already pending.`,
+      };
+    }
+
+    const proposal = await this.insertProposal({
+      ...input,
+      action: "patch",
+      skillName: name,
+      content: null,
+      patchOldString: oldString,
+      patchNewString: newString,
+    });
+
+    return {
+      outcome: "created",
+      proposalId: proposal.id,
+      message: `Staged patch for skill "${name}" (proposal ${proposal.id}). An org admin must approve before it goes live.`,
+      warnings: this.warningsForPatch(oldString, newString),
+    };
+  }
+
+  private async stageDelete(input: StageSkillProposalInput): Promise<StageSkillProposalResult> {
+    const name = this.readSkillName(input);
+    assertNotBundledSkillName(name);
+    await this.assertProfileOwnedSkill(input.orgId, input.profileId, name);
+
+    const db = this.requireDatabase();
+    const pending = await db.getPendingSkillProposalForCreate(
+      input.orgId,
+      input.profileId,
+      name,
+    );
+    if (pending) {
+      return {
+        outcome: "already_pending",
+        proposalId: pending.id,
+        message: `A pending proposal already exists for skill "${name}".`,
+      };
+    }
+
+    const proposal = await this.insertProposal({
+      ...input,
+      action: "delete",
+      skillName: name,
+      content: null,
+      patchOldString: null,
+      patchNewString: null,
+    });
+
+    return {
+      outcome: "created",
+      proposalId: proposal.id,
+      message: `Staged delete for skill "${name}" (proposal ${proposal.id}). An org admin must approve before it is removed.`,
+    };
+  }
+
+  private async insertProposal(
+    input: StageSkillProposalInput & {
+      skillName: string;
+      content: string | null;
+      patchOldString: string | null;
+      patchNewString: string | null;
+    },
+  ): Promise<StoredSkillProposal> {
+    const db = this.requireDatabase();
+    const now = new Date().toISOString();
+    const proposal: StoredSkillProposal = {
+      id: `skprop_${crypto.randomUUID().replace(/-/g, "")}`,
+      orgId: input.orgId,
+      profileId: input.profileId,
+      sessionId: input.sessionId ?? null,
+      proposedByUserId: input.proposedByUserId ?? null,
+      action: input.action,
+      skillName: input.skillName,
+      content: input.content,
+      patchOldString: input.patchOldString,
+      patchNewString: input.patchNewString,
+      status: "pending",
+      reviewerUserId: null,
+      reviewedAt: null,
+      createdAt: now,
+    };
+    await db.createSkillProposal(proposal);
+    return proposal;
+  }
+
+  private async getProposal(orgId: string, proposalId: string): Promise<StoredSkillProposal> {
+    const db = this.requireDatabase();
+    const proposal = await db.getSkillProposal(orgId, proposalId);
+    if (!proposal) {
+      throw new NakamaApiError("Skill proposal not found.", 404);
+    }
+    return proposal;
+  }
+
+  private async assertProfileOwnedSkill(
+    orgId: string,
+    profileId: string,
+    name: string,
+  ): Promise<void> {
+    const db = this.requireDatabase();
+    const skillName = assertValidSkillName(name);
+    const record = await db.getSkillByName(skillName);
+    if (!record) {
+      throw new NakamaApiError(`Skill "${skillName}" not found.`, 404);
+    }
+    if (isGlobalSkillSourcePath(record.sourcePath)) {
+      throw new NakamaApiError("Global skills cannot be modified by agents.", 403);
+    }
+    if (!isPathWithinProfileSkillsDir(orgId, profileId, record.sourcePath)) {
+      throw new NakamaApiError(
+        `Skill "${skillName}" is not owned by this profile.`,
+        403,
+      );
+    }
+  }
+
+  private readSkillName(input: StageSkillProposalInput): string {
+    const name = input.skillName?.trim();
+    if (!name) {
+      throw new NakamaApiError("name is required.", 400);
+    }
+    return assertValidSkillName(name);
+  }
+
+  private assertContentSize(content: string): void {
+    if (Buffer.byteLength(content, "utf8") > MAX_SKILL_PROPOSAL_CONTENT_BYTES) {
+      throw new NakamaApiError("SKILL.md content exceeds the proposal size limit.", 400);
+    }
+  }
+
+  private assertPatchFieldSize(value: string): void {
+    if (Buffer.byteLength(value, "utf8") > MAX_SKILL_PATCH_FIELD_LENGTH) {
+      throw new NakamaApiError("Patch field exceeds the size limit.", 400);
+    }
+  }
+
+  private warningsForContent(content: string): string[] | undefined {
+    const warnings = detectOrgMemoryInjectionWarnings(content);
+    return warnings.length > 0 ? warnings : undefined;
+  }
+
+  private warningsForPatch(oldString: string, newString: string): string[] | undefined {
+    const warnings = [
+      ...detectOrgMemoryInjectionWarnings(oldString),
+      ...detectOrgMemoryInjectionWarnings(newString),
+    ];
+    return warnings.length > 0 ? [...new Set(warnings)] : undefined;
+  }
+
+  private withWarnings(proposal: StoredSkillProposal): StoredSkillProposal & {
+    warnings?: string[];
+  } {
+    if (proposal.action === "create" && proposal.content) {
+      const warnings = this.warningsForContent(proposal.content);
+      return warnings ? { ...proposal, warnings } : proposal;
+    }
+    if (
+      proposal.action === "patch" &&
+      proposal.patchOldString !== null &&
+      proposal.patchNewString !== null
+    ) {
+      const warnings = this.warningsForPatch(
+        proposal.patchOldString,
+        proposal.patchNewString,
+      );
+      return warnings ? { ...proposal, warnings } : proposal;
+    }
+    return proposal;
+  }
+
+  private requireDatabase(): DatabaseAdapter {
+    if (!this.database) {
+      throw new NakamaApiError("Database not configured.", 500);
+    }
+    return this.database;
+  }
+
+  private requireSkillsService(): SkillsService {
+    if (!this.skillsService) {
+      throw new NakamaApiError("Skills service not configured.", 500);
+    }
+    return this.skillsService;
+  }
+}

--- a/apps/server/src/services/skill-proposal-service.ts
+++ b/apps/server/src/services/skill-proposal-service.ts
@@ -204,7 +204,7 @@ export class SkillProposalService {
       );
     }
 
-    const pending = await db.getPendingSkillProposalForCreate(
+    const pending = await db.getPendingSkillProposalForSkill(
       input.orgId,
       input.profileId,
       name,
@@ -213,7 +213,7 @@ export class SkillProposalService {
       return {
         outcome: "already_pending",
         proposalId: pending.id,
-        message: `A create proposal for skill "${name}" is already pending admin approval.`,
+        message: `A pending proposal already exists for skill "${name}".`,
         warnings: this.warningsForContent(content),
       };
     }
@@ -267,6 +267,19 @@ export class SkillProposalService {
       };
     }
 
+    const conflicting = await db.getPendingSkillProposalForSkill(
+      input.orgId,
+      input.profileId,
+      name,
+    );
+    if (conflicting) {
+      return {
+        outcome: "already_pending",
+        proposalId: conflicting.id,
+        message: `A pending proposal already exists for skill "${name}".`,
+      };
+    }
+
     const proposal = await this.insertProposal({
       ...input,
       action: "patch",
@@ -290,7 +303,7 @@ export class SkillProposalService {
     await this.assertProfileOwnedSkill(input.orgId, input.profileId, name);
 
     const db = this.requireDatabase();
-    const pending = await db.getPendingSkillProposalForCreate(
+    const pending = await db.getPendingSkillProposalForSkill(
       input.orgId,
       input.profileId,
       name,

--- a/apps/server/src/tools/skill-manage-tool.test.ts
+++ b/apps/server/src/tools/skill-manage-tool.test.ts
@@ -4,8 +4,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathExists, runWriteFile } from "@nakama/core";
 import type { ToolContext } from "@nakama/core";
-import { createInMemoryDatabaseAdapter } from "@nakama/db";
+import { createInMemoryDatabaseAdapter, seedOrgDefaultProfile } from "@nakama/db";
 import { SkillsService } from "../services/skills-service";
+import { SkillProposalService } from "../services/skill-proposal-service";
 import { createSkillManageTools } from "./skill-manage-tool";
 
 const ORG_ID = "org_test";
@@ -30,12 +31,42 @@ function memberContext(overrides: Partial<ToolContext> = {}): ToolContext {
   };
 }
 
-function skillManageTool(service: SkillsService) {
-  const [tool] = createSkillManageTools(service);
+function skillManageTool(
+  service: SkillsService,
+  skillProposalService?: SkillProposalService | null,
+) {
+  const [tool] = createSkillManageTools({
+    skillsService: service,
+    skillProposalService: skillProposalService ?? null,
+  });
   if (!tool) {
     throw new Error("skill_manage tool missing");
   }
   return tool;
+}
+
+async function seedOrgProfile(
+  db: ReturnType<typeof createInMemoryDatabaseAdapter>,
+  options: { orgSkillsWriteApproval?: boolean; profileSkillsWriteApproval?: boolean | null } = {},
+) {
+  const now = new Date().toISOString();
+  await db.upsertOrganization({
+    id: ORG_ID,
+    name: "Test Org",
+    slug: "test-org",
+    skillsWriteApproval: options.orgSkillsWriteApproval ?? false,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const profile = await seedOrgDefaultProfile(db, ORG_ID);
+  if (options.profileSkillsWriteApproval !== undefined) {
+    await db.upsertProfile({
+      ...profile,
+      skillsWriteApproval: options.profileSkillsWriteApproval,
+      updatedAt: now,
+    });
+  }
+  return profile;
 }
 
 describe("skill_manage tool", () => {
@@ -332,6 +363,46 @@ Profile body.
         memberContext({ channel: "telegram" }),
       ),
     ).rejects.toThrow(/interactive web or CLI/);
+  });
+
+  test("gate off creates immediately (AE1 regression)", async () => {
+    const { db, tool } = await setup();
+    await seedOrgProfile(db, { orgSkillsWriteApproval: false });
+
+    const result = await tool.run(
+      { action: "create", content: researchSkillMarkdown },
+      memberContext(),
+    );
+
+    expect(result).toMatchObject({
+      action: "create",
+      name: "research-paper",
+      assigned: true,
+    });
+    expect((result as { staged?: boolean }).staged).toBeUndefined();
+  });
+
+  test("gate on stages create without writing disk", async () => {
+    configDir = await mkdtemp(join(tmpdir(), "nakama-skill-manage-gate-"));
+    process.env.NAKAMA_CONFIG_DIR = configDir;
+    const db = createInMemoryDatabaseAdapter();
+    const profile = await seedOrgProfile(db, { orgSkillsWriteApproval: true });
+    const service = new SkillsService(db);
+    const proposalService = new SkillProposalService(db, service);
+    const tool = skillManageTool(service, proposalService);
+
+    const result = await tool.run(
+      { action: "create", content: researchSkillMarkdown },
+      memberContext({ profileId: profile.id }),
+    );
+
+    expect(result).toMatchObject({
+      staged: true,
+      action: "create",
+      name: "research-paper",
+      outcome: "created",
+    });
+    expect(await db.listSkillsForProfile(profile.id)).toHaveLength(0);
   });
 
   test("write_file refuses skills/*/SKILL.md when forbidProfileSkillMarkdownWrites is set", async () => {

--- a/apps/server/src/tools/skill-manage-tool.ts
+++ b/apps/server/src/tools/skill-manage-tool.ts
@@ -1,8 +1,15 @@
 import {
   type ToolContext,
   type ToolDefinition,
+  parseRawProfileSkillContent,
 } from "@nakama/core";
+import type { SkillProposalService } from "../services/skill-proposal-service";
 import type { SkillsService } from "../services/skills-service";
+
+export interface SkillManageToolDeps {
+  skillsService: SkillsService;
+  skillProposalService?: SkillProposalService | null;
+}
 
 function requireOrgId(context: ToolContext): string {
   const orgId = context.orgId?.trim();
@@ -102,12 +109,33 @@ function skillManageResult(options: {
   };
 }
 
-export function createSkillManageTools(service: SkillsService): ToolDefinition[] {
+function stagedSkillManageResult(options: {
+  action: "create" | "patch" | "delete";
+  name: string;
+  proposalId?: string;
+  outcome: "created" | "already_pending";
+  message: string;
+}) {
+  return {
+    staged: true as const,
+    proposalId: options.proposalId,
+    action: options.action,
+    name: options.name,
+    outcome: options.outcome,
+    message: options.message,
+    matchHint:
+      "The skill change is pending admin approval and is not live yet. It will not match until an org admin approves the proposal.",
+  };
+}
+
+export function createSkillManageTools(deps: SkillManageToolDeps): ToolDefinition[] {
+  const { skillsService: service, skillProposalService = null } = deps;
+
   return [
     {
       name: "skill_manage",
       description:
-        "Create, patch, or delete reusable profile skills (SKILL.md under the profile skills directory) with auto-assign. Prefer patch with unique old_string/new_string over rewriting whole files. Crystallize a skill after complex multi-step success (about 5+ tool calls), error recovery, or when the user corrects your approach — do not dump procedures into MEMORY.md.",
+        "Create, patch, or delete reusable profile skills (SKILL.md under the profile skills directory) with auto-assign. When write approval is enabled for this org/profile, changes are staged for admin review instead of applying immediately. Prefer patch with unique old_string/new_string over rewriting whole files. Crystallize a skill after complex multi-step success (about 5+ tool calls), error recovery, or when the user corrects your approach — do not dump procedures into MEMORY.md.",
       parameters: {
         type: "object",
         properties: {
@@ -140,6 +168,95 @@ export function createSkillManageTools(service: SkillsService): ToolDefinition[]
       async run(input, context: ToolContext) {
         const { orgId, profileId } = requireSkillManageAccess(context);
         const action = readAction(input);
+
+        const gateOn =
+          skillProposalService !== null &&
+          (await skillProposalService.isWriteApprovalRequired(orgId, profileId));
+
+        if (gateOn) {
+          if (action === "create") {
+            const content = readRawString(input, "content");
+            if (!content?.trim()) {
+              throw new Error("content is required for create (full SKILL.md markdown).");
+            }
+
+            const staged = await skillProposalService!.stageProposal({
+              orgId,
+              profileId,
+              action: "create",
+              content,
+              sessionId: context.sessionId ?? null,
+              proposedByUserId: context.userId ?? null,
+            });
+
+            const { name } = parseRawProfileSkillContent(content, orgId, profileId);
+
+            return stagedSkillManageResult({
+              action: "create",
+              name,
+              proposalId: staged.proposalId,
+              outcome: staged.outcome,
+              message: staged.message,
+            });
+          }
+
+          if (action === "patch") {
+            const name = readString(input, "name");
+            const oldString = readRawString(input, "old_string");
+            const newString = readRawString(input, "new_string");
+
+            if (!name) {
+              throw new Error("name is required for patch.");
+            }
+            if (oldString === null || oldString === "") {
+              throw new Error("old_string is required for patch.");
+            }
+            if (newString === null) {
+              throw new Error("new_string is required for patch.");
+            }
+
+            const staged = await skillProposalService!.stageProposal({
+              orgId,
+              profileId,
+              action: "patch",
+              skillName: name,
+              oldString,
+              newString,
+              sessionId: context.sessionId ?? null,
+              proposedByUserId: context.userId ?? null,
+            });
+
+            return stagedSkillManageResult({
+              action: "patch",
+              name,
+              proposalId: staged.proposalId,
+              outcome: staged.outcome,
+              message: staged.message,
+            });
+          }
+
+          const name = readString(input, "name");
+          if (!name) {
+            throw new Error("name is required for delete.");
+          }
+
+          const staged = await skillProposalService!.stageProposal({
+            orgId,
+            profileId,
+            action: "delete",
+            skillName: name,
+            sessionId: context.sessionId ?? null,
+            proposedByUserId: context.userId ?? null,
+          });
+
+          return stagedSkillManageResult({
+            action: "delete",
+            name,
+            proposalId: staged.proposalId,
+            outcome: staged.outcome,
+            message: staged.message,
+          });
+        }
 
         if (action === "create") {
           const content = readRawString(input, "content");

--- a/apps/web/src/components/profiles/ProfileSkillsWriteApprovalField.tsx
+++ b/apps/web/src/components/profiles/ProfileSkillsWriteApprovalField.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from "react";
+import type { ProfileDetail } from "@nakama/core/contract";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Spinner } from "@/components/ui/spinner";
+import { useAuth } from "@/context/use-auth";
+import { useUpdateProfileMutation } from "@/hooks/use-resource-mutations";
+import { formatError } from "@/lib/client";
+import { toast } from "@/lib/toast";
+
+type OverrideValue = "inherit" | "on" | "off";
+
+function toOverrideValue(value: boolean | null | undefined): OverrideValue {
+  if (value === true) {
+    return "on";
+  }
+  if (value === false) {
+    return "off";
+  }
+  return "inherit";
+}
+
+function fromOverrideValue(value: OverrideValue): boolean | null {
+  if (value === "on") {
+    return true;
+  }
+  if (value === "off") {
+    return false;
+  }
+  return null;
+}
+
+export function ProfileSkillsWriteApprovalField({
+  profile,
+  disabled = false,
+}: {
+  profile: ProfileDetail;
+  disabled?: boolean;
+}) {
+  const { activeOrg } = useAuth();
+  const updateMutation = useUpdateProfileMutation();
+  const [value, setValue] = useState<OverrideValue>(toOverrideValue(profile.skillsWriteApproval));
+  const busy = updateMutation.isPending;
+
+  useEffect(() => {
+    setValue(toOverrideValue(profile.skillsWriteApproval));
+  }, [profile.id, profile.skillsWriteApproval]);
+
+  if (!activeOrg || activeOrg.role !== "admin") {
+    return null;
+  }
+
+  async function handleChange(nextValue: OverrideValue) {
+    setValue(nextValue);
+    try {
+      await updateMutation.mutateAsync({
+        profileId: profile.id,
+        input: { skillsWriteApproval: fromOverrideValue(nextValue) },
+      });
+      toast("Skill write approval setting saved.");
+    } catch (err) {
+      setValue(toOverrideValue(profile.skillsWriteApproval));
+      toast(formatError(err));
+    }
+  }
+
+  return (
+    <div className="mb-3 rounded-md border border-border p-3 sm:p-4">
+      <label htmlFor="profile-skills-write-approval" className="mb-1 block text-xs font-medium text-muted-foreground">
+        Skill write approval
+      </label>
+      <div className="flex items-center gap-2">
+        <Select
+          value={value}
+          disabled={disabled || busy}
+          onValueChange={(next) => {
+            if (!next) {
+              return;
+            }
+            void handleChange(next as OverrideValue);
+          }}
+        >
+          <SelectTrigger id="profile-skills-write-approval" className="h-8 max-w-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="inherit">Inherit org default</SelectItem>
+            <SelectItem value="on">Require approval</SelectItem>
+            <SelectItem value="off">Allow immediate writes</SelectItem>
+          </SelectContent>
+        </Select>
+        {busy ? <Spinner /> : null}
+      </div>
+      <p className="mt-1.5 text-xs text-muted-foreground">
+        Overrides the org-wide gate for this profile only.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/profiles/ProfileSkillsWriteApprovalField.tsx
+++ b/apps/web/src/components/profiles/ProfileSkillsWriteApprovalField.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import type { ProfileDetail } from "@nakama/core/contract";
 import {
   Select,
@@ -42,14 +42,26 @@ export function ProfileSkillsWriteApprovalField({
   profile: ProfileDetail;
   disabled?: boolean;
 }) {
+  return (
+    <ProfileSkillsWriteApprovalFieldBody
+      key={`${profile.id}:${String(profile.skillsWriteApproval)}`}
+      profile={profile}
+      disabled={disabled}
+    />
+  );
+}
+
+function ProfileSkillsWriteApprovalFieldBody({
+  profile,
+  disabled = false,
+}: {
+  profile: ProfileDetail;
+  disabled?: boolean;
+}) {
   const { activeOrg } = useAuth();
   const updateMutation = useUpdateProfileMutation();
-  const [value, setValue] = useState<OverrideValue>(toOverrideValue(profile.skillsWriteApproval));
+  const [value, setValue] = useState<OverrideValue>(() => toOverrideValue(profile.skillsWriteApproval));
   const busy = updateMutation.isPending;
-
-  useEffect(() => {
-    setValue(toOverrideValue(profile.skillsWriteApproval));
-  }, [profile.id, profile.skillsWriteApproval]);
 
   if (!activeOrg || activeOrg.role !== "admin") {
     return null;

--- a/apps/web/src/components/profiles/SkillProposalsPanel.tsx
+++ b/apps/web/src/components/profiles/SkillProposalsPanel.tsx
@@ -1,0 +1,231 @@
+import { useState } from "react";
+import type { OrgMemberSummary, SkillProposal } from "@nakama/core/contract";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Spinner } from "@/components/ui/spinner";
+import { useOrgMembers } from "@/hooks/use-org-members";
+import {
+  useApproveSkillProposal,
+  useRejectSkillProposal,
+  useSkillProposals,
+} from "@/hooks/use-skill-proposals";
+import { formatSessionRelativeTime, formatSessionTimestamp } from "@/lib/chat-history";
+import { formatError } from "@/lib/client";
+import { toast } from "@/lib/toast";
+
+function shortenId(value: string): string {
+  return value.length > 16 ? `${value.slice(0, 12)}…` : value;
+}
+
+function resolveProposer(userId: string | null, members: OrgMemberSummary[]): string | null {
+  if (!userId) {
+    return null;
+  }
+  const member = members.find((entry) => entry.userId === userId);
+  if (!member) {
+    return shortenId(userId);
+  }
+  return member.name?.trim() || member.email;
+}
+
+function proposalPreview(proposal: SkillProposal): string {
+  if (proposal.action === "create" && proposal.content) {
+    return proposal.content;
+  }
+  if (proposal.action === "patch") {
+    return `Replace:\n${proposal.patchOldString ?? ""}\n\nWith:\n${proposal.patchNewString ?? ""}`;
+  }
+  return `Delete skill "${proposal.skillName}"`;
+}
+
+function actionLabel(action: SkillProposal["action"]): string {
+  if (action === "create") {
+    return "Create";
+  }
+  if (action === "patch") {
+    return "Patch";
+  }
+  return "Delete";
+}
+
+function ProposalReviewDialog({
+  proposal,
+  orgId,
+  proposer,
+  open,
+  onOpenChange,
+}: {
+  proposal: SkillProposal;
+  orgId: string;
+  proposer: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const approveMutation = useApproveSkillProposal(orgId);
+  const rejectMutation = useRejectSkillProposal(orgId);
+  const busy = approveMutation.isPending || rejectMutation.isPending;
+  const preview = proposalPreview(proposal);
+
+  async function handleApprove() {
+    try {
+      await approveMutation.mutateAsync(proposal.id);
+      toast(`Approved ${proposal.action} for "${proposal.skillName}".`);
+      onOpenChange(false);
+    } catch (err) {
+      toast(formatError(err));
+    }
+  }
+
+  async function handleReject() {
+    try {
+      await rejectMutation.mutateAsync(proposal.id);
+      toast("Proposal rejected.");
+      onOpenChange(false);
+    } catch (err) {
+      toast(formatError(err));
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="gap-4 overflow-hidden p-4 sm:max-w-lg sm:p-6">
+        <DialogHeader className="pr-8">
+          <DialogTitle>
+            {actionLabel(proposal.action)} skill &ldquo;{proposal.skillName}&rdquo;?
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="min-w-0 space-y-3">
+          <p className="text-xs text-muted-foreground">
+            <time dateTime={proposal.createdAt} title={formatSessionTimestamp(proposal.createdAt)}>
+              {formatSessionRelativeTime(proposal.createdAt)}
+            </time>
+            {proposer ? <> · {proposer}</> : null}
+          </p>
+
+          <pre className="max-h-64 overflow-auto rounded-md border border-border bg-muted/50 p-3 font-mono text-xs leading-relaxed whitespace-pre-wrap break-all text-foreground">
+            {preview}
+          </pre>
+
+          {proposal.warnings && proposal.warnings.length > 0 ? (
+            <p className="text-xs text-amber-600 dark:text-amber-400">
+              {proposal.warnings.join(" ")}
+            </p>
+          ) : null}
+        </div>
+
+        <DialogFooter className="mx-0 mb-0 gap-2 border-t-0 bg-transparent p-0 pt-2 sm:justify-end">
+          <Button type="button" size="sm" variant="outline" disabled={busy} onClick={() => void handleReject()}>
+            {rejectMutation.isPending ? <Spinner className="mr-2" /> : null}
+            Reject
+          </Button>
+          <Button type="button" size="sm" disabled={busy} onClick={() => void handleApprove()}>
+            {approveMutation.isPending ? <Spinner className="mr-2" /> : null}
+            Approve
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ProposalRow({
+  proposal,
+  orgId,
+  proposer,
+}: {
+  proposal: SkillProposal;
+  orgId: string;
+  proposer: string | null;
+}) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const preview = proposalPreview(proposal);
+
+  return (
+    <>
+      <div className="flex items-start gap-2 overflow-hidden py-2 pl-4 pr-4">
+        <div className="min-w-0 flex-1 space-y-1">
+          <p className="text-sm font-medium text-foreground">
+            {actionLabel(proposal.action)} · {proposal.skillName}
+          </p>
+          <p className="line-clamp-3 max-w-full min-w-0 break-all font-mono text-xs leading-relaxed whitespace-pre-wrap text-muted-foreground">
+            {preview}
+          </p>
+          {proposal.warnings && proposal.warnings.length > 0 ? (
+            <p className="text-xs text-amber-600 dark:text-amber-400">
+              Warning: {proposal.warnings.join(" ")}
+            </p>
+          ) : null}
+          <p className="text-xs text-muted-foreground">
+            <time dateTime={proposal.createdAt} title={formatSessionTimestamp(proposal.createdAt)}>
+              {formatSessionRelativeTime(proposal.createdAt)}
+            </time>
+            {proposer ? <> · {proposer}</> : null}
+          </p>
+        </div>
+        <Button type="button" size="sm" variant="outline" className="shrink-0" onClick={() => setDialogOpen(true)}>
+          Review
+        </Button>
+      </div>
+
+      <ProposalReviewDialog
+        proposal={proposal}
+        orgId={orgId}
+        proposer={proposer}
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+      />
+    </>
+  );
+}
+
+export function SkillProposalsPanel({
+  orgId,
+  profileId,
+}: {
+  orgId: string;
+  profileId: string;
+}) {
+  const { data, isLoading, error } = useSkillProposals(orgId, {
+    status: "pending",
+    profileId,
+  });
+  const { data: membersData } = useOrgMembers(orgId);
+  const proposals = data?.proposals ?? [];
+  const members = membersData?.members ?? [];
+
+  if (isLoading) {
+    return <p className="px-4 py-2 text-xs text-muted-foreground">Loading proposals…</p>;
+  }
+
+  if (error) {
+    return (
+      <p className="px-4 py-2 text-sm text-destructive" role="alert">
+        {formatError(error)}
+      </p>
+    );
+  }
+
+  if (proposals.length === 0) {
+    return <p className="px-4 py-2 text-xs text-muted-foreground">No pending skill proposals.</p>;
+  }
+
+  return (
+    <div className="min-w-0 divide-y divide-border">
+      {proposals.map((proposal) => (
+        <ProposalRow
+          key={proposal.id}
+          proposal={proposal}
+          orgId={orgId}
+          proposer={resolveProposer(proposal.proposedByUserId, members)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/profiles/SkillProposalsPanel.tsx
+++ b/apps/web/src/components/profiles/SkillProposalsPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { OrgMemberSummary, SkillProposal } from "@nakama/core/contract";
+import type { OrgMemberSummary, ProfileSummary, SkillProposal } from "@nakama/core/contract";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -9,6 +9,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
+import { useProfilesQuery } from "@/hooks/use-app-queries";
 import { useOrgMembers } from "@/hooks/use-org-members";
 import {
   useApproveSkillProposal,
@@ -135,14 +136,20 @@ function ProposalReviewDialog({
   );
 }
 
+function resolveProfileLabel(profileId: string, profiles: ProfileSummary[]): string {
+  return profiles.find((profile) => profile.id === profileId)?.name ?? shortenId(profileId);
+}
+
 function ProposalRow({
   proposal,
   orgId,
   proposer,
+  profileLabel,
 }: {
   proposal: SkillProposal;
   orgId: string;
   proposer: string | null;
+  profileLabel?: string | null;
 }) {
   const [dialogOpen, setDialogOpen] = useState(false);
   const preview = proposalPreview(proposal);
@@ -166,6 +173,7 @@ function ProposalRow({
             <time dateTime={proposal.createdAt} title={formatSessionTimestamp(proposal.createdAt)}>
               {formatSessionRelativeTime(proposal.createdAt)}
             </time>
+            {profileLabel ? <> · {profileLabel}</> : null}
             {proposer ? <> · {proposer}</> : null}
           </p>
         </div>
@@ -188,15 +196,18 @@ function ProposalRow({
 export function SkillProposalsPanel({
   orgId,
   profileId,
+  showProfileLabels = false,
 }: {
   orgId: string;
-  profileId: string;
+  profileId?: string;
+  showProfileLabels?: boolean;
 }) {
   const { data, isLoading, error } = useSkillProposals(orgId, {
     status: "pending",
     profileId,
   });
   const { data: membersData } = useOrgMembers(orgId);
+  const { data: profiles = [] } = useProfilesQuery();
   const proposals = data?.proposals ?? [];
   const members = membersData?.members ?? [];
 
@@ -224,6 +235,9 @@ export function SkillProposalsPanel({
           proposal={proposal}
           orgId={orgId}
           proposer={resolveProposer(proposal.proposedByUserId, members)}
+          profileLabel={
+            showProfileLabels ? resolveProfileLabel(proposal.profileId, profiles) : null
+          }
         />
       ))}
     </div>

--- a/apps/web/src/components/settings/SkillsWriteApprovalOrgCard.tsx
+++ b/apps/web/src/components/settings/SkillsWriteApprovalOrgCard.tsx
@@ -1,14 +1,181 @@
-import { useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
+import { useSearchParams } from "react-router-dom";
+import type { ProfileSummary } from "@nakama/core/contract";
+import { SkillProposalsPanel } from "@/components/profiles/SkillProposalsPanel";
 import { Card } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { Spinner } from "@/components/ui/spinner";
 import { useAuth } from "@/context/use-auth";
+import { useProfilesQuery } from "@/hooks/use-app-queries";
+import { useSkillProposals } from "@/hooks/use-skill-proposals";
+import { useUpdateProfileMutation } from "@/hooks/use-resource-mutations";
 import { formatError } from "@/lib/client";
 import { toast } from "@/lib/toast";
+import { cn } from "@/lib/utils";
+
+type SkillApprovalTab = "gate" | "proposals";
+
+type OverrideValue = "inherit" | "on" | "off";
+
+function toOverrideValue(value: boolean | null | undefined): OverrideValue {
+  if (value === true) {
+    return "on";
+  }
+  if (value === false) {
+    return "off";
+  }
+  return "inherit";
+}
+
+function fromOverrideValue(value: OverrideValue): boolean | null {
+  if (value === "on") {
+    return true;
+  }
+  if (value === "off") {
+    return false;
+  }
+  return null;
+}
+
+function SkillApprovalTabButton({
+  active,
+  children,
+  onClick,
+}: {
+  active: boolean;
+  children: ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "-mb-px border-b-2 px-0 py-2.5 text-sm transition-colors",
+        active
+          ? "border-foreground font-semibold text-foreground"
+          : "border-transparent font-normal text-muted-foreground hover:text-foreground",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function OrgProfileSkillsWriteApprovalField({
+  profiles,
+  disabled = false,
+}: {
+  profiles: ProfileSummary[];
+  disabled?: boolean;
+}) {
+  const updateMutation = useUpdateProfileMutation();
+  const [profileId, setProfileId] = useState<string>("");
+  const selectedProfile = profiles.find((profile) => profile.id === profileId) ?? null;
+  const [value, setValue] = useState<OverrideValue>("inherit");
+  const busy = updateMutation.isPending;
+
+  useEffect(() => {
+    if (!selectedProfile) {
+      setValue("inherit");
+      return;
+    }
+    setValue(toOverrideValue(selectedProfile.skillsWriteApproval));
+  }, [selectedProfile]);
+
+  async function handleOverrideChange(nextValue: OverrideValue) {
+    if (!selectedProfile) {
+      return;
+    }
+    setValue(nextValue);
+    try {
+      await updateMutation.mutateAsync({
+        profileId: selectedProfile.id,
+        input: { skillsWriteApproval: fromOverrideValue(nextValue) },
+      });
+      toast("Profile skill write approval setting saved.");
+    } catch (err) {
+      setValue(toOverrideValue(selectedProfile.skillsWriteApproval));
+      toast(formatError(err));
+    }
+  }
+
+  if (profiles.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="border-t border-border px-4 py-3">
+      <p className="mb-2 text-xs font-medium text-muted-foreground">Per-profile override</p>
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <Select
+          value={profileId}
+          disabled={disabled || busy}
+          onValueChange={(next) => setProfileId(next ? String(next) : "")}
+        >
+          <SelectTrigger className="h-8 max-w-xs" aria-label="Profile">
+            <SelectValue placeholder="Select profile" />
+          </SelectTrigger>
+          <SelectContent>
+            {profiles.map((profile) => (
+              <SelectItem key={profile.id} value={profile.id}>
+                {profile.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select
+          value={value}
+          disabled={disabled || busy || !selectedProfile}
+          onValueChange={(next) => {
+            if (!next) {
+              return;
+            }
+            void handleOverrideChange(next as OverrideValue);
+          }}
+        >
+          <SelectTrigger className="h-8 max-w-xs" aria-label="Skill write approval override">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="inherit">Inherit org default</SelectItem>
+            <SelectItem value="on">Require approval</SelectItem>
+            <SelectItem value="off">Allow immediate writes</SelectItem>
+          </SelectContent>
+        </Select>
+        {busy ? <Spinner /> : null}
+      </div>
+      <p className="mt-1.5 text-xs text-muted-foreground">
+        Overrides the org-wide gate for the selected profile only.
+      </p>
+    </div>
+  );
+}
 
 export function SkillsWriteApprovalOrgCard() {
   const { activeOrg, updateOrg } = useAuth();
+  const [searchParams] = useSearchParams();
   const [busy, setBusy] = useState(false);
+  const [activeTab, setActiveTab] = useState<SkillApprovalTab>("gate");
+  const orgId = activeOrg?.id ?? null;
+  const filterProfileId = searchParams.get("profileId") ?? undefined;
+
+  const { data: proposalsData } = useSkillProposals(orgId, { status: "pending" });
+  const { data: profiles = [] } = useProfilesQuery();
+  const pendingCount = proposalsData?.pendingCount ?? 0;
+
+  useEffect(() => {
+    if (searchParams.get("skillProposals") === "proposals") {
+      setActiveTab("proposals");
+    }
+  }, [searchParams]);
 
   if (!activeOrg || activeOrg.role !== "admin") {
     return null;
@@ -30,24 +197,55 @@ export function SkillsWriteApprovalOrgCard() {
 
   return (
     <Card className="w-full overflow-hidden shadow-none">
-      <div className="flex items-start justify-between gap-4 px-4 py-3">
-        <div className="min-w-0 space-y-0.5">
-          <p className="text-sm font-medium text-foreground">Skill write approval</p>
-          <p className="max-w-prose text-xs leading-relaxed text-muted-foreground">
-            When enabled, agent skill creates, patches, and deletes require org admin approval before
-            they go live.
-          </p>
-        </div>
-        <div className="flex shrink-0 items-center gap-2 pt-0.5">
-          {busy ? <Spinner /> : null}
-          <Switch
-            checked={enabled}
-            disabled={busy}
-            onCheckedChange={(checked) => void handleToggle(checked)}
-            aria-label="Require approval for skill writes"
-          />
+      <div className="border-b border-border px-4 py-3">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0 space-y-0.5">
+            <p className="text-sm font-medium text-foreground">Skill write approval</p>
+            <p className="max-w-prose text-xs leading-relaxed text-muted-foreground">
+              When enabled, agent skill creates, patches, and deletes require org admin approval
+              before they go live.
+            </p>
+          </div>
+          {activeTab === "gate" ? (
+            <div className="flex shrink-0 items-center gap-2 pt-0.5">
+              {busy ? <Spinner /> : null}
+              <Switch
+                checked={enabled}
+                disabled={busy}
+                onCheckedChange={(checked) => void handleToggle(checked)}
+                aria-label="Require approval for skill writes"
+              />
+            </div>
+          ) : null}
         </div>
       </div>
+
+      <div className="border-b border-border px-4">
+        <div className="flex gap-5">
+          <SkillApprovalTabButton active={activeTab === "gate"} onClick={() => setActiveTab("gate")}>
+            Gate settings
+          </SkillApprovalTabButton>
+          <SkillApprovalTabButton
+            active={activeTab === "proposals"}
+            onClick={() => setActiveTab("proposals")}
+          >
+            Proposals
+            {pendingCount > 0 ? (
+              <span className="ml-1 text-xs font-normal text-muted-foreground">
+                ({pendingCount > 99 ? "99+" : pendingCount})
+              </span>
+            ) : null}
+          </SkillApprovalTabButton>
+        </div>
+      </div>
+
+      {activeTab === "proposals" ? (
+        orgId ? (
+          <SkillProposalsPanel orgId={orgId} profileId={filterProfileId} showProfileLabels />
+        ) : null
+      ) : (
+        <OrgProfileSkillsWriteApprovalField profiles={profiles} disabled={busy} />
+      )}
     </Card>
   );
 }

--- a/apps/web/src/components/settings/SkillsWriteApprovalOrgCard.tsx
+++ b/apps/web/src/components/settings/SkillsWriteApprovalOrgCard.tsx
@@ -69,6 +69,57 @@ function SkillApprovalTabButton({
   );
 }
 
+function OrgProfileSkillsWriteApprovalOverrideSelect({
+  profile,
+  disabled = false,
+}: {
+  profile: ProfileSummary;
+  disabled?: boolean;
+}) {
+  const updateMutation = useUpdateProfileMutation();
+  const [value, setValue] = useState<OverrideValue>(() => toOverrideValue(profile.skillsWriteApproval));
+  const busy = updateMutation.isPending;
+
+  async function handleOverrideChange(nextValue: OverrideValue) {
+    setValue(nextValue);
+    try {
+      await updateMutation.mutateAsync({
+        profileId: profile.id,
+        input: { skillsWriteApproval: fromOverrideValue(nextValue) },
+      });
+      toast("Profile skill write approval setting saved.");
+    } catch (err) {
+      setValue(toOverrideValue(profile.skillsWriteApproval));
+      toast(formatError(err));
+    }
+  }
+
+  return (
+    <>
+      <Select
+        value={value}
+        disabled={disabled || busy}
+        onValueChange={(next) => {
+          if (!next) {
+            return;
+          }
+          void handleOverrideChange(next as OverrideValue);
+        }}
+      >
+        <SelectTrigger className="h-8 max-w-xs" aria-label="Skill write approval override">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="inherit">Inherit org default</SelectItem>
+          <SelectItem value="on">Require approval</SelectItem>
+          <SelectItem value="off">Allow immediate writes</SelectItem>
+        </SelectContent>
+      </Select>
+      {busy ? <Spinner /> : null}
+    </>
+  );
+}
+
 function OrgProfileSkillsWriteApprovalField({
   profiles,
   disabled = false,
@@ -76,36 +127,8 @@ function OrgProfileSkillsWriteApprovalField({
   profiles: ProfileSummary[];
   disabled?: boolean;
 }) {
-  const updateMutation = useUpdateProfileMutation();
   const [profileId, setProfileId] = useState<string>("");
   const selectedProfile = profiles.find((profile) => profile.id === profileId) ?? null;
-  const [value, setValue] = useState<OverrideValue>("inherit");
-  const busy = updateMutation.isPending;
-
-  useEffect(() => {
-    if (!selectedProfile) {
-      setValue("inherit");
-      return;
-    }
-    setValue(toOverrideValue(selectedProfile.skillsWriteApproval));
-  }, [selectedProfile]);
-
-  async function handleOverrideChange(nextValue: OverrideValue) {
-    if (!selectedProfile) {
-      return;
-    }
-    setValue(nextValue);
-    try {
-      await updateMutation.mutateAsync({
-        profileId: selectedProfile.id,
-        input: { skillsWriteApproval: fromOverrideValue(nextValue) },
-      });
-      toast("Profile skill write approval setting saved.");
-    } catch (err) {
-      setValue(toOverrideValue(selectedProfile.skillsWriteApproval));
-      toast(formatError(err));
-    }
-  }
 
   if (profiles.length === 0) {
     return null;
@@ -117,7 +140,7 @@ function OrgProfileSkillsWriteApprovalField({
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
         <Select
           value={profileId}
-          disabled={disabled || busy}
+          disabled={disabled}
           onValueChange={(next) => setProfileId(next ? String(next) : "")}
         >
           <SelectTrigger className="h-8 max-w-xs" aria-label="Profile">
@@ -131,26 +154,24 @@ function OrgProfileSkillsWriteApprovalField({
             ))}
           </SelectContent>
         </Select>
-        <Select
-          value={value}
-          disabled={disabled || busy || !selectedProfile}
-          onValueChange={(next) => {
-            if (!next) {
-              return;
-            }
-            void handleOverrideChange(next as OverrideValue);
-          }}
-        >
-          <SelectTrigger className="h-8 max-w-xs" aria-label="Skill write approval override">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="inherit">Inherit org default</SelectItem>
-            <SelectItem value="on">Require approval</SelectItem>
-            <SelectItem value="off">Allow immediate writes</SelectItem>
-          </SelectContent>
-        </Select>
-        {busy ? <Spinner /> : null}
+        {selectedProfile ? (
+          <OrgProfileSkillsWriteApprovalOverrideSelect
+            key={`${selectedProfile.id}:${String(selectedProfile.skillsWriteApproval)}`}
+            profile={selectedProfile}
+            disabled={disabled}
+          />
+        ) : (
+          <Select value="inherit" disabled>
+            <SelectTrigger className="h-8 max-w-xs" aria-label="Skill write approval override">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="inherit">Inherit org default</SelectItem>
+              <SelectItem value="on">Require approval</SelectItem>
+              <SelectItem value="off">Allow immediate writes</SelectItem>
+            </SelectContent>
+          </Select>
+        )}
       </div>
       <p className="mt-1.5 text-xs text-muted-foreground">
         Overrides the org-wide gate for the selected profile only.

--- a/apps/web/src/components/settings/SkillsWriteApprovalOrgCard.tsx
+++ b/apps/web/src/components/settings/SkillsWriteApprovalOrgCard.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { Card } from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import { Spinner } from "@/components/ui/spinner";
+import { useAuth } from "@/context/use-auth";
+import { formatError } from "@/lib/client";
+import { toast } from "@/lib/toast";
+
+export function SkillsWriteApprovalOrgCard() {
+  const { activeOrg, updateOrg } = useAuth();
+  const [busy, setBusy] = useState(false);
+
+  if (!activeOrg || activeOrg.role !== "admin") {
+    return null;
+  }
+
+  const enabled = activeOrg.skillsWriteApproval === true;
+
+  async function handleToggle(checked: boolean) {
+    setBusy(true);
+    try {
+      await updateOrg(activeOrg!.id, { skillsWriteApproval: checked });
+      toast(checked ? "Skill write approval enabled." : "Skill write approval disabled.");
+    } catch (err) {
+      toast(formatError(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Card className="w-full overflow-hidden shadow-none">
+      <div className="flex items-start justify-between gap-4 px-4 py-3">
+        <div className="min-w-0 space-y-0.5">
+          <p className="text-sm font-medium text-foreground">Skill write approval</p>
+          <p className="max-w-prose text-xs leading-relaxed text-muted-foreground">
+            When enabled, agent skill creates, patches, and deletes require org admin approval before
+            they go live.
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2 pt-0.5">
+          {busy ? <Spinner /> : null}
+          <Switch
+            checked={enabled}
+            disabled={busy}
+            onCheckedChange={(checked) => void handleToggle(checked)}
+            aria-label="Require approval for skill writes"
+          />
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/apps/web/src/components/system/OrganizationPanel.tsx
+++ b/apps/web/src/components/system/OrganizationPanel.tsx
@@ -1,10 +1,12 @@
 import { OrgMembersCard } from "@/components/settings/OrgMembersCard";
 import { OrgMemoryCard } from "@/components/settings/OrgMemoryCard";
+import { SkillsWriteApprovalOrgCard } from "@/components/settings/SkillsWriteApprovalOrgCard";
 
 export function OrganizationPanel() {
   return (
     <div className="min-w-0 space-y-8 p-4 sm:p-5">
       <OrgMembersCard />
+      <SkillsWriteApprovalOrgCard />
       <OrgMemoryCard />
     </div>
   );

--- a/apps/web/src/context/auth-context-shared.ts
+++ b/apps/web/src/context/auth-context-shared.ts
@@ -1,5 +1,5 @@
 import { createContext } from "react";
-import type { AuthUserResponse, SetupAuthRequest, UserOrgSummary } from "@nakama/core/contract";
+import type { AuthUserResponse, SetupAuthRequest, UpdateOrganizationRequest, UserOrgSummary } from "@nakama/core/contract";
 
 export interface AuthContextValue {
   user: AuthUserResponse | null;
@@ -12,7 +12,7 @@ export interface AuthContextValue {
   logout: () => Promise<void>;
   switchOrg: (orgId: string) => Promise<void>;
   createOrg: (input: { name: string; slug: string }) => Promise<void>;
-  updateOrg: (orgId: string, input: { name: string }) => Promise<void>;
+  updateOrg: (orgId: string, input: UpdateOrganizationRequest) => Promise<void>;
   refreshSession: () => Promise<void>;
 }
 

--- a/apps/web/src/context/auth-context.tsx
+++ b/apps/web/src/context/auth-context.tsx
@@ -7,7 +7,7 @@ import {
 } from "react";
 import { client } from "@/lib/client";
 import { queryClient } from "@/lib/query-client";
-import type { SetupAuthRequest, UserOrgSummary, AuthUserResponse } from "@nakama/core/contract";
+import type { SetupAuthRequest, UpdateOrganizationRequest, UserOrgSummary, AuthUserResponse } from "@nakama/core/contract";
 import { AuthContext, type AuthContextValue } from "@/context/auth-context-shared";
 
 function refreshAuthenticatedQueries(): void {
@@ -110,7 +110,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   );
 
   const updateOrg = useCallback(
-    async (orgId: string, input: { name: string }) => {
+    async (orgId: string, input: UpdateOrganizationRequest) => {
       const org = orgs.find((entry) => entry.id === orgId);
       if (!org) {
         throw new Error("Organization not found.");

--- a/apps/web/src/hooks/use-notifications.ts
+++ b/apps/web/src/hooks/use-notifications.ts
@@ -2,9 +2,10 @@ import { useMemo } from "react";
 import { useAuth } from "@/context/use-auth";
 import { useAutomationsQuery } from "@/hooks/use-automations";
 import { useOrgMemoryProposals } from "@/hooks/use-org-memory-proposals";
-import { PAGE_PATHS } from "@/lib/navigation";
+import { useSkillProposals } from "@/hooks/use-skill-proposals";
+import { PAGE_PATHS, profileProposalsPath } from "@/lib/navigation";
 
-export type NotificationKind = "automation-run" | "org-memory-proposal";
+export type NotificationKind = "automation-run" | "org-memory-proposal" | "skill-proposal";
 
 export interface NotificationItem {
   id: string;
@@ -21,6 +22,7 @@ export function useNotifications(): {
   items: NotificationItem[];
   automationItems: NotificationItem[];
   orgMemoryItems: NotificationItem[];
+  skillProposalItems: NotificationItem[];
   totalCount: number;
   isLoading: boolean;
 } {
@@ -34,10 +36,15 @@ export function useNotifications(): {
     "pending",
     { refetchInterval: 30_000 },
   );
+  const { data: skillProposalsData, isLoading: skillProposalsLoading } = useSkillProposals(
+    isOrgAdmin ? orgId : null,
+    { status: "pending", refetchInterval: 30_000 },
+  );
 
-  const { items, automationItems, orgMemoryItems } = useMemo(() => {
+  const { items, automationItems, orgMemoryItems, skillProposalItems } = useMemo(() => {
     const automationItems: NotificationItem[] = [];
     const orgMemoryItems: NotificationItem[] = [];
+    const skillProposalItems: NotificationItem[] = [];
 
     const automations = automationsData?.automations ?? [];
     const unreadByAutomationId = automationsData?.unread?.byAutomationId ?? {};
@@ -74,21 +81,35 @@ export function useNotifications(): {
       });
     }
 
+    for (const proposal of skillProposalsData?.proposals ?? []) {
+      skillProposalItems.push({
+        id: `skill-proposal-${proposal.id}`,
+        kind: "skill-proposal",
+        kindLabel: "Skill proposal",
+        title: `${proposal.action} · ${proposal.skillName}`,
+        description: "Skill change awaiting admin approval",
+        href: profileProposalsPath(proposal.profileId),
+        count: 1,
+        createdAt: proposal.createdAt,
+      });
+    }
+
     return {
-      items: [...automationItems, ...orgMemoryItems],
+      items: [...automationItems, ...orgMemoryItems, ...skillProposalItems],
       automationItems,
       orgMemoryItems,
+      skillProposalItems,
     };
-  }, [automationsData, proposalsData?.proposals]);
+  }, [automationsData, proposalsData?.proposals, skillProposalsData?.proposals]);
 
   const totalCount = items.reduce((sum, item) => sum + item.count, 0);
   const isLoading =
     authLoading ||
     !isAuthenticated ||
     automationsLoading ||
-    (isOrgAdmin && proposalsLoading);
+    (isOrgAdmin && (proposalsLoading || skillProposalsLoading));
 
-  return { items, automationItems, orgMemoryItems, totalCount, isLoading };
+  return { items, automationItems, orgMemoryItems, skillProposalItems, totalCount, isLoading };
 }
 
 /** @deprecated Use useNotifications */

--- a/apps/web/src/hooks/use-notifications.ts
+++ b/apps/web/src/hooks/use-notifications.ts
@@ -3,7 +3,7 @@ import { useAuth } from "@/context/use-auth";
 import { useAutomationsQuery } from "@/hooks/use-automations";
 import { useOrgMemoryProposals } from "@/hooks/use-org-memory-proposals";
 import { useSkillProposals } from "@/hooks/use-skill-proposals";
-import { PAGE_PATHS, profileProposalsPath } from "@/lib/navigation";
+import { PAGE_PATHS, orgSkillProposalsPath } from "@/lib/navigation";
 
 export type NotificationKind = "automation-run" | "org-memory-proposal" | "skill-proposal";
 
@@ -88,7 +88,7 @@ export function useNotifications(): {
         kindLabel: "Skill proposal",
         title: `${proposal.action} · ${proposal.skillName}`,
         description: "Skill change awaiting admin approval",
-        href: profileProposalsPath(proposal.profileId),
+        href: orgSkillProposalsPath(proposal.profileId),
         count: 1,
         createdAt: proposal.createdAt,
       });

--- a/apps/web/src/hooks/use-skill-proposals.ts
+++ b/apps/web/src/hooks/use-skill-proposals.ts
@@ -1,0 +1,47 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { client } from "@/lib/client";
+import { queryKeys } from "@/lib/query-keys";
+
+export function useSkillProposals(
+  orgId: string | null,
+  options: {
+    status?: "pending" | "approved" | "rejected";
+    profileId?: string;
+    refetchInterval?: number;
+  } = {},
+) {
+  const status = options.status ?? "pending";
+  return useQuery({
+    queryKey: queryKeys.skillProposals(orgId ?? "", status, options.profileId),
+    queryFn: () =>
+      client.listSkillProposals(orgId ?? "", {
+        status,
+        profileId: options.profileId,
+      }),
+    enabled: Boolean(orgId),
+    refetchInterval: options.refetchInterval,
+  });
+}
+
+function invalidateSkillProposalQueries(
+  queryClient: ReturnType<typeof useQueryClient>,
+  orgId: string,
+) {
+  return queryClient.invalidateQueries({ queryKey: ["skillProposals", orgId] });
+}
+
+export function useApproveSkillProposal(orgId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (proposalId: string) => client.approveSkillProposal(orgId, proposalId),
+    onSuccess: () => invalidateSkillProposalQueries(queryClient, orgId),
+  });
+}
+
+export function useRejectSkillProposal(orgId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (proposalId: string) => client.rejectSkillProposal(orgId, proposalId),
+    onSuccess: () => invalidateSkillProposalQueries(queryClient, orgId),
+  });
+}

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -180,6 +180,10 @@ export function toolPlaygroundBackTarget(searchParams: URLSearchParams): {
   return { href: toolsTabPath(), label: "Tools" };
 }
 
+export function profileProposalsPath(profileId: string): string {
+  return `${PAGE_PATHS.profiles}?profile=${encodeURIComponent(profileId)}&tab=proposals`;
+}
+
 export const PAGE_PATHS: Record<PageId, string> = {
   chat: "/chat",
   history: "/history",

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -181,7 +181,18 @@ export function toolPlaygroundBackTarget(searchParams: URLSearchParams): {
 }
 
 export function profileProposalsPath(profileId: string): string {
-  return `${PAGE_PATHS.profiles}?profile=${encodeURIComponent(profileId)}&tab=proposals`;
+  return orgSkillProposalsPath(profileId);
+}
+
+export function orgSkillProposalsPath(profileId?: string): string {
+  const params = new URLSearchParams({
+    tab: "organization",
+    skillProposals: "proposals",
+  });
+  if (profileId) {
+    params.set("profileId", profileId);
+  }
+  return `${PAGE_PATHS.soul}?${params.toString()}`;
 }
 
 export const PAGE_PATHS: Record<PageId, string> = {

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -95,4 +95,6 @@ export const queryKeys = {
     ["orgMemoryHistoryRevision", orgId, revisionId] as const,
   orgMemoryProposals: (orgId: string, status?: string) =>
     ["orgMemoryProposals", orgId, status ?? "all"] as const,
+  skillProposals: (orgId: string, status?: string, profileId?: string) =>
+    ["skillProposals", orgId, status ?? "all", profileId ?? "all"] as const,
 } as const;

--- a/apps/web/src/pages/profiles/profile-config-tab.tsx
+++ b/apps/web/src/pages/profiles/profile-config-tab.tsx
@@ -1,6 +1,7 @@
 import type { ProfilesPageState } from "@/pages/profiles/use-profiles-page";
 import { ProfileConfigAssignmentsSection } from "@/pages/profiles/profile-config-assignments-section";
 import { ProfileConfigIdentitySection } from "@/pages/profiles/profile-config-identity-section";
+import { ProfileSkillsWriteApprovalField } from "@/components/profiles/ProfileSkillsWriteApprovalField";
 
 export function ProfileConfigTab({ state }: { state: ProfilesPageState }) {
   if (!state.detail) {
@@ -14,6 +15,7 @@ export function ProfileConfigTab({ state }: { state: ProfilesPageState }) {
       aria-labelledby="profile-detail-tab-profile"
     >
       <ProfileConfigIdentitySection state={state} />
+      <ProfileSkillsWriteApprovalField profile={state.detail} disabled={state.busy} />
       <ProfileConfigAssignmentsSection state={state} />
     </div>
   );

--- a/apps/web/src/pages/profiles/profiles-page-layout.tsx
+++ b/apps/web/src/pages/profiles/profiles-page-layout.tsx
@@ -14,9 +14,11 @@ import { ProfileAdminPlusButton } from "@/components/ProfileAdminPlusButton";
 import { ProfileAvatar } from "@/components/ProfileAvatar";
 import { useAuth } from "@/context/use-auth";
 import { useAppNavigation } from "@/hooks/use-app-navigation";
+import { useSkillProposals } from "@/hooks/use-skill-proposals";
 import { resolveSuperBotChatProfileId } from "@/lib/profiles";
 import { cn } from "@/lib/utils";
 import { ProfileConfigTab } from "@/pages/profiles/profile-config-tab";
+import { SkillProposalsPanel } from "@/components/profiles/SkillProposalsPanel";
 import { sectionClass, profilePanelHeaderClass, profilePanelHeaderLabelClass } from "@/pages/profiles/profiles-page.shared";
 import type { ProfilesPageState } from "@/pages/profiles/use-profiles-page";
 import {
@@ -43,10 +45,16 @@ export function ProfilesPageLayout(state: ProfilesPageState) {
     setCreateOpen,
     openDeleteDialog,
   } = state;
-  const { user } = useAuth();
+  const { user, activeOrg } = useAuth();
+  const isOrgAdmin = activeOrg?.role === "admin";
   const canCreateProfile = user?.isPlatformAdmin === true;
   const { navigateToNewChat } = useAppNavigation();
   const superBotProfileId = resolveSuperBotChatProfileId(profiles);
+  const { data: skillProposalsData } = useSkillProposals(
+    isOrgAdmin && selectedId ? (activeOrg?.id ?? null) : null,
+    { status: "pending", profileId: selectedId ?? undefined },
+  );
+  const pendingSkillProposals = skillProposalsData?.pendingCount ?? 0;
   const onAskSuperBot = superBotProfileId
     ? () => navigateToNewChat(superBotProfileId)
     : undefined;
@@ -211,6 +219,21 @@ export function ProfilesPageLayout(state: ProfilesPageState) {
                       >
                         Artifacts
                       </ProfileDetailTabButton>
+                      {isOrgAdmin ? (
+                        <ProfileDetailTabButton
+                          id="profile-detail-tab-proposals"
+                          active={detailTab === "proposals"}
+                          controls="profile-detail-panel-proposals"
+                          onSelect={() => setDetailTab("proposals")}
+                        >
+                          Proposals
+                          {pendingSkillProposals > 0 ? (
+                            <span className="ml-1 text-xs text-amber-600 dark:text-amber-400">
+                              ({pendingSkillProposals > 99 ? "99+" : pendingSkillProposals})
+                            </span>
+                          ) : null}
+                        </ProfileDetailTabButton>
+                      ) : null}
                     </div>
                     {!detail.isSuper ? (
                       <Button
@@ -229,6 +252,14 @@ export function ProfilesPageLayout(state: ProfilesPageState) {
                   <div className="no-scrollbar min-h-0 flex-1 overflow-y-auto p-4 sm:p-5">
                     {detailTab === "profile" ? (
                       <ProfileConfigTab state={state} />
+                    ) : detailTab === "proposals" && isOrgAdmin && activeOrg && selectedId ? (
+                      <div
+                        id="profile-detail-panel-proposals"
+                        role="tabpanel"
+                        aria-labelledby="profile-detail-tab-proposals"
+                      >
+                        <SkillProposalsPanel orgId={activeOrg.id} profileId={selectedId} />
+                      </div>
                     ) : detailTab === "prompt" ? (
                       <div
                         id="profile-detail-panel-prompt"

--- a/apps/web/src/pages/profiles/profiles-page.shared.ts
+++ b/apps/web/src/pages/profiles/profiles-page.shared.ts
@@ -11,10 +11,15 @@ export const profileModelSaveDelayMs = 400;
 
 export type ProfileSaveStatus = "idle" | "pending" | "saving" | "saved" | "error";
 
-export type ProfileDetailTab = "profile" | "prompt" | "knowledge" | "artifacts";
+export type ProfileDetailTab = "profile" | "prompt" | "knowledge" | "artifacts" | "proposals";
 
 export function resolveProfileDetailTab(value: string | null): ProfileDetailTab {
-  if (value === "prompt" || value === "knowledge" || value === "artifacts") {
+  if (
+    value === "prompt" ||
+    value === "knowledge" ||
+    value === "artifacts" ||
+    value === "proposals"
+  ) {
     return value;
   }
 

--- a/docs/website/content/docs/skills.mdx
+++ b/docs/website/content/docs/skills.mdx
@@ -166,7 +166,11 @@ Profiles receive bundled skills for common workflows:
 
 New custom profiles receive the file tools and `knowledge_base_search` by default when those builtins are available. Default and super-bot profiles also receive the bundled skills above when they are installed and synced on the server (except opt-in skills such as `agent-browser`). Super Bot also receives `bash` for one-off host commands and coding-agent workflows.
 
-When `manage-skills` is assigned, interactive chat gets a `skill_manage` tool (`create` / `patch` / `delete`). Creates auto-assign to the profile. Automations and messaging channels do not receive `skill_manage` in this phase. Soft system-prompt guidance nudges crystallization after complex successes, error recovery, or user corrections — treat that as advisory until dogfood confirms useful skill creation.
+When `manage-skills` is assigned, interactive chat gets a `skill_manage` tool (`create` / `patch` / `delete`). Creates auto-assign to the profile unless **write approval** is enabled (org default with optional per-profile override). When the gate is on, `skill_manage` stages proposals for org-admin review on the profile **Proposals** tab; skills go live only after approval. Automations and messaging channels do not receive `skill_manage` in this phase. Soft system-prompt guidance nudges crystallization after complex successes, error recovery, or user corrections — treat that as advisory until dogfood confirms useful skill creation.
+
+### Write approval (optional)
+
+Org admins can enable **skill write approval** under **Soul → Organization**. Members can still call `skill_manage`, but creates/patches/deletes are queued in `skill_proposals` until an org admin approves or rejects them from the profile **Proposals** tab. Profile settings can override the org default (inherit / require approval / allow immediate writes). Platform-admin HTTP skill CRUD and dashboard manual create remain immediate-write bypass paths.
 
 ### Bundled system skills
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -166,6 +166,8 @@ import type {
   ListOrgMemoryProposalsResponse,
   ApproveOrgMemoryProposalRequest,
   OrgMemoryProposalResponse,
+  ListSkillProposalsResponse,
+  SkillProposalResponse,
   ListOrgMemoryHistoryResponse,
   RestoreOrgMemoryHistoryResponse,
   OrgMemoryHistoryRevisionResponse,
@@ -1777,6 +1779,50 @@ export class NakamaClient {
   ): Promise<OrgMemoryProposalResponse> {
     return this.request<OrgMemoryProposalResponse>(
       `/v1/orgs/${encodeURIComponent(orgId)}/memory/proposals/${encodeURIComponent(proposalId)}/reject`,
+      {
+        method: "POST",
+        headers: { "X-Org-Id": orgId },
+      },
+    );
+  }
+
+  async listSkillProposals(
+    orgId: string,
+    options: { status?: "pending" | "approved" | "rejected"; profileId?: string } = {},
+  ): Promise<ListSkillProposalsResponse> {
+    const params = new URLSearchParams();
+    if (options.status) {
+      params.set("status", options.status);
+    }
+    if (options.profileId) {
+      params.set("profileId", options.profileId);
+    }
+    const query = params.toString();
+    return this.request<ListSkillProposalsResponse>(
+      `/v1/orgs/${encodeURIComponent(orgId)}/skill-proposals${query ? `?${query}` : ""}`,
+      { headers: { "X-Org-Id": orgId } },
+    );
+  }
+
+  async approveSkillProposal(
+    orgId: string,
+    proposalId: string,
+  ): Promise<SkillProposalResponse> {
+    return this.request<SkillProposalResponse>(
+      `/v1/orgs/${encodeURIComponent(orgId)}/skill-proposals/${encodeURIComponent(proposalId)}/approve`,
+      {
+        method: "POST",
+        headers: { "X-Org-Id": orgId },
+      },
+    );
+  }
+
+  async rejectSkillProposal(
+    orgId: string,
+    proposalId: string,
+  ): Promise<SkillProposalResponse> {
+    return this.request<SkillProposalResponse>(
+      `/v1/orgs/${encodeURIComponent(orgId)}/skill-proposals/${encodeURIComponent(proposalId)}/reject`,
       {
         method: "POST",
         headers: { "X-Org-Id": orgId },

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -285,6 +285,7 @@ export interface OrganizationSummary {
   id: string;
   name: string;
   slug: string;
+  skillsWriteApproval?: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -300,7 +301,8 @@ export interface CreateOrganizationRequest {
 }
 
 export interface UpdateOrganizationRequest {
-  name: string;
+  name?: string;
+  skillsWriteApproval?: boolean;
 }
 
 export interface ListOrganizationsResponse {
@@ -476,6 +478,36 @@ export interface ApproveOrgMemoryProposalRequest {
 export interface OrgMemoryProposalResponse {
   proposal: OrgMemoryProposal;
   content?: string;
+}
+
+export type SkillProposalStatus = "pending" | "approved" | "rejected";
+export type SkillProposalAction = "create" | "patch" | "delete";
+
+export interface SkillProposal {
+  id: string;
+  orgId: string;
+  profileId: string;
+  sessionId: string | null;
+  proposedByUserId: string | null;
+  action: SkillProposalAction;
+  skillName: string;
+  content: string | null;
+  patchOldString: string | null;
+  patchNewString: string | null;
+  status: SkillProposalStatus;
+  reviewerUserId: string | null;
+  reviewedAt: string | null;
+  createdAt: string;
+  warnings?: string[];
+}
+
+export interface ListSkillProposalsResponse {
+  proposals: SkillProposal[];
+  pendingCount: number;
+}
+
+export interface SkillProposalResponse {
+  proposal: SkillProposal;
 }
 
 export interface InviteOrgMemberRequest {
@@ -1325,6 +1357,8 @@ export interface ProfileSummary {
   model: string | null;
   isSuper: boolean;
   isDefault?: boolean;
+  /** null = inherit org default; true/false = force gate on/off for this profile */
+  skillsWriteApproval?: boolean | null;
   toolCount: number;
   mcpServerCount: number;
   soulActive: boolean;
@@ -1509,6 +1543,7 @@ export interface UpdateProfileRequest {
   name?: string;
   systemPrompt?: string;
   model?: string | null;
+  skillsWriteApproval?: boolean | null;
 }
 
 export interface CreateToolRequest {

--- a/packages/core/src/skills/bundled/manage-skills/SKILL.md
+++ b/packages/core/src/skills/bundled/manage-skills/SKILL.md
@@ -18,6 +18,8 @@ When the `skill_manage` tool is available, use it for all `SKILL.md` create/upda
 
 `skill_manage` writes under the profile skills directory, validates frontmatter, and **auto-assigns** the skill so it can match on later turns. Bundled and global skills are read-only.
 
+When **write approval** is enabled for the org or profile, `skill_manage` **stages** changes instead of writing immediately. The tool returns `{ staged: true, proposalId, … }` and an org admin must approve the proposal before the skill goes live. Do not re-submit identical pending proposals; wait for review or ask an admin.
+
 Example create content:
 
 ```markdown

--- a/packages/core/src/skills/index.ts
+++ b/packages/core/src/skills/index.ts
@@ -7,6 +7,7 @@ export * from "./parse";
 export * from "./paths";
 export * from "./types";
 export * from "./write";
+export * from "./write-approval";
 export * from "./bundled/install";
 export * from "./bundled-names";
 export { readBundledSkillBody, readBundledSkillMarkdown } from "./bundled/index";

--- a/packages/core/src/skills/write-approval.test.ts
+++ b/packages/core/src/skills/write-approval.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { resolveSkillWriteApprovalRequired } from "./write-approval";
+
+describe("resolveSkillWriteApprovalRequired", () => {
+  test("defaults to false when org and profile unset", () => {
+    expect(resolveSkillWriteApprovalRequired({})).toBe(false);
+  });
+
+  test("org true enables gate when profile inherits", () => {
+    expect(
+      resolveSkillWriteApprovalRequired({
+        orgSkillsWriteApproval: true,
+        profileSkillsWriteApproval: null,
+      }),
+    ).toBe(true);
+  });
+
+  test("profile false overrides org true (AE7)", () => {
+    expect(
+      resolveSkillWriteApprovalRequired({
+        orgSkillsWriteApproval: true,
+        profileSkillsWriteApproval: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("profile true forces gate on when org false", () => {
+    expect(
+      resolveSkillWriteApprovalRequired({
+        orgSkillsWriteApproval: false,
+        profileSkillsWriteApproval: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/core/src/skills/write-approval.ts
+++ b/packages/core/src/skills/write-approval.ts
@@ -1,0 +1,14 @@
+export interface SkillWriteApprovalSources {
+  orgSkillsWriteApproval?: boolean | null;
+  profileSkillsWriteApproval?: boolean | null;
+}
+
+/** Profile override wins when non-null; otherwise org default (false when unset). */
+export function resolveSkillWriteApprovalRequired(
+  sources: SkillWriteApprovalSources,
+): boolean {
+  if (sources.profileSkillsWriteApproval !== undefined && sources.profileSkillsWriteApproval !== null) {
+    return sources.profileSkillsWriteApproval;
+  }
+  return sources.orgSkillsWriteApproval === true;
+}

--- a/packages/core/src/soul/org-memory-history.ts
+++ b/packages/core/src/soul/org-memory-history.ts
@@ -17,8 +17,11 @@ function historyContentPath(orgId: string, id: string, configDir?: string): stri
   return join(getOrgMemoryHistoryDir(orgId, configDir), `${id}.md`);
 }
 
+let orgMemoryChangeSequence = 0;
+
 export function createOrgMemoryChangeId(): string {
-  return `omh_${crypto.randomUUID().replace(/-/g, "")}`;
+  orgMemoryChangeSequence += 1;
+  return `omh_${String(orgMemoryChangeSequence).padStart(8, "0")}_${crypto.randomUUID().replace(/-/g, "")}`;
 }
 
 export async function appendOrgMemoryHistory(
@@ -66,7 +69,13 @@ export async function listOrgMemoryHistory(
     records.push(JSON.parse(raw) as OrgMemoryChangeLogEntry);
   }
 
-  records.sort((left, right) => right.createdAt.localeCompare(left.createdAt));
+  records.sort((left, right) => {
+    const byCreatedAt = right.createdAt.localeCompare(left.createdAt);
+    if (byCreatedAt !== 0) {
+      return byCreatedAt;
+    }
+    return right.id.localeCompare(left.id);
+  });
   return records.slice(0, limit);
 }
 

--- a/packages/db/sql/schema.sql
+++ b/packages/db/sql/schema.sql
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS profiles (
   is_super INTEGER DEFAULT 0 NOT NULL,
   org_id TEXT,
   is_default INTEGER DEFAULT 0 NOT NULL,
+  skills_write_approval INTEGER,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL,
   FOREIGN KEY (org_id) REFERENCES organizations (id) ON DELETE CASCADE
@@ -252,6 +253,7 @@ CREATE TABLE IF NOT EXISTS organizations (
   id TEXT PRIMARY KEY NOT NULL,
   name TEXT NOT NULL,
   slug TEXT NOT NULL,
+  skills_write_approval INTEGER NOT NULL DEFAULT 0,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL
 );
@@ -302,6 +304,27 @@ CREATE TABLE IF NOT EXISTS org_memory_proposals (
 );
 
 CREATE INDEX IF NOT EXISTS org_memory_proposals_org_status ON org_memory_proposals (org_id, status);
+
+CREATE TABLE IF NOT EXISTS skill_proposals (
+  id TEXT PRIMARY KEY NOT NULL,
+  org_id TEXT NOT NULL,
+  profile_id TEXT NOT NULL,
+  session_id TEXT,
+  proposed_by_user_id TEXT,
+  action TEXT NOT NULL,
+  skill_name TEXT NOT NULL,
+  content TEXT,
+  patch_old_string TEXT,
+  patch_new_string TEXT,
+  status TEXT NOT NULL,
+  reviewer_user_id TEXT,
+  reviewed_at TEXT,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY (org_id) REFERENCES organizations (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS skill_proposals_org_status ON skill_proposals (org_id, status);
+CREATE INDEX IF NOT EXISTS skill_proposals_org_profile_status ON skill_proposals (org_id, profile_id, status);
 
 CREATE TABLE IF NOT EXISTS channel_org_mappings (
   channel TEXT NOT NULL,

--- a/packages/db/src/adapters/in-memory.ts
+++ b/packages/db/src/adapters/in-memory.ts
@@ -380,6 +380,20 @@ export function createInMemoryDatabaseAdapter(): DatabaseAdapter {
       return null;
     },
 
+    async getPendingSkillProposalForSkill(orgId, profileId, skillName) {
+      for (const proposal of skillProposals.values()) {
+        if (
+          proposal.orgId === orgId &&
+          proposal.profileId === profileId &&
+          proposal.skillName === skillName &&
+          proposal.status === "pending"
+        ) {
+          return proposal;
+        }
+      }
+      return null;
+    },
+
     async getPendingSkillProposalForPatch(
       orgId,
       profileId,

--- a/packages/db/src/adapters/in-memory.ts
+++ b/packages/db/src/adapters/in-memory.ts
@@ -15,6 +15,8 @@ import type {
   StoredOrgInviteRecord,
   StoredOrgMemoryProposal,
   OrgMemoryProposalStatus,
+  StoredSkillProposal,
+  SkillProposalStatus,
   StoredArtifactShareRecord,
   StoredOrganizationRecord,
   StoredUserOrganizationRecord,
@@ -66,6 +68,7 @@ export function createInMemoryDatabaseAdapter(): DatabaseAdapter {
   const orgInvites = new Map<string, StoredOrgInviteRecord>();
   const orgInvitesByTokenHash = new Map<string, StoredOrgInviteRecord>();
   const orgMemoryProposals = new Map<string, StoredOrgMemoryProposal>();
+  const skillProposals = new Map<string, StoredSkillProposal>();
   const artifactShares = new Map<string, StoredArtifactShareRecord>();
   const artifactSharesByTokenHash = new Map<string, StoredArtifactShareRecord>();
   let llmUsageStats: StoredLlmUsageStatsRecord | null = null;
@@ -329,6 +332,101 @@ export function createInMemoryDatabaseAdapter(): DatabaseAdapter {
         if (proposal.orgId === orgId && proposal.status === status) {
           count += 1;
         }
+      }
+      return count;
+    },
+
+    async createSkillProposal(record) {
+      skillProposals.set(record.id, record);
+    },
+
+    async listSkillProposals(orgId, options = {}) {
+      const { status, profileId } = options;
+      const proposals = [...skillProposals.values()].filter((proposal) => {
+        if (proposal.orgId !== orgId) {
+          return false;
+        }
+        if (status && proposal.status !== status) {
+          return false;
+        }
+        if (profileId && proposal.profileId !== profileId) {
+          return false;
+        }
+        return true;
+      });
+      return proposals.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    },
+
+    async getSkillProposal(orgId, id) {
+      const proposal = skillProposals.get(id);
+      if (!proposal || proposal.orgId !== orgId) {
+        return null;
+      }
+      return proposal;
+    },
+
+    async getPendingSkillProposalForCreate(orgId, profileId, skillName) {
+      for (const proposal of skillProposals.values()) {
+        if (
+          proposal.orgId === orgId &&
+          proposal.profileId === profileId &&
+          proposal.skillName === skillName &&
+          proposal.action === "create" &&
+          proposal.status === "pending"
+        ) {
+          return proposal;
+        }
+      }
+      return null;
+    },
+
+    async getPendingSkillProposalForPatch(
+      orgId,
+      profileId,
+      skillName,
+      patchOldString,
+      patchNewString,
+    ) {
+      for (const proposal of skillProposals.values()) {
+        if (
+          proposal.orgId === orgId &&
+          proposal.profileId === profileId &&
+          proposal.skillName === skillName &&
+          proposal.action === "patch" &&
+          proposal.patchOldString === patchOldString &&
+          proposal.patchNewString === patchNewString &&
+          proposal.status === "pending"
+        ) {
+          return proposal;
+        }
+      }
+      return null;
+    },
+
+    async updateSkillProposalStatus(orgId, id, update) {
+      const proposal = skillProposals.get(id);
+      if (!proposal || proposal.orgId !== orgId) {
+        return false;
+      }
+      skillProposals.set(id, {
+        ...proposal,
+        status: update.status,
+        reviewerUserId: update.reviewerUserId,
+        reviewedAt: update.reviewedAt,
+      });
+      return true;
+    },
+
+    async countPendingSkillProposals(orgId, profileId) {
+      let count = 0;
+      for (const proposal of skillProposals.values()) {
+        if (proposal.orgId !== orgId || proposal.status !== "pending") {
+          continue;
+        }
+        if (profileId && proposal.profileId !== profileId) {
+          continue;
+        }
+        count += 1;
       }
       return count;
     },

--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -18,6 +18,9 @@ import type {
   StoredOrgInviteRecord,
   StoredOrgMemoryProposal,
   OrgMemoryProposalStatus,
+  StoredSkillProposal,
+  SkillProposalStatus,
+  SkillProposalAction,
   StoredArtifactShareRecord,
   StoredOrganizationRecord,
   StoredUserOrganizationRecord,
@@ -76,6 +79,7 @@ interface ProfileRow {
   is_super: number;
   org_id: string | null;
   is_default: number;
+  skills_write_approval: number | null;
   created_at: string;
   updated_at: string;
 }
@@ -286,6 +290,7 @@ interface OrganizationRow {
   id: string;
   name: string;
   slug: string;
+  skills_write_approval: number;
   created_at: string;
   updated_at: string;
 }
@@ -312,6 +317,23 @@ interface OrgMemoryProposalRow {
   bullet: string;
   status: string;
   pinned: number;
+  reviewer_user_id: string | null;
+  reviewed_at: string | null;
+  created_at: string;
+}
+
+interface SkillProposalRow {
+  id: string;
+  org_id: string;
+  profile_id: string;
+  session_id: string | null;
+  proposed_by_user_id: string | null;
+  action: string;
+  skill_name: string;
+  content: string | null;
+  patch_old_string: string | null;
+  patch_new_string: string | null;
+  status: string;
   reviewer_user_id: string | null;
   reviewed_at: string | null;
   created_at: string;
@@ -443,10 +465,11 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
       is_super,
       org_id,
       is_default,
+      skills_write_approval,
       created_at,
       updated_at
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(id) DO UPDATE SET
       name = excluded.name,
       system_prompt = excluded.system_prompt,
@@ -456,6 +479,7 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
       is_super = excluded.is_super,
       org_id = excluded.org_id,
       is_default = excluded.is_default,
+      skills_write_approval = excluded.skills_write_approval,
       updated_at = excluded.updated_at
   `);
   const deleteProfileStmt = db.prepare("DELETE FROM profiles WHERE id = ?");
@@ -1037,26 +1061,27 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
     WHERE id = ?
   `);
   const upsertOrganizationStmt = db.prepare(`
-    INSERT INTO organizations (id, name, slug, created_at, updated_at)
-    VALUES (?, ?, ?, ?, ?)
+    INSERT INTO organizations (id, name, slug, skills_write_approval, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?)
     ON CONFLICT(id) DO UPDATE SET
       name = excluded.name,
       slug = excluded.slug,
+      skills_write_approval = excluded.skills_write_approval,
       updated_at = excluded.updated_at
   `);
   const listOrganizationsStmt = db.prepare(`
-    SELECT id, name, slug, created_at, updated_at
+    SELECT id, name, slug, skills_write_approval, created_at, updated_at
     FROM organizations
     ORDER BY name ASC
   `);
   const getOrganizationBySlugStmt = db.prepare(`
-    SELECT id, name, slug, created_at, updated_at
+    SELECT id, name, slug, skills_write_approval, created_at, updated_at
     FROM organizations
     WHERE slug = ?
     LIMIT 1
   `);
   const getOrganizationByIdStmt = db.prepare(`
-    SELECT id, name, slug, created_at, updated_at
+    SELECT id, name, slug, skills_write_approval, created_at, updated_at
     FROM organizations
     WHERE id = ?
     LIMIT 1
@@ -1136,6 +1161,92 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
     FROM org_memory_proposals
     WHERE org_id = ? AND status = ?
   `);
+  const createSkillProposalStmt = db.prepare(`
+    INSERT INTO skill_proposals (
+      id, org_id, profile_id, session_id, proposed_by_user_id,
+      action, skill_name, content, patch_old_string, patch_new_string,
+      status, reviewer_user_id, reviewed_at, created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const listSkillProposalsByStatusStmt = db.prepare(`
+    SELECT
+      id, org_id, profile_id, session_id, proposed_by_user_id,
+      action, skill_name, content, patch_old_string, patch_new_string,
+      status, reviewer_user_id, reviewed_at, created_at
+    FROM skill_proposals
+    WHERE org_id = ? AND status = ?
+    ORDER BY created_at DESC
+  `);
+  const listSkillProposalsByStatusAndProfileStmt = db.prepare(`
+    SELECT
+      id, org_id, profile_id, session_id, proposed_by_user_id,
+      action, skill_name, content, patch_old_string, patch_new_string,
+      status, reviewer_user_id, reviewed_at, created_at
+    FROM skill_proposals
+    WHERE org_id = ? AND status = ? AND profile_id = ?
+    ORDER BY created_at DESC
+  `);
+  const listAllSkillProposalsStmt = db.prepare(`
+    SELECT
+      id, org_id, profile_id, session_id, proposed_by_user_id,
+      action, skill_name, content, patch_old_string, patch_new_string,
+      status, reviewer_user_id, reviewed_at, created_at
+    FROM skill_proposals
+    WHERE org_id = ?
+    ORDER BY created_at DESC
+  `);
+  const listAllSkillProposalsForProfileStmt = db.prepare(`
+    SELECT
+      id, org_id, profile_id, session_id, proposed_by_user_id,
+      action, skill_name, content, patch_old_string, patch_new_string,
+      status, reviewer_user_id, reviewed_at, created_at
+    FROM skill_proposals
+    WHERE org_id = ? AND profile_id = ?
+    ORDER BY created_at DESC
+  `);
+  const getSkillProposalStmt = db.prepare(`
+    SELECT
+      id, org_id, profile_id, session_id, proposed_by_user_id,
+      action, skill_name, content, patch_old_string, patch_new_string,
+      status, reviewer_user_id, reviewed_at, created_at
+    FROM skill_proposals
+    WHERE org_id = ? AND id = ?
+    LIMIT 1
+  `);
+  const getPendingSkillProposalForCreateStmt = db.prepare(`
+    SELECT
+      id, org_id, profile_id, session_id, proposed_by_user_id,
+      action, skill_name, content, patch_old_string, patch_new_string,
+      status, reviewer_user_id, reviewed_at, created_at
+    FROM skill_proposals
+    WHERE org_id = ? AND profile_id = ? AND skill_name = ? AND action = 'create' AND status = 'pending'
+    LIMIT 1
+  `);
+  const getPendingSkillProposalForPatchStmt = db.prepare(`
+    SELECT
+      id, org_id, profile_id, session_id, proposed_by_user_id,
+      action, skill_name, content, patch_old_string, patch_new_string,
+      status, reviewer_user_id, reviewed_at, created_at
+    FROM skill_proposals
+    WHERE org_id = ? AND profile_id = ? AND skill_name = ? AND action = 'patch'
+      AND patch_old_string = ? AND patch_new_string = ? AND status = 'pending'
+    LIMIT 1
+  `);
+  const updateSkillProposalStatusStmt = db.prepare(`
+    UPDATE skill_proposals
+    SET status = ?, reviewer_user_id = ?, reviewed_at = ?
+    WHERE org_id = ? AND id = ?
+  `);
+  const countPendingSkillProposalsStmt = db.prepare(`
+    SELECT COUNT(*) AS count
+    FROM skill_proposals
+    WHERE org_id = ? AND status = 'pending'
+  `);
+  const countPendingSkillProposalsForProfileStmt = db.prepare(`
+    SELECT COUNT(*) AS count
+    FROM skill_proposals
+    WHERE org_id = ? AND profile_id = ? AND status = 'pending'
+  `);
   const createArtifactShareStmt = db.prepare(`
     INSERT INTO artifact_shares (
       id, org_id, profile_id, source_path, filename, mime_type, size_bytes,
@@ -1199,6 +1310,7 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
       o.id,
       o.name,
       o.slug,
+      o.skills_write_approval,
       o.created_at,
       o.updated_at,
       om.role,
@@ -1307,6 +1419,7 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
         record.id,
         record.name,
         record.slug,
+        record.skillsWriteApproval ? 1 : 0,
         record.createdAt,
         record.updatedAt,
       );
@@ -1386,6 +1499,7 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
           id: string;
           name: string;
           slug: string;
+          skills_write_approval: number;
           created_at: string;
           updated_at: string;
           role: string;
@@ -1397,6 +1511,7 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
             id: record.id,
             name: record.name,
             slug: record.slug,
+            skillsWriteApproval: record.skills_write_approval !== 0,
             createdAt: record.created_at,
             updatedAt: record.updated_at,
           },
@@ -1491,6 +1606,95 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
 
     async countOrgMemoryProposals(orgId, status) {
       const row = countOrgMemoryProposalsStmt.get(orgId, status) as { count: number };
+      return row.count;
+    },
+
+    async createSkillProposal(record) {
+      createSkillProposalStmt.run(
+        record.id,
+        record.orgId,
+        record.profileId,
+        record.sessionId,
+        record.proposedByUserId,
+        record.action,
+        record.skillName,
+        record.content,
+        record.patchOldString,
+        record.patchNewString,
+        record.status,
+        record.reviewerUserId,
+        record.reviewedAt,
+        record.createdAt,
+      );
+    },
+
+    async listSkillProposals(orgId, options = {}) {
+      const { status, profileId } = options;
+      let rows: SkillProposalRow[];
+      if (status && profileId) {
+        rows = listSkillProposalsByStatusAndProfileStmt.all(
+          orgId,
+          status,
+          profileId,
+        ) as SkillProposalRow[];
+      } else if (status) {
+        rows = listSkillProposalsByStatusStmt.all(orgId, status) as SkillProposalRow[];
+      } else if (profileId) {
+        rows = listAllSkillProposalsForProfileStmt.all(orgId, profileId) as SkillProposalRow[];
+      } else {
+        rows = listAllSkillProposalsStmt.all(orgId) as SkillProposalRow[];
+      }
+      return rows.map(toSkillProposalRecord);
+    },
+
+    async getSkillProposal(orgId, id) {
+      const row = getSkillProposalStmt.get(orgId, id) as SkillProposalRow | null;
+      return row ? toSkillProposalRecord(row) : null;
+    },
+
+    async getPendingSkillProposalForCreate(orgId, profileId, skillName) {
+      const row = getPendingSkillProposalForCreateStmt.get(
+        orgId,
+        profileId,
+        skillName,
+      ) as SkillProposalRow | null;
+      return row ? toSkillProposalRecord(row) : null;
+    },
+
+    async getPendingSkillProposalForPatch(
+      orgId,
+      profileId,
+      skillName,
+      patchOldString,
+      patchNewString,
+    ) {
+      const row = getPendingSkillProposalForPatchStmt.get(
+        orgId,
+        profileId,
+        skillName,
+        patchOldString,
+        patchNewString,
+      ) as SkillProposalRow | null;
+      return row ? toSkillProposalRecord(row) : null;
+    },
+
+    async updateSkillProposalStatus(orgId, id, update) {
+      const result = updateSkillProposalStatusStmt.run(
+        update.status,
+        update.reviewerUserId,
+        update.reviewedAt,
+        orgId,
+        id,
+      );
+      return result.changes > 0;
+    },
+
+    async countPendingSkillProposals(orgId, profileId) {
+      const row = (
+        profileId
+          ? countPendingSkillProposalsForProfileStmt.get(orgId, profileId)
+          : countPendingSkillProposalsStmt.get(orgId)
+      ) as { count: number };
       return row.count;
     },
 
@@ -1682,6 +1886,11 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
         record.isSuper ? 1 : 0,
         record.orgId ?? null,
         record.isDefault ? 1 : 0,
+        record.skillsWriteApproval == null
+          ? null
+          : record.skillsWriteApproval
+            ? 1
+            : 0,
         record.createdAt,
         record.updatedAt,
       );
@@ -2276,6 +2485,8 @@ function toProfileRecord(row: ProfileRow): StoredProfileRecord {
     isSuper: row.is_super !== 0,
     orgId: row.org_id ?? null,
     isDefault: row.is_default !== 0,
+    skillsWriteApproval:
+      row.skills_write_approval == null ? null : row.skills_write_approval !== 0,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -2720,6 +2931,7 @@ function toOrganizationRecord(row: OrganizationRow): StoredOrganizationRecord {
     id: row.id,
     name: row.name,
     slug: row.slug,
+    skillsWriteApproval: row.skills_write_approval !== 0,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -2750,6 +2962,25 @@ function toOrgMemoryProposalRecord(row: OrgMemoryProposalRow): StoredOrgMemoryPr
     bullet: row.bullet,
     status: row.status as OrgMemoryProposalStatus,
     pinned: Boolean(row.pinned),
+    reviewerUserId: row.reviewer_user_id,
+    reviewedAt: row.reviewed_at,
+    createdAt: row.created_at,
+  };
+}
+
+function toSkillProposalRecord(row: SkillProposalRow): StoredSkillProposal {
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    profileId: row.profile_id,
+    sessionId: row.session_id,
+    proposedByUserId: row.proposed_by_user_id,
+    action: row.action as StoredSkillProposal["action"],
+    skillName: row.skill_name,
+    content: row.content,
+    patchOldString: row.patch_old_string,
+    patchNewString: row.patch_new_string,
+    status: row.status as StoredSkillProposal["status"],
     reviewerUserId: row.reviewer_user_id,
     reviewedAt: row.reviewed_at,
     createdAt: row.created_at,

--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -1222,6 +1222,15 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
     WHERE org_id = ? AND profile_id = ? AND skill_name = ? AND action = 'create' AND status = 'pending'
     LIMIT 1
   `);
+  const getPendingSkillProposalForSkillStmt = db.prepare(`
+    SELECT
+      id, org_id, profile_id, session_id, proposed_by_user_id,
+      action, skill_name, content, patch_old_string, patch_new_string,
+      status, reviewer_user_id, reviewed_at, created_at
+    FROM skill_proposals
+    WHERE org_id = ? AND profile_id = ? AND skill_name = ? AND status = 'pending'
+    LIMIT 1
+  `);
   const getPendingSkillProposalForPatchStmt = db.prepare(`
     SELECT
       id, org_id, profile_id, session_id, proposed_by_user_id,
@@ -1654,6 +1663,15 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
 
     async getPendingSkillProposalForCreate(orgId, profileId, skillName) {
       const row = getPendingSkillProposalForCreateStmt.get(
+        orgId,
+        profileId,
+        skillName,
+      ) as SkillProposalRow | null;
+      return row ? toSkillProposalRecord(row) : null;
+    },
+
+    async getPendingSkillProposalForSkill(orgId, profileId, skillName) {
+      const row = getPendingSkillProposalForSkillStmt.get(
         orgId,
         profileId,
         skillName,

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -16,6 +16,8 @@ export function migrateDatabase(db: Database): void {
   migrateUsersTable(db);
   migrateOrgTables(db);
   migrateOrgMemoryProposalsTable(db);
+  migrateSkillProposalsTable(db);
+  migrateSkillsWriteApprovalColumns(db);
   migrateTenantOrgScope(db);
   migrateProfileOrgColumns(db);
   migrateBrowserSessionsTable(db);
@@ -335,6 +337,48 @@ function migrateOrgMemoryProposalsTable(db: Database): void {
     );
     CREATE INDEX IF NOT EXISTS org_memory_proposals_org_status ON org_memory_proposals (org_id, status);
   `);
+}
+
+function migrateSkillProposalsTable(db: Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS skill_proposals (
+      id TEXT PRIMARY KEY NOT NULL,
+      org_id TEXT NOT NULL,
+      profile_id TEXT NOT NULL,
+      session_id TEXT,
+      proposed_by_user_id TEXT,
+      action TEXT NOT NULL,
+      skill_name TEXT NOT NULL,
+      content TEXT,
+      patch_old_string TEXT,
+      patch_new_string TEXT,
+      status TEXT NOT NULL,
+      reviewer_user_id TEXT,
+      reviewed_at TEXT,
+      created_at TEXT NOT NULL,
+      FOREIGN KEY (org_id) REFERENCES organizations (id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS skill_proposals_org_status ON skill_proposals (org_id, status);
+    CREATE INDEX IF NOT EXISTS skill_proposals_org_profile_status ON skill_proposals (org_id, profile_id, status);
+  `);
+}
+
+function migrateSkillsWriteApprovalColumns(db: Database): void {
+  const orgColumns = db
+    .prepare("PRAGMA table_info(organizations)")
+    .all() as Array<{ name: string }>;
+  if (!new Set(orgColumns.map((column) => column.name)).has("skills_write_approval")) {
+    db.exec(
+      `ALTER TABLE organizations ADD COLUMN skills_write_approval INTEGER NOT NULL DEFAULT 0;`,
+    );
+  }
+
+  const profileColumns = db
+    .prepare("PRAGMA table_info(profiles)")
+    .all() as Array<{ name: string }>;
+  if (!new Set(profileColumns.map((column) => column.name)).has("skills_write_approval")) {
+    db.exec(`ALTER TABLE profiles ADD COLUMN skills_write_approval INTEGER;`);
+  }
 }
 
 const TENANT_ORG_ID_TABLES = [

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -482,6 +482,11 @@ export interface DatabaseAdapter {
     profileId: string,
     skillName: string,
   ): Promise<StoredSkillProposal | null>;
+  getPendingSkillProposalForSkill(
+    orgId: string,
+    profileId: string,
+    skillName: string,
+  ): Promise<StoredSkillProposal | null>;
   getPendingSkillProposalForPatch(
     orgId: string,
     profileId: string,

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -44,6 +44,8 @@ export interface StoredProfileRecord {
   isSuper: boolean;
   orgId?: string | null;
   isDefault?: boolean;
+  /** null = inherit org default; true/false = force gate on/off for this profile */
+  skillsWriteApproval?: boolean | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -305,6 +307,7 @@ export interface StoredOrganizationRecord {
   id: string;
   name: string;
   slug: string;
+  skillsWriteApproval?: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -347,6 +350,26 @@ export interface StoredOrgMemoryProposal {
   bullet: string;
   status: OrgMemoryProposalStatus;
   pinned: boolean;
+  reviewerUserId: string | null;
+  reviewedAt: string | null;
+  createdAt: string;
+}
+
+export type SkillProposalStatus = "pending" | "approved" | "rejected";
+export type SkillProposalAction = "create" | "patch" | "delete";
+
+export interface StoredSkillProposal {
+  id: string;
+  orgId: string;
+  profileId: string;
+  sessionId: string | null;
+  proposedByUserId: string | null;
+  action: SkillProposalAction;
+  skillName: string;
+  content: string | null;
+  patchOldString: string | null;
+  patchNewString: string | null;
+  status: SkillProposalStatus;
   reviewerUserId: string | null;
   reviewedAt: string | null;
   createdAt: string;
@@ -447,6 +470,35 @@ export interface DatabaseAdapter {
     },
   ): Promise<boolean>;
   countOrgMemoryProposals(orgId: string, status: OrgMemoryProposalStatus): Promise<number>;
+
+  createSkillProposal(record: StoredSkillProposal): Promise<void>;
+  listSkillProposals(
+    orgId: string,
+    options?: { status?: SkillProposalStatus; profileId?: string },
+  ): Promise<StoredSkillProposal[]>;
+  getSkillProposal(orgId: string, id: string): Promise<StoredSkillProposal | null>;
+  getPendingSkillProposalForCreate(
+    orgId: string,
+    profileId: string,
+    skillName: string,
+  ): Promise<StoredSkillProposal | null>;
+  getPendingSkillProposalForPatch(
+    orgId: string,
+    profileId: string,
+    skillName: string,
+    patchOldString: string,
+    patchNewString: string,
+  ): Promise<StoredSkillProposal | null>;
+  updateSkillProposalStatus(
+    orgId: string,
+    id: string,
+    update: {
+      status: SkillProposalStatus;
+      reviewerUserId: string;
+      reviewedAt: string;
+    },
+  ): Promise<boolean>;
+  countPendingSkillProposals(orgId: string, profileId?: string): Promise<number>;
 
   createArtifactShare(record: StoredArtifactShareRecord): Promise<void>;
   updateArtifactShareSnapshot(


### PR DESCRIPTION
- Introduced a new `SkillProposalService` to manage skill change proposals.
- Updated `skill_manage` tool to stage changes for admin approval when write approval is enabled.
- Enhanced organization and profile models to include `skillsWriteApproval` flag.
- Added new routes and database schema for handling skill proposals.
- Updated relevant components and hooks to support skill proposal notifications and management.
- Enhanced documentation to reflect the new skill management process.