### PR TITLE
feat: self-improving skills Phase 4 — post-turn review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ Path: `~/.nakama/orgs/{orgId}/profiles/{profileId}/` (`getProfileSoulDir`). Load
 | `coding-agent` | Codex / Claude Code / OpenCode via `bash` |
 | `agent-browser` | Opt-in browser CLI; needs host install — `docs/website/agent-browser.md` |
 | `create-profile` | Super Bot only, confirm-first — `apps/server/src/tools/super-bot-tools.ts` |
-| `skill_manage` | Interactive web/cli with `manage-skills` — create/patch/delete profile skills + auto-assign (`apps/server/src/tools/skill-manage-tool.ts`). When org/profile **write approval** is enabled, mutations stage as proposals for org-admin review instead of writing immediately. When present, file tools refuse `skills/*/SKILL.md` (`forbidProfileSkillMarkdownWrites`). Not injected for automations or Telegram/WhatsApp/Discord. |
+| `skill_manage` | Interactive web/cli with `manage-skills` — create/patch/delete profile skills + auto-assign (`apps/server/src/tools/skill-manage-tool.ts`). When org/profile **write approval** is enabled, mutations stage as proposals for org-admin review instead of writing immediately. When present, file tools refuse `skills/*/SKILL.md` (`forbidProfileSkillMarkdownWrites`). Not injected for automations or Telegram/WhatsApp/Discord. Opt-in **post-turn skill review** (`skills_post_turn_review`) may suggest or stage create/patch after complex turns without writing into model history. |
 | Composio | Org toolkits + per-user OAuth — `docs/website/composio.md` |
 
 **Channel artifacts (Telegram/Discord):** `packages/core/src/channel-artifacts.ts`, `channel-artifact-delivery.ts`; handlers in `apps/platform/{telegram,discord}/src/channel-artifact-flow.ts`.

--- a/apps/server/src/http/app.test.ts
+++ b/apps/server/src/http/app.test.ts
@@ -58,6 +58,7 @@ function createServerOptions() {
         getContextUsage: () => null,
       }),
       scheduleSessionTitleGeneration: (_sessionId: string) => {},
+      schedulePostTurnSkillReview: (_sessionId: string) => {},
       listProfiles: async () => ({ profiles: [{ id: "default" }] }),
       createProfile: async (_body: unknown) => ({ id: "profile_1" }),
       getProfileSoulStatus: async (_profileId: string, includeContents: boolean) => ({ hasSoul: true, content: includeContents ? "soul" : null }),

--- a/apps/server/src/http/app.ts
+++ b/apps/server/src/http/app.ts
@@ -22,6 +22,7 @@ import { registerPlatformOrgRoutes } from "./routes/platform-orgs";
 import { registerOrgMemberRoutes } from "./routes/org-members";
 import { registerOrgMemoryRoutes } from "./routes/org-memory";
 import { registerSkillProposalRoutes } from "./routes/skill-proposals";
+import { registerSkillSuggestionRoutes } from "./routes/skill-suggestions";
 import { registerCodingAgentRoutes } from "./routes/coding-agents";
 import { registerInternalAutomationRoutes } from "./routes/internal-automations";
 import { registerNotificationDestinationRoutes } from "./routes/notification-destinations";
@@ -111,6 +112,7 @@ export function createHonoApp(options: ServerOptions) {
   registerOrgMemberRoutes(app, options);
   registerOrgMemoryRoutes(app, options);
   registerSkillProposalRoutes(app, options);
+  registerSkillSuggestionRoutes(app, options);
   registerCodingAgentRoutes(app, options);
 
   app.get("/openapi.json", (c) => {

--- a/apps/server/src/http/context.ts
+++ b/apps/server/src/http/context.ts
@@ -8,6 +8,7 @@ import type { AuthService } from "../services/auth-service";
 import type { OrgService } from "../services/org-service";
 import type { OrgMemoryService } from "../services/org-memory-service";
 import type { SkillProposalService } from "../services/skill-proposal-service";
+import type { SkillSuggestionService } from "../services/skill-suggestion-service";
 import type { ComposioService } from "../services/composio-service";
 import type { DatabaseAdapter } from "@nakama/db";
 
@@ -23,6 +24,7 @@ export interface ServerOptions {
   orgService?: OrgService | null;
   orgMemoryService?: OrgMemoryService | null;
   skillProposalService?: SkillProposalService | null;
+  skillSuggestionService?: SkillSuggestionService | null;
   databaseAdapter?: DatabaseAdapter | null;
   webDistDir?: string | null;
 }

--- a/apps/server/src/http/platform-orgs.test.ts
+++ b/apps/server/src/http/platform-orgs.test.ts
@@ -54,6 +54,7 @@ describe("platform org routes", () => {
         name: "Acme Corp",
         slug: "acme-corp",
         skillsWriteApproval: false,
+        skillsPostTurnReview: false,
         createdAt: expect.any(String),
         updatedAt: expect.any(String),
       },

--- a/apps/server/src/http/routes/profiles-skills-write-approval.test.ts
+++ b/apps/server/src/http/routes/profiles-skills-write-approval.test.ts
@@ -75,6 +75,19 @@ describe("profile skillsWriteApproval auth", () => {
     const okBody = (await okResp.json()) as { profile: { skillsWriteApproval: boolean | null } };
     expect(okBody.profile.skillsWriteApproval).toBe(true);
 
+    const reviewResp = await app.fetch(
+      new Request(`${BASE}/v1/profiles/${profileId}`, {
+        method: "PUT",
+        headers: orgAdminSession.headers({ "X-CSRF-Token": orgAdminSession.csrfToken }, orgId),
+        body: JSON.stringify({ skillsPostTurnReview: true }),
+      }),
+    );
+    expect(reviewResp.status).toBe(200);
+    const reviewBody = (await reviewResp.json()) as {
+      profile: { skillsPostTurnReview: boolean | null };
+    };
+    expect(reviewBody.profile.skillsPostTurnReview).toBe(true);
+
     const forbiddenResp = await app.fetch(
       new Request(`${BASE}/v1/profiles/${profileId}`, {
         method: "PUT",

--- a/apps/server/src/http/routes/profiles.ts
+++ b/apps/server/src/http/routes/profiles.ts
@@ -28,11 +28,16 @@ import {
 import type { HonoApp } from "../types";
 import type { ServerOptions } from "../context";
 
-function isSkillsWriteApprovalOnlyUpdate(body: UpdateProfileRequest): boolean {
+const ORG_ADMIN_PROFILE_SETTING_KEYS = new Set([
+  "skillsWriteApproval",
+  "skillsPostTurnReview",
+]);
+
+function isOrgAdminAllowedProfileSettingsUpdate(body: UpdateProfileRequest): boolean {
   const keys = Object.keys(body).filter(
     (key) => body[key as keyof UpdateProfileRequest] !== undefined,
   );
-  return keys.length === 1 && keys[0] === "skillsWriteApproval";
+  return keys.length > 0 && keys.every((key) => ORG_ADMIN_PROFILE_SETTING_KEYS.has(key));
 }
 
 export function registerProfileRoutes(app: HonoApp, options: ServerOptions): void {
@@ -463,7 +468,7 @@ export function registerProfileRoutes(app: HonoApp, options: ServerOptions): voi
 
     if (!auth.isPlatformAdmin) {
       requireOrgAdmin(auth);
-      if (!isSkillsWriteApprovalOnlyUpdate(body)) {
+      if (!isOrgAdminAllowedProfileSettingsUpdate(body)) {
         throw new NakamaApiError("Forbidden", 403);
       }
     }

--- a/apps/server/src/http/routes/sessions.ts
+++ b/apps/server/src/http/routes/sessions.ts
@@ -351,8 +351,11 @@ export function registerSessionRoutes(app: HonoApp, options: ServerOptions): voi
     }
 
     if (wantsStream) {
-      return streamMessage(sessionId, session, input, () => {
+      return streamMessage(sessionId, session, input, (terminal) => {
         agent.scheduleSessionTitleGeneration(sessionId);
+        if (terminal.type === "done") {
+          agent.schedulePostTurnSkillReview(sessionId);
+        }
       });
     }
 
@@ -365,6 +368,7 @@ export function registerSessionRoutes(app: HonoApp, options: ServerOptions): voi
         ...(contextUsage ? { contextUsage } : {}),
       });
       agent.scheduleSessionTitleGeneration(sessionId);
+      agent.schedulePostTurnSkillReview(sessionId);
       return json<SendMessageResponse>({
         reply,
         ...(contextUsage ? { contextUsage } : {}),

--- a/apps/server/src/http/routes/skill-proposals.test.ts
+++ b/apps/server/src/http/routes/skill-proposals.test.ts
@@ -49,18 +49,20 @@ function createApp() {
 const BASE = "http://localhost:4310";
 
 describe("skill proposal routes (v1)", () => {
-  test("admin can list, approve, and reject proposals; member cannot list", async () => {
+  test("admin can list, approve, and reject proposals; member needs sessionId to list", async () => {
     const { app, authService, databaseAdapter, skillProposalService } = createApp();
     const adminSession = await setupFreshInstallSession(app, databaseAdapter, "admin@org.com");
     const orgId = adminSession.orgId!;
     const profiles = await databaseAdapter.listProfilesForOrg(orgId);
     const profileId = profiles[0]!.id;
+    const sessionId = "sess_post_turn_notice";
 
     const staged = await skillProposalService.stageProposal({
       orgId,
       profileId,
       action: "create",
       content: sampleSkillMarkdown,
+      sessionId,
     });
     expect(staged.outcome).toBe("created");
 
@@ -114,6 +116,36 @@ describe("skill proposal routes (v1)", () => {
       }),
     );
     expect(memberListResp.status).toBe(403);
+
+    const otherStaged = await skillProposalService.stageProposal({
+      orgId,
+      profileId,
+      action: "create",
+      content: sampleSkillMarkdown.replace("deploy-notes", "rollback-notes").replace(
+        "Notes about deploy process.",
+        "Notes about rollback.",
+      ),
+      sessionId,
+    });
+    expect(otherStaged.outcome).toBe("created");
+
+    const memberSessionListResp = await app.fetch(
+      new Request(
+        `${BASE}/v1/orgs/${orgId}/skill-proposals?status=pending&sessionId=${encodeURIComponent(sessionId)}`,
+        {
+          headers: memberSession.headers({}, orgId),
+        },
+      ),
+    );
+    expect(memberSessionListResp.status).toBe(200);
+    const memberSessionBody = (await memberSessionListResp.json()) as {
+      proposals: { skillName: string; sessionId: string | null }[];
+      pendingCount: number;
+    };
+    expect(memberSessionBody.pendingCount).toBe(1);
+    expect(memberSessionBody.proposals).toHaveLength(1);
+    expect(memberSessionBody.proposals[0]?.skillName).toBe("rollback-notes");
+    expect(memberSessionBody.proposals[0]?.sessionId).toBe(sessionId);
   });
 
   test("admin can reject a pending proposal", async () => {

--- a/apps/server/src/http/routes/skill-proposals.ts
+++ b/apps/server/src/http/routes/skill-proposals.ts
@@ -7,7 +7,10 @@ import type {
 import type { HonoApp } from "../types";
 import type { ServerOptions } from "../context";
 import { json } from "../shared";
-import { requireOrgAdminFromContext } from "../org-guards";
+import {
+  requireNotViewerFromContext,
+  requireOrgAdminFromContext,
+} from "../org-guards";
 import { SkillProposalService, toSkillProposal } from "../../services/skill-proposal-service";
 
 export function registerSkillProposalRoutes(app: HonoApp, options: ServerOptions): void {
@@ -52,6 +55,7 @@ export function registerSkillProposalRoutes(app: HonoApp, options: ServerOptions
         query: z.object({
           status: z.enum(["pending", "approved", "rejected"]).optional(),
           profileId: z.string().optional(),
+          sessionId: z.string().optional(),
         }),
       },
       responses: {
@@ -67,14 +71,20 @@ export function registerSkillProposalRoutes(app: HonoApp, options: ServerOptions
   );
 
   app.get("/v1/orgs/:orgId/skill-proposals", async (c) => {
-    const auth = requireOrgAdminFromContext(c);
+    const auth = requireNotViewerFromContext(c);
     const orgId = resolveOrgId(c, auth.activeOrgId ?? "");
     const service = requireService();
     const status = c.req.query("status") as "pending" | "approved" | "rejected" | undefined;
     const profileId = c.req.query("profileId");
+    const sessionId = c.req.query("sessionId");
+    const isOrgAdmin = auth.orgRole === "admin" || auth.isPlatformAdmin;
+    if (!isOrgAdmin && !sessionId) {
+      throw new NakamaApiError("Forbidden", 403);
+    }
     const result = await service.listProposals(orgId, {
       status,
       profileId: profileId || undefined,
+      sessionId: sessionId || undefined,
     });
     return json<ListSkillProposalsResponse>({
       proposals: result.proposals.map(toSkillProposal),

--- a/apps/server/src/http/routes/skill-suggestions.test.ts
+++ b/apps/server/src/http/routes/skill-suggestions.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "bun:test";
+import { createHonoApp } from "../app";
+import { AuthService } from "../../services/auth-service";
+import { OrgService } from "../../services/org-service";
+import { SkillProposalService } from "../../services/skill-proposal-service";
+import { SkillSuggestionService } from "../../services/skill-suggestion-service";
+import { SkillsService } from "../../services/skills-service";
+import { createInMemoryDatabaseAdapter } from "@nakama/db";
+import { setupFreshInstallSession, loginUserSession } from "../test-session-helpers";
+import { setupTestConfigDir } from "../../test-config-dir";
+
+setupTestConfigDir("nakama-skill-suggestions-routes-test-");
+
+const sampleSkillMarkdown = `---
+name: deploy-notes
+description: Notes about deploy process.
+---
+
+Run the deploy checklist before shipping.
+`;
+
+function createApp() {
+  const databaseAdapter = createInMemoryDatabaseAdapter();
+  const authService = new AuthService();
+  const skillsService = new SkillsService(databaseAdapter);
+  const skillProposalService = new SkillProposalService(databaseAdapter, skillsService);
+  const skillSuggestionService = new SkillSuggestionService(
+    databaseAdapter,
+    skillsService,
+    skillProposalService,
+  );
+  return {
+    databaseAdapter,
+    authService,
+    skillsService,
+    skillProposalService,
+    skillSuggestionService,
+    app: createHonoApp({
+      agent: {
+        listProfiles: async () => ({ profiles: [{ id: "default" }] }),
+      } as any,
+      automationService: {} as any,
+      taskService: {} as any,
+      systemStatus: { getStatus: async () => ({ ok: true }) } as any,
+      workerManager: {} as any,
+      mcpService: {} as any,
+      authService,
+      orgService: new OrgService(databaseAdapter, authService),
+      skillProposalService,
+      skillSuggestionService,
+      databaseAdapter,
+      webDistDir: null,
+    }),
+  };
+}
+
+const BASE = "http://localhost:4310";
+
+describe("skill suggestion routes (v1)", () => {
+  test("admin can list and apply suggestions; member can too; viewer is forbidden", async () => {
+    const { app, databaseAdapter, skillSuggestionService } = createApp();
+    const adminSession = await setupFreshInstallSession(app, databaseAdapter, "admin@org.com");
+    const orgId = adminSession.orgId!;
+    const profiles = await databaseAdapter.listProfilesForOrg(orgId);
+    const profileId = profiles[0]!.id;
+
+    const created = await skillSuggestionService.createSuggestion({
+      orgId,
+      profileId,
+      outcome: { action: "create", name: "deploy-notes", content: sampleSkillMarkdown },
+    });
+
+    const listResp = await app.fetch(
+      new Request(`${BASE}/v1/orgs/${orgId}/skill-suggestions?status=pending`, {
+        headers: adminSession.headers({}, orgId),
+      }),
+    );
+    expect(listResp.status).toBe(200);
+    const listBody = (await listResp.json()) as {
+      suggestions: { id: string; skillName: string }[];
+    };
+    expect(listBody.suggestions).toHaveLength(1);
+    expect(listBody.suggestions[0]?.skillName).toBe("deploy-notes");
+
+    const applyResp = await app.fetch(
+      new Request(`${BASE}/v1/orgs/${orgId}/skill-suggestions/${created.id}/apply`, {
+        method: "POST",
+        headers: adminSession.headers({ "X-CSRF-Token": adminSession.csrfToken }, orgId),
+      }),
+    );
+    expect(applyResp.status).toBe(200);
+    const applyBody = (await applyResp.json()) as {
+      outcome: string;
+      suggestion: { status: string };
+    };
+    expect(applyBody.outcome).toBe("applied");
+    expect(applyBody.suggestion.status).toBe("applied");
+
+    const memberResp = await app.fetch(
+      new Request(`${BASE}/v1/orgs/${orgId}/members`, {
+        method: "POST",
+        headers: adminSession.headers({ "X-CSRF-Token": adminSession.csrfToken }, orgId),
+        body: JSON.stringify({
+          email: "viewer@org.com",
+          name: "Viewer",
+          role: "viewer",
+        }),
+      }),
+    );
+    const viewerProvisioned = (await memberResp.json()) as { temporaryPassword: string };
+    const viewerSession = await loginUserSession(
+      app,
+      "viewer@org.com",
+      viewerProvisioned.temporaryPassword,
+      orgId,
+    );
+    const viewerListResp = await app.fetch(
+      new Request(`${BASE}/v1/orgs/${orgId}/skill-suggestions`, {
+        headers: viewerSession.headers({}, orgId),
+      }),
+    );
+    expect(viewerListResp.status).toBe(403);
+  });
+
+  test("apply suggestion from wrong org returns 404", async () => {
+    const { app, databaseAdapter, skillSuggestionService } = createApp();
+    const adminSession = await setupFreshInstallSession(app, databaseAdapter, "admin3@org.com");
+    const orgId = adminSession.orgId!;
+    const profileId = (await databaseAdapter.listProfilesForOrg(orgId))[0]!.id;
+
+    const created = await skillSuggestionService.createSuggestion({
+      orgId,
+      profileId,
+      outcome: { action: "create", name: "deploy-notes", content: sampleSkillMarkdown },
+    });
+
+    const otherOrgResp = await app.fetch(
+      new Request(`${BASE}/v1/orgs/org_other/skill-suggestions/${created.id}/apply`, {
+        method: "POST",
+        headers: adminSession.headers({ "X-CSRF-Token": adminSession.csrfToken }, orgId),
+      }),
+    );
+    expect(otherOrgResp.status).toBe(404);
+  });
+
+  test("gate flip on apply stages a proposal instead of writing", async () => {
+    const { app, databaseAdapter, skillSuggestionService, skillProposalService } = createApp();
+    const adminSession = await setupFreshInstallSession(app, databaseAdapter, "admin4@org.com");
+    const orgId = adminSession.orgId!;
+    const profileId = (await databaseAdapter.listProfilesForOrg(orgId))[0]!.id;
+
+    const created = await skillSuggestionService.createSuggestion({
+      orgId,
+      profileId,
+      outcome: { action: "create", name: "deploy-notes", content: sampleSkillMarkdown },
+    });
+
+    const org = await databaseAdapter.getOrganizationById(orgId);
+    await databaseAdapter.upsertOrganization({ ...org!, skillsWriteApproval: true });
+
+    const applyResp = await app.fetch(
+      new Request(`${BASE}/v1/orgs/${orgId}/skill-suggestions/${created.id}/apply`, {
+        method: "POST",
+        headers: adminSession.headers({ "X-CSRF-Token": adminSession.csrfToken }, orgId),
+      }),
+    );
+    expect(applyResp.status).toBe(200);
+    const applyBody = (await applyResp.json()) as { outcome: string; proposalId?: string };
+    expect(applyBody.outcome).toBe("staged_as_proposal");
+    expect(applyBody.proposalId).toBeTruthy();
+
+    const { proposals } = await skillProposalService.listProposals(orgId, { profileId });
+    expect(proposals.some((proposal) => proposal.id === applyBody.proposalId)).toBe(true);
+  });
+});

--- a/apps/server/src/http/routes/skill-suggestions.ts
+++ b/apps/server/src/http/routes/skill-suggestions.ts
@@ -1,0 +1,124 @@
+import { createRoute, z } from "@hono/zod-openapi";
+import { NakamaApiError } from "@nakama/core";
+import type {
+  ApplySkillSuggestionResponse,
+  ListSkillSuggestionsResponse,
+} from "@nakama/core/contract";
+import type { HonoApp } from "../types";
+import type { ServerOptions } from "../context";
+import { json } from "../shared";
+import { requireNotViewerFromContext } from "../org-guards";
+import { SkillSuggestionService, toSkillSuggestion } from "../../services/skill-suggestion-service";
+
+export function registerSkillSuggestionRoutes(app: HonoApp, options: ServerOptions): void {
+  const skillSuggestionService = options.skillSuggestionService;
+  const errorSchema = z.object({ error: z.string() }).openapi("ApiErrorResponse");
+  const orgIdParam = z.object({
+    orgId: z.string().openapi({ param: { name: "orgId", in: "path" } }),
+  });
+  const listSkillSuggestionsResponseSchema = z
+    .object({})
+    .passthrough()
+    .openapi("ListSkillSuggestionsResponse");
+  const applySkillSuggestionResponseSchema = z
+    .object({})
+    .passthrough()
+    .openapi("ApplySkillSuggestionResponse");
+
+  function resolveOrgId(c: { req: { param: (n: string) => string } }, authOrgId: string): string {
+    const orgId = decodeURIComponent(c.req.param("orgId"));
+    if (authOrgId !== orgId) {
+      throw new NakamaApiError("Not found", 404);
+    }
+    return orgId;
+  }
+
+  function requireService(): SkillSuggestionService {
+    if (!skillSuggestionService) {
+      throw new NakamaApiError("Skill suggestion service not configured", 500);
+    }
+    return skillSuggestionService;
+  }
+
+  app.openAPIRegistry.registerPath(
+    createRoute({
+      method: "get",
+      path: "/v1/orgs/{orgId}/skill-suggestions",
+      tags: ["Organizations"],
+      summary: "List post-turn skill suggestions",
+      operationId: "listSkillSuggestions",
+      request: {
+        params: orgIdParam,
+        query: z.object({
+          sessionId: z.string().optional(),
+          status: z.enum(["pending", "applied"]).optional(),
+          profileId: z.string().optional(),
+        }),
+      },
+      responses: {
+        200: {
+          description: "Skill suggestions",
+          content: { "application/json": { schema: listSkillSuggestionsResponseSchema } },
+        },
+        403: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        404: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        500: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+      },
+    }),
+  );
+
+  app.get("/v1/orgs/:orgId/skill-suggestions", async (c) => {
+    const auth = requireNotViewerFromContext(c);
+    const orgId = resolveOrgId(c, auth.activeOrgId ?? "");
+    const service = requireService();
+    const sessionId = c.req.query("sessionId");
+    const status = c.req.query("status") as "pending" | "applied" | undefined;
+    const profileId = c.req.query("profileId");
+    const suggestions = await service.listSuggestions(orgId, {
+      sessionId: sessionId || undefined,
+      status,
+      profileId: profileId || undefined,
+    });
+    return json<ListSkillSuggestionsResponse>({
+      suggestions: suggestions.map(toSkillSuggestion),
+    });
+  });
+
+  app.openAPIRegistry.registerPath(
+    createRoute({
+      method: "post",
+      path: "/v1/orgs/{orgId}/skill-suggestions/{suggestionId}/apply",
+      tags: ["Organizations"],
+      summary: "Apply a pending skill suggestion",
+      operationId: "applySkillSuggestion",
+      request: {
+        params: orgIdParam.extend({
+          suggestionId: z.string().openapi({ param: { name: "suggestionId", in: "path" } }),
+        }),
+      },
+      responses: {
+        200: {
+          description: "Applied",
+          content: { "application/json": { schema: applySkillSuggestionResponseSchema } },
+        },
+        400: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        403: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        404: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+        500: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+      },
+    }),
+  );
+
+  app.post("/v1/orgs/:orgId/skill-suggestions/:suggestionId/apply", async (c) => {
+    const auth = requireNotViewerFromContext(c);
+    const orgId = resolveOrgId(c, auth.activeOrgId ?? "");
+    const suggestionId = decodeURIComponent(c.req.param("suggestionId"));
+    const service = requireService();
+    const result = await service.applySuggestion(orgId, suggestionId, auth.user.id);
+    return json<ApplySkillSuggestionResponse>({
+      outcome: result.outcome,
+      suggestion: toSkillSuggestion(result.suggestion),
+      proposalId: result.proposalId,
+    });
+  });
+}

--- a/apps/server/src/http/shared.ts
+++ b/apps/server/src/http/shared.ts
@@ -533,7 +533,7 @@ export function streamMessage(
   sessionId: string,
   session: AgentChatSession,
   input: SendMessageInput,
-  onComplete?: () => void,
+  onComplete?: (terminal: StreamEvent) => void,
 ): Response {
   const encoder = new TextEncoder();
   const keepaliveIntervalMs = 4_000;
@@ -582,7 +582,7 @@ export function streamMessage(
 
         sessionTurnRegistry.endTurn(sessionId, terminal);
         controller.close();
-        onComplete?.();
+        onComplete?.(terminal);
       }
     },
   });

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -27,6 +27,7 @@ import { AuthService } from "./services/auth-service";
 import { OrgService } from "./services/org-service";
 import { OrgMemoryService } from "./services/org-memory-service";
 import { SkillProposalService } from "./services/skill-proposal-service";
+import { SkillSuggestionService } from "./services/skill-suggestion-service";
 import {
   mergeOrgMemoryWithApprovedBullet,
 } from "@nakama/agent";
@@ -132,6 +133,12 @@ const orgMemoryService = new OrgMemoryService(database.adapter, {
 });
 const skillProposalService = new SkillProposalService(database.adapter, skillsService);
 agent.setSkillProposalService(skillProposalService);
+const skillSuggestionService = new SkillSuggestionService(
+  database.adapter,
+  skillsService,
+  skillProposalService,
+);
+agent.setSkillSuggestionService(skillSuggestionService);
 
 const systemStatus = new SystemStatusService(
   agent,
@@ -156,6 +163,7 @@ const app = createHonoApp({
   orgService,
   orgMemoryService,
   skillProposalService,
+  skillSuggestionService,
   databaseAdapter: database.adapter,
   webDistDir,
 });

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -245,6 +245,7 @@ import { OrgMemoryService } from "./org-memory-service";
 import { ProfileService } from "./profile-service";
 import type { SkillsService } from "./skills-service";
 import type { SkillProposalService } from "./skill-proposal-service";
+import type { SkillSuggestionService } from "./skill-suggestion-service";
 import { SessionTitleService } from "./session-title-service";
 import { SkillPostTurnReviewService } from "./skill-post-turn-review-service";
 import { SuperBotSessionState } from "./super-bot-session-state";
@@ -308,6 +309,7 @@ export class AgentService {
   private composioService: ComposioService | null = null;
   private skillsService: SkillsService | null = null;
   private skillProposalService: SkillProposalService | null = null;
+  private skillSuggestionService: SkillSuggestionService | null = null;
   private orgMemoryService: OrgMemoryService | null = null;
   private readonly sessions = new Map<string, StoredSession>();
   private readonly sessionTitleService: SessionTitleService;
@@ -402,6 +404,65 @@ export class AgentService {
 
   setSkillProposalService(service: SkillProposalService): void {
     this.skillProposalService = service;
+    this.wireSkillPostTurnReviewOutcomeHandling();
+  }
+
+  setSkillSuggestionService(service: SkillSuggestionService): void {
+    this.skillSuggestionService = service;
+    this.wireSkillPostTurnReviewOutcomeHandling();
+  }
+
+  /**
+   * U4: once both services are injected, review outcomes from the LLM runner
+   * are turned into a staged proposal (write-approval gate on) or a pending
+   * suggestion (gate off) instead of being discarded.
+   */
+  private wireSkillPostTurnReviewOutcomeHandling(): void {
+    const proposals = this.skillProposalService;
+    const suggestions = this.skillSuggestionService;
+    if (!proposals || !suggestions) {
+      return;
+    }
+
+    this.skillPostTurnReviewService.setRunner(async (context) => {
+      const outcome = await this.skillPostTurnReviewService.reviewTurnWithLlm(context);
+      if (outcome.action === "noop") {
+        return outcome;
+      }
+
+      try {
+        const writeApprovalRequired = await proposals.isWriteApprovalRequired(
+          context.orgId,
+          context.profileId,
+        );
+
+        if (writeApprovalRequired) {
+          await proposals.stageProposal({
+            orgId: context.orgId,
+            profileId: context.profileId,
+            action: outcome.action,
+            skillName: outcome.name,
+            content: outcome.action === "create" ? outcome.content : undefined,
+            oldString: outcome.action === "patch" ? outcome.oldString : undefined,
+            newString: outcome.action === "patch" ? outcome.newString : undefined,
+            sessionId: context.sessionId,
+            proposedByUserId: context.userId,
+          });
+        } else {
+          await suggestions.createSuggestion({
+            orgId: context.orgId,
+            profileId: context.profileId,
+            sessionId: context.sessionId,
+            proposedByUserId: context.userId,
+            outcome,
+          });
+        }
+      } catch (error) {
+        console.error("Failed to record post-turn skill review outcome:", error);
+      }
+
+      return outcome;
+    });
   }
 
   getMcpService(): McpService {

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -246,6 +246,7 @@ import { ProfileService } from "./profile-service";
 import type { SkillsService } from "./skills-service";
 import type { SkillProposalService } from "./skill-proposal-service";
 import { SessionTitleService } from "./session-title-service";
+import { SkillPostTurnReviewService } from "./skill-post-turn-review-service";
 import { SuperBotSessionState } from "./super-bot-session-state";
 import { resolveProfileStoredTools } from "./tool-resolver";
 import {
@@ -310,6 +311,7 @@ export class AgentService {
   private orgMemoryService: OrgMemoryService | null = null;
   private readonly sessions = new Map<string, StoredSession>();
   private readonly sessionTitleService: SessionTitleService;
+  private skillPostTurnReviewService: SkillPostTurnReviewService;
   private _providerConfigured: boolean;
   private visionSettingsPromise: Promise<void> | null = null;
   private transcriptionSettingsPromise: Promise<void> | null = null;
@@ -324,6 +326,7 @@ export class AgentService {
     this.db = db;
     this.profileService = new ProfileService(db);
     this.sessionTitleService = new SessionTitleService(db, () => this.userConfig);
+    this.skillPostTurnReviewService = new SkillPostTurnReviewService(db, () => this.userConfig);
     this.agentTodoState = new AgentTodoState(db);
     this.agentQuestionnaireState = new AgentQuestionnaireState(db);
     this.questionTools = createAskUserQuestionTools(this.agentQuestionnaireState);
@@ -1463,6 +1466,14 @@ export class AgentService {
 
   scheduleSessionTitleGeneration(sessionId: string): void {
     this.sessionTitleService.scheduleSessionTitleGeneration(sessionId);
+  }
+
+  schedulePostTurnSkillReview(sessionId: string): void {
+    this.skillPostTurnReviewService.schedulePostTurnSkillReview(sessionId);
+  }
+
+  getSkillPostTurnReviewService(): SkillPostTurnReviewService {
+    return this.skillPostTurnReviewService;
   }
 
   async purgeSession(sessionId: string): Promise<boolean> {

--- a/apps/server/src/services/org-service.ts
+++ b/apps/server/src/services/org-service.ts
@@ -72,6 +72,10 @@ export class OrgService {
         request.skillsWriteApproval !== undefined
           ? request.skillsWriteApproval
           : org.skillsWriteApproval ?? false,
+      skillsPostTurnReview:
+        request.skillsPostTurnReview !== undefined
+          ? request.skillsPostTurnReview
+          : org.skillsPostTurnReview ?? false,
       updatedAt: now,
     };
 
@@ -747,6 +751,7 @@ function toOrganizationSummary(record: StoredOrganizationRecord): OrganizationSu
     name: record.name,
     slug: record.slug,
     skillsWriteApproval: record.skillsWriteApproval ?? false,
+    skillsPostTurnReview: record.skillsPostTurnReview ?? false,
     createdAt: record.createdAt,
     updatedAt: record.updatedAt,
   };

--- a/apps/server/src/services/profile-service.ts
+++ b/apps/server/src/services/profile-service.ts
@@ -155,6 +155,10 @@ export class ProfileService {
         request.skillsWriteApproval === undefined
           ? profile.skillsWriteApproval
           : request.skillsWriteApproval,
+      skillsPostTurnReview:
+        request.skillsPostTurnReview === undefined
+          ? profile.skillsPostTurnReview
+          : request.skillsPostTurnReview,
       updatedAt: now,
     });
 
@@ -534,6 +538,7 @@ export class ProfileService {
       isSuper: profile.isSuper,
       isDefault: profile.isDefault ?? false,
       skillsWriteApproval: profile.skillsWriteApproval ?? null,
+      skillsPostTurnReview: profile.skillsPostTurnReview ?? null,
       toolCount: tools.length,
       mcpServerCount: mcpServers.length,
       soulActive: soulStack !== null,

--- a/apps/server/src/services/skill-post-turn-review-service.test.ts
+++ b/apps/server/src/services/skill-post-turn-review-service.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, test } from "bun:test";
+import type { ChatMessage } from "@nakama/core";
+import { createInMemoryDatabaseAdapter } from "@nakama/db";
+import {
+  evaluatePostTurnReviewTurnEligibility,
+  SkillPostTurnReviewService,
+} from "./skill-post-turn-review-service";
+
+function toolCall(id: string, name = "read_file") {
+  return { id, name, arguments: "{}" };
+}
+
+function assistantWithTools(count: number, names?: string[]): ChatMessage {
+  const toolCalls = Array.from({ length: count }, (_, index) =>
+    toolCall(`call_${index}`, names?.[index] ?? "read_file"),
+  );
+  return { role: "assistant", content: "working", toolCalls };
+}
+
+describe("evaluatePostTurnReviewTurnEligibility", () => {
+  test("eligible when turn has 5+ tool calls", () => {
+    const result = evaluatePostTurnReviewTurnEligibility([
+      { role: "user", content: "do the thing" },
+      assistantWithTools(5),
+    ]);
+    expect(result.eligible).toBe(true);
+    expect(result.toolCallCount).toBe(5);
+  });
+
+  test("skips when fewer than 5 tools and no errors", () => {
+    const result = evaluatePostTurnReviewTurnEligibility([
+      { role: "user", content: "simple" },
+      assistantWithTools(4),
+    ]);
+    expect(result.eligible).toBe(false);
+    expect(result.reason).toBe("turn_not_complex");
+  });
+
+  test("eligible when tool error present even with fewer than 5 tools", () => {
+    const result = evaluatePostTurnReviewTurnEligibility([
+      { role: "user", content: "fix it" },
+      assistantWithTools(1),
+      {
+        role: "tool",
+        toolCallId: "call_0",
+        name: "read_file",
+        content: JSON.stringify({ error: "not found" }),
+      },
+    ]);
+    expect(result.eligible).toBe(true);
+    expect(result.hasToolError).toBe(true);
+  });
+
+  test("skips when skill_manage already used this turn", () => {
+    const result = evaluatePostTurnReviewTurnEligibility([
+      { role: "user", content: "save skill" },
+      assistantWithTools(5, [
+        "read_file",
+        "read_file",
+        "read_file",
+        "read_file",
+        "skill_manage",
+      ]),
+    ]);
+    expect(result.eligible).toBe(false);
+    expect(result.reason).toBe("skill_manage_already_used");
+  });
+});
+
+describe("SkillPostTurnReviewService", () => {
+  test("runs runner once for eligible web turn when flag on and manage-skills assigned", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const now = new Date().toISOString();
+    await db.upsertOrganization({
+      id: "org_1",
+      name: "Org",
+      slug: "org",
+      skillsPostTurnReview: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.upsertProfile({
+      id: "profile_1",
+      name: "Bot",
+      systemPrompt: "",
+      model: null,
+      isSuper: false,
+      orgId: "org_1",
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.upsertSkill({
+      id: "skill_manage_skills",
+      name: "manage-skills",
+      description: "Manage skills",
+      sourcePath: "/tmp/manage-skills/SKILL.md",
+      hasTool: false,
+      disableModelInvocation: false,
+      enabled: true,
+      createdBy: "bundled",
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.assignSkillToProfile("profile_1", "skill_manage_skills");
+    await db.upsertSession({
+      id: "session_1",
+      profileId: "profile_1",
+      channel: "web",
+      orgId: "org_1",
+      userId: "user_1",
+      createdAt: now,
+      title: null,
+      agentTodos: [],
+      agentQuestionnaire: null,
+    });
+
+    const turn: ChatMessage[] = [
+      { role: "user", content: "complex" },
+      assistantWithTools(5),
+      ...Array.from({ length: 5 }, (_, index) => ({
+        role: "tool" as const,
+        toolCallId: `call_${index}`,
+        name: "read_file",
+        content: "{}",
+      })),
+    ];
+    await db.appendMessagesForSession(
+      "session_1",
+      turn.map((message, index) => ({
+        id: `msg_${index}`,
+        sessionId: "session_1",
+        seq: index,
+        payload: message,
+        createdAt: now,
+      })),
+    );
+
+    let ran = 0;
+    const service = new SkillPostTurnReviewService(db, () => null, async () => {
+      ran += 1;
+    });
+
+    expect(await service.runPostTurnSkillReview("session_1")).toBe("ran");
+    expect(ran).toBe(1);
+  });
+
+  test("skips when flag disabled", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const now = new Date().toISOString();
+    await db.upsertOrganization({
+      id: "org_1",
+      name: "Org",
+      slug: "org",
+      skillsPostTurnReview: false,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.upsertProfile({
+      id: "profile_1",
+      name: "Bot",
+      systemPrompt: "",
+      model: null,
+      isSuper: false,
+      orgId: "org_1",
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.upsertSession({
+      id: "session_1",
+      profileId: "profile_1",
+      channel: "web",
+      orgId: "org_1",
+      userId: "user_1",
+      createdAt: now,
+      title: null,
+      agentTodos: [],
+      agentQuestionnaire: null,
+    });
+
+    let ran = 0;
+    const service = new SkillPostTurnReviewService(db, () => null, async () => {
+      ran += 1;
+    });
+    expect(await service.runPostTurnSkillReview("session_1")).toBe("flag_disabled");
+    expect(ran).toBe(0);
+  });
+
+  test("skips duplicate while in flight", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const now = new Date().toISOString();
+    await db.upsertOrganization({
+      id: "org_1",
+      name: "Org",
+      slug: "org",
+      skillsPostTurnReview: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.upsertProfile({
+      id: "profile_1",
+      name: "Bot",
+      systemPrompt: "",
+      model: null,
+      isSuper: false,
+      orgId: "org_1",
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.upsertSkill({
+      id: "skill_manage_skills",
+      name: "manage-skills",
+      description: "Manage skills",
+      sourcePath: "/tmp/manage-skills/SKILL.md",
+      hasTool: false,
+      disableModelInvocation: false,
+      enabled: true,
+      createdBy: "bundled",
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.assignSkillToProfile("profile_1", "skill_manage_skills");
+    await db.upsertSession({
+      id: "session_1",
+      profileId: "profile_1",
+      channel: "cli",
+      orgId: "org_1",
+      userId: "user_1",
+      createdAt: now,
+      title: null,
+      agentTodos: [],
+      agentQuestionnaire: null,
+    });
+    await db.appendMessagesForSession("session_1", [
+      {
+        id: "msg_0",
+        sessionId: "session_1",
+        seq: 0,
+        payload: { role: "user", content: "go" },
+        createdAt: now,
+      },
+      {
+        id: "msg_1",
+        sessionId: "session_1",
+        seq: 1,
+        payload: assistantWithTools(5),
+        createdAt: now,
+      },
+    ]);
+
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let ran = 0;
+    const service = new SkillPostTurnReviewService(db, () => null, async () => {
+      ran += 1;
+      await gate;
+    });
+
+    const first = service.runPostTurnSkillReview("session_1");
+    await Promise.resolve();
+    expect(await service.runPostTurnSkillReview("session_1")).toBe("in_flight");
+    release();
+    expect(await first).toBe("ran");
+    expect(ran).toBe(1);
+  });
+});

--- a/apps/server/src/services/skill-post-turn-review-service.ts
+++ b/apps/server/src/services/skill-post-turn-review-service.ts
@@ -4,6 +4,10 @@ import {
   type ChatMessage,
   type UserConfig,
 } from "@nakama/core";
+import {
+  generateSkillPostTurnReview,
+  type SkillPostTurnReviewOutcome,
+} from "@nakama/agent";
 import type { DatabaseAdapter } from "@nakama/db";
 import { createProviderForInstance } from "../providers/create";
 import { resolveProfileProviderSelection } from "./provider-instance-helpers";
@@ -43,7 +47,7 @@ export interface PostTurnReviewRunnerContext {
 
 export type PostTurnReviewRunner = (
   context: PostTurnReviewRunnerContext,
-) => Promise<void>;
+) => Promise<SkillPostTurnReviewOutcome | void>;
 
 export function countToolCallsInTurn(turnMessages: ChatMessage[]): number {
   let count = 0;
@@ -136,10 +140,10 @@ export class SkillPostTurnReviewService {
     private readonly getUserConfig: () => UserConfig | null,
     runner?: PostTurnReviewRunner,
   ) {
-    this.runner = runner ?? (async () => {});
+    this.runner = runner ?? ((context) => this.reviewTurnWithLlm(context));
   }
 
-  /** Test/injection hook — U3 replaces the default no-op with the LLM reviewer. */
+  /** Test/injection hook — U4 wraps this to stage/suggest after the LLM outcome. */
   setRunner(runner: PostTurnReviewRunner): void {
     this.runner = runner;
   }
@@ -147,6 +151,27 @@ export class SkillPostTurnReviewService {
   schedulePostTurnSkillReview(sessionId: string): void {
     void this.runPostTurnSkillReview(sessionId).catch((error) => {
       console.error(`Failed post-turn skill review for ${sessionId}:`, error);
+    });
+  }
+
+  async reviewTurnWithLlm(
+    context: PostTurnReviewRunnerContext,
+  ): Promise<SkillPostTurnReviewOutcome> {
+    const provider = await this.resolveProviderForProfile(context.profileId);
+    if (!provider) {
+      return { action: "noop", reason: "provider_unavailable" };
+    }
+
+    const assigned = await this.db.listSkillsForProfile(context.profileId);
+    const catalog = assigned.map((skill) => ({
+      name: skill.name,
+      description: skill.description,
+    }));
+
+    return generateSkillPostTurnReview({
+      turnMessages: context.turnMessages,
+      catalog,
+      provider,
     });
   }
 

--- a/apps/server/src/services/skill-post-turn-review-service.ts
+++ b/apps/server/src/services/skill-post-turn-review-service.ts
@@ -1,0 +1,242 @@
+import {
+  extractLatestTurnMessages,
+  resolveSkillPostTurnReviewEnabled,
+  type ChatMessage,
+  type UserConfig,
+} from "@nakama/core";
+import type { DatabaseAdapter } from "@nakama/db";
+import { createProviderForInstance } from "../providers/create";
+import { resolveProfileProviderSelection } from "./provider-instance-helpers";
+
+const MIN_TOOL_CALLS_FOR_COMPLEX_TURN = 5;
+const MANAGE_SKILLS_NAME = "manage-skills";
+const SKILL_MANAGE_TOOL_NAME = "skill_manage";
+
+export type PostTurnReviewSkipReason =
+  | "in_flight"
+  | "session_missing"
+  | "profile_missing"
+  | "org_missing"
+  | "channel_not_interactive"
+  | "flag_disabled"
+  | "manage_skills_unassigned"
+  | "turn_not_complex"
+  | "skill_manage_already_used"
+  | "noop";
+
+export interface PostTurnReviewEligibility {
+  eligible: boolean;
+  reason?: PostTurnReviewSkipReason;
+  toolCallCount: number;
+  hasToolError: boolean;
+  usedSkillManage: boolean;
+}
+
+export interface PostTurnReviewRunnerContext {
+  sessionId: string;
+  orgId: string;
+  profileId: string;
+  userId: string | null;
+  messages: ChatMessage[];
+  turnMessages: ChatMessage[];
+}
+
+export type PostTurnReviewRunner = (
+  context: PostTurnReviewRunnerContext,
+) => Promise<void>;
+
+export function countToolCallsInTurn(turnMessages: ChatMessage[]): number {
+  let count = 0;
+  for (const message of turnMessages) {
+    if (message.role === "assistant" && message.toolCalls) {
+      count += message.toolCalls.length;
+    }
+  }
+  return count;
+}
+
+export function turnHasToolError(turnMessages: ChatMessage[]): boolean {
+  for (const message of turnMessages) {
+    if (message.role !== "tool") {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(message.content) as unknown;
+      if (
+        typeof parsed === "object" &&
+        parsed !== null &&
+        "error" in parsed &&
+        (parsed as { error: unknown }).error != null
+      ) {
+        return true;
+      }
+    } catch {
+      // non-JSON tool content is not treated as an error signal
+    }
+  }
+  return false;
+}
+
+export function turnUsedSkillManage(turnMessages: ChatMessage[]): boolean {
+  for (const message of turnMessages) {
+    if (message.role === "assistant" && message.toolCalls) {
+      if (message.toolCalls.some((call) => call.name === SKILL_MANAGE_TOOL_NAME)) {
+        return true;
+      }
+    }
+    if (message.role === "tool" && message.name === SKILL_MANAGE_TOOL_NAME) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function evaluatePostTurnReviewTurnEligibility(
+  turnMessages: ChatMessage[],
+): PostTurnReviewEligibility {
+  const toolCallCount = countToolCallsInTurn(turnMessages);
+  const hasToolError = turnHasToolError(turnMessages);
+  const usedSkillManage = turnUsedSkillManage(turnMessages);
+
+  if (usedSkillManage) {
+    return {
+      eligible: false,
+      reason: "skill_manage_already_used",
+      toolCallCount,
+      hasToolError,
+      usedSkillManage,
+    };
+  }
+
+  const complex = toolCallCount >= MIN_TOOL_CALLS_FOR_COMPLEX_TURN || hasToolError;
+  if (!complex) {
+    return {
+      eligible: false,
+      reason: "turn_not_complex",
+      toolCallCount,
+      hasToolError,
+      usedSkillManage,
+    };
+  }
+
+  return {
+    eligible: true,
+    toolCallCount,
+    hasToolError,
+    usedSkillManage,
+  };
+}
+
+export class SkillPostTurnReviewService {
+  private readonly inFlight = new Set<string>();
+  private runner: PostTurnReviewRunner;
+
+  constructor(
+    private readonly db: DatabaseAdapter,
+    private readonly getUserConfig: () => UserConfig | null,
+    runner?: PostTurnReviewRunner,
+  ) {
+    this.runner = runner ?? (async () => {});
+  }
+
+  /** Test/injection hook — U3 replaces the default no-op with the LLM reviewer. */
+  setRunner(runner: PostTurnReviewRunner): void {
+    this.runner = runner;
+  }
+
+  schedulePostTurnSkillReview(sessionId: string): void {
+    void this.runPostTurnSkillReview(sessionId).catch((error) => {
+      console.error(`Failed post-turn skill review for ${sessionId}:`, error);
+    });
+  }
+
+  async runPostTurnSkillReview(sessionId: string): Promise<PostTurnReviewSkipReason | "ran"> {
+    if (this.inFlight.has(sessionId)) {
+      return "in_flight";
+    }
+
+    this.inFlight.add(sessionId);
+
+    try {
+      const session = await this.db.getSession(sessionId);
+      if (!session) {
+        return "session_missing";
+      }
+
+      const channel = session.channel;
+      if (channel !== "web" && channel !== "cli") {
+        return "channel_not_interactive";
+      }
+
+      const profile = await this.db.getProfile(session.profileId);
+      if (!profile?.orgId) {
+        return "profile_missing";
+      }
+
+      const org = await this.db.getOrganizationById(profile.orgId);
+      if (!org) {
+        return "org_missing";
+      }
+
+      const enabled = resolveSkillPostTurnReviewEnabled({
+        orgSkillsPostTurnReview: org.skillsPostTurnReview ?? false,
+        profileSkillsPostTurnReview: profile.skillsPostTurnReview ?? null,
+      });
+      if (!enabled) {
+        return "flag_disabled";
+      }
+
+      const assignedSkills = await this.db.listSkillsForProfile(profile.id);
+      if (!assignedSkills.some((skill) => skill.name === MANAGE_SKILLS_NAME)) {
+        return "manage_skills_unassigned";
+      }
+
+      const storedMessages = await this.db.listMessagesForSession(sessionId);
+      const messages = storedMessages.map((record) => record.payload as ChatMessage);
+      const turnMessages = extractLatestTurnMessages(messages);
+      const eligibility = evaluatePostTurnReviewTurnEligibility(turnMessages);
+      if (!eligibility.eligible) {
+        return eligibility.reason ?? "turn_not_complex";
+      }
+
+      await this.runner({
+        sessionId,
+        orgId: profile.orgId,
+        profileId: profile.id,
+        userId: session.userId ?? null,
+        messages,
+        turnMessages,
+      });
+
+      return "ran";
+    } finally {
+      this.inFlight.delete(sessionId);
+    }
+  }
+
+  async resolveProviderForProfile(profileId: string) {
+    const userConfig = this.getUserConfig();
+    if (!userConfig) {
+      return null;
+    }
+
+    const profile = await this.db.getProfile(profileId);
+    if (!profile) {
+      return null;
+    }
+
+    const selection = resolveProfileProviderSelection({
+      providers: userConfig.providers,
+      defaultProviderId: userConfig.defaultProviderId,
+      profileModel: profile.model,
+    });
+
+    if (!selection) {
+      return null;
+    }
+
+    return createProviderForInstance(selection.instance, {
+      model: selection.model,
+    });
+  }
+}

--- a/apps/server/src/services/skill-proposal-service.ts
+++ b/apps/server/src/services/skill-proposal-service.ts
@@ -85,11 +85,17 @@ export class SkillProposalService {
 
   async listProposals(
     orgId: string,
-    options: { status?: StoredSkillProposal["status"]; profileId?: string } = {},
+    options: {
+      status?: StoredSkillProposal["status"];
+      profileId?: string;
+      sessionId?: string;
+    } = {},
   ): Promise<{ proposals: StoredSkillProposal[]; pendingCount: number }> {
     const db = this.requireDatabase();
     const proposals = await db.listSkillProposals(orgId, options);
-    const pendingCount = await db.countPendingSkillProposals(orgId, options.profileId);
+    const pendingCount = options.sessionId
+      ? proposals.filter((proposal) => proposal.status === "pending").length
+      : await db.countPendingSkillProposals(orgId, options.profileId);
     return { proposals: proposals.map((proposal) => this.withWarnings(proposal)), pendingCount };
   }
 

--- a/apps/server/src/services/skill-suggestion-service.test.ts
+++ b/apps/server/src/services/skill-suggestion-service.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { NakamaApiError } from "@nakama/core";
+import {
+  createInMemoryDatabaseAdapter,
+  seedOrgDefaultProfile,
+  type DatabaseAdapter,
+} from "@nakama/db";
+import { SkillProposalService } from "./skill-proposal-service";
+import { SkillSuggestionService } from "./skill-suggestion-service";
+import { SkillsService } from "./skills-service";
+
+const ORG_ID = "org_test";
+
+const sampleSkillMarkdown = `---
+name: deploy-notes
+description: Notes about deploy process.
+---
+
+Run the deploy checklist before shipping.
+`;
+
+async function seedOrg(
+  db: DatabaseAdapter,
+  options: {
+    orgSkillsWriteApproval?: boolean;
+    profileSkillsWriteApproval?: boolean | null;
+  } = {},
+) {
+  const now = new Date().toISOString();
+  await db.upsertOrganization({
+    id: ORG_ID,
+    name: "Test Org",
+    slug: "test-org",
+    skillsWriteApproval: options.orgSkillsWriteApproval ?? false,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const profile = await seedOrgDefaultProfile(db, ORG_ID);
+  if (options.profileSkillsWriteApproval !== undefined) {
+    await db.upsertProfile({
+      ...profile,
+      skillsWriteApproval: options.profileSkillsWriteApproval,
+      updatedAt: now,
+    });
+  }
+  return profile;
+}
+
+function buildServices(db: DatabaseAdapter) {
+  const skills = new SkillsService(db);
+  const proposals = new SkillProposalService(db, skills);
+  const suggestions = new SkillSuggestionService(db, skills, proposals);
+  return { skills, proposals, suggestions };
+}
+
+describe("SkillSuggestionService", () => {
+  let configDir: string;
+
+  beforeEach(async () => {
+    configDir = await mkdtemp(join(tmpdir(), "nakama-skill-suggestions-"));
+    process.env.NAKAMA_CONFIG_DIR = configDir;
+  });
+
+  afterEach(() => {
+    delete process.env.NAKAMA_CONFIG_DIR;
+  });
+
+  test("createSuggestion inserts a pending row without writing to disk", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const profile = await seedOrg(db);
+    const { skills, suggestions } = buildServices(db);
+
+    const created = await suggestions.createSuggestion({
+      orgId: ORG_ID,
+      profileId: profile.id,
+      sessionId: "session_1",
+      proposedByUserId: "user_1",
+      outcome: { action: "create", name: "deploy-notes", content: sampleSkillMarkdown },
+    });
+
+    expect(created.status).toBe("pending");
+    expect(created.skillName).toBe("deploy-notes");
+    expect(created.source).toBe("post_turn_review");
+
+    const listed = await skills.listSkills();
+    expect(listed.skills.some((skill) => skill.name === "deploy-notes")).toBe(false);
+
+    const rows = await suggestions.listSuggestions(ORG_ID);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe(created.id);
+  });
+
+  test("apply with write approval off writes the skill directly via SkillsService", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const profile = await seedOrg(db, { orgSkillsWriteApproval: false });
+    const { skills, suggestions } = buildServices(db);
+
+    const created = await suggestions.createSuggestion({
+      orgId: ORG_ID,
+      profileId: profile.id,
+      outcome: { action: "create", name: "deploy-notes", content: sampleSkillMarkdown },
+    });
+
+    const result = await suggestions.applySuggestion(ORG_ID, created.id, "admin_user");
+    expect(result.outcome).toBe("applied");
+    expect(result.suggestion.status).toBe("applied");
+    expect(result.suggestion.appliedAt).toBeTruthy();
+
+    const listed = await skills.listSkills();
+    expect(listed.skills.some((skill) => skill.name === "deploy-notes")).toBe(true);
+  });
+
+  test("apply is idempotent when suggestion is already applied", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const profile = await seedOrg(db, { orgSkillsWriteApproval: false });
+    const { suggestions } = buildServices(db);
+
+    const created = await suggestions.createSuggestion({
+      orgId: ORG_ID,
+      profileId: profile.id,
+      outcome: { action: "create", name: "deploy-notes", content: sampleSkillMarkdown },
+    });
+
+    const first = await suggestions.applySuggestion(ORG_ID, created.id, "admin_user");
+    expect(first.outcome).toBe("applied");
+
+    const second = await suggestions.applySuggestion(ORG_ID, created.id, "admin_user");
+    expect(second.outcome).toBe("already_applied");
+  });
+
+  test("gate-flip on apply: suggested under gate-off, gate flips on, apply stages a proposal instead of writing", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const profile = await seedOrg(db, { orgSkillsWriteApproval: false });
+    const { skills, proposals, suggestions } = buildServices(db);
+
+    const created = await suggestions.createSuggestion({
+      orgId: ORG_ID,
+      profileId: profile.id,
+      sessionId: "session_1",
+      outcome: { action: "create", name: "deploy-notes", content: sampleSkillMarkdown },
+    });
+
+    // Gate flips on after the suggestion was created but before it's applied.
+    const org = await db.getOrganizationById(ORG_ID);
+    await db.upsertOrganization({ ...org!, skillsWriteApproval: true });
+
+    const result = await suggestions.applySuggestion(ORG_ID, created.id, "admin_user");
+    expect(result.outcome).toBe("staged_as_proposal");
+    expect(result.proposalId).toBeTruthy();
+    expect(result.suggestion.status).toBe("applied");
+
+    const listed = await skills.listSkills();
+    expect(listed.skills.some((skill) => skill.name === "deploy-notes")).toBe(false);
+
+    const { proposals: pending } = await proposals.listProposals(ORG_ID, { profileId: profile.id });
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.id).toBe(result.proposalId!);
+    expect(pending[0]?.status).toBe("pending");
+  });
+
+  test("apply refuses bundled skill names", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const profile = await seedOrg(db);
+    const { suggestions } = buildServices(db);
+
+    // Directly persist a suggestion targeting a bundled skill (bypassing the
+    // createSuggestion guard) to exercise the apply-time guard too.
+    await db.createSkillSuggestion({
+      id: "sksug_bundled",
+      orgId: ORG_ID,
+      profileId: profile.id,
+      sessionId: null,
+      proposedByUserId: null,
+      action: "patch",
+      skillName: "manage-skills",
+      content: null,
+      patchOldString: "old",
+      patchNewString: "new",
+      status: "pending",
+      source: "post_turn_review",
+      warnings: null,
+      createdAt: new Date().toISOString(),
+      appliedAt: null,
+    });
+
+    await expect(
+      suggestions.applySuggestion(ORG_ID, "sksug_bundled", "admin_user"),
+    ).rejects.toThrow(/bundled/i);
+  });
+
+  test("createSuggestion refuses bundled skill names", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const profile = await seedOrg(db);
+    const { suggestions } = buildServices(db);
+
+    await expect(
+      suggestions.createSuggestion({
+        orgId: ORG_ID,
+        profileId: profile.id,
+        outcome: { action: "patch", name: "manage-skills", oldString: "a", newString: "b" },
+      }),
+    ).rejects.toThrow(/bundled/i);
+  });
+
+  test("cross-org suggestion id returns 404 on apply", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const profile = await seedOrg(db);
+    const { suggestions } = buildServices(db);
+
+    const created = await suggestions.createSuggestion({
+      orgId: ORG_ID,
+      profileId: profile.id,
+      outcome: { action: "create", name: "deploy-notes", content: sampleSkillMarkdown },
+    });
+
+    await expect(
+      suggestions.applySuggestion("org_other", created.id, "admin_user"),
+    ).rejects.toBeInstanceOf(NakamaApiError);
+    await expect(
+      suggestions.applySuggestion("org_other", created.id, "admin_user"),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});

--- a/apps/server/src/services/skill-suggestion-service.ts
+++ b/apps/server/src/services/skill-suggestion-service.ts
@@ -1,0 +1,247 @@
+import {
+  NakamaApiError,
+  detectOrgMemoryInjectionWarnings,
+  isGlobalSkillSourcePath,
+  isPathWithinProfileSkillsDir,
+  parseRawProfileSkillContent,
+  resolveSkillWriteApprovalRequired,
+} from "@nakama/core";
+import {
+  assertNotBundledSkillName,
+  assertValidSkillName,
+} from "@nakama/core/skills/write";
+import type { DatabaseAdapter, SkillSuggestionAction, StoredSkillSuggestion } from "@nakama/db";
+import type { ApplySkillSuggestionOutcome, SkillSuggestion } from "@nakama/core/contract";
+import type { SkillsService } from "./skills-service";
+import type { SkillProposalService } from "./skill-proposal-service";
+
+export function toSkillSuggestion(record: StoredSkillSuggestion): SkillSuggestion {
+  const { warnings, ...suggestion } = record;
+  return warnings?.length ? { ...suggestion, warnings } : suggestion;
+}
+
+export type SkillSuggestionOutcome =
+  | { action: "create"; name: string; content: string }
+  | { action: "patch"; name: string; oldString: string; newString: string };
+
+export interface CreateSkillSuggestionInput {
+  orgId: string;
+  profileId: string;
+  sessionId?: string | null;
+  proposedByUserId?: string | null;
+  outcome: SkillSuggestionOutcome;
+}
+
+export interface ApplySkillSuggestionResult {
+  outcome: ApplySkillSuggestionOutcome;
+  suggestion: StoredSkillSuggestion;
+  proposalId?: string;
+}
+
+export class SkillSuggestionService {
+  constructor(
+    private readonly database: DatabaseAdapter | null = null,
+    private readonly skillsService: SkillsService | null = null,
+    private readonly skillProposalService: SkillProposalService | null = null,
+  ) {}
+
+  async isWriteApprovalRequired(orgId: string, profileId: string): Promise<boolean> {
+    const db = this.requireDatabase();
+    const org = await db.getOrganizationById(orgId);
+    if (!org) {
+      throw new NakamaApiError("Organization not found.", 404);
+    }
+    const profile = await db.getProfileForOrg(profileId, orgId);
+    if (!profile) {
+      throw new NakamaApiError("Profile not found.", 404);
+    }
+    return resolveSkillWriteApprovalRequired({
+      orgSkillsWriteApproval: org.skillsWriteApproval ?? false,
+      profileSkillsWriteApproval: profile.skillsWriteApproval ?? null,
+    });
+  }
+
+  async createSuggestion(input: CreateSkillSuggestionInput): Promise<StoredSkillSuggestion> {
+    const db = this.requireDatabase();
+    const { outcome } = input;
+    const name = assertValidSkillName(outcome.name);
+    assertNotBundledSkillName(name);
+
+    const now = new Date().toISOString();
+    const record: StoredSkillSuggestion = {
+      id: `sksug_${crypto.randomUUID().replace(/-/g, "")}`,
+      orgId: input.orgId,
+      profileId: input.profileId,
+      sessionId: input.sessionId ?? null,
+      proposedByUserId: input.proposedByUserId ?? null,
+      action: outcome.action,
+      skillName: name,
+      content: outcome.action === "create" ? outcome.content : null,
+      patchOldString: outcome.action === "patch" ? outcome.oldString : null,
+      patchNewString: outcome.action === "patch" ? outcome.newString : null,
+      status: "pending",
+      source: "post_turn_review",
+      warnings: this.computeWarnings(outcome) ?? null,
+      createdAt: now,
+      appliedAt: null,
+    };
+
+    await db.createSkillSuggestion(record);
+    return record;
+  }
+
+  async listSuggestions(
+    orgId: string,
+    options: {
+      sessionId?: string;
+      status?: StoredSkillSuggestion["status"];
+      profileId?: string;
+    } = {},
+  ): Promise<StoredSkillSuggestion[]> {
+    return this.requireDatabase().listSkillSuggestions(orgId, options);
+  }
+
+  async getSuggestion(orgId: string, id: string): Promise<StoredSkillSuggestion> {
+    const suggestion = await this.requireDatabase().getSkillSuggestion(orgId, id);
+    if (!suggestion) {
+      throw new NakamaApiError("Skill suggestion not found.", 404);
+    }
+    return suggestion;
+  }
+
+  /**
+   * Commits a pending suggestion. Re-checks org/profile write-approval at apply
+   * time (not creation time) since the gate can flip between suggestion and
+   * apply — if it is now on, the suggestion is converted into a pending
+   * proposal instead of writing directly.
+   */
+  async applySuggestion(
+    orgId: string,
+    id: string,
+    actorUserId: string,
+  ): Promise<ApplySkillSuggestionResult> {
+    const db = this.requireDatabase();
+    const suggestion = await this.getSuggestion(orgId, id);
+
+    if (suggestion.status === "applied") {
+      return { outcome: "already_applied", suggestion };
+    }
+
+    assertNotBundledSkillName(suggestion.skillName);
+
+    const writeApprovalRequired = await this.isWriteApprovalRequired(
+      orgId,
+      suggestion.profileId,
+    );
+
+    if (writeApprovalRequired) {
+      const proposals = this.requireProposalService();
+      const staged = await proposals.stageProposal({
+        orgId,
+        profileId: suggestion.profileId,
+        action: suggestion.action,
+        skillName: suggestion.skillName,
+        content: suggestion.content ?? undefined,
+        oldString: suggestion.patchOldString ?? undefined,
+        newString: suggestion.patchNewString ?? undefined,
+        sessionId: suggestion.sessionId,
+        proposedByUserId: actorUserId,
+      });
+
+      const appliedAt = new Date().toISOString();
+      await db.markSkillSuggestionApplied(orgId, id, appliedAt);
+
+      return {
+        outcome: "staged_as_proposal",
+        suggestion: { ...suggestion, status: "applied", appliedAt },
+        proposalId: staged.proposalId,
+      };
+    }
+
+    const skills = this.requireSkillsService();
+    if (suggestion.action === "create") {
+      const content = suggestion.content;
+      if (!content?.trim()) {
+        throw new NakamaApiError("Suggestion is missing content.", 400);
+      }
+      parseRawProfileSkillContent(content, orgId, suggestion.profileId);
+      await skills.createAndAssignRawSkillToProfile(orgId, suggestion.profileId, content);
+    } else {
+      const oldString = suggestion.patchOldString;
+      const newString = suggestion.patchNewString;
+      if (oldString === null || oldString === "" || newString === null) {
+        throw new NakamaApiError("Suggestion is missing patch fields.", 400);
+      }
+      await this.assertProfileOwnedSkill(orgId, suggestion.profileId, suggestion.skillName);
+      await skills.patchAssignedProfileSkill(
+        orgId,
+        suggestion.profileId,
+        suggestion.skillName,
+        oldString,
+        newString,
+      );
+    }
+
+    const appliedAt = new Date().toISOString();
+    await db.markSkillSuggestionApplied(orgId, id, appliedAt);
+
+    return {
+      outcome: "applied",
+      suggestion: { ...suggestion, status: "applied", appliedAt },
+    };
+  }
+
+  private async assertProfileOwnedSkill(
+    orgId: string,
+    profileId: string,
+    name: string,
+  ): Promise<void> {
+    const db = this.requireDatabase();
+    const skillName = assertValidSkillName(name);
+    const record = await db.getSkillByName(skillName);
+    if (!record) {
+      throw new NakamaApiError(`Skill "${skillName}" not found.`, 404);
+    }
+    if (isGlobalSkillSourcePath(record.sourcePath)) {
+      throw new NakamaApiError("Global skills cannot be modified by agents.", 403);
+    }
+    if (!isPathWithinProfileSkillsDir(orgId, profileId, record.sourcePath)) {
+      throw new NakamaApiError(`Skill "${skillName}" is not owned by this profile.`, 403);
+    }
+  }
+
+  private computeWarnings(outcome: SkillSuggestionOutcome): string[] | undefined {
+    const warnings =
+      outcome.action === "create"
+        ? detectOrgMemoryInjectionWarnings(outcome.content)
+        : [
+            ...detectOrgMemoryInjectionWarnings(outcome.oldString),
+            ...detectOrgMemoryInjectionWarnings(outcome.newString),
+          ];
+    const unique = [...new Set(warnings)];
+    return unique.length > 0 ? unique : undefined;
+  }
+
+  private requireDatabase(): DatabaseAdapter {
+    if (!this.database) {
+      throw new NakamaApiError("Database not configured.", 500);
+    }
+    return this.database;
+  }
+
+  private requireSkillsService(): SkillsService {
+    if (!this.skillsService) {
+      throw new NakamaApiError("Skills service not configured.", 500);
+    }
+    return this.skillsService;
+  }
+
+  private requireProposalService(): SkillProposalService {
+    if (!this.skillProposalService) {
+      throw new NakamaApiError("Skill proposal service not configured.", 500);
+    }
+    return this.skillProposalService;
+  }
+}
+
+export type { SkillSuggestionAction };

--- a/apps/web/src/components/SidebarUserMenu.tsx
+++ b/apps/web/src/components/SidebarUserMenu.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { LogOutIcon, UserIcon } from "lucide-react";
+import { THEME_OPTIONS } from "@/components/ThemeToggle";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -22,10 +23,13 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useAuth } from "@/context/use-auth";
+import { useTheme } from "@/context/use-theme";
 import { client, formatError } from "@/lib/client";
+import { cn } from "@/lib/utils";
 
 export function SidebarUserMenu() {
   const { user, logout, refreshSession } = useAuth();
+  const { theme, setTheme } = useTheme();
   const [profileOpen, setProfileOpen] = useState(false);
 
   if (!user) {
@@ -69,6 +73,38 @@ export function SidebarUserMenu() {
                     <UserIcon className="size-4" />
                     Profile
                   </DropdownMenuItem>
+                  <div className="flex items-center justify-between gap-2 px-1.5 py-1">
+                    <span className="text-sm text-muted-foreground">Theme</span>
+                    <div
+                      className="flex rounded-md bg-muted/60 p-0.5"
+                      role="group"
+                      aria-label="Color theme"
+                    >
+                      {THEME_OPTIONS.map((option) => {
+                        const Icon = option.icon;
+                        const selected = theme === option.id;
+
+                        return (
+                          <button
+                            key={option.id}
+                            type="button"
+                            aria-label={option.label}
+                            aria-pressed={selected}
+                            className={cn(
+                              "rounded-sm p-1 text-muted-foreground transition-colors hover:text-foreground",
+                              selected && "bg-background text-foreground shadow-sm",
+                            )}
+                            onClick={() => {
+                              setTheme(option.id);
+                            }}
+                          >
+                            <Icon className="size-3.5" strokeWidth={1.75} aria-hidden="true" />
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                  <div className="my-1 h-px bg-border" />
                   <DropdownMenuItem
                     variant="destructive"
                     onClick={() => {

--- a/apps/web/src/components/SidebarUserMenu.tsx
+++ b/apps/web/src/components/SidebarUserMenu.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { LogOutIcon, UserIcon } from "lucide-react";
-import { THEME_OPTIONS } from "@/components/ThemeToggle";
+import { THEME_OPTIONS } from "@/components/theme-options";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,

--- a/apps/web/src/components/ThemeToggle.tsx
+++ b/apps/web/src/components/ThemeToggle.tsx
@@ -1,22 +1,12 @@
-import { MonitorIcon, MoonIcon, SunIcon } from "lucide-react";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
 } from "@/components/ui/select";
+import { THEME_OPTIONS } from "@/components/theme-options";
 import { useTheme } from "@/context/use-theme";
-import { isTheme, type Theme } from "@/lib/theme";
-
-export const THEME_OPTIONS: {
-  id: Theme;
-  label: string;
-  icon: typeof SunIcon;
-}[] = [
-  { id: "light", label: "Light", icon: SunIcon },
-  { id: "dark", label: "Dark", icon: MoonIcon },
-  { id: "system", label: "System", icon: MonitorIcon },
-];
+import { isTheme } from "@/lib/theme";
 
 export function ThemeToggle() {
   const { theme, setTheme } = useTheme();

--- a/apps/web/src/components/ThemeToggle.tsx
+++ b/apps/web/src/components/ThemeToggle.tsx
@@ -8,7 +8,7 @@ import {
 import { useTheme } from "@/context/use-theme";
 import { isTheme, type Theme } from "@/lib/theme";
 
-const THEME_OPTIONS: {
+export const THEME_OPTIONS: {
   id: Theme;
   label: string;
   icon: typeof SunIcon;

--- a/apps/web/src/components/ai-elements/prompt-input.tsx
+++ b/apps/web/src/components/ai-elements/prompt-input.tsx
@@ -536,18 +536,6 @@ export const PromptInputFooter = ({
   />
 );
 
-export type PromptInputToolsProps = HTMLAttributes<HTMLDivElement>;
-
-export const PromptInputTools = ({
-  className,
-  ...props
-}: PromptInputToolsProps) => (
-  <div
-    className={cn("flex min-w-0 items-center gap-1", className)}
-    {...props}
-  />
-);
-
 // Note: Actions that perform side-effects (like opening a file dialog)
 // are provided in opt-in modules (e.g., prompt-input-attachments).
 

--- a/apps/web/src/components/chat/SkillPostTurnReviewBanner.tsx
+++ b/apps/web/src/components/chat/SkillPostTurnReviewBanner.tsx
@@ -1,0 +1,108 @@
+import { Link } from "react-router-dom";
+import type { SkillProposal, SkillSuggestion } from "@nakama/core/contract";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { skillSuggestionPreview } from "@/components/chat/skill-post-turn-review.shared";
+import { orgSkillProposalsPath } from "@/lib/navigation";
+
+export type SuggestionApplyState = "idle" | "loading" | "applied" | "staged" | "error";
+
+interface SkillPostTurnReviewBannerProps {
+  suggestions: SkillSuggestion[];
+  pendingProposals: SkillProposal[];
+  applyStateById: Record<string, SuggestionApplyState>;
+  applyErrorById: Record<string, string | undefined>;
+  canApply: boolean;
+  isOrgAdmin: boolean;
+  onApply: (suggestionId: string) => void;
+}
+
+export function SkillPostTurnReviewBanner({
+  suggestions,
+  pendingProposals,
+  applyStateById,
+  applyErrorById,
+  canApply,
+  isOrgAdmin,
+  onApply,
+}: SkillPostTurnReviewBannerProps) {
+  if (suggestions.length === 0 && pendingProposals.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mb-3 flex flex-col gap-2" data-testid="skill-post-turn-review-banner">
+      {pendingProposals.map((proposal) => (
+        <div
+          key={proposal.id}
+          className="rounded-md border border-border bg-muted/40 px-3 py-2 text-sm"
+        >
+          <p className="font-medium text-foreground">
+            Skill {proposal.action} “{proposal.skillName}” pending admin review
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Post-turn review staged this change. It will not go live until an org admin approves it.
+          </p>
+          {isOrgAdmin ? (
+            <p className="mt-2 text-xs">
+              <Link
+                to={orgSkillProposalsPath(proposal.profileId)}
+                className="underline underline-offset-2 hover:text-foreground"
+              >
+                Review proposals
+              </Link>
+            </p>
+          ) : null}
+        </div>
+      ))}
+
+      {suggestions.map((suggestion) => {
+        const preview = skillSuggestionPreview(suggestion);
+        const state = applyStateById[suggestion.id] ?? "idle";
+        const error = applyErrorById[suggestion.id];
+        const applied = state === "applied" || state === "staged";
+        const loading = state === "loading";
+
+        return (
+          <div
+            key={suggestion.id}
+            className="rounded-md border border-border bg-muted/40 px-3 py-2 text-sm"
+          >
+            <p className="font-medium text-foreground">{preview.title}</p>
+            <p className="mt-1 text-xs text-muted-foreground">{preview.description}</p>
+            {preview.excerpt ? (
+              <pre className="mt-2 max-h-32 overflow-auto rounded-md border border-border/70 bg-background/70 p-2 font-mono text-[11px] leading-relaxed whitespace-pre-wrap break-words text-foreground">
+                {preview.excerpt}
+              </pre>
+            ) : null}
+            {suggestion.warnings && suggestion.warnings.length > 0 ? (
+              <p className="mt-2 text-xs text-amber-600 dark:text-amber-400">
+                {suggestion.warnings.join(" ")}
+              </p>
+            ) : null}
+            {error ? <p className="mt-2 text-xs text-destructive">{error}</p> : null}
+            {state === "staged" ? (
+              <p className="mt-2 text-xs text-muted-foreground">
+                Write approval is on — staged for admin review instead of writing immediately.
+              </p>
+            ) : null}
+            <div className="mt-2 flex items-center gap-2">
+              <Button
+                type="button"
+                size="sm"
+                disabled={!canApply || applied || loading}
+                onClick={() => onApply(suggestion.id)}
+              >
+                {loading ? <Spinner className="mr-2" /> : null}
+                {applied ? (state === "staged" ? "Staged" : "Applied") : "Apply"}
+              </Button>
+              {!canApply ? (
+                <span className="text-xs text-muted-foreground">Viewers cannot apply.</span>
+              ) : null}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/artifact-attachment-preview.tsx
+++ b/apps/web/src/components/chat/artifact-attachment-preview.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { FileTextIcon, FilmIcon, ImageIcon } from "lucide-react";
+import { EyeIcon, FileTextIcon, FilmIcon, ImageIcon } from "lucide-react";
 import { ArtifactAttachmentPanelActions } from "@/components/chat/artifact-attachment-panel-actions";
 import {
   ArtifactShareMenuItem,
@@ -16,6 +16,12 @@ import {
   artifactPanelSubtitle,
 } from "@/components/chat/artifact-attachment-panel-body.shared";
 import { useArtifactPreviewContent } from "@/components/chat/use-artifact-preview-content";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useChatAttachmentPanel } from "@/context/use-chat-attachment-panel";
 import {
   artifactCodeLanguage,
@@ -40,6 +46,8 @@ interface ArtifactAttachmentPreviewProps {
   id: string;
   artifact: ChatArtifactRef;
   className?: string;
+  /** `chip` is the chat attachment chip; `icon` is an icon-only view button. */
+  variant?: "chip" | "icon";
 }
 
 function ArtifactAttachmentPreviewPanelBody({
@@ -123,6 +131,7 @@ export function ArtifactAttachmentPreview({
   id,
   artifact,
   className,
+  variant = "chip",
 }: ArtifactAttachmentPreviewProps) {
   const { show, update, activeId } = useChatAttachmentPanel();
   const share = useArtifactShareControls({ profileId, artifactPath: artifact.path });
@@ -301,6 +310,31 @@ export function ArtifactAttachmentPreview({
         setCopied(false);
       },
     });
+  }
+
+  if (variant === "icon") {
+    return (
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              type="button"
+              variant="outline"
+              size="icon-sm"
+              aria-label="View"
+              title="View"
+              className={className}
+              onClick={openPanel}
+            >
+              <EyeIcon className="size-3.5" aria-hidden />
+            </Button>
+          }
+        />
+        <TooltipContent side="top" sideOffset={8}>
+          View
+        </TooltipContent>
+      </Tooltip>
+    );
   }
 
   return (

--- a/apps/web/src/components/chat/artifact-share-controls.tsx
+++ b/apps/web/src/components/chat/artifact-share-controls.tsx
@@ -1,6 +1,11 @@
 import { EyeIcon, Loader2Icon, Share2Icon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { ArtifactSharePublishDialog } from "@/components/chat/artifact-share-publish-dialog";
 import {
   useArtifactShareControls,
@@ -87,20 +92,30 @@ export function ArtifactShareControls({
   if (compact) {
     return (
       <>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          disabled={share.busy || !share.orgId}
-          onClick={share.handleShareClick}
-        >
-          {share.busy ? (
-            <Loader2Icon className="size-3.5 animate-spin" aria-hidden />
-          ) : (
-            <Share2Icon className="size-3.5" aria-hidden />
-          )}
-          Share
-        </Button>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                type="button"
+                variant="outline"
+                size="icon-sm"
+                disabled={share.busy || !share.orgId}
+                aria-label="Share"
+                title="Share"
+                onClick={share.handleShareClick}
+              >
+                {share.busy ? (
+                  <Loader2Icon className="size-3.5 animate-spin" aria-hidden />
+                ) : (
+                  <Share2Icon className="size-3.5" aria-hidden />
+                )}
+              </Button>
+            }
+          />
+          <TooltipContent side="top" sideOffset={8}>
+            Share
+          </TooltipContent>
+        </Tooltip>
         {publishDialog}
       </>
     );

--- a/apps/web/src/components/chat/attachment-detail-panel.tsx
+++ b/apps/web/src/components/chat/attachment-detail-panel.tsx
@@ -1,8 +1,17 @@
 import { XIcon } from "lucide-react";
-import { useCallback, useEffect, useRef, type PointerEvent, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent,
+  type ReactNode,
+} from "react";
 import { Button } from "@/components/ui/button";
 import { clampAttachmentPanelWidth } from "@/components/chat/attachment-panel-width";
 import { cn } from "@/lib/utils";
+
+const WIDTH_MOTION_MS = 200;
 
 interface AttachmentDetailPanelProps {
   title: string;
@@ -31,7 +40,11 @@ export function AttachmentDetailPanel({
   onClose,
   className,
 }: AttachmentDetailPanelProps) {
+  const asideRef = useRef<HTMLElement>(null);
   const draggingRef = useRef(false);
+  const prevFullscreenRef = useRef(fullscreen);
+  const [displayWidth, setDisplayWidth] = useState(width);
+  const [animateWidth, setAnimateWidth] = useState(false);
 
   const clampWidth = useCallback(
     (nextWidth: number) => clampAttachmentPanelWidth(nextWidth),
@@ -39,6 +52,57 @@ export function AttachmentDetailPanel({
   );
 
   useEffect(() => {
+    if (!fullscreen && !animateWidth) {
+      setDisplayWidth(width);
+    }
+  }, [animateWidth, fullscreen, width]);
+
+  useEffect(() => {
+    if (prevFullscreenRef.current === fullscreen) {
+      return;
+    }
+
+    prevFullscreenRef.current = fullscreen;
+    setAnimateWidth(true);
+
+    const frame = window.requestAnimationFrame(() => {
+      if (fullscreen) {
+        const parent = asideRef.current?.parentElement;
+        setDisplayWidth(parent?.clientWidth ?? width);
+        return;
+      }
+
+      setDisplayWidth(width);
+    });
+
+    const timeout = window.setTimeout(() => setAnimateWidth(false), WIDTH_MOTION_MS);
+    return () => {
+      window.cancelAnimationFrame(frame);
+      window.clearTimeout(timeout);
+    };
+  }, [fullscreen, width]);
+
+  useEffect(() => {
+    if (!fullscreen) {
+      return;
+    }
+
+    function measure() {
+      const parent = asideRef.current?.parentElement;
+      if (parent) {
+        setDisplayWidth(parent.clientWidth);
+      }
+    }
+
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, [fullscreen]);
+
+  useEffect(() => {
+    if (fullscreen) {
+      return;
+    }
+
     function handleResize() {
       const clamped = clampWidth(width);
       if (clamped !== width) {
@@ -49,7 +113,7 @@ export function AttachmentDetailPanel({
     handleResize();
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
-  }, [clampWidth, onWidthChange, width]);
+  }, [clampWidth, fullscreen, onWidthChange, width]);
 
   const updateWidthFromPointer = useCallback(
     (clientX: number) => {
@@ -94,11 +158,14 @@ export function AttachmentDetailPanel({
 
   return (
     <aside
+      ref={asideRef}
       data-slot="attachment-detail-panel"
-      style={fullscreen ? undefined : { width }}
+      style={{ width: displayWidth }}
       className={cn(
         "relative flex min-h-0 shrink-0 flex-col border-l border-border bg-background",
-        fullscreen ? "min-w-0 flex-1" : "max-w-[50vw] lg:max-w-[75vw]",
+        animateWidth &&
+          "transition-[width] duration-200 ease-out motion-reduce:transition-none",
+        !fullscreen && !animateWidth && "max-w-[50vw] lg:max-w-[75vw]",
         className,
       )}
     >

--- a/apps/web/src/components/chat/skill-post-turn-review.shared.test.ts
+++ b/apps/web/src/components/chat/skill-post-turn-review.shared.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import {
+  extractSkillDescription,
+  skillSuggestionPreview,
+} from "./skill-post-turn-review.shared";
+import type { SkillSuggestion } from "@nakama/core/contract";
+
+function suggestion(partial: Partial<SkillSuggestion>): SkillSuggestion {
+  return {
+    id: "sug_1",
+    orgId: "org_1",
+    profileId: "profile_1",
+    sessionId: "sess_1",
+    proposedByUserId: "user_1",
+    action: "create",
+    skillName: "deploy-notes",
+    content: null,
+    patchOldString: null,
+    patchNewString: null,
+    status: "pending",
+    source: "post_turn_review",
+    createdAt: "2026-08-04T00:00:00.000Z",
+    appliedAt: null,
+    ...partial,
+  };
+}
+
+describe("skillSuggestionPreview", () => {
+  test("create uses frontmatter description", () => {
+    const preview = skillSuggestionPreview(
+      suggestion({
+        content: `---
+name: deploy-notes
+description: Run the deploy checklist.
+---
+
+# Steps
+1. Build
+`,
+      }),
+    );
+    expect(preview.title).toContain("deploy-notes");
+    expect(preview.description).toBe("Run the deploy checklist.");
+    expect(preview.excerpt).toContain("Steps");
+  });
+
+  test("patch shows replace excerpt", () => {
+    const preview = skillSuggestionPreview(
+      suggestion({
+        action: "patch",
+        patchOldString: "old step",
+        patchNewString: "new step",
+      }),
+    );
+    expect(preview.title).toContain("Update");
+    expect(preview.excerpt).toContain("old step");
+    expect(preview.excerpt).toContain("new step");
+  });
+});
+
+describe("extractSkillDescription", () => {
+  test("returns null without frontmatter", () => {
+    expect(extractSkillDescription("# Hello")).toBeNull();
+  });
+});

--- a/apps/web/src/components/chat/skill-post-turn-review.shared.ts
+++ b/apps/web/src/components/chat/skill-post-turn-review.shared.ts
@@ -1,0 +1,59 @@
+import type { SkillSuggestion } from "@nakama/core/contract";
+
+/** Prefer YAML frontmatter description; fall back to a short body excerpt. */
+export function skillSuggestionPreview(suggestion: SkillSuggestion): {
+  title: string;
+  description: string;
+  excerpt: string | null;
+} {
+  const title =
+    suggestion.action === "create"
+      ? `Create skill “${suggestion.skillName}”`
+      : `Update skill “${suggestion.skillName}”`;
+
+  if (suggestion.action === "patch") {
+    const oldPart = (suggestion.patchOldString ?? "").trim();
+    const newPart = (suggestion.patchNewString ?? "").trim();
+    const excerpt =
+      oldPart || newPart
+        ? `Replace:\n${truncate(oldPart, 180)}\n\nWith:\n${truncate(newPart, 180)}`
+        : null;
+    return {
+      title,
+      description: "Suggested improvement from this chat turn.",
+      excerpt,
+    };
+  }
+
+  const content = suggestion.content ?? "";
+  const description = extractSkillDescription(content) ?? "Suggested new skill from this chat turn.";
+  const excerpt = truncate(stripFrontmatter(content), 280) || null;
+  return { title, description, excerpt };
+}
+
+export function extractSkillDescription(content: string): string | null {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) {
+    return null;
+  }
+  for (const line of match[1]!.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed.toLowerCase().startsWith("description:")) {
+      continue;
+    }
+    const value = trimmed.slice("description:".length).trim().replace(/^["']|["']$/g, "");
+    return value || null;
+  }
+  return null;
+}
+
+function stripFrontmatter(content: string): string {
+  return content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, "").trim();
+}
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) {
+    return value;
+  }
+  return `${value.slice(0, Math.max(0, max - 1))}…`;
+}

--- a/apps/web/src/components/notifications/notification-list.tsx
+++ b/apps/web/src/components/notifications/notification-list.tsx
@@ -24,7 +24,7 @@ function NotificationIcon({
   );
 }
 
-export function NotificationListItem({
+function NotificationListItem({
   item,
   compact = false,
   onNavigate,

--- a/apps/web/src/components/profiles/ProfileSkillsPostTurnReviewField.tsx
+++ b/apps/web/src/components/profiles/ProfileSkillsPostTurnReviewField.tsx
@@ -1,0 +1,122 @@
+import { useState } from "react";
+import type { ProfileDetail } from "@nakama/core/contract";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Spinner } from "@/components/ui/spinner";
+import { useAuth } from "@/context/use-auth";
+import { useUpdateProfileMutation } from "@/hooks/use-resource-mutations";
+import { formatError } from "@/lib/client";
+import { toast } from "@/lib/toast";
+
+type OverrideValue = "inherit" | "on" | "off";
+
+function toOverrideValue(value: boolean | null | undefined): OverrideValue {
+  if (value === true) {
+    return "on";
+  }
+  if (value === false) {
+    return "off";
+  }
+  return "inherit";
+}
+
+function fromOverrideValue(value: OverrideValue): boolean | null {
+  if (value === "on") {
+    return true;
+  }
+  if (value === "off") {
+    return false;
+  }
+  return null;
+}
+
+export function ProfileSkillsPostTurnReviewField({
+  profile,
+  disabled = false,
+}: {
+  profile: ProfileDetail;
+  disabled?: boolean;
+}) {
+  return (
+    <ProfileSkillsPostTurnReviewFieldBody
+      key={`${profile.id}:${String(profile.skillsPostTurnReview)}`}
+      profile={profile}
+      disabled={disabled}
+    />
+  );
+}
+
+function ProfileSkillsPostTurnReviewFieldBody({
+  profile,
+  disabled = false,
+}: {
+  profile: ProfileDetail;
+  disabled?: boolean;
+}) {
+  const { activeOrg } = useAuth();
+  const updateMutation = useUpdateProfileMutation();
+  const [value, setValue] = useState<OverrideValue>(() =>
+    toOverrideValue(profile.skillsPostTurnReview),
+  );
+  const busy = updateMutation.isPending;
+
+  if (!activeOrg || activeOrg.role !== "admin") {
+    return null;
+  }
+
+  async function handleChange(nextValue: OverrideValue) {
+    setValue(nextValue);
+    try {
+      await updateMutation.mutateAsync({
+        profileId: profile.id,
+        input: { skillsPostTurnReview: fromOverrideValue(nextValue) },
+      });
+      toast("Post-turn skill review setting saved.");
+    } catch (err) {
+      setValue(toOverrideValue(profile.skillsPostTurnReview));
+      toast(formatError(err));
+    }
+  }
+
+  return (
+    <div className="mb-3 rounded-md border border-border p-3 sm:p-4">
+      <label
+        htmlFor="profile-skills-post-turn-review"
+        className="mb-1 block text-xs font-medium text-muted-foreground"
+      >
+        Post-turn skill review
+      </label>
+      <div className="flex items-center gap-2">
+        <Select
+          value={value}
+          disabled={disabled || busy}
+          onValueChange={(next) => {
+            if (!next) {
+              return;
+            }
+            void handleChange(next as OverrideValue);
+          }}
+        >
+          <SelectTrigger id="profile-skills-post-turn-review" className="h-8 max-w-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="inherit">Inherit org default</SelectItem>
+            <SelectItem value="on">Enable review</SelectItem>
+            <SelectItem value="off">Disable review</SelectItem>
+          </SelectContent>
+        </Select>
+        {busy ? <Spinner /> : null}
+      </div>
+      <p className="mt-1.5 text-xs text-muted-foreground">
+        Overrides the org-wide post-turn review setting for this profile only. Separate from skill
+        write approval.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/SkillsPostTurnReviewOrgCard.tsx
+++ b/apps/web/src/components/settings/SkillsPostTurnReviewOrgCard.tsx
@@ -106,7 +106,7 @@ function OrgProfilePostTurnReviewField({
   }
 
   return (
-    <div className="border-t border-border px-4 py-3">
+    <div className="px-4 py-3">
       <p className="mb-2 text-xs font-medium text-muted-foreground">Per-profile override</p>
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
         <Select

--- a/apps/web/src/components/settings/SkillsPostTurnReviewOrgCard.tsx
+++ b/apps/web/src/components/settings/SkillsPostTurnReviewOrgCard.tsx
@@ -181,9 +181,8 @@ export function SkillsPostTurnReviewOrgCard() {
           <div className="min-w-0 space-y-0.5">
             <p className="text-sm font-medium text-foreground">Post-turn skill review</p>
             <p className="max-w-prose text-xs leading-relaxed text-muted-foreground">
-              After complex web or CLI chats, optionally suggest or stage skill updates. Separate from
-              write approval: review off does nothing; review on + approval off lets chat users Apply
-              suggestions; review on + approval on stages proposals for admin review.
+              Suggest skill updates after complex chats. Apply directly, or stage for admin review when
+              write approval is on.
             </p>
           </div>
           <div className="flex shrink-0 items-center gap-2 pt-0.5">

--- a/apps/web/src/components/settings/SkillsPostTurnReviewOrgCard.tsx
+++ b/apps/web/src/components/settings/SkillsPostTurnReviewOrgCard.tsx
@@ -1,0 +1,203 @@
+import { useState } from "react";
+import type { ProfileSummary } from "@nakama/core/contract";
+import { Card } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { Spinner } from "@/components/ui/spinner";
+import { useAuth } from "@/context/use-auth";
+import { useProfilesQuery } from "@/hooks/use-app-queries";
+import { useUpdateProfileMutation } from "@/hooks/use-resource-mutations";
+import { formatError } from "@/lib/client";
+import { toast } from "@/lib/toast";
+
+type OverrideValue = "inherit" | "on" | "off";
+
+function toOverrideValue(value: boolean | null | undefined): OverrideValue {
+  if (value === true) {
+    return "on";
+  }
+  if (value === false) {
+    return "off";
+  }
+  return "inherit";
+}
+
+function fromOverrideValue(value: OverrideValue): boolean | null {
+  if (value === "on") {
+    return true;
+  }
+  if (value === "off") {
+    return false;
+  }
+  return null;
+}
+
+function OrgProfilePostTurnReviewOverrideSelect({
+  profile,
+  disabled = false,
+}: {
+  profile: ProfileSummary;
+  disabled?: boolean;
+}) {
+  const updateMutation = useUpdateProfileMutation();
+  const [value, setValue] = useState<OverrideValue>(() =>
+    toOverrideValue(profile.skillsPostTurnReview),
+  );
+  const busy = updateMutation.isPending;
+
+  async function handleOverrideChange(nextValue: OverrideValue) {
+    setValue(nextValue);
+    try {
+      await updateMutation.mutateAsync({
+        profileId: profile.id,
+        input: { skillsPostTurnReview: fromOverrideValue(nextValue) },
+      });
+      toast("Profile post-turn review setting saved.");
+    } catch (err) {
+      setValue(toOverrideValue(profile.skillsPostTurnReview));
+      toast(formatError(err));
+    }
+  }
+
+  return (
+    <>
+      <Select
+        value={value}
+        disabled={disabled || busy}
+        onValueChange={(next) => {
+          if (!next) {
+            return;
+          }
+          void handleOverrideChange(next as OverrideValue);
+        }}
+      >
+        <SelectTrigger className="h-8 max-w-xs" aria-label="Post-turn skill review override">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="inherit">Inherit org default</SelectItem>
+          <SelectItem value="on">Enable review</SelectItem>
+          <SelectItem value="off">Disable review</SelectItem>
+        </SelectContent>
+      </Select>
+      {busy ? <Spinner /> : null}
+    </>
+  );
+}
+
+function OrgProfilePostTurnReviewField({
+  profiles,
+  disabled = false,
+}: {
+  profiles: ProfileSummary[];
+  disabled?: boolean;
+}) {
+  const [profileId, setProfileId] = useState<string>("");
+  const selectedProfile = profiles.find((profile) => profile.id === profileId) ?? null;
+
+  if (profiles.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="border-t border-border px-4 py-3">
+      <p className="mb-2 text-xs font-medium text-muted-foreground">Per-profile override</p>
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <Select
+          value={profileId}
+          disabled={disabled}
+          onValueChange={(next) => setProfileId(next ? String(next) : "")}
+        >
+          <SelectTrigger className="h-8 max-w-xs" aria-label="Profile">
+            <SelectValue placeholder="Select profile" />
+          </SelectTrigger>
+          <SelectContent>
+            {profiles.map((profile) => (
+              <SelectItem key={profile.id} value={profile.id}>
+                {profile.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {selectedProfile ? (
+          <OrgProfilePostTurnReviewOverrideSelect
+            key={`${selectedProfile.id}:${String(selectedProfile.skillsPostTurnReview)}`}
+            profile={selectedProfile}
+            disabled={disabled}
+          />
+        ) : (
+          <Select value="inherit" disabled>
+            <SelectTrigger className="h-8 max-w-xs" aria-label="Post-turn skill review override">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="inherit">Inherit org default</SelectItem>
+              <SelectItem value="on">Enable review</SelectItem>
+              <SelectItem value="off">Disable review</SelectItem>
+            </SelectContent>
+          </Select>
+        )}
+      </div>
+      <p className="mt-1.5 text-xs text-muted-foreground">
+        Overrides the org-wide post-turn review setting for the selected profile only.
+      </p>
+    </div>
+  );
+}
+
+export function SkillsPostTurnReviewOrgCard() {
+  const { activeOrg, updateOrg } = useAuth();
+  const [busy, setBusy] = useState(false);
+  const { data: profiles = [] } = useProfilesQuery();
+
+  if (!activeOrg || activeOrg.role !== "admin") {
+    return null;
+  }
+
+  const enabled = activeOrg.skillsPostTurnReview === true;
+
+  async function handleToggle(checked: boolean) {
+    setBusy(true);
+    try {
+      await updateOrg(activeOrg!.id, { skillsPostTurnReview: checked });
+      toast(checked ? "Post-turn skill review enabled." : "Post-turn skill review disabled.");
+    } catch (err) {
+      toast(formatError(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Card className="w-full overflow-hidden shadow-none">
+      <div className="border-b border-border px-4 py-3">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0 space-y-0.5">
+            <p className="text-sm font-medium text-foreground">Post-turn skill review</p>
+            <p className="max-w-prose text-xs leading-relaxed text-muted-foreground">
+              After complex web or CLI chats, optionally suggest or stage skill updates. Separate from
+              write approval: review off does nothing; review on + approval off lets chat users Apply
+              suggestions; review on + approval on stages proposals for admin review.
+            </p>
+          </div>
+          <div className="flex shrink-0 items-center gap-2 pt-0.5">
+            {busy ? <Spinner /> : null}
+            <Switch
+              checked={enabled}
+              disabled={busy}
+              onCheckedChange={(checked) => void handleToggle(checked)}
+              aria-label="Enable post-turn skill review"
+            />
+          </div>
+        </div>
+      </div>
+      <OrgProfilePostTurnReviewField profiles={profiles} disabled={busy} />
+    </Card>
+  );
+}

--- a/apps/web/src/components/settings/SkillsWriteApprovalOrgCard.tsx
+++ b/apps/web/src/components/settings/SkillsWriteApprovalOrgCard.tsx
@@ -135,7 +135,7 @@ function OrgProfileSkillsWriteApprovalField({
   }
 
   return (
-    <div className="border-t border-border px-4 py-3">
+    <div className="px-4 py-3">
       <p className="mb-2 text-xs font-medium text-muted-foreground">Per-profile override</p>
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
         <Select

--- a/apps/web/src/components/settings/org-member-dialogs.tsx
+++ b/apps/web/src/components/settings/org-member-dialogs.tsx
@@ -154,50 +154,6 @@ export function OrgMemberInvitePopover({
   );
 }
 
-export function OrgMemberInviteDialog({
-  open,
-  inviteEmail,
-  inviteRole,
-  formError,
-  pending,
-  onOpenChange,
-  onInviteEmailChange,
-  onInviteRoleChange,
-  onSubmit,
-}: {
-  open: boolean;
-  inviteEmail: string;
-  inviteRole: OrgRole;
-  formError: string | null;
-  pending: boolean;
-  onOpenChange: (open: boolean) => void;
-  onInviteEmailChange: (value: string) => void;
-  onInviteRoleChange: (role: OrgRole) => void;
-  onSubmit: (event: React.FormEvent) => void;
-}) {
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Invite member</DialogTitle>
-          <DialogDescription>
-            Send an invite by email. The recipient gets a link to join this organization.
-          </DialogDescription>
-        </DialogHeader>
-        <OrgMemberInviteForm
-          inviteEmail={inviteEmail}
-          inviteRole={inviteRole}
-          formError={formError}
-          pending={pending}
-          onInviteEmailChange={onInviteEmailChange}
-          onInviteRoleChange={onInviteRoleChange}
-          onSubmit={onSubmit}
-        />
-      </DialogContent>
-    </Dialog>
-  );
-}
-
 function CredentialRow({
   label,
   value,

--- a/apps/web/src/components/soul-tools/ArtifactsTab.tsx
+++ b/apps/web/src/components/soul-tools/ArtifactsTab.tsx
@@ -4,12 +4,12 @@ import {
   FileTextIcon,
   FilmIcon,
   ImageIcon,
+  MoreHorizontalIcon,
   SearchIcon,
   Trash2Icon,
 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { buttonVariants } from "@/components/ui/button-variants";
 import {
   Dialog,
   DialogContent,
@@ -18,6 +18,12 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -27,7 +33,12 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
-import { ArtifactShareControls } from "@/components/chat/artifact-share-controls";
+import { ArtifactAttachmentPreview } from "@/components/chat/artifact-attachment-preview";
+import {
+  ArtifactShareMenuItem,
+  ArtifactSharePublishDialogFromState,
+} from "@/components/chat/artifact-share-controls";
+import { useArtifactShareControls } from "@/components/chat/use-artifact-share-controls";
 import {
   ARTIFACT_TYPE_FILTER_LABELS,
   artifactMatchesTypeFilter,
@@ -38,12 +49,21 @@ import {
 import { useArtifactsQuery, useDeleteArtifactMutation } from "@/hooks/use-resource-mutations";
 import { formatError } from "@/lib/client";
 import { client } from "@/lib/client";
+import type { ChatArtifactRef } from "@/lib/chat-artifacts";
 import { formatBytes } from "@/lib/knowledge-base-files";
-import { cn } from "@/lib/utils";
 
 const sectionClass = "rounded-md border border-border bg-card";
 const EMPTY_ARTIFACTS: ArtifactFile[] = [];
 
+function toChatArtifactRef(artifact: ArtifactFile): ChatArtifactRef {
+  return {
+    filename: artifact.filename,
+    path: artifact.path || artifact.filename,
+    mimeType: artifact.mimeType,
+    sizeBytes: artifact.sizeBytes,
+    savedAt: artifact.updatedAt,
+  };
+}
 const artifactTimestampFormatter = new Intl.DateTimeFormat(undefined, {
   dateStyle: "medium",
   timeStyle: "short",
@@ -80,6 +100,69 @@ function ArtifactIcon({ mimeType, filename }: { mimeType: string; filename: stri
   }
 
   return <FileTextIcon className="mt-0.5 size-4 text-muted-foreground" aria-hidden />;
+}
+
+function ArtifactRowMenu({
+  profileId,
+  artifact,
+  deletePending,
+  onDelete,
+}: {
+  profileId: string;
+  artifact: ArtifactFile;
+  deletePending: boolean;
+  onDelete: () => void;
+}) {
+  const artifactPath = artifact.path || artifact.filename;
+  const share = useArtifactShareControls({ profileId, artifactPath });
+  const downloadUrl = getArtifactDownloadUrl(profileId, artifactPath);
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              type="button"
+              variant="outline"
+              size="icon-sm"
+              aria-label="Artifact actions"
+            />
+          }
+        >
+          <MoreHorizontalIcon className="size-4" aria-hidden />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="min-w-44">
+          <ArtifactShareMenuItem share={share} />
+          <DropdownMenuItem
+            className="cursor-pointer"
+            onClick={() => {
+              const link = document.createElement("a");
+              link.href = downloadUrl;
+              link.download = artifact.filename;
+              link.rel = "noopener";
+              document.body.append(link);
+              link.click();
+              link.remove();
+            }}
+          >
+            <FileDownIcon aria-hidden />
+            Download
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            variant="destructive"
+            className="cursor-pointer"
+            disabled={deletePending}
+            onClick={onDelete}
+          >
+            <Trash2Icon aria-hidden />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <ArtifactSharePublishDialogFromState share={share} artifactPath={artifactPath} />
+    </>
+  );
 }
 
 export function ArtifactsTab({ profileId }: { profileId: string | null }) {
@@ -190,7 +273,6 @@ export function ArtifactsTab({ profileId }: { profileId: string | null }) {
                   }}
                 >
                   <SelectTrigger
-                    size="sm"
                     className="h-8 w-full shrink-0 border-border/60 bg-muted/20 shadow-none sm:w-40 dark:bg-muted/15"
                     aria-label="Filter by file type"
                   >
@@ -242,27 +324,18 @@ export function ArtifactsTab({ profileId }: { profileId: string | null }) {
                     </div>
                   </div>
                   <div className="flex items-center gap-2">
-                    <ArtifactShareControls
+                    <ArtifactAttachmentPreview
+                      id={`artifacts-tab:${artifact.path || artifact.filename}`}
                       profileId={profileId}
-                      artifactPath={artifact.filename}
-                      compact
+                      artifact={toChatArtifactRef(artifact)}
+                      variant="icon"
                     />
-                    <a
-                      href={getArtifactDownloadUrl(profileId, artifact.filename)}
-                      className={cn(buttonVariants({ variant: "outline", size: "sm" }))}
-                    >
-                      <FileDownIcon className="mr-2 size-4" aria-hidden />
-                      Download
-                    </a>
-                    <Button
-                      type="button"
-                      variant="destructive"
-                      size="sm"
-                      onClick={() => setDeleteTarget(artifact)}
-                      disabled={deleteMutation.isPending}
-                    >
-                      <Trash2Icon className="size-4" aria-hidden />
-                    </Button>
+                    <ArtifactRowMenu
+                      profileId={profileId}
+                      artifact={artifact}
+                      deletePending={deleteMutation.isPending}
+                      onDelete={() => setDeleteTarget(artifact)}
+                    />
                   </div>
                 </li>
               ))}

--- a/apps/web/src/components/soul-tools/ArtifactsTab.tsx
+++ b/apps/web/src/components/soul-tools/ArtifactsTab.tsx
@@ -241,7 +241,7 @@ export function ArtifactsTab({ profileId }: { profileId: string | null }) {
               <div>
                 <h2 className="text-sm font-semibold text-foreground">Artifacts</h2>
                 <p className="text-xs text-muted-foreground">
-                  Persistent files saved by the agent under `artifacts/`.
+                  Files your agent created and saved for you.
                 </p>
               </div>
               <Button type="button" variant="outline" size="sm" onClick={() => void refetch()}>

--- a/apps/web/src/components/system/OrganizationPanel.tsx
+++ b/apps/web/src/components/system/OrganizationPanel.tsx
@@ -1,5 +1,6 @@
 import { OrgMembersCard } from "@/components/settings/OrgMembersCard";
 import { OrgMemoryCard } from "@/components/settings/OrgMemoryCard";
+import { SkillsPostTurnReviewOrgCard } from "@/components/settings/SkillsPostTurnReviewOrgCard";
 import { SkillsWriteApprovalOrgCard } from "@/components/settings/SkillsWriteApprovalOrgCard";
 
 export function OrganizationPanel() {
@@ -7,6 +8,7 @@ export function OrganizationPanel() {
     <div className="min-w-0 space-y-8 p-4 sm:p-5">
       <OrgMembersCard />
       <SkillsWriteApprovalOrgCard />
+      <SkillsPostTurnReviewOrgCard />
       <OrgMemoryCard />
     </div>
   );

--- a/apps/web/src/components/theme-options.ts
+++ b/apps/web/src/components/theme-options.ts
@@ -1,0 +1,12 @@
+import { MonitorIcon, MoonIcon, SunIcon } from "lucide-react";
+import type { Theme } from "@/lib/theme";
+
+export const THEME_OPTIONS: {
+  id: Theme;
+  label: string;
+  icon: typeof SunIcon;
+}[] = [
+  { id: "light", label: "Light", icon: SunIcon },
+  { id: "dark", label: "Dark", icon: MoonIcon },
+  { id: "system", label: "System", icon: MonitorIcon },
+];

--- a/apps/web/src/context/chat-attachment-panel-context.tsx
+++ b/apps/web/src/context/chat-attachment-panel-context.tsx
@@ -12,10 +12,18 @@ import {
   ChatAttachmentPanelContext,
   type ChatAttachmentPanelConfig,
 } from "@/context/chat-attachment-panel-context-shared";
+import { cn } from "@/lib/utils";
 
 const DEFAULT_PANEL_WIDTH = 448;
 
-export function ChatAttachmentPanelProvider({ children }: { children: ReactNode }) {
+export function ChatAttachmentPanelProvider({
+  children,
+  presentation = "push",
+}: {
+  children: ReactNode;
+  /** `push` shares row space (chat). `overlay` slides over content from the right. */
+  presentation?: "push" | "overlay";
+}) {
   const [config, setConfig] = useState<ChatAttachmentPanelConfig | null>(null);
   const [width, setWidth] = useState(DEFAULT_PANEL_WIDTH);
   const configRef = useRef<ChatAttachmentPanelConfig | null>(config);
@@ -77,24 +85,54 @@ export function ChatAttachmentPanelProvider({ children }: { children: ReactNode 
     [config, show, update, hide],
   );
 
+  const overlay = presentation === "overlay";
+  const fullscreen = config?.fullscreen ?? false;
+
   return (
     <ChatAttachmentPanelContext.Provider value={value}>
-      <div className="flex min-h-0 flex-1 overflow-hidden">
-        {children}
+      <div
+        className={cn(
+          "min-h-0 flex-1 overflow-hidden",
+          overlay ? "relative" : "flex",
+        )}
+      >
+        {overlay ? (
+          <div className="absolute inset-0 flex min-h-0 flex-col overflow-hidden">
+            {children}
+          </div>
+        ) : (
+          children
+        )}
         {config ? (
-          <AttachmentDetailPanel
-            title={config.title}
-            subtitle={config.subtitle}
-            headerActions={config.headerActions}
-            bodyClassName={config.bodyClassName}
-            resizable={config.resizable ?? !config.fullscreen}
-            fullscreen={config.fullscreen ?? false}
-            width={width}
-            onWidthChange={setWidth}
-            onClose={handlePanelClose}
-          >
-            {config.content}
-          </AttachmentDetailPanel>
+          <>
+            {overlay && !fullscreen ? (
+              <button
+                type="button"
+                aria-label="Close artifact preview"
+                className="absolute inset-0 z-20 bg-background/50 animate-in fade-in-0 duration-200"
+                onClick={handlePanelClose}
+              />
+            ) : null}
+            <AttachmentDetailPanel
+              title={config.title}
+              subtitle={config.subtitle}
+              headerActions={config.headerActions}
+              bodyClassName={config.bodyClassName}
+              resizable={config.resizable ?? !fullscreen}
+              fullscreen={fullscreen}
+              width={width}
+              onWidthChange={setWidth}
+              onClose={handlePanelClose}
+              className={cn(
+                overlay &&
+                  (fullscreen
+                    ? "absolute inset-0 z-30 overflow-hidden"
+                    : "absolute inset-y-0 right-0 z-30 h-full max-h-full overflow-hidden shadow-xl animate-in slide-in-from-right duration-200"),
+              )}
+            >
+              {config.content}
+            </AttachmentDetailPanel>
+          </>
         ) : null}
       </div>
     </ChatAttachmentPanelContext.Provider>

--- a/apps/web/src/context/chat-attachment-panel-context.tsx
+++ b/apps/web/src/context/chat-attachment-panel-context.tsx
@@ -15,6 +15,7 @@ import {
 import { cn } from "@/lib/utils";
 
 const DEFAULT_PANEL_WIDTH = 448;
+const ENTER_SLIDE_MS = 200;
 
 export function ChatAttachmentPanelProvider({
   children,
@@ -26,11 +27,25 @@ export function ChatAttachmentPanelProvider({
 }) {
   const [config, setConfig] = useState<ChatAttachmentPanelConfig | null>(null);
   const [width, setWidth] = useState(DEFAULT_PANEL_WIDTH);
+  const [enterSlide, setEnterSlide] = useState(false);
   const configRef = useRef<ChatAttachmentPanelConfig | null>(config);
 
   useEffect(() => {
     configRef.current = config;
   }, [config]);
+
+  const openId = config?.id ?? null;
+
+  useEffect(() => {
+    if (!openId || presentation !== "overlay") {
+      setEnterSlide(false);
+      return;
+    }
+
+    setEnterSlide(true);
+    const timeout = window.setTimeout(() => setEnterSlide(false), ENTER_SLIDE_MS);
+    return () => window.clearTimeout(timeout);
+  }, [openId, presentation]);
 
   const hide = useCallback((id?: string) => {
     setConfig((current) => {
@@ -125,9 +140,8 @@ export function ChatAttachmentPanelProvider({
               onClose={handlePanelClose}
               className={cn(
                 overlay &&
-                  (fullscreen
-                    ? "absolute inset-0 z-30 overflow-hidden"
-                    : "absolute inset-y-0 right-0 z-30 h-full max-h-full overflow-hidden shadow-xl animate-in slide-in-from-right duration-200"),
+                  "absolute inset-y-0 right-0 z-30 h-full max-h-full overflow-hidden shadow-xl",
+                overlay && enterSlide && "animate-in slide-in-from-right duration-200",
               )}
             >
               {config.content}

--- a/apps/web/src/context/chat-attachment-panel-context.tsx
+++ b/apps/web/src/context/chat-attachment-panel-context.tsx
@@ -124,7 +124,7 @@ export function ChatAttachmentPanelProvider({
               <button
                 type="button"
                 aria-label="Close artifact preview"
-                className="absolute inset-0 z-20 bg-background/50 animate-in fade-in-0 duration-200"
+                className="absolute inset-0 z-20 bg-background/50 animate-in fade-in-0 duration-200 transition-none"
                 onClick={handlePanelClose}
               />
             ) : null}
@@ -141,7 +141,9 @@ export function ChatAttachmentPanelProvider({
               className={cn(
                 overlay &&
                   "absolute inset-y-0 right-0 z-30 h-full max-h-full overflow-hidden shadow-xl",
-                overlay && enterSlide && "animate-in slide-in-from-right duration-200",
+                overlay &&
+                  enterSlide &&
+                  "animate-in slide-in-from-right duration-200 transition-none",
               )}
             >
               {config.content}

--- a/apps/web/src/hooks/use-fireworks-discover-models.ts
+++ b/apps/web/src/hooks/use-fireworks-discover-models.ts
@@ -1,4 +1,4 @@
-import type { CustomModelEntry } from "@nakama/core";
+import type { CustomModelEntry } from "@nakama/core/contract";
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import type { CapabilityBrowseRow } from "@/components/model-browse-utils";
 import { client } from "@/lib/client";

--- a/apps/web/src/hooks/use-notifications.ts
+++ b/apps/web/src/hooks/use-notifications.ts
@@ -111,12 +111,3 @@ export function useNotifications(): {
 
   return { items, automationItems, orgMemoryItems, skillProposalItems, totalCount, isLoading };
 }
-
-/** @deprecated Use useNotifications */
-export const useSidebarNotifications = useNotifications;
-
-/** @deprecated Use NotificationItem */
-export type SidebarNotificationItem = NotificationItem;
-
-/** @deprecated Use NotificationKind */
-export type SidebarNotificationKind = NotificationKind;

--- a/apps/web/src/hooks/use-post-turn-skill-review-overlay.tsx
+++ b/apps/web/src/hooks/use-post-turn-skill-review-overlay.tsx
@@ -29,7 +29,6 @@ export function usePostTurnSkillReviewOverlay({
   readOnlySession,
 }: UsePostTurnSkillReviewOverlayArgs) {
   const { activeOrg } = useAuth();
-  const [pollUntil, setPollUntil] = useState<number | null>(null);
   const [now, setNow] = useState(() => Date.now());
   const [applyStateById, setApplyStateById] = useState<Record<string, SuggestionApplyState>>({});
   const [applyErrorById, setApplyErrorById] = useState<Record<string, string | undefined>>({});
@@ -47,12 +46,10 @@ export function usePostTurnSkillReviewOverlay({
     !readOnlySession &&
     activeOrg?.role !== "viewer";
 
-  useEffect(() => {
-    if (!lastSuccessfulTurnAt || !canPoll) {
-      return;
-    }
-    setPollUntil(lastSuccessfulTurnAt + POST_TURN_POLL_WINDOW_MS);
-  }, [lastSuccessfulTurnAt, canPoll]);
+  const pollUntil =
+    lastSuccessfulTurnAt != null && canPoll
+      ? lastSuccessfulTurnAt + POST_TURN_POLL_WINDOW_MS
+      : null;
 
   const polling = pollUntil != null && now < pollUntil;
 

--- a/apps/web/src/hooks/use-post-turn-skill-review-overlay.tsx
+++ b/apps/web/src/hooks/use-post-turn-skill-review-overlay.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useMemo, useState } from "react";
+import { resolveSkillPostTurnReviewEnabled } from "@nakama/core";
+import type { AgentChannel, ProfileSummary } from "@nakama/core/contract";
+import {
+  SkillPostTurnReviewBanner,
+  type SuggestionApplyState,
+} from "@/components/chat/SkillPostTurnReviewBanner";
+import { useAuth } from "@/context/use-auth";
+import { useApplySkillSuggestion, useSkillSuggestions } from "@/hooks/use-skill-suggestions";
+import { useSkillProposals } from "@/hooks/use-skill-proposals";
+import { formatError } from "@/lib/client";
+
+const POST_TURN_POLL_WINDOW_MS = 45_000;
+const POST_TURN_POLL_INTERVAL_MS = 3_000;
+
+interface UsePostTurnSkillReviewOverlayArgs {
+  sessionId: string | null;
+  profile: ProfileSummary | undefined;
+  sessionChannel: AgentChannel;
+  lastSuccessfulTurnAt: number | null;
+  readOnlySession: boolean;
+}
+
+export function usePostTurnSkillReviewOverlay({
+  sessionId,
+  profile,
+  sessionChannel,
+  lastSuccessfulTurnAt,
+  readOnlySession,
+}: UsePostTurnSkillReviewOverlayArgs) {
+  const { activeOrg } = useAuth();
+  const [pollUntil, setPollUntil] = useState<number | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+  const [applyStateById, setApplyStateById] = useState<Record<string, SuggestionApplyState>>({});
+  const [applyErrorById, setApplyErrorById] = useState<Record<string, string | undefined>>({});
+
+  const reviewEnabled = resolveSkillPostTurnReviewEnabled({
+    orgSkillsPostTurnReview: activeOrg?.skillsPostTurnReview ?? false,
+    profileSkillsPostTurnReview: profile?.skillsPostTurnReview ?? null,
+  });
+
+  const canPoll =
+    reviewEnabled &&
+    Boolean(activeOrg?.id) &&
+    Boolean(sessionId) &&
+    sessionChannel === "web" &&
+    !readOnlySession &&
+    activeOrg?.role !== "viewer";
+
+  useEffect(() => {
+    if (!lastSuccessfulTurnAt || !canPoll) {
+      return;
+    }
+    setPollUntil(lastSuccessfulTurnAt + POST_TURN_POLL_WINDOW_MS);
+  }, [lastSuccessfulTurnAt, canPoll]);
+
+  const polling = pollUntil != null && now < pollUntil;
+
+  useEffect(() => {
+    if (!polling) {
+      return;
+    }
+    const timer = window.setInterval(() => {
+      setNow(Date.now());
+    }, 1_000);
+    return () => window.clearInterval(timer);
+  }, [polling]);
+
+  const suggestionsQuery = useSkillSuggestions(canPoll ? (activeOrg?.id ?? null) : null, {
+    sessionId: sessionId ?? undefined,
+    status: "pending",
+    enabled: canPoll,
+    refetchInterval: polling ? POST_TURN_POLL_INTERVAL_MS : false,
+  });
+
+  const proposalsQuery = useSkillProposals(canPoll ? (activeOrg?.id ?? null) : null, {
+    status: "pending",
+    sessionId: sessionId ?? undefined,
+    enabled: canPoll,
+    refetchInterval: polling ? POST_TURN_POLL_INTERVAL_MS : false,
+  });
+
+  const applyMutation = useApplySkillSuggestion(activeOrg?.id ?? "");
+
+  const suggestions = suggestionsQuery.data?.suggestions ?? [];
+  const pendingProposals = useMemo(
+    () =>
+      (proposalsQuery.data?.proposals ?? []).filter(
+        (proposal) => proposal.sessionId === sessionId && proposal.status === "pending",
+      ),
+    [proposalsQuery.data?.proposals, sessionId],
+  );
+
+  async function handleApply(suggestionId: string) {
+    if (!activeOrg?.id) {
+      return;
+    }
+    setApplyStateById((current) => ({ ...current, [suggestionId]: "loading" }));
+    setApplyErrorById((current) => ({ ...current, [suggestionId]: undefined }));
+    try {
+      const result = await applyMutation.mutateAsync(suggestionId);
+      setApplyStateById((current) => ({
+        ...current,
+        [suggestionId]: result.outcome === "staged_as_proposal" ? "staged" : "applied",
+      }));
+      void suggestionsQuery.refetch();
+      void proposalsQuery.refetch();
+    } catch (error) {
+      setApplyStateById((current) => ({ ...current, [suggestionId]: "error" }));
+      setApplyErrorById((current) => ({
+        ...current,
+        [suggestionId]: formatError(error),
+      }));
+    }
+  }
+
+  const banner =
+    canPoll && (suggestions.length > 0 || pendingProposals.length > 0) ? (
+      <SkillPostTurnReviewBanner
+        suggestions={suggestions}
+        pendingProposals={pendingProposals}
+        applyStateById={applyStateById}
+        applyErrorById={applyErrorById}
+        canApply={activeOrg?.role !== "viewer"}
+        isOrgAdmin={activeOrg?.role === "admin"}
+        onApply={(id) => void handleApply(id)}
+      />
+    ) : null;
+
+  return { banner, reviewEnabled };
+}

--- a/apps/web/src/hooks/use-post-turn-skill-review-overlay.tsx
+++ b/apps/web/src/hooks/use-post-turn-skill-review-overlay.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
-import { resolveSkillPostTurnReviewEnabled } from "@nakama/core";
 import type { AgentChannel, ProfileSummary } from "@nakama/core/contract";
+import { resolveSkillPostTurnReviewEnabled } from "@nakama/core/skills/post-turn-review";
 import {
   SkillPostTurnReviewBanner,
   type SuggestionApplyState,

--- a/apps/web/src/hooks/use-skill-proposals.ts
+++ b/apps/web/src/hooks/use-skill-proposals.ts
@@ -7,18 +7,24 @@ export function useSkillProposals(
   options: {
     status?: "pending" | "approved" | "rejected";
     profileId?: string;
-    refetchInterval?: number;
+    sessionId?: string;
+    enabled?: boolean;
+    refetchInterval?: number | false;
   } = {},
 ) {
   const status = options.status ?? "pending";
   return useQuery({
-    queryKey: queryKeys.skillProposals(orgId ?? "", status, options.profileId),
+    queryKey: [
+      ...queryKeys.skillProposals(orgId ?? "", status, options.profileId),
+      options.sessionId ?? "all",
+    ],
     queryFn: () =>
       client.listSkillProposals(orgId ?? "", {
         status,
         profileId: options.profileId,
+        sessionId: options.sessionId,
       }),
-    enabled: Boolean(orgId),
+    enabled: Boolean(orgId) && (options.enabled ?? true),
     refetchInterval: options.refetchInterval,
   });
 }

--- a/apps/web/src/hooks/use-skill-suggestions.ts
+++ b/apps/web/src/hooks/use-skill-suggestions.ts
@@ -1,0 +1,51 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { client } from "@/lib/client";
+import { queryKeys } from "@/lib/query-keys";
+
+export function useSkillSuggestions(
+  orgId: string | null,
+  options: {
+    sessionId?: string;
+    status?: "pending" | "applied";
+    profileId?: string;
+    enabled?: boolean;
+    refetchInterval?: number | false;
+  } = {},
+) {
+  const status = options.status ?? "pending";
+  return useQuery({
+    queryKey: queryKeys.skillSuggestions(orgId ?? "", {
+      status,
+      sessionId: options.sessionId,
+      profileId: options.profileId,
+    }),
+    queryFn: () =>
+      client.listSkillSuggestions(orgId ?? "", {
+        status,
+        sessionId: options.sessionId,
+        profileId: options.profileId,
+      }),
+    enabled: Boolean(orgId) && (options.enabled ?? true),
+    refetchInterval: options.refetchInterval,
+  });
+}
+
+function invalidateSkillSuggestionQueries(
+  queryClient: ReturnType<typeof useQueryClient>,
+  orgId: string,
+) {
+  return queryClient.invalidateQueries({ queryKey: ["skillSuggestions", orgId] });
+}
+
+export function useApplySkillSuggestion(orgId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (suggestionId: string) => client.applySkillSuggestion(orgId, suggestionId),
+    onSuccess: () => {
+      void invalidateSkillSuggestionQueries(queryClient, orgId);
+      void queryClient.invalidateQueries({ queryKey: ["skillProposals", orgId] });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.skills.all });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.profiles.all });
+    },
+  });
+}

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -206,10 +206,6 @@ export function toolPlaygroundBackTarget(searchParams: URLSearchParams): {
   return { href: toolsTabPath(), label: "Tools" };
 }
 
-export function profileProposalsPath(profileId: string): string {
-  return orgSkillProposalsPath(profileId);
-}
-
 export function orgSkillProposalsPath(profileId?: string): string {
   const params = new URLSearchParams({
     tab: "organization",

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -97,4 +97,15 @@ export const queryKeys = {
     ["orgMemoryProposals", orgId, status ?? "all"] as const,
   skillProposals: (orgId: string, status?: string, profileId?: string) =>
     ["skillProposals", orgId, status ?? "all", profileId ?? "all"] as const,
+  skillSuggestions: (
+    orgId: string,
+    options: { status?: string; sessionId?: string; profileId?: string } = {},
+  ) =>
+    [
+      "skillSuggestions",
+      orgId,
+      options.status ?? "all",
+      options.sessionId ?? "all",
+      options.profileId ?? "all",
+    ] as const,
 } as const;

--- a/apps/web/src/pages/chat/chat-page-content.tsx
+++ b/apps/web/src/pages/chat/chat-page-content.tsx
@@ -6,6 +6,7 @@ import { ArtifactStreamingPanelBridge } from "@/components/chat/artifact-streami
 import { formatAgentQuestionnaireAnswersMessage } from "@nakama/core/agent-questionnaire";
 import { formatSessionChannelLabel } from "@/lib/chat-history";
 import { extractModelId } from "@/lib/models";
+import { usePostTurnSkillReviewOverlay } from "@/hooks/use-post-turn-skill-review-overlay";
 import { ChatPageColumn, ChatWelcome } from "@/pages/chat/chat-page-layout";
 import type { ChatPageState } from "@/pages/chat/use-chat-page";
 
@@ -19,6 +20,7 @@ export function ChatPageContent(state: ChatPageState) {
     availableSkills,
     chatStatus,
     busy,
+    lastSuccessfulTurnAt,
     turnStartedAt,
     canStop,
     error,
@@ -53,6 +55,14 @@ export function ChatPageContent(state: ChatPageState) {
     agentQuestionnaire,
   } = state;
 
+  const { banner: skillReviewBanner } = usePostTurnSkillReviewOverlay({
+    sessionId: session?.id ?? null,
+    profile: activeProfile,
+    sessionChannel,
+    lastSuccessfulTurnAt,
+    readOnlySession,
+  });
+
   const readOnlyBanner = readOnlySession ? (
     <p className="mb-3 rounded-md border border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
       View-only {formatSessionChannelLabel(sessionChannel)} conversation. Reply from{" "}
@@ -62,6 +72,7 @@ export function ChatPageContent(state: ChatPageState) {
 
   const composer = (
     <PromptInputProvider key={composerDraft || "empty"} initialInput={composerDraft}>
+      {skillReviewBanner}
       {readOnlyBanner}
       <ChatComposer
         className={isEmptyState && !error ? "py-0 [&>p:first-child]:min-h-0 z-10" : "py-0 z-10"}

--- a/apps/web/src/pages/chat/chat-page-layout.tsx
+++ b/apps/web/src/pages/chat/chat-page-layout.tsx
@@ -15,8 +15,10 @@ export function ChatPageColumn({
   return (
     <div
       className={cn(
-        "flex min-h-0 min-w-0 flex-1 flex-col px-6",
-        attachmentPanel.isFullscreen && "hidden",
+        "flex min-h-0 min-w-0 flex-col transition-[width,opacity,padding] duration-200 ease-out motion-reduce:transition-none",
+        attachmentPanel.isFullscreen
+          ? "pointer-events-none w-0 flex-none overflow-hidden px-0 opacity-0"
+          : "flex-1 px-6",
         centered && "justify-center",
       )}
     >

--- a/apps/web/src/pages/chat/use-chat-page.ts
+++ b/apps/web/src/pages/chat/use-chat-page.ts
@@ -113,6 +113,7 @@ export function useChatPage() {
   const [agentQuestionnaire, setAgentQuestionnaire] = useState<AgentQuestionnaire | null>(null);
   const [contextUsage, setContextUsage] = useState<ChatContextUsage | null>(null);
   const [busy, setBusy] = useState(false);
+  const [lastSuccessfulTurnAt, setLastSuccessfulTurnAt] = useState<number | null>(null);
   const [turnStartedAt, setTurnStartedAt] = useState<string | null>(null);
   const [branchingMessageId, setBranchingMessageId] = useState<string | null>(null);
   const [canStop, setCanStop] = useState(false);
@@ -462,6 +463,10 @@ export function useChatPage() {
             setAgentQuestionnaire(refreshed.questionnaire);
             setContextUsage(refreshed.contextUsage ?? null);
 
+            if (reconnected) {
+              setLastSuccessfulTurnAt(Date.now());
+            }
+
             if (!reconnected && !status.active) {
               setError(null);
             }
@@ -719,6 +724,7 @@ export function useChatPage() {
         setAgentTodos(todos);
         setAgentQuestionnaire(questionnaire);
         setContextUsage(nextContextUsage ?? null);
+        setLastSuccessfulTurnAt(Date.now());
       } catch (err) {
         if (isAbortError(err)) {
           setMessages((current) => finalizeStreamingMessages(current));
@@ -892,6 +898,7 @@ export function useChatPage() {
     availableSkills,
     chatStatus,
     busy,
+    lastSuccessfulTurnAt,
     turnStartedAt,
     canStop,
     error,

--- a/apps/web/src/pages/profiles/profile-config-tab.tsx
+++ b/apps/web/src/pages/profiles/profile-config-tab.tsx
@@ -1,6 +1,7 @@
 import type { ProfilesPageState } from "@/pages/profiles/use-profiles-page";
 import { ProfileConfigAssignmentsSection } from "@/pages/profiles/profile-config-assignments-section";
 import { ProfileConfigIdentitySection } from "@/pages/profiles/profile-config-identity-section";
+import { ProfileSkillsPostTurnReviewField } from "@/components/profiles/ProfileSkillsPostTurnReviewField";
 import { ProfileSkillsWriteApprovalField } from "@/components/profiles/ProfileSkillsWriteApprovalField";
 
 export function ProfileConfigTab({ state }: { state: ProfilesPageState }) {
@@ -16,6 +17,7 @@ export function ProfileConfigTab({ state }: { state: ProfilesPageState }) {
     >
       <ProfileConfigIdentitySection state={state} />
       <ProfileSkillsWriteApprovalField profile={state.detail} disabled={state.busy} />
+      <ProfileSkillsPostTurnReviewField profile={state.detail} disabled={state.busy} />
       <ProfileConfigAssignmentsSection state={state} />
     </div>
   );

--- a/apps/web/src/pages/profiles/profiles-page-layout.tsx
+++ b/apps/web/src/pages/profiles/profiles-page-layout.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/select";
 import { ProfileAdminPlusButton } from "@/components/ProfileAdminPlusButton";
 import { ProfileAvatar } from "@/components/ProfileAvatar";
+import { ChatAttachmentPanelProvider } from "@/context/chat-attachment-panel-context";
 import { useAuth } from "@/context/use-auth";
 import { useAppNavigation } from "@/hooks/use-app-navigation";
 import { useSkillProposals } from "@/hooks/use-skill-proposals";
@@ -83,7 +84,7 @@ export function ProfilesPageLayout(state: ProfilesPageState) {
           </p>
         ) : null}
 
-        <section className={cn(sectionClass, "overflow-hidden")}>
+        <section className={cn(sectionClass, "flex min-h-[calc(100svh-7rem)] flex-col overflow-hidden")}>
           <div className="flex flex-col gap-3 border-b border-border p-4 lg:hidden">
             <div className="flex flex-wrap items-center gap-3">
               <Select
@@ -249,43 +250,49 @@ export function ProfilesPageLayout(state: ProfilesPageState) {
                       </Button>
                     ) : null}
                   </div>
-                  <div className="no-scrollbar min-h-0 flex-1 overflow-y-auto p-4 sm:p-5">
-                    {detailTab === "profile" ? (
+                  {detailTab === "profile" ? (
+                    <div className="no-scrollbar min-h-0 flex-1 overflow-y-auto p-4 sm:p-5">
                       <ProfileConfigTab state={state} />
-                    ) : detailTab === "proposals" && isOrgAdmin && activeOrg && selectedId ? (
-                      <div
-                        id="profile-detail-panel-proposals"
-                        role="tabpanel"
-                        aria-labelledby="profile-detail-tab-proposals"
-                      >
-                        <SkillProposalsPanel orgId={activeOrg.id} profileId={selectedId} />
-                      </div>
-                    ) : detailTab === "prompt" ? (
-                      <div
-                        id="profile-detail-panel-prompt"
-                        role="tabpanel"
-                        aria-labelledby="profile-detail-tab-prompt"
-                      >
-                        <SoulTab profileId={selectedId} />
-                      </div>
-                    ) : detailTab === "knowledge" ? (
-                      <div
-                        id="profile-detail-panel-knowledge"
-                        role="tabpanel"
-                        aria-labelledby="profile-detail-tab-knowledge"
-                      >
-                        <KnowledgeTab profileId={selectedId} />
-                      </div>
-                    ) : (
+                    </div>
+                  ) : detailTab === "proposals" && isOrgAdmin && activeOrg && selectedId ? (
+                    <div
+                      id="profile-detail-panel-proposals"
+                      role="tabpanel"
+                      aria-labelledby="profile-detail-tab-proposals"
+                      className="no-scrollbar min-h-0 flex-1 overflow-y-auto p-4 sm:p-5"
+                    >
+                      <SkillProposalsPanel orgId={activeOrg.id} profileId={selectedId} />
+                    </div>
+                  ) : detailTab === "prompt" ? (
+                    <div
+                      id="profile-detail-panel-prompt"
+                      role="tabpanel"
+                      aria-labelledby="profile-detail-tab-prompt"
+                      className="no-scrollbar min-h-0 flex-1 overflow-y-auto p-4 sm:p-5"
+                    >
+                      <SoulTab profileId={selectedId} />
+                    </div>
+                  ) : detailTab === "knowledge" ? (
+                    <div
+                      id="profile-detail-panel-knowledge"
+                      role="tabpanel"
+                      aria-labelledby="profile-detail-tab-knowledge"
+                      className="no-scrollbar min-h-0 flex-1 overflow-y-auto p-4 sm:p-5"
+                    >
+                      <KnowledgeTab profileId={selectedId} />
+                    </div>
+                  ) : (
+                    <ChatAttachmentPanelProvider presentation="overlay">
                       <div
                         id="profile-detail-panel-artifacts"
                         role="tabpanel"
                         aria-labelledby="profile-detail-tab-artifacts"
+                        className="no-scrollbar min-h-0 min-w-0 flex-1 overflow-y-auto p-4 sm:p-5"
                       >
                         <ArtifactsTab profileId={selectedId} />
                       </div>
-                    )}
-                  </div>
+                    </ChatAttachmentPanelProvider>
+                  )}
                 </>
               )}
             </div>

--- a/docs/website/content/docs/agent-prompt.mdx
+++ b/docs/website/content/docs/agent-prompt.mdx
@@ -88,11 +88,11 @@ Profiles do not use dedicated memory or artifact builtins. The chat wrapper nudg
 |-------|-------------|---------|
 | `update-profile-memory` | `read_file` + `edit_file` | Append facts and preferences to active `MEMORY.md` |
 | `archive-profile-memory` | `read_file` + `edit_file` | Move bullets from `MEMORY.md` into `memory-archive/` without deleting them |
-| `save-artifact` | `write_file` or `write_docx` | Save persistent outputs under `artifacts/` with metadata for the dashboard; on web chat, paired saves also show as message attachment chips with in-chat preview |
+| `save-artifact` | `write_file` or `write_docx` | Save files the agent produces under `artifacts/` with metadata for the dashboard; on web chat, paired saves also show as message attachment chips with in-chat preview |
 
 The skills catalog is always visible. When a user message matches a skill description, Nakama can attach the full skill body for that turn (`include-body-on-match: true`).
 
-Active `MEMORY.md` is also composed into the soul stack. Archived content under `memory-archive/` is not loaded automatically — the agent uses `search_files` or `read_file` to retrieve it. Artifacts under `artifacts/` are not loaded into the agent prompt — users browse them in the dashboard Artifacts tab, download via the API, or open them from web chat attachment chips on assistant messages (HTML, Markdown, Word, code, and text previews are rendered by content type).
+Active `MEMORY.md` is also composed into the soul stack. Archived content under `memory-archive/` is not loaded automatically — the agent uses `search_files` or `read_file` to retrieve it. Artifact files under `artifacts/` are not loaded into the agent prompt — users browse them in the dashboard Artifacts tab, download via the API, or open them from web chat attachment chips on assistant messages (HTML, Markdown, Word, code, and text previews are rendered by content type).
 
 See [Skills](/skills) for the bundled skill list and [Profiles](/profiles) for where memory and artifact files live on disk.
 

--- a/docs/website/content/docs/builtin-tools.mdx
+++ b/docs/website/content/docs/builtin-tools.mdx
@@ -86,7 +86,9 @@ Active `MEMORY.md` has a **4096-byte** soft limit. Default and super-bot profile
 
 ## Artifact saves
 
-Persistent outputs (reports, summaries, generated text, Word documents) are not a separate builtin. Agents use `write_file` or `write_docx` with the `save-artifact` bundled skill under `artifacts/`. The skill also documents writing a `{filename}.nakama-meta.json` sidecar so the dashboard Artifacts tab shows MIME types and timestamps.
+Artifacts are files your agent creates and saves for you — reports, summaries, generated text, Word documents, and other outputs you can preview or download later from the dashboard Artifacts tab or from web chat.
+
+They are not a separate builtin. Agents use `write_file` or `write_docx` with the `save-artifact` bundled skill under `artifacts/`. The skill also documents writing a `{filename}.nakama-meta.json` sidecar so the Artifacts tab shows MIME types and timestamps.
 
 On web chat, `write_file` and `write_docx` saves under `artifacts/` appear as attachment chips on the assistant message. Click a chip to open a resizable preview panel with copy, download, and fullscreen:
 
@@ -393,7 +395,7 @@ File tools (`read_file`, `write_file`, `edit_file`, `delete_file`) are scoped to
 - **Profile workspace:** `~/.nakama/orgs/{orgId}/profiles/{profileId}/` (soul files, knowledge base, `artifacts/`, etc.)
 - **Custom tools directory:** `~/.nakama/tools/` (follows `NAKAMA_CONFIG_DIR` if set)
 
-Agents save persistent outputs under `artifacts/` via the `save-artifact` bundled skill and `write_file`, not a dedicated builtin.
+Agents save artifact files under `artifacts/` via the `save-artifact` bundled skill and `write_file`, not a dedicated builtin.
 
 Path guards enforce:
 

--- a/docs/website/content/docs/discord.mdx
+++ b/docs/website/content/docs/discord.mdx
@@ -158,7 +158,7 @@ Discord has a 2000-character limit per message. Nakama automatically chunks long
 
 ## Saved artifacts and share links
 
-When the agent saves a file with the `save-artifact` skill (content file plus `.nakama-meta.json` sidecar in the same turn), Nakama posts a **Publish-style share link** after the reply in Discord.
+When your agent saves a file for you with the `save-artifact` skill (content file plus `.nakama-meta.json` sidecar in the same turn), Nakama posts a **Publish-style share link** after the reply in Discord.
 
 - The link uses the same unguessable `/s/{token}` URLs as dashboard Publish — no Nakama login required to open it.
 - Anyone who can read the Discord message can open the link until the share is revoked from the web app.

--- a/docs/website/content/docs/profiles.mdx
+++ b/docs/website/content/docs/profiles.mdx
@@ -107,7 +107,7 @@ Profile-scoped skills are stored at:
 ~/.nakama/orgs/{orgId}/profiles/{profileId}/skills/
 ```
 
-Artifacts saved by the agent (via the `save-artifact` skill and `write_file`) are stored at:
+Artifacts are files your agent creates and saves for you (reports, documents, generated text). They are stored at:
 
 ```text
 ~/.nakama/orgs/{orgId}/profiles/{profileId}/artifacts/
@@ -140,7 +140,7 @@ Profiles keep their own context on disk under the org-scoped profile directory:
 - **Inherited knowledge sources** for shared product references, such as the Nakama documentation
 - **`MEMORY.md`** for active facts and continuity the agent should remember across sessions
 - **`memory-archive/`** for facts moved out of active memory without deleting them
-- **Artifacts** for persistent reports and generated text saved via the `save-artifact` skill
+- **Artifacts** — files your agent creates and saves for you (reports, documents, generated text)
 
 At the **organization** level (not inside a profile directory), [org memory](/org-memory) stores shared facts every profile in the org sees — admin-curated, distinct from per-profile `MEMORY.md`.
 

--- a/docs/website/content/docs/self-improving-skills.mdx
+++ b/docs/website/content/docs/self-improving-skills.mdx
@@ -16,33 +16,35 @@ With self-improving skills:
 - **Less repeat explanation** — the agent captures a workflow once and reuses it when a similar request comes up.
 - **Cleaner profiles** — procedures live in skills instead of bloating the main prompt.
 - **Team safety** — org admins can require approval before a new or changed skill affects future behavior.
+- **Safety net after complex work** — optional post-turn review can catch missed saves without silently changing skills.
 
 Think of it as the agent learning *how to do the job*, while you decide whether that learning goes live immediately or waits for a quick review.
 
 ## How it works
 
 ```text
-Complex task succeeds  →  Agent saves a skill  →  Skill matches on later chats
+Complex task succeeds  →  Agent saves a skill (or review suggests one)  →  Skill matches on later chats
                               ↓
                     (optional) Org admin approves
 ```
 
 1. **During chat** — after a hard problem, recovery, or correction, the agent may offer to save the approach as a skill (for example, a deploy checklist or support triage flow).
-2. **On later turns** — when someone asks for something similar, Nakama can load that skill and follow the saved steps.
-3. **Optional gate** — if write approval is on, the skill change waits in a proposal queue until an org admin approves or rejects it.
+2. **After complex turns (optional)** — when **post-turn skill review** is on, Nakama may review the finished turn in the background and either show an **Apply** suggestion in chat or stage a proposal for an org admin.
+3. **On later turns** — when someone asks for something similar, Nakama can load that skill and follow the saved steps.
+4. **Optional gate** — if write approval is on, skill changes wait in a proposal queue until an org admin approves or rejects them.
 
 Skills hold **procedures** (how to do something). Profile memory holds **facts** about the user (preferences, context). Keep preferences in memory; keep repeatable workflows in skills.
 
 ## Where it works
 
-| Channel | Agent can update skills? |
-|---------|--------------------------|
-| **Web chat** | Yes |
-| **CLI chat** | Yes |
-| **Telegram, WhatsApp, Discord** | No |
-| **Automations / scheduled runs** | No |
+| Channel | Agent can update skills? | Post-turn review? |
+|---------|--------------------------|-------------------|
+| **Web chat** | Yes | Yes (when enabled) |
+| **CLI chat** | Yes | Yes (review may run; Apply is web-first) |
+| **Telegram, WhatsApp, Discord** | No | No |
+| **Automations / scheduled runs** | No | No |
 
-Org **viewers** can read chat but cannot run agents, so they cannot trigger skill updates.
+Org **viewers** can read chat but cannot run agents, so they cannot trigger skill updates or Apply suggestions.
 
 Default and Super Bot profiles include the skill-authoring capability after sync. Other profiles need the **manage-skills** skill assigned — see [Skills](/skills).
 
@@ -75,14 +77,38 @@ Nakama flags suspicious patterns in proposals the same way it does for org memor
 
 Platform admins managing a specific bot can also open **Agent → Profiles**, select the profile, and use the **Proposals** tab there.
 
+## Post-turn skill review (optional)
+
+In-session saves can still miss a good workflow: the agent finishes a long tool-heavy turn and never crystallizes a skill. **Post-turn skill review** is an opt-in safety net for that case.
+
+### Turn it on
+
+Org admins: **System → Organization**, on the **Post-turn skill review** card (next to Skill write approval).
+
+- Default is **off** (no extra review pass).
+- Optionally override per profile: inherit the org default, always review, or never review for that bot.
+
+When enabled, after a **successful** web or CLI turn that looks complex (many tool calls, or a tool error recovery) — and only if the agent did **not** already save a skill that turn — Nakama runs a lightweight background review. Chat is not blocked while that runs. It uses an extra model call on eligible turns, so leave it off unless you want the safety net.
+
+### What you see (review × write approval)
+
+| | **Write approval off** | **Write approval on** |
+|---|---|---|
+| **Post-turn review off** | No background pass | No background pass |
+| **Post-turn review on** | Chat shows a suggestion with preview + **Apply** — nothing is written until you Apply | Review stages a proposal; chat shows a pending-admin notice; live skill waits for org-admin approve |
+
+Unlike some other agents that auto-write skills in the background when approval is off, Nakama **never silent-writes** from post-turn review. Gate off means you still choose **Apply**; gate on means an admin must approve.
+
+Suggestions appear as a chat UI card (not as a message in the conversation history the model will see next turn). Ignore a suggestion by leaving it; there is no separate reject queue for suggestions.
+
 ## Who can do what
 
-| Role | Chat and trigger skill updates | Approve or reject proposals | Change gate settings |
-|------|-------------------------------|----------------------------|----------------------|
-| **Org admin** | Yes | Yes | Yes |
-| **Org member** | Yes | No | No |
-| **Org viewer** | No (read-only chat) | No | No |
-| **Platform admin** | Yes | Yes | Yes |
+| Role | Chat and trigger skill updates | Apply post-turn suggestions | Approve or reject proposals | Change gate / review settings |
+|------|-------------------------------|----------------------------|----------------------------|------------------------------|
+| **Org admin** | Yes | Yes | Yes | Yes |
+| **Org member** | Yes | Yes | No | No |
+| **Org viewer** | No (read-only chat) | No | No | No |
+| **Platform admin** | Yes | Yes | Yes | Yes |
 
 ## Skills vs org memory
 
@@ -113,10 +139,6 @@ Click a skill to open its detail dialog for the full breakdown:
 These numbers update during **web** and **CLI** chat. They do not change from Telegram, WhatsApp, Discord, or automations — those channels do not run the skill-authoring flow today.
 
 Automated cleanup (archiving unused skills, curator reports) is planned for a later release and will apply only to **agent- or human-authored** skills — not bundled system skills. For now, use the usage hints to decide what to unassign, edit, or keep.
-
-## What's next
-
-Nakama is extending this area over time — for example, gentle suggestions after complex turns when saving a skill might help, and automated curation for skills that stay unused. What you have today is agent-driven skill authoring, optional org-admin approval, and usage visibility on each profile's skills list.
 
 ## Related
 

--- a/docs/website/content/docs/skills.mdx
+++ b/docs/website/content/docs/skills.mdx
@@ -160,7 +160,7 @@ Profiles receive bundled skills for common workflows:
 - `manage-skills` — create, patch, and delete profile-scoped skills with the `skill_manage` tool (file tools still inspect skills; they cannot write `skills/*/SKILL.md` when `skill_manage` is present)
 - `update-profile-memory` — record facts in active `MEMORY.md` via file tools
 - `archive-profile-memory` — move facts from active `MEMORY.md` into `memory-archive/` without deleting them
-- `save-artifact` — save persistent text outputs under `artifacts/` via `write_file`
+- `save-artifact` — save files the agent produces (reports, documents, generated text) under `artifacts/` via `write_file`
 - `coding-agent` — invoke a coding agent for repo work via `bash` (Super Bot by default; see [Coding agent](/coding-agent))
 - `agent-browser` — interactive browser automation via `bash` (opt-in; see [Agent browser](/agent-browser))
 
@@ -178,7 +178,7 @@ Org admins can enable **skill write approval** under **System → Organization �
 
 - **Memory write path:** read or create `MEMORY.md`, append a dated `- bullet` under the user's timezone date, keep the `# Memory Log` preamble, stay under 4096 bytes
 - **Archive path:** copy exact bullets to `memory-archive/YYYY-MM.md`, then remove them from `MEMORY.md`
-- **Artifact path:** `write_file` or `write_docx` under `artifacts/{filename}`, then write `{filename}.nakama-meta.json` with MIME metadata for the dashboard. Use `write_file` for text, Markdown, HTML, JSON, and code; use `write_docx` when the user wants a real Word document.
+- **Artifact path:** save the file the agent produced with `write_file` or `write_docx` under `artifacts/{filename}`, then write `{filename}.nakama-meta.json` with MIME metadata for the dashboard. Use `write_file` for text, Markdown, HTML, JSON, and code; use `write_docx` when the user wants a real Word document.
 
 These skills use `include-body-on-match: true`, so the full procedure loads when the user's message matches the skill description. The chat wrapper also mentions memory skills when `read_file` and `edit_file` are available, and `save-artifact` when `write_file` is available.
 
@@ -223,7 +223,7 @@ Viewers cannot invoke agents, so they cannot trigger skills either.
 - Use **`archive-profile-memory`** when the user wants to forget, tidy, or free space in active memory without deleting history
 - Use the **main profile prompt** for always-on behavior and identity
 - Use a **builtin tool** for a native capability like web search or file access
-- Use **`save-artifact`** with **`write_file`** or **`write_docx`** for persistent reports, summaries, generated text, and Word documents under `artifacts/`
+- Use **`save-artifact`** with **`write_file`** or **`write_docx`** when the agent should save a file for you (reports, summaries, generated text, Word documents) under `artifacts/`
 - Use **`coding-agent`** with **`bash`** when repo work is better handled by a dedicated coding agent ([setup](/coding-agent))
 - Use **`agent-browser`** with **`bash`** for login walls, forms, and interactive browsing ([setup](/agent-browser))
 - Use an **MCP server** for external tool integrations

--- a/docs/website/content/docs/telegram/chat.mdx
+++ b/docs/website/content/docs/telegram/chat.mdx
@@ -85,7 +85,7 @@ If Telegram rejects the rich rendering, Nakama falls back to plain text.
 
 ## Saved artifacts and share links
 
-When the agent saves a file with the `save-artifact` skill (content file plus `.nakama-meta.json` sidecar in the same turn), Nakama posts a **Publish-style share link** after the reply in Telegram chat.
+When your agent saves a file for you with the `save-artifact` skill (content file plus `.nakama-meta.json` sidecar in the same turn), Nakama posts a **Publish-style share link** after the reply in Telegram chat.
 
 - The link uses the same unguessable `/s/{token}` URLs as dashboard Publish — no Nakama login required to open it.
 - Anyone who can read the Telegram message can open the link until the share is revoked from the web app.

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -73,6 +73,15 @@ export {
   normalizeSessionTitle,
 } from "./session-title";
 export {
+  buildSkillPostTurnReviewPrompt,
+  generateSkillPostTurnReview,
+  parseSkillPostTurnReviewResponse,
+} from "./skill-post-turn-review";
+export type {
+  SkillCatalogEntry,
+  SkillPostTurnReviewOutcome,
+} from "./skill-post-turn-review";
+export {
   mergeOrgMemoryWithApprovedBullet,
   mergeOrgMemoryWithApprovedBulletFallback,
 } from "./org-memory-merge";

--- a/packages/agent/src/skill-post-turn-review.test.ts
+++ b/packages/agent/src/skill-post-turn-review.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildSkillPostTurnReviewPrompt,
+  parseSkillPostTurnReviewResponse,
+} from "./skill-post-turn-review";
+
+describe("parseSkillPostTurnReviewResponse", () => {
+  const catalogNames = new Set(["deploy-checklist"]);
+
+  test("accepts valid create", () => {
+    const outcome = parseSkillPostTurnReviewResponse(
+      JSON.stringify({
+        action: "create",
+        name: "triage-support",
+        content: "---\nname: triage-support\ndescription: Triage tickets\n---\n\nSteps",
+      }),
+      { catalogNames },
+    );
+    expect(outcome).toEqual({
+      action: "create",
+      name: "triage-support",
+      content: "---\nname: triage-support\ndescription: Triage tickets\n---\n\nSteps",
+    });
+  });
+
+  test("accepts valid patch for known skill", () => {
+    const outcome = parseSkillPostTurnReviewResponse(
+      JSON.stringify({
+        action: "patch",
+        name: "deploy-checklist",
+        oldString: "step 1",
+        newString: "step 1 updated",
+      }),
+      { catalogNames },
+    );
+    expect(outcome.action).toBe("patch");
+  });
+
+  test("rejects delete", () => {
+    expect(
+      parseSkillPostTurnReviewResponse(JSON.stringify({ action: "delete", name: "x" }), {
+        catalogNames,
+      }),
+    ).toEqual({ action: "noop", reason: "delete_forbidden" });
+  });
+
+  test("rejects bundled skill name", () => {
+    expect(
+      parseSkillPostTurnReviewResponse(
+        JSON.stringify({
+          action: "create",
+          name: "manage-skills",
+          content: "---\nname: manage-skills\ndescription: x\n---\n",
+        }),
+        { catalogNames },
+      ),
+    ).toEqual({ action: "noop", reason: "bundled_forbidden" });
+  });
+
+  test("rejects malformed json", () => {
+    expect(parseSkillPostTurnReviewResponse("not json", { catalogNames })).toEqual({
+      action: "noop",
+      reason: "malformed_json",
+    });
+  });
+});
+
+describe("buildSkillPostTurnReviewPrompt", () => {
+  test("includes catalog and turn tools", () => {
+    const prompt = buildSkillPostTurnReviewPrompt({
+      catalog: [{ name: "deploy-checklist", description: "Deploy steps" }],
+      turnMessages: [
+        { role: "user", content: "deploy staging" },
+        {
+          role: "assistant",
+          content: "ok",
+          toolCalls: [{ id: "1", name: "bash", arguments: "{}" }],
+        },
+        { role: "tool", toolCallId: "1", name: "bash", content: '{"ok":true}' },
+      ],
+    });
+    expect(prompt).toContain("deploy-checklist");
+    expect(prompt).toContain("bash");
+    expect(prompt).toContain("deploy staging");
+  });
+});

--- a/packages/agent/src/skill-post-turn-review.ts
+++ b/packages/agent/src/skill-post-turn-review.ts
@@ -1,0 +1,188 @@
+import {
+  BUNDLED_SKILL_NAMES,
+  getUserMessageText,
+  type ChatMessage,
+  type ProviderClient,
+} from "@nakama/core";
+
+const TURN_SNIPPET_MAX = 4_000;
+const TOOL_RESULT_MAX = 400;
+const bundledNames = new Set<string>(BUNDLED_SKILL_NAMES);
+
+export type SkillPostTurnReviewOutcome =
+  | { action: "noop"; reason?: string }
+  | { action: "create"; name: string; content: string }
+  | { action: "patch"; name: string; oldString: string; newString: string };
+
+export interface SkillCatalogEntry {
+  name: string;
+  description: string;
+}
+
+const REVIEW_SYSTEM = [
+  "You review a completed agent chat turn and decide whether a reusable profile skill should be created or patched.",
+  "Return ONLY compact JSON with one of these shapes:",
+  '{"action":"noop","reason":"..."}',
+  '{"action":"create","name":"kebab-case-name","content":"full SKILL.md with YAML frontmatter"}',
+  '{"action":"patch","name":"existing-skill","oldString":"exact excerpt","newString":"replacement"}',
+  "",
+  "Rules:",
+  "- Prefer patch over create when an existing profile skill clearly matches",
+  "- Prefer noop when the turn is routine, already covered, or low confidence",
+  "- Never delete skills; never target bundled/global system skills",
+  "- create name must match ^[a-z0-9-]{1,64}$",
+  "- create content must include frontmatter with name and description",
+  "- patch oldString must be unique in the current skill body you would expect",
+  "- Do not wrap JSON in markdown fences",
+].join("\n");
+
+function truncate(value: string, max: number): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= max) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, max).trimEnd()}…`;
+}
+
+export function buildSkillPostTurnReviewPrompt(input: {
+  turnMessages: ChatMessage[];
+  catalog: SkillCatalogEntry[];
+}): string {
+  const lines: string[] = ["## Assigned profile skills", ""];
+
+  if (input.catalog.length === 0) {
+    lines.push("(none)");
+  } else {
+    for (const skill of input.catalog) {
+      lines.push(`- ${skill.name}: ${truncate(skill.description, 200)}`);
+    }
+  }
+
+  lines.push("", "## Latest turn", "");
+
+  for (const message of input.turnMessages) {
+    if (message.role === "user") {
+      lines.push(`User: ${truncate(getUserMessageText(message.content), 800)}`);
+      continue;
+    }
+    if (message.role === "assistant") {
+      const tools = message.toolCalls?.map((call) => call.name).join(", ") ?? "";
+      lines.push(
+        `Assistant: ${truncate(message.content || "(tool calls)", 800)}${tools ? ` [tools: ${tools}]` : ""}`,
+      );
+      continue;
+    }
+    if (message.role === "tool") {
+      lines.push(`Tool ${message.name}: ${truncate(message.content, TOOL_RESULT_MAX)}`);
+    }
+  }
+
+  return truncate(lines.join("\n"), TURN_SNIPPET_MAX);
+}
+
+function extractJsonObject(raw: string): unknown {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    const start = trimmed.indexOf("{");
+    const end = trimmed.lastIndexOf("}");
+    if (start === -1 || end <= start) {
+      return null;
+    }
+    try {
+      return JSON.parse(trimmed.slice(start, end + 1)) as unknown;
+    } catch {
+      return null;
+    }
+  }
+}
+
+function isValidSkillName(name: string): boolean {
+  return /^[a-z0-9-]{1,64}$/.test(name);
+}
+
+export function parseSkillPostTurnReviewResponse(
+  raw: string,
+  options: { catalogNames: Set<string> },
+): SkillPostTurnReviewOutcome {
+  const parsed = extractJsonObject(raw);
+  if (typeof parsed !== "object" || parsed === null) {
+    return { action: "noop", reason: "malformed_json" };
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const action = record.action;
+
+  if (action === "noop") {
+    return {
+      action: "noop",
+      reason: typeof record.reason === "string" ? record.reason : undefined,
+    };
+  }
+
+  if (action === "delete") {
+    return { action: "noop", reason: "delete_forbidden" };
+  }
+
+  if (action === "create") {
+    const name = typeof record.name === "string" ? record.name.trim() : "";
+    const content = typeof record.content === "string" ? record.content : "";
+    if (!isValidSkillName(name) || !content.trim()) {
+      return { action: "noop", reason: "invalid_create" };
+    }
+    if (bundledNames.has(name)) {
+      return { action: "noop", reason: "bundled_forbidden" };
+    }
+    if (options.catalogNames.has(name)) {
+      return { action: "noop", reason: "create_collides_with_existing" };
+    }
+    return { action: "create", name, content };
+  }
+
+  if (action === "patch") {
+    const name = typeof record.name === "string" ? record.name.trim() : "";
+    const oldString = typeof record.oldString === "string" ? record.oldString : "";
+    const newString = typeof record.newString === "string" ? record.newString : "";
+    if (!isValidSkillName(name) || !oldString || newString === undefined) {
+      return { action: "noop", reason: "invalid_patch" };
+    }
+    if (bundledNames.has(name)) {
+      return { action: "noop", reason: "bundled_forbidden" };
+    }
+    if (!options.catalogNames.has(name)) {
+      return { action: "noop", reason: "patch_unknown_skill" };
+    }
+    return { action: "patch", name, oldString, newString };
+  }
+
+  return { action: "noop", reason: "unknown_action" };
+}
+
+export async function generateSkillPostTurnReview(input: {
+  turnMessages: ChatMessage[];
+  catalog: SkillCatalogEntry[];
+  provider: ProviderClient;
+}): Promise<SkillPostTurnReviewOutcome> {
+  const prompt = buildSkillPostTurnReviewPrompt({
+    turnMessages: input.turnMessages,
+    catalog: input.catalog,
+  });
+  const catalogNames = new Set(input.catalog.map((skill) => skill.name));
+
+  try {
+    const result = await input.provider.generateText({
+      system: REVIEW_SYSTEM,
+      prompt,
+      format: "text",
+    });
+    return parseSkillPostTurnReviewResponse(result.content, { catalogNames });
+  } catch (error) {
+    console.error("Failed post-turn skill review LLM call:", error);
+    return { action: "noop", reason: "provider_error" };
+  }
+}

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -169,6 +169,8 @@ import type {
   OrgMemoryProposalResponse,
   ListSkillProposalsResponse,
   SkillProposalResponse,
+  ListSkillSuggestionsResponse,
+  ApplySkillSuggestionResponse,
   ListOrgMemoryHistoryResponse,
   RestoreOrgMemoryHistoryResponse,
   OrgMemoryHistoryRevisionResponse,
@@ -1843,6 +1845,40 @@ export class NakamaClient {
   ): Promise<SkillProposalResponse> {
     return this.request<SkillProposalResponse>(
       `/v1/orgs/${encodeURIComponent(orgId)}/skill-proposals/${encodeURIComponent(proposalId)}/reject`,
+      {
+        method: "POST",
+        headers: { "X-Org-Id": orgId },
+      },
+    );
+  }
+
+  async listSkillSuggestions(
+    orgId: string,
+    options: { sessionId?: string; status?: "pending" | "applied"; profileId?: string } = {},
+  ): Promise<ListSkillSuggestionsResponse> {
+    const params = new URLSearchParams();
+    if (options.sessionId) {
+      params.set("sessionId", options.sessionId);
+    }
+    if (options.status) {
+      params.set("status", options.status);
+    }
+    if (options.profileId) {
+      params.set("profileId", options.profileId);
+    }
+    const query = params.toString();
+    return this.request<ListSkillSuggestionsResponse>(
+      `/v1/orgs/${encodeURIComponent(orgId)}/skill-suggestions${query ? `?${query}` : ""}`,
+      { headers: { "X-Org-Id": orgId } },
+    );
+  }
+
+  async applySkillSuggestion(
+    orgId: string,
+    suggestionId: string,
+  ): Promise<ApplySkillSuggestionResponse> {
+    return this.request<ApplySkillSuggestionResponse>(
+      `/v1/orgs/${encodeURIComponent(orgId)}/skill-suggestions/${encodeURIComponent(suggestionId)}/apply`,
       {
         method: "POST",
         headers: { "X-Org-Id": orgId },

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1810,7 +1810,11 @@ export class NakamaClient {
 
   async listSkillProposals(
     orgId: string,
-    options: { status?: "pending" | "approved" | "rejected"; profileId?: string } = {},
+    options: {
+      status?: "pending" | "approved" | "rejected";
+      profileId?: string;
+      sessionId?: string;
+    } = {},
   ): Promise<ListSkillProposalsResponse> {
     const params = new URLSearchParams();
     if (options.status) {
@@ -1818,6 +1822,9 @@ export class NakamaClient {
     }
     if (options.profileId) {
       params.set("profileId", options.profileId);
+    }
+    if (options.sessionId) {
+      params.set("sessionId", options.sessionId);
     }
     const query = params.toString();
     return this.request<ListSkillProposalsResponse>(

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,6 +38,7 @@
     "./whatsapp-config": "./src/whatsapp-config.ts",
     "./whatsapp-worker": "./src/whatsapp-worker.ts",
     "./skills/bundled-names": "./src/skills/bundled-names.ts",
+    "./skills/post-turn-review": "./src/skills/post-turn-review.ts",
     "./skills/write": "./src/skills/write.ts",
     "./soul/org-memory": "./src/soul/org-memory.ts",
     "./tools/protected": "./src/tools/protected.ts",

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -286,6 +286,7 @@ export interface OrganizationSummary {
   name: string;
   slug: string;
   skillsWriteApproval?: boolean;
+  skillsPostTurnReview?: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -303,6 +304,7 @@ export interface CreateOrganizationRequest {
 export interface UpdateOrganizationRequest {
   name?: string;
   skillsWriteApproval?: boolean;
+  skillsPostTurnReview?: boolean;
 }
 
 export interface ListOrganizationsResponse {
@@ -1359,6 +1361,8 @@ export interface ProfileSummary {
   isDefault?: boolean;
   /** null = inherit org default; true/false = force gate on/off for this profile */
   skillsWriteApproval?: boolean | null;
+  /** null = inherit org default; true/false = force post-turn review on/off for this profile */
+  skillsPostTurnReview?: boolean | null;
   toolCount: number;
   mcpServerCount: number;
   soulActive: boolean;
@@ -1563,6 +1567,7 @@ export interface UpdateProfileRequest {
   systemPrompt?: string;
   model?: string | null;
   skillsWriteApproval?: boolean | null;
+  skillsPostTurnReview?: boolean | null;
 }
 
 export interface CreateToolRequest {

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -512,6 +512,40 @@ export interface SkillProposalResponse {
   proposal: SkillProposal;
 }
 
+export type SkillSuggestionStatus = "pending" | "applied";
+export type SkillSuggestionAction = "create" | "patch";
+export type SkillSuggestionSource = "post_turn_review";
+
+export interface SkillSuggestion {
+  id: string;
+  orgId: string;
+  profileId: string;
+  sessionId: string | null;
+  proposedByUserId: string | null;
+  action: SkillSuggestionAction;
+  skillName: string;
+  content: string | null;
+  patchOldString: string | null;
+  patchNewString: string | null;
+  status: SkillSuggestionStatus;
+  source: SkillSuggestionSource;
+  warnings?: string[];
+  createdAt: string;
+  appliedAt: string | null;
+}
+
+export interface ListSkillSuggestionsResponse {
+  suggestions: SkillSuggestion[];
+}
+
+export type ApplySkillSuggestionOutcome = "applied" | "already_applied" | "staged_as_proposal";
+
+export interface ApplySkillSuggestionResponse {
+  outcome: ApplySkillSuggestionOutcome;
+  suggestion: SkillSuggestion;
+  proposalId?: string;
+}
+
 export interface InviteOrgMemberRequest {
   email: string;
   role: OrgRole;

--- a/packages/core/src/skills/index.ts
+++ b/packages/core/src/skills/index.ts
@@ -8,6 +8,7 @@ export * from "./paths";
 export * from "./types";
 export * from "./write";
 export * from "./write-approval";
+export * from "./post-turn-review";
 export * from "./bundled/install";
 export * from "./bundled-names";
 export { readBundledSkillBody, readBundledSkillMarkdown } from "./bundled/index";

--- a/packages/core/src/skills/post-turn-review.test.ts
+++ b/packages/core/src/skills/post-turn-review.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { resolveSkillPostTurnReviewEnabled } from "./post-turn-review";
+
+describe("resolveSkillPostTurnReviewEnabled", () => {
+  test("defaults to false when org and profile unset", () => {
+    expect(resolveSkillPostTurnReviewEnabled({})).toBe(false);
+  });
+
+  test("org true enables review when profile inherits", () => {
+    expect(
+      resolveSkillPostTurnReviewEnabled({
+        orgSkillsPostTurnReview: true,
+        profileSkillsPostTurnReview: null,
+      }),
+    ).toBe(true);
+  });
+
+  test("profile false overrides org true", () => {
+    expect(
+      resolveSkillPostTurnReviewEnabled({
+        orgSkillsPostTurnReview: true,
+        profileSkillsPostTurnReview: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("profile true forces review on when org false", () => {
+    expect(
+      resolveSkillPostTurnReviewEnabled({
+        orgSkillsPostTurnReview: false,
+        profileSkillsPostTurnReview: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/core/src/skills/post-turn-review.ts
+++ b/packages/core/src/skills/post-turn-review.ts
@@ -1,0 +1,17 @@
+export interface SkillPostTurnReviewSources {
+  orgSkillsPostTurnReview?: boolean | null;
+  profileSkillsPostTurnReview?: boolean | null;
+}
+
+/** Profile override wins when non-null; otherwise org default (false when unset). */
+export function resolveSkillPostTurnReviewEnabled(
+  sources: SkillPostTurnReviewSources,
+): boolean {
+  if (
+    sources.profileSkillsPostTurnReview !== undefined &&
+    sources.profileSkillsPostTurnReview !== null
+  ) {
+    return sources.profileSkillsPostTurnReview;
+  }
+  return sources.orgSkillsPostTurnReview === true;
+}

--- a/packages/db/sql/schema.sql
+++ b/packages/db/sql/schema.sql
@@ -329,6 +329,29 @@ CREATE TABLE IF NOT EXISTS skill_proposals (
 CREATE INDEX IF NOT EXISTS skill_proposals_org_status ON skill_proposals (org_id, status);
 CREATE INDEX IF NOT EXISTS skill_proposals_org_profile_status ON skill_proposals (org_id, profile_id, status);
 
+CREATE TABLE IF NOT EXISTS skill_suggestions (
+  id TEXT PRIMARY KEY NOT NULL,
+  org_id TEXT NOT NULL,
+  profile_id TEXT NOT NULL,
+  session_id TEXT,
+  proposed_by_user_id TEXT,
+  action TEXT NOT NULL,
+  skill_name TEXT NOT NULL,
+  content TEXT,
+  patch_old_string TEXT,
+  patch_new_string TEXT,
+  status TEXT NOT NULL,
+  source TEXT NOT NULL DEFAULT 'post_turn_review',
+  warnings TEXT,
+  created_at TEXT NOT NULL,
+  applied_at TEXT,
+  FOREIGN KEY (org_id) REFERENCES organizations (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS skill_suggestions_org_status ON skill_suggestions (org_id, status);
+CREATE INDEX IF NOT EXISTS skill_suggestions_org_session ON skill_suggestions (org_id, session_id);
+CREATE INDEX IF NOT EXISTS skill_suggestions_org_profile_status ON skill_suggestions (org_id, profile_id, status);
+
 CREATE TABLE IF NOT EXISTS profile_skill_usage (
   org_id TEXT NOT NULL,
   profile_id TEXT NOT NULL,

--- a/packages/db/sql/schema.sql
+++ b/packages/db/sql/schema.sql
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS profiles (
   org_id TEXT,
   is_default INTEGER DEFAULT 0 NOT NULL,
   skills_write_approval INTEGER,
+  skills_post_turn_review INTEGER,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL,
   FOREIGN KEY (org_id) REFERENCES organizations (id) ON DELETE CASCADE
@@ -255,6 +256,7 @@ CREATE TABLE IF NOT EXISTS organizations (
   name TEXT NOT NULL,
   slug TEXT NOT NULL,
   skills_write_approval INTEGER NOT NULL DEFAULT 0,
+  skills_post_turn_review INTEGER NOT NULL DEFAULT 0,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL
 );

--- a/packages/db/src/adapters/in-memory.ts
+++ b/packages/db/src/adapters/in-memory.ts
@@ -18,6 +18,7 @@ import type {
   OrgMemoryProposalStatus,
   StoredSkillProposal,
   SkillProposalStatus,
+  StoredSkillSuggestion,
   StoredArtifactShareRecord,
   StoredOrganizationRecord,
   StoredUserOrganizationRecord,
@@ -71,6 +72,7 @@ export function createInMemoryDatabaseAdapter(): DatabaseAdapter {
   const orgInvitesByTokenHash = new Map<string, StoredOrgInviteRecord>();
   const orgMemoryProposals = new Map<string, StoredOrgMemoryProposal>();
   const skillProposals = new Map<string, StoredSkillProposal>();
+  const skillSuggestions = new Map<string, StoredSkillSuggestion>();
   const artifactShares = new Map<string, StoredArtifactShareRecord>();
   const artifactSharesByTokenHash = new Map<string, StoredArtifactShareRecord>();
   let llmUsageStats: StoredLlmUsageStatsRecord | null = null;
@@ -445,6 +447,51 @@ export function createInMemoryDatabaseAdapter(): DatabaseAdapter {
         count += 1;
       }
       return count;
+    },
+
+    async createSkillSuggestion(record) {
+      skillSuggestions.set(record.id, record);
+    },
+
+    async listSkillSuggestions(orgId, options = {}) {
+      const { sessionId, status, profileId } = options;
+      const suggestions = [...skillSuggestions.values()].filter((suggestion) => {
+        if (suggestion.orgId !== orgId) {
+          return false;
+        }
+        if (sessionId && suggestion.sessionId !== sessionId) {
+          return false;
+        }
+        if (status && suggestion.status !== status) {
+          return false;
+        }
+        if (profileId && suggestion.profileId !== profileId) {
+          return false;
+        }
+        return true;
+      });
+      return suggestions.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    },
+
+    async getSkillSuggestion(orgId, id) {
+      const suggestion = skillSuggestions.get(id);
+      if (!suggestion || suggestion.orgId !== orgId) {
+        return null;
+      }
+      return suggestion;
+    },
+
+    async markSkillSuggestionApplied(orgId, id, appliedAt) {
+      const suggestion = skillSuggestions.get(id);
+      if (!suggestion || suggestion.orgId !== orgId) {
+        return false;
+      }
+      skillSuggestions.set(id, {
+        ...suggestion,
+        status: "applied",
+        appliedAt,
+      });
+      return true;
     },
 
     async createArtifactShare(record) {

--- a/packages/db/src/adapters/in-memory.ts
+++ b/packages/db/src/adapters/in-memory.ts
@@ -345,7 +345,7 @@ export function createInMemoryDatabaseAdapter(): DatabaseAdapter {
     },
 
     async listSkillProposals(orgId, options = {}) {
-      const { status, profileId } = options;
+      const { status, profileId, sessionId } = options;
       const proposals = [...skillProposals.values()].filter((proposal) => {
         if (proposal.orgId !== orgId) {
           return false;
@@ -354,6 +354,9 @@ export function createInMemoryDatabaseAdapter(): DatabaseAdapter {
           return false;
         }
         if (profileId && proposal.profileId !== profileId) {
+          return false;
+        }
+        if (sessionId && proposal.sessionId !== sessionId) {
           return false;
         }
         return true;

--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -1735,7 +1735,7 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
     },
 
     async listSkillProposals(orgId, options = {}) {
-      const { status, profileId } = options;
+      const { status, profileId, sessionId } = options;
       let rows: SkillProposalRow[];
       if (status && profileId) {
         rows = listSkillProposalsByStatusAndProfileStmt.all(
@@ -1750,7 +1750,11 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
       } else {
         rows = listAllSkillProposalsStmt.all(orgId) as SkillProposalRow[];
       }
-      return rows.map(toSkillProposalRecord);
+      const records = rows.map(toSkillProposalRecord);
+      if (!sessionId) {
+        return records;
+      }
+      return records.filter((proposal) => proposal.sessionId === sessionId);
     },
 
     async getSkillProposal(orgId, id) {

--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -22,6 +22,8 @@ import type {
   StoredSkillProposal,
   SkillProposalStatus,
   SkillProposalAction,
+  StoredSkillSuggestion,
+  SkillSuggestionStatus,
   StoredArtifactShareRecord,
   StoredOrganizationRecord,
   StoredUserOrganizationRecord,
@@ -355,6 +357,24 @@ interface SkillProposalRow {
   reviewer_user_id: string | null;
   reviewed_at: string | null;
   created_at: string;
+}
+
+interface SkillSuggestionRow {
+  id: string;
+  org_id: string;
+  profile_id: string;
+  session_id: string | null;
+  proposed_by_user_id: string | null;
+  action: string;
+  skill_name: string;
+  content: string | null;
+  patch_old_string: string | null;
+  patch_new_string: string | null;
+  status: string;
+  source: string;
+  warnings: string | null;
+  created_at: string;
+  applied_at: string | null;
 }
 
 interface ArtifactShareRow {
@@ -1308,6 +1328,27 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
     FROM skill_proposals
     WHERE org_id = ? AND profile_id = ? AND status = 'pending'
   `);
+  const createSkillSuggestionStmt = db.prepare(`
+    INSERT INTO skill_suggestions (
+      id, org_id, profile_id, session_id, proposed_by_user_id,
+      action, skill_name, content, patch_old_string, patch_new_string,
+      status, source, warnings, created_at, applied_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const getSkillSuggestionStmt = db.prepare(`
+    SELECT
+      id, org_id, profile_id, session_id, proposed_by_user_id,
+      action, skill_name, content, patch_old_string, patch_new_string,
+      status, source, warnings, created_at, applied_at
+    FROM skill_suggestions
+    WHERE org_id = ? AND id = ?
+    LIMIT 1
+  `);
+  const markSkillSuggestionAppliedStmt = db.prepare(`
+    UPDATE skill_suggestions
+    SET status = 'applied', applied_at = ?
+    WHERE org_id = ? AND id = ?
+  `);
   const createArtifactShareStmt = db.prepare(`
     INSERT INTO artifact_shares (
       id, org_id, profile_id, source_path, filename, mime_type, size_bytes,
@@ -1760,6 +1801,67 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
         orgId,
         id,
       );
+      return result.changes > 0;
+    },
+
+    async createSkillSuggestion(record) {
+      createSkillSuggestionStmt.run(
+        record.id,
+        record.orgId,
+        record.profileId,
+        record.sessionId,
+        record.proposedByUserId,
+        record.action,
+        record.skillName,
+        record.content,
+        record.patchOldString,
+        record.patchNewString,
+        record.status,
+        record.source,
+        record.warnings ? JSON.stringify(record.warnings) : null,
+        record.createdAt,
+        record.appliedAt,
+      );
+    },
+
+    async listSkillSuggestions(orgId, options = {}) {
+      const { sessionId, status, profileId } = options;
+      const conditions = ["org_id = ?"];
+      const params: string[] = [orgId];
+
+      if (sessionId) {
+        conditions.push("session_id = ?");
+        params.push(sessionId);
+      }
+      if (status) {
+        conditions.push("status = ?");
+        params.push(status);
+      }
+      if (profileId) {
+        conditions.push("profile_id = ?");
+        params.push(profileId);
+      }
+
+      const sql = `
+        SELECT
+          id, org_id, profile_id, session_id, proposed_by_user_id,
+          action, skill_name, content, patch_old_string, patch_new_string,
+          status, source, warnings, created_at, applied_at
+        FROM skill_suggestions
+        WHERE ${conditions.join(" AND ")}
+        ORDER BY created_at DESC
+      `;
+      const rows = db.query(sql).all(...params) as SkillSuggestionRow[];
+      return rows.map(toSkillSuggestionRecord);
+    },
+
+    async getSkillSuggestion(orgId, id) {
+      const row = getSkillSuggestionStmt.get(orgId, id) as SkillSuggestionRow | null;
+      return row ? toSkillSuggestionRecord(row) : null;
+    },
+
+    async markSkillSuggestionApplied(orgId, id, appliedAt) {
+      const result = markSkillSuggestionAppliedStmt.run(appliedAt, orgId, id);
       return result.changes > 0;
     },
 
@@ -3120,6 +3222,26 @@ function toSkillProposalRecord(row: SkillProposalRow): StoredSkillProposal {
     reviewerUserId: row.reviewer_user_id,
     reviewedAt: row.reviewed_at,
     createdAt: row.created_at,
+  };
+}
+
+function toSkillSuggestionRecord(row: SkillSuggestionRow): StoredSkillSuggestion {
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    profileId: row.profile_id,
+    sessionId: row.session_id,
+    proposedByUserId: row.proposed_by_user_id,
+    action: row.action as StoredSkillSuggestion["action"],
+    skillName: row.skill_name,
+    content: row.content,
+    patchOldString: row.patch_old_string,
+    patchNewString: row.patch_new_string,
+    status: row.status as StoredSkillSuggestion["status"],
+    source: row.source as StoredSkillSuggestion["source"],
+    warnings: row.warnings ? (JSON.parse(row.warnings) as string[]) : null,
+    createdAt: row.created_at,
+    appliedAt: row.applied_at,
   };
 }
 

--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -81,6 +81,7 @@ interface ProfileRow {
   org_id: string | null;
   is_default: number;
   skills_write_approval: number | null;
+  skills_post_turn_review: number | null;
   created_at: string;
   updated_at: string;
 }
@@ -307,6 +308,7 @@ interface OrganizationRow {
   name: string;
   slug: string;
   skills_write_approval: number;
+  skills_post_turn_review: number;
   created_at: string;
   updated_at: string;
 }
@@ -482,10 +484,11 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
       org_id,
       is_default,
       skills_write_approval,
+      skills_post_turn_review,
       created_at,
       updated_at
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(id) DO UPDATE SET
       name = excluded.name,
       system_prompt = excluded.system_prompt,
@@ -496,6 +499,7 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
       org_id = excluded.org_id,
       is_default = excluded.is_default,
       skills_write_approval = excluded.skills_write_approval,
+      skills_post_turn_review = excluded.skills_post_turn_review,
       updated_at = excluded.updated_at
   `);
   const deleteProfileStmt = db.prepare("DELETE FROM profiles WHERE id = ?");
@@ -1108,27 +1112,28 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
     WHERE id = ?
   `);
   const upsertOrganizationStmt = db.prepare(`
-    INSERT INTO organizations (id, name, slug, skills_write_approval, created_at, updated_at)
-    VALUES (?, ?, ?, ?, ?, ?)
+    INSERT INTO organizations (id, name, slug, skills_write_approval, skills_post_turn_review, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(id) DO UPDATE SET
       name = excluded.name,
       slug = excluded.slug,
       skills_write_approval = excluded.skills_write_approval,
+      skills_post_turn_review = excluded.skills_post_turn_review,
       updated_at = excluded.updated_at
   `);
   const listOrganizationsStmt = db.prepare(`
-    SELECT id, name, slug, skills_write_approval, created_at, updated_at
+    SELECT id, name, slug, skills_write_approval, skills_post_turn_review, created_at, updated_at
     FROM organizations
     ORDER BY name ASC
   `);
   const getOrganizationBySlugStmt = db.prepare(`
-    SELECT id, name, slug, skills_write_approval, created_at, updated_at
+    SELECT id, name, slug, skills_write_approval, skills_post_turn_review, created_at, updated_at
     FROM organizations
     WHERE slug = ?
     LIMIT 1
   `);
   const getOrganizationByIdStmt = db.prepare(`
-    SELECT id, name, slug, skills_write_approval, created_at, updated_at
+    SELECT id, name, slug, skills_write_approval, skills_post_turn_review, created_at, updated_at
     FROM organizations
     WHERE id = ?
     LIMIT 1
@@ -1367,6 +1372,7 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
       o.name,
       o.slug,
       o.skills_write_approval,
+      o.skills_post_turn_review,
       o.created_at,
       o.updated_at,
       om.role,
@@ -1476,6 +1482,7 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
         record.name,
         record.slug,
         record.skillsWriteApproval ? 1 : 0,
+        record.skillsPostTurnReview ? 1 : 0,
         record.createdAt,
         record.updatedAt,
       );
@@ -1556,6 +1563,7 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
           name: string;
           slug: string;
           skills_write_approval: number;
+          skills_post_turn_review: number;
           created_at: string;
           updated_at: string;
           role: string;
@@ -1568,6 +1576,7 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
             name: record.name,
             slug: record.slug,
             skillsWriteApproval: record.skills_write_approval !== 0,
+            skillsPostTurnReview: record.skills_post_turn_review !== 0,
             createdAt: record.created_at,
             updatedAt: record.updated_at,
           },
@@ -1954,6 +1963,11 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
         record.skillsWriteApproval == null
           ? null
           : record.skillsWriteApproval
+            ? 1
+            : 0,
+        record.skillsPostTurnReview == null
+          ? null
+          : record.skillsPostTurnReview
             ? 1
             : 0,
         record.createdAt,
@@ -2581,6 +2595,8 @@ function toProfileRecord(row: ProfileRow): StoredProfileRecord {
     isDefault: row.is_default !== 0,
     skillsWriteApproval:
       row.skills_write_approval == null ? null : row.skills_write_approval !== 0,
+    skillsPostTurnReview:
+      row.skills_post_turn_review == null ? null : row.skills_post_turn_review !== 0,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -3051,6 +3067,7 @@ function toOrganizationRecord(row: OrganizationRow): StoredOrganizationRecord {
     name: row.name,
     slug: row.slug,
     skillsWriteApproval: row.skills_write_approval !== 0,
+    skillsPostTurnReview: row.skills_post_turn_review !== 0,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -17,6 +17,7 @@ export function migrateDatabase(db: Database): void {
   migrateOrgTables(db);
   migrateOrgMemoryProposalsTable(db);
   migrateSkillProposalsTable(db);
+  migrateSkillSuggestionsTable(db);
   migrateSkillsWriteApprovalColumns(db);
   migrateSkillsPostTurnReviewColumns(db);
   migrateSkillUsageTables(db);
@@ -362,6 +363,32 @@ function migrateSkillProposalsTable(db: Database): void {
     );
     CREATE INDEX IF NOT EXISTS skill_proposals_org_status ON skill_proposals (org_id, status);
     CREATE INDEX IF NOT EXISTS skill_proposals_org_profile_status ON skill_proposals (org_id, profile_id, status);
+  `);
+}
+
+function migrateSkillSuggestionsTable(db: Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS skill_suggestions (
+      id TEXT PRIMARY KEY NOT NULL,
+      org_id TEXT NOT NULL,
+      profile_id TEXT NOT NULL,
+      session_id TEXT,
+      proposed_by_user_id TEXT,
+      action TEXT NOT NULL,
+      skill_name TEXT NOT NULL,
+      content TEXT,
+      patch_old_string TEXT,
+      patch_new_string TEXT,
+      status TEXT NOT NULL,
+      source TEXT NOT NULL DEFAULT 'post_turn_review',
+      warnings TEXT,
+      created_at TEXT NOT NULL,
+      applied_at TEXT,
+      FOREIGN KEY (org_id) REFERENCES organizations (id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS skill_suggestions_org_status ON skill_suggestions (org_id, status);
+    CREATE INDEX IF NOT EXISTS skill_suggestions_org_session ON skill_suggestions (org_id, session_id);
+    CREATE INDEX IF NOT EXISTS skill_suggestions_org_profile_status ON skill_suggestions (org_id, profile_id, status);
   `);
 }
 

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -18,6 +18,7 @@ export function migrateDatabase(db: Database): void {
   migrateOrgMemoryProposalsTable(db);
   migrateSkillProposalsTable(db);
   migrateSkillsWriteApprovalColumns(db);
+  migrateSkillsPostTurnReviewColumns(db);
   migrateSkillUsageTables(db);
   migrateTenantOrgScope(db);
   migrateProfileOrgColumns(db);
@@ -379,6 +380,24 @@ function migrateSkillsWriteApprovalColumns(db: Database): void {
     .all() as Array<{ name: string }>;
   if (!new Set(profileColumns.map((column) => column.name)).has("skills_write_approval")) {
     db.exec(`ALTER TABLE profiles ADD COLUMN skills_write_approval INTEGER;`);
+  }
+}
+
+function migrateSkillsPostTurnReviewColumns(db: Database): void {
+  const orgColumns = db
+    .prepare("PRAGMA table_info(organizations)")
+    .all() as Array<{ name: string }>;
+  if (!new Set(orgColumns.map((column) => column.name)).has("skills_post_turn_review")) {
+    db.exec(
+      `ALTER TABLE organizations ADD COLUMN skills_post_turn_review INTEGER NOT NULL DEFAULT 0;`,
+    );
+  }
+
+  const profileColumns = db
+    .prepare("PRAGMA table_info(profiles)")
+    .all() as Array<{ name: string }>;
+  if (!new Set(profileColumns.map((column) => column.name)).has("skills_post_turn_review")) {
+    db.exec(`ALTER TABLE profiles ADD COLUMN skills_post_turn_review INTEGER;`);
   }
 }
 

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -46,6 +46,8 @@ export interface StoredProfileRecord {
   isDefault?: boolean;
   /** null = inherit org default; true/false = force gate on/off for this profile */
   skillsWriteApproval?: boolean | null;
+  /** null = inherit org default; true/false = force post-turn review on/off for this profile */
+  skillsPostTurnReview?: boolean | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -325,6 +327,7 @@ export interface StoredOrganizationRecord {
   name: string;
   slug: string;
   skillsWriteApproval?: boolean;
+  skillsPostTurnReview?: boolean;
   createdAt: string;
   updatedAt: string;
 }

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -516,7 +516,7 @@ export interface DatabaseAdapter {
   createSkillProposal(record: StoredSkillProposal): Promise<void>;
   listSkillProposals(
     orgId: string,
-    options?: { status?: SkillProposalStatus; profileId?: string },
+    options?: { status?: SkillProposalStatus; profileId?: string; sessionId?: string },
   ): Promise<StoredSkillProposal[]>;
   getSkillProposal(orgId: string, id: string): Promise<StoredSkillProposal | null>;
   getPendingSkillProposalForCreate(

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -395,6 +395,28 @@ export interface StoredSkillProposal {
   createdAt: string;
 }
 
+export type SkillSuggestionStatus = "pending" | "applied";
+export type SkillSuggestionAction = "create" | "patch";
+export type SkillSuggestionSource = "post_turn_review";
+
+export interface StoredSkillSuggestion {
+  id: string;
+  orgId: string;
+  profileId: string;
+  sessionId: string | null;
+  proposedByUserId: string | null;
+  action: SkillSuggestionAction;
+  skillName: string;
+  content: string | null;
+  patchOldString: string | null;
+  patchNewString: string | null;
+  status: SkillSuggestionStatus;
+  source: SkillSuggestionSource;
+  warnings: string[] | null;
+  createdAt: string;
+  appliedAt: string | null;
+}
+
 export interface StoredArtifactShareRecord {
   id: string;
   orgId: string;
@@ -524,6 +546,14 @@ export interface DatabaseAdapter {
     },
   ): Promise<boolean>;
   countPendingSkillProposals(orgId: string, profileId?: string): Promise<number>;
+
+  createSkillSuggestion(record: StoredSkillSuggestion): Promise<void>;
+  listSkillSuggestions(
+    orgId: string,
+    options?: { sessionId?: string; status?: SkillSuggestionStatus; profileId?: string },
+  ): Promise<StoredSkillSuggestion[]>;
+  getSkillSuggestion(orgId: string, id: string): Promise<StoredSkillSuggestion | null>;
+  markSkillSuggestionApplied(orgId: string, id: string, appliedAt: string): Promise<boolean>;
 
   createArtifactShare(record: StoredArtifactShareRecord): Promise<void>;
   updateArtifactShareSnapshot(


### PR DESCRIPTION
## Summary
- Closes Phase 4 of [#136](https://github.com/ahmadrosid/nakama/issues/136): opt-in post-turn skill review after successful web/CLI turns (complex tool use / tool errors), without blocking chat.
- Suggest-or-stage outcomes: gate off persists a chat-visible suggestion with **Apply**; gate on stages a normal skill proposal plus a pending-admin notice. Never silent-writes when write approval is off.
- Delivery stays out of model history — UI overlay + session-scoped poll (~45s); members can list proposals only with `sessionId`. Docs cover the review × write-approval matrix.

## Test plan
- [ ] Enable **Post-turn skill review** under System → Organization; leave write approval off
- [ ] Complete a web turn with ≥5 tool calls (or a tool error recovery) without in-session `skill_manage` → suggestion card appears; disk unchanged until Apply
- [ ] Apply suggestion → skill created/patched; second Apply is idempotent
- [ ] Flip write approval on → same flow stages a proposal; chat shows pending-admin notice; admin approve/reject still required
- [ ] Confirm failed/aborted turns and Telegram/WhatsApp/Discord sessions do not schedule review
- [ ] Confirm suggestion/notice content is not present in session messages / next-turn model history
- [ ] `bun test` for touched suites (post-turn review, suggestions, proposals, preview helpers)