### PR TITLE
feat(coding-agent): add pi.dev as supported coding harness

### DIFF
--- a/apps/server/src/services/coding-agent-command.test.ts
+++ b/apps/server/src/services/coding-agent-command.test.ts
@@ -47,6 +47,29 @@ describe("buildCodingAgentCommandTemplate", () => {
     expect(template.command).toContain("'Refactor auth module'");
   });
 
+  test("builds pi.dev command and spawn env", async () => {
+    const template = await buildCodingAgentCommandTemplate(
+      {
+        kind: "pi",
+        name: "pi.dev",
+        command: "pi",
+        args: [],
+      },
+      "Fix bugs",
+      "/workspace",
+      {
+        userConfig: anthropicUserConfig,
+        profileModel: "claude-sonnet-4-6",
+      },
+    );
+    expect(template.backend).toBe("pi");
+    expect(template.command).toContain("pi");
+    expect(template.command).toContain("--provider");
+    expect(template.command).toContain("anthropic");
+    expect(template.command).toContain("--model");
+    expect(template.command).toContain("-p");
+  });
+
   test("builds OpenCode run command with workspace dir", async () => {
     const template = await buildCodingAgentCommandTemplate(
       {

--- a/apps/server/src/services/coding-agent-command.ts
+++ b/apps/server/src/services/coding-agent-command.ts
@@ -1,7 +1,10 @@
 import type { StoredCodingAgentHarnessKind } from "@nakama/db";
+import type { ProviderName } from "@nakama/core";
 import {
   resolveCodingAgentSpawnBundle,
   redactSpawnEnvForPrompt,
+  mapNakamaProviderToPi,
+  formatModelForHarness,
 } from "./coding-agent-spawn-env";
 
 export interface CodingAgentCommandHarness {
@@ -21,7 +24,13 @@ export interface CodingAgentCommandTemplate {
 
 export function buildHarnessNonInteractiveArgs(
   kind: StoredCodingAgentHarnessKind,
-  options: { prompt: string; cwd: string; baseArgs?: string[] },
+  options: {
+    prompt: string;
+    cwd: string;
+    baseArgs?: string[];
+    piProvider?: string | null;
+    piModel?: string | null;
+  },
 ): string[] {
   const baseArgs = [...(options.baseArgs ?? [])];
   const prompt = options.prompt.trim() || "Reply with OK and nothing else.";
@@ -53,6 +62,21 @@ export function buildHarnessNonInteractiveArgs(
     ];
   }
 
+  if (kind === "pi") {
+    const piArgs = [...baseArgs];
+
+    if (options.piProvider) {
+      piArgs.push("--provider", options.piProvider);
+    }
+
+    if (options.piModel) {
+      piArgs.push("--model", options.piModel);
+    }
+
+    piArgs.push("-p", prompt);
+    return piArgs;
+  }
+
   return [
     ...baseArgs,
     "run",
@@ -76,7 +100,7 @@ export async function buildCodingAgentCommandTemplate(
 ): Promise<CodingAgentCommandTemplate> {
   const escapedTask = shellEscape(taskPrompt.trim());
   const baseCommand = [harness.command, ...harness.args].join(" ");
-  const { spawn } = await resolveCodingAgentSpawnBundle({
+  const { spawn, routing } = await resolveCodingAgentSpawnBundle({
     userConfig: options.userConfig,
     profileModel: options.profileModel,
     harnessKind: harness.kind,
@@ -124,6 +148,34 @@ export async function buildCodingAgentCommandTemplate(
       ].join(" "),
       notes: [
         "Print mode is non-interactive and preferred for one-shot coding agent runs.",
+        "Run from the profile workspace cwd unless the user specifies another path inside it.",
+      ],
+    };
+  }
+
+  if (harness.kind === "pi") {
+    const piProvider = routing.providerType ? mapNakamaProviderToPi(routing.providerType, routing.baseUrl) : null;
+    const piModel = routing.model
+      ? formatModelForHarness("pi", routing.providerType ?? "openai", routing.model)
+      : null;
+    const commandParts = [baseCommand];
+
+    if (piProvider) {
+      commandParts.push("--provider", piProvider);
+    }
+
+    if (piModel) {
+      commandParts.push("--model", shellEscape(piModel));
+    }
+
+    commandParts.push("-p", escapedTask);
+
+    return {
+      ...shared,
+      command: commandParts.join(" "),
+      notes: [
+        "pi runs in non-interactive print mode with -p <prompt>.",
+        "Provider and model are passed via --provider and --model flags from Nakama provider routing.",
         "Run from the profile workspace cwd unless the user specifies another path inside it.",
       ],
     };
@@ -184,13 +236,17 @@ export function formatCodingAgentCommandContext(
 
 function getBackendSkillName(
   backend: StoredCodingAgentHarnessKind,
-): "coding-backend-codex" | "coding-backend-claude-code" | "coding-backend-opencode" {
+): "coding-backend-codex" | "coding-backend-claude-code" | "coding-backend-opencode" | "coding-backend-pi" {
   if (backend === "codex") {
     return "coding-backend-codex";
   }
 
   if (backend === "claude_code") {
     return "coding-backend-claude-code";
+  }
+
+  if (backend === "pi") {
+    return "coding-backend-pi";
   }
 
   return "coding-backend-opencode";

--- a/apps/server/src/services/coding-agent-harness-config-files.ts
+++ b/apps/server/src/services/coding-agent-harness-config-files.ts
@@ -109,3 +109,105 @@ function resolveOpenCodeProviderKey(providerType: ProviderName): string {
 
   return "nakama";
 }
+
+/**
+ * Maps a Nakama provider type to the pi CLI built-in provider ID.
+ * pi has named providers (e.g. "openai", "anthropic", "openrouter") with
+ * hardcoded base URLs. We override their baseUrl + apiKey via models.json.
+ */
+function resolvePiProviderId(providerType: ProviderName): string {
+  if (providerType === "anthropic") return "anthropic";
+  if (providerType === "openai") return "openai";
+  if (providerType === "openrouter") return "openrouter";
+  if (providerType === "deepseek") return "deepseek";
+  if (providerType === "cerebras") return "cerebras";
+  if (providerType === "fireworks") return "fireworks";
+  if (providerType === "opencode_go") return "opencode";
+  return "nakama";
+}
+
+/**
+ * Default base URLs for built-in pi providers.
+ * When the configured base URL matches the default, we can safely override
+ * the built-in provider (which keeps the correct API type).
+ * When it doesn't match (proxy/gateway), we create a custom "nakama" provider
+ * with the OpenAI Chat Completions API, which is universally supported.
+ */
+const PI_DEFAULT_BASE_URLS: Partial<Record<ProviderName, string>> = {
+  anthropic: "https://api.anthropic.com",
+  openai: "https://api.openai.com/v1",
+  openrouter: "https://openrouter.ai/api/v1",
+  deepseek: "https://api.deepseek.com",
+  cerebras: "https://api.cerebras.ai/v1",
+  fireworks: "https://api.fireworks.ai/inference",
+};
+
+function isDefaultBaseUrl(providerType: ProviderName, baseUrl: string | null | undefined): boolean {
+  if (!baseUrl) return false;
+  const defaultUrl = PI_DEFAULT_BASE_URLS[providerType];
+  if (!defaultUrl) return false;
+  return baseUrl.replace(/\/+$/, "") === defaultUrl.replace(/\/+$/, "");
+}
+
+/**
+ * Writes a models.json that routes pi requests through the Nakama-configured
+ * provider.
+ *
+ * Strategy:
+ * - If the base URL matches the built-in provider's default (e.g. real
+ *   api.anthropic.com), override the built-in provider's baseUrl + apiKey.
+ *   This keeps the provider's native API type (anthropic-messages, etc).
+ * - If the base URL is custom (proxy/gateway), create a standalone "nakama"
+ *   provider with the OpenAI Chat Completions API ("openai-completions"),
+ *   which is the most universally supported format across proxies/gateways.
+ *   Using the built-in "anthropic" or "openai" provider with a custom base URL
+ *   would keep the Anthropic Messages / OpenAI Responses API format, which most
+ *   proxies don't support.
+ */
+export async function writePiModelsJson(
+  configDir: string,
+  routing: CodingAgentProviderRouting,
+  providerType: ProviderName,
+): Promise<string> {
+  const configPath = path.join(configDir, "models.json");
+  const baseUrl = routing.baseUrl ?? "";
+  const apiKey = routing.apiKey ?? "";
+
+  const providers: Record<string, Record<string, unknown>> = {};
+
+  if (isDefaultBaseUrl(providerType, routing.baseUrl)) {
+    // Override the built-in provider's baseUrl + apiKey.
+    // The built-in provider keeps its native API type (anthropic-messages,
+    // openai-responses, openai-completions, etc).
+    const providerId = resolvePiProviderId(providerType);
+    providers[providerId] = {
+      baseUrl,
+      apiKey,
+    };
+  } else {
+    // Custom base URL (proxy/gateway): create a standalone "nakama" provider
+    // with the OpenAI Chat Completions API, which is universally supported.
+    const model = formatModelForHarness("pi", providerType, routing.model ?? "gpt-4o");
+    providers["nakama"] = {
+      name: "Nakama",
+      baseUrl,
+      apiKey,
+      api: "openai-completions",
+      models: [
+        {
+          id: model,
+          name: model,
+          reasoning: false,
+          input: ["text"],
+          contextWindow: 128000,
+          maxTokens: 16384,
+        },
+      ],
+    };
+  }
+
+  const config = { providers };
+  await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
+  await chmod(configPath, 0o600);
+  return configPath;
+}

--- a/apps/server/src/services/coding-agent-harness-service.ts
+++ b/apps/server/src/services/coding-agent-harness-service.ts
@@ -10,7 +10,7 @@ import type {
 import { WORKSPACE_SETTINGS_ID } from "@nakama/db";
 import type { UserConfig } from "@nakama/core";
 import { ensureProcessPath, ensureBunGlobalInstallDirs, getToolExecutionEnv } from "../lib/ensure-process-path";
-import { mergeCodingAgentSpawnEnv, resolveCodingAgentSpawnBundle } from "./coding-agent-spawn-env";
+import { mergeCodingAgentSpawnEnv, resolveCodingAgentSpawnBundle, mapNakamaProviderToPi, formatModelForHarness } from "./coding-agent-spawn-env";
 import { buildHarnessNonInteractiveArgs } from "./coding-agent-command";
 
 export interface CodingAgentHarnessStatus extends StoredCodingAgentHarnessRecord {
@@ -32,6 +32,7 @@ const HARNESS_PACKAGES: Record<StoredCodingAgentHarnessKind, string> = {
   codex: "@openai/codex",
   claude_code: "@anthropic-ai/claude-code",
   opencode: "opencode-ai",
+  pi: "@earendil-works/pi-coding-agent",
 };
 
 function detectCodingHarnessPackageManager(): "npm" | "bun" {
@@ -115,6 +116,14 @@ const DEFAULT_HARNESSES: StoredCodingAgentHarnessRecord[] = [
     kind: "opencode",
     name: "OpenCode",
     command: "opencode",
+    args: [],
+    enabled: true,
+  },
+  {
+    id: "coding-harness-pi",
+    kind: "pi",
+    name: "pi.dev",
+    command: "pi",
     args: [],
     enabled: true,
   },
@@ -654,6 +663,10 @@ export function getCodingHarnessInstallHint(kind: StoredCodingAgentHarnessKind):
     return "Install Claude Code on this machine, then check again.";
   }
 
+  if (kind === "pi") {
+    return "Install pi CLI (@earendil-works/pi-coding-agent) on this machine, then check again.";
+  }
+
   return "Install OpenCode on this machine, then check again.";
 }
 
@@ -756,8 +769,13 @@ async function probeHarnessExec(
   });
   const tempDir = await mkdtemp(path.join(tmpdir(), "nakama-coding-agent-probe-"));
 
+  const piProvider = routing.providerType ? mapNakamaProviderToPi(routing.providerType, routing.baseUrl) : null;
+  const piModel = routing.model && routing.providerType
+    ? formatModelForHarness("pi", routing.providerType, routing.model)
+    : null;
+
   try {
-    const result = await runProbeCommand(harness, tempDir, spawn.env);
+    const result = await runProbeCommand(harness, tempDir, spawn.env, { provider: piProvider, model: piModel });
     const combinedOutput = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
 
     if (result.timedOut) {
@@ -765,7 +783,9 @@ async function probeHarnessExec(
         authenticated: null,
         ready: false,
         nextStep: "retry",
-        statusMessage: "Readiness check timed out.",
+        statusMessage: combinedOutput
+          ? `Readiness check timed out. Last output from ${harness.name}: ${summarizeProbeOutput(combinedOutput)}`
+          : "Readiness check timed out.",
       };
     }
 
@@ -785,7 +805,9 @@ async function probeHarnessExec(
         nextStep: "retry",
         statusMessage:
           routing.error ??
-          `${harness.name} could not authenticate with the configured Nakama provider. Check Settings → Provider.`,
+          (combinedOutput
+            ? `${harness.name} could not authenticate with the configured Nakama provider. ${summarizeProbeOutput(combinedOutput)} Check Settings → Provider.`
+            : `${harness.name} could not authenticate with the configured Nakama provider. Check Settings → Provider.`),
       };
     }
 
@@ -793,7 +815,9 @@ async function probeHarnessExec(
       authenticated: null,
       ready: false,
       nextStep: "retry",
-      statusMessage: `${harness.name} is installed but the readiness check failed.`,
+      statusMessage: combinedOutput
+        ? `${harness.name} is installed but the readiness check failed (exit ${result.exitCode}). ${summarizeProbeOutput(combinedOutput)}`
+        : `${harness.name} is installed but the readiness check failed (exit ${result.exitCode}).`,
     };
   } finally {
     await spawn.cleanup?.();
@@ -805,6 +829,7 @@ async function runProbeCommand(
   harness: CodingAgentHarnessStatus,
   cwd: string,
   spawnEnv: Record<string, string> = {},
+  piOptions?: { provider?: string | null; model?: string | null },
 ): Promise<{
   exitCode: number | null;
   stdout: string;
@@ -818,6 +843,8 @@ async function runProbeCommand(
     prompt,
     cwd,
     baseArgs: harness.args,
+    piProvider: piOptions?.provider,
+    piModel: piOptions?.model,
   });
 
   return new Promise((resolve) => {
@@ -985,4 +1012,17 @@ function summarizeInstallOutput(output: string): string {
     lines[0] ??
     output.trim();
   return meaningful.length > 180 ? `${meaningful.slice(0, 177)}...` : meaningful;
+}
+
+function summarizeProbeOutput(output: string): string {
+  const lines = output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const meaningful =
+    lines.find((line) => /^(?:error|fatal|panic):/i.test(line)) ??
+    lines.find((line) => /(?:error|failed|not found|invalid|unexpected|exception|traceback)/i.test(line)) ??
+    lines[lines.length - 1] ??
+    output.trim();
+  return meaningful.length > 240 ? `${meaningful.slice(0, 237)}...` : meaningful;
 }

--- a/apps/server/src/services/coding-agent-launcher.ts
+++ b/apps/server/src/services/coding-agent-launcher.ts
@@ -24,6 +24,9 @@ export const CODING_AGENT_KIND_ALIASES: Record<string, StoredCodingAgentHarnessK
   claude_code: "claude_code",
   codex: "codex",
   opencode: "opencode",
+  pi: "pi",
+  "pi.dev": "pi",
+  pidev: "pi",
 };
 
 export interface CodingAgentLaunchPlan {

--- a/apps/server/src/services/coding-agent-provider-routing.ts
+++ b/apps/server/src/services/coding-agent-provider-routing.ts
@@ -55,6 +55,18 @@ const OPENCODE_PROVIDER_TYPES = new Set<ProviderName>([
   "ollama",
 ]);
 
+const PI_PROVIDER_TYPES = new Set<ProviderName>([
+  "anthropic",
+  "openai",
+  "openrouter",
+  "openai_compatible",
+  "opencode_go",
+  "deepseek",
+  "cerebras",
+  "fireworks",
+  "ollama",
+]);
+
 export function isProviderCompatibleWithHarness(
   providerType: ProviderName,
   harnessKind: StoredCodingAgentHarnessKind,
@@ -65,6 +77,10 @@ export function isProviderCompatibleWithHarness(
 
   if (harnessKind === "codex") {
     return CODEX_PROVIDER_TYPES.has(providerType);
+  }
+
+  if (harnessKind === "pi") {
+    return PI_PROVIDER_TYPES.has(providerType);
   }
 
   return OPENCODE_PROVIDER_TYPES.has(providerType);
@@ -132,6 +148,10 @@ function incompatibilityMessage(
 
   if (harnessKind === "codex") {
     return `Codex does not support the ${providerType} provider. Choose a compatible provider in Settings → Provider.`;
+  }
+
+  if (harnessKind === "pi") {
+    return `pi does not support the ${providerType} provider. Choose a compatible provider in Settings → Provider.`;
   }
 
   return `OpenCode does not support the ${providerType} provider. Choose a compatible provider in Settings → Provider.`;

--- a/apps/server/src/services/coding-agent-settings.ts
+++ b/apps/server/src/services/coding-agent-settings.ts
@@ -19,7 +19,7 @@ import {
   type CodingAgentProviderRouting,
 } from "./coding-agent-provider-routing";
 
-const HARNESS_KINDS = ["codex", "claude_code", "opencode"] as const;
+const HARNESS_KINDS = ["codex", "claude_code", "opencode", "pi"] as const;
 
 export function toPassthroughSummary(
   routing: CodingAgentProviderRouting | null | undefined,

--- a/apps/server/src/services/coding-agent-spawn-env.test.ts
+++ b/apps/server/src/services/coding-agent-spawn-env.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   buildClaudeCodeSpawnEnv,
   buildCodexSpawnEnv,
+  buildPiSpawnEnv,
   mergeCodingAgentSpawnEnv,
   normalizeCodingAgentModel,
   redactSpawnEnvForPrompt,
@@ -31,6 +32,110 @@ describe("coding-agent spawn env", () => {
     expect(env.ANTHROPIC_API_KEY).toBe("sk-ant-test");
     expect(env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("claude-opus-4-6");
     expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+  });
+
+  test("builds pi.dev provider passthrough env for anthropic", async () => {
+    const env = await buildPiSpawnEnv(
+      activeAnthropicRouting({
+        providerType: "anthropic",
+        providerLabel: "Anthropic",
+        baseUrl: "https://api.anthropic.com",
+        apiKey: "test-anthropic-key",
+      }),
+      "anthropic",
+    );
+    expect(env.env.PI_CODING_AGENT_DIR).toBeDefined();
+    expect(env.cleanup).toBeDefined();
+  });
+
+  test("builds pi.dev provider passthrough env for openrouter", async () => {
+    const env = await buildPiSpawnEnv(
+      activeAnthropicRouting({
+        providerType: "openrouter",
+        providerLabel: "OpenRouter",
+        baseUrl: "https://openrouter.ai/api/v1",
+        apiKey: "sk-or-test",
+      }),
+      "openrouter",
+    );
+    expect(env.env.PI_CODING_AGENT_DIR).toBeDefined();
+    expect(env.cleanup).toBeDefined();
+  });
+
+  test("builds pi.dev provider passthrough env for openai_compatible", async () => {
+    const env = await buildPiSpawnEnv(
+      activeAnthropicRouting({
+        providerType: "openai_compatible",
+        providerLabel: "Custom",
+        baseUrl: "https://custom.example.com/v1",
+        apiKey: "sk-custom-test",
+        model: "custom-model",
+      }),
+      "openai_compatible",
+    );
+    expect(env.env.PI_CODING_AGENT_DIR).toBeDefined();
+    expect(env.cleanup).toBeDefined();
+    // Verify the models.json was written
+    const { readFile } = await import("node:fs/promises");
+    const modelsJson = JSON.parse(
+      await readFile(`${env.env.PI_CODING_AGENT_DIR}/models.json`, "utf-8"),
+    );
+    expect(modelsJson.providers.nakama).toBeDefined();
+    expect(modelsJson.providers.nakama.baseUrl).toBe("https://custom.example.com/v1");
+    expect(modelsJson.providers.nakama.apiKey).toBe("sk-custom-test");
+    expect(modelsJson.providers.nakama.api).toBe("openai-completions");
+    await env.cleanup?.();
+  });
+
+  test("uses nakama provider in models.json for anthropic with custom base URL", async () => {
+    const env = await buildPiSpawnEnv(
+      activeAnthropicRouting({
+        providerType: "anthropic",
+        providerLabel: "Anthropic Proxy",
+        baseUrl: "https://proxy.example.com/v1",
+        apiKey: "sk-proxy-test",
+        model: "claude-sonnet-4-6",
+      }),
+      "anthropic",
+    );
+    const { readFile } = await import("node:fs/promises");
+    const modelsJson = JSON.parse(
+      await readFile(`${env.env.PI_CODING_AGENT_DIR}/models.json`, "utf-8"),
+    );
+    // Custom base URL → nakama provider with openai-completions, NOT anthropic
+    expect(modelsJson.providers.nakama).toBeDefined();
+    expect(modelsJson.providers.anthropic).toBeUndefined();
+    expect(modelsJson.providers.nakama.api).toBe("openai-completions");
+    expect(modelsJson.providers.nakama.baseUrl).toBe("https://proxy.example.com/v1");
+    await env.cleanup?.();
+  });
+
+  test("overrides built-in anthropic provider for default base URL", async () => {
+    const env = await buildPiSpawnEnv(
+      activeAnthropicRouting({
+        providerType: "anthropic",
+        providerLabel: "Anthropic",
+        baseUrl: "https://api.anthropic.com",
+        apiKey: "sk-ant-test",
+        model: "claude-sonnet-4-6",
+      }),
+      "anthropic",
+    );
+    const { readFile } = await import("node:fs/promises");
+    const modelsJson = JSON.parse(
+      await readFile(`${env.env.PI_CODING_AGENT_DIR}/models.json`, "utf-8"),
+    );
+    // Default base URL → override built-in anthropic provider
+    expect(modelsJson.providers.anthropic).toBeDefined();
+    expect(modelsJson.providers.nakama).toBeUndefined();
+    expect(modelsJson.providers.anthropic.apiKey).toBe("sk-ant-test");
+    await env.cleanup?.();
+  });
+
+  test("returns no env overrides when routing is inactive for pi", async () => {
+    const env = await buildPiSpawnEnv(inactiveRouting(), "openai");
+    expect(env.env).toEqual({});
+    expect(env.cleanup).toBeUndefined();
   });
 
   test("builds Codex provider passthrough env", () => {

--- a/apps/server/src/services/coding-agent-spawn-env.ts
+++ b/apps/server/src/services/coding-agent-spawn-env.ts
@@ -8,6 +8,7 @@ import {
   createHarnessConfigDir,
   writeCodexConfigToml,
   writeOpenCodeConfig,
+  writePiModelsJson,
 } from "./coding-agent-harness-config-files";
 
 export function normalizeCodingAgentModel(model: string | null | undefined): string | null {
@@ -39,6 +40,22 @@ export function formatModelForHarness(
   model: string,
 ): string {
   if (providerType === "openrouter" || providerType === "opencode_go") {
+    return model.trim();
+  }
+
+  // pi sends the model ID directly to the provider's API. For openai_compatible
+  // providers, the model ID may contain slashes (e.g. "cx/gpt-5.4") that are
+  // part of the actual model name — stripping them would break routing.
+  if (harnessKind === "pi") {
+    if (providerType === "openai_compatible") {
+      return model.trim();
+    }
+    // For known providers, only strip the "provider:" prefix (e.g. "anthropic:claude-sonnet-4-6"),
+    // not slashes (e.g. "openrouter/anthropic/claude-sonnet-4-6").
+    const colonIndex = model.indexOf(":");
+    if (colonIndex >= 0) {
+      return model.slice(colonIndex + 1).trim() || model.trim();
+    }
     return model.trim();
   }
 
@@ -95,7 +112,57 @@ export const CODING_AGENT_CREDENTIAL_ENV_KEYS = [
   "OPENAI_MODEL",
   "CODEX_HOME",
   "XDG_CONFIG_HOME",
+  "PI_CODING_AGENT_DIR",
 ] as const;
+
+/**
+ * Maps a Nakama provider type to the pi CLI provider name.
+ * pi has its own provider system with named providers (see `pi --list-models`).
+ *
+ * When the base URL is the default for the provider type, we use the built-in
+ * pi provider name (e.g. "anthropic", "openai"). When the base URL is custom
+ * (proxy/gateway), we use "nakama" — matching the custom provider entry in
+ * models.json that uses the OpenAI Chat Completions API.
+ */
+const PI_PROVIDER_NAME: Partial<Record<ProviderName, string>> = {
+  anthropic: "anthropic",
+  openai: "openai",
+  openrouter: "openrouter",
+  openai_compatible: "nakama",
+  opencode_go: "opencode",
+  deepseek: "deepseek",
+  cerebras: "cerebras",
+  fireworks: "fireworks",
+  ollama: "ollama",
+};
+
+const PI_DEFAULT_BASE_URLS: Partial<Record<ProviderName, string>> = {
+  anthropic: "https://api.anthropic.com",
+  openai: "https://api.openai.com/v1",
+  openrouter: "https://openrouter.ai/api/v1",
+  deepseek: "https://api.deepseek.com",
+  cerebras: "https://api.cerebras.ai/v1",
+  fireworks: "https://api.fireworks.ai/inference",
+};
+
+export function mapNakamaProviderToPi(
+  providerType: ProviderName,
+  baseUrl?: string | null,
+): string | null {
+  const builtinName = PI_PROVIDER_NAME[providerType];
+  if (!builtinName) return null;
+
+  // For providers with a non-default base URL (proxy/gateway), use the custom
+  // "nakama" provider entry from models.json instead of the built-in provider.
+  if (baseUrl) {
+    const defaultUrl = PI_DEFAULT_BASE_URLS[providerType];
+    if (defaultUrl && baseUrl.replace(/\/+$/, "") !== defaultUrl.replace(/\/+$/, "")) {
+      return "nakama";
+    }
+  }
+
+  return builtinName;
+}
 
 export function buildClaudeCodeSpawnEnv(
   routing: CodingAgentProviderRouting,
@@ -163,6 +230,30 @@ export async function buildOpenCodeSpawnEnv(
   };
 }
 
+export async function buildPiSpawnEnv(
+  routing: CodingAgentProviderRouting,
+  providerType: ProviderName = "openai",
+): Promise<CodingAgentSpawnEnvResult> {
+  if (!routing.active || !routing.baseUrl || !routing.apiKey) {
+    return { env: {} };
+  }
+
+  // pi does not read OPENAI_BASE_URL / ANTHROPIC_BASE_URL env vars.
+  // The base URL is hardcoded per built-in provider and can only be overridden
+  // via models.json in the pi config directory (PI_CODING_AGENT_DIR).
+  // We create a temp config dir with a models.json that overrides the
+  // provider's baseUrl + apiKey, then point pi to it.
+  const configDir = await createHarnessConfigDir("nakama-pi-config-");
+  await writePiModelsJson(configDir.dir, routing, providerType);
+
+  return {
+    env: {
+      PI_CODING_AGENT_DIR: configDir.dir,
+    },
+    cleanup: configDir.cleanup,
+  };
+}
+
 export async function buildSpawnEnvForHarness(
   kind: StoredCodingAgentHarnessKind,
   routing: CodingAgentProviderRouting,
@@ -174,6 +265,10 @@ export async function buildSpawnEnvForHarness(
 
   if (kind === "claude_code") {
     return { env: buildClaudeCodeSpawnEnv(routing, providerType) };
+  }
+
+  if (kind === "pi") {
+    return buildPiSpawnEnv(routing, providerType);
   }
 
   if (kind === "codex") {

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -1099,7 +1099,7 @@ export interface SendEmailTestResponse {
   messageId: string;
 }
 
-export type CodingHarnessKind = "codex" | "claude_code" | "opencode";
+export type CodingHarnessKind = "codex" | "claude_code" | "opencode" | "pi";
 
 export interface CodingAgentProviderPassthroughSummary {
   active: boolean;

--- a/packages/core/src/skills/bundled-names.ts
+++ b/packages/core/src/skills/bundled-names.ts
@@ -13,6 +13,7 @@ export const RUNTIME_ONLY_BUNDLED_SKILL_NAMES = [
   "coding-backend-codex",
   "coding-backend-claude-code",
   "coding-backend-opencode",
+  "coding-backend-pi",
 ] as const;
 
 /** Bundled skills that install/sync but are never auto-assigned (manual opt-in). */

--- a/packages/core/src/skills/bundled/coding-agent.test.ts
+++ b/packages/core/src/skills/bundled/coding-agent.test.ts
@@ -57,5 +57,6 @@ describe("ensureBundledSkillFiles for coding agent", () => {
     expect(created).toContain("coding-backend-codex");
     expect(created).toContain("coding-backend-claude-code");
     expect(created).toContain("coding-backend-opencode");
+    expect(created).toContain("coding-backend-pi");
   });
 });

--- a/packages/core/src/skills/bundled/coding-backend-pi/SKILL.md
+++ b/packages/core/src/skills/bundled/coding-backend-pi/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: coding-backend-pi
+description: Runtime prompt layer for pi.dev (pi CLI) coding agent runs.
+---
+
+You are preparing a coding agent run for [pi.dev](https://github.com/earendil-works/pi-coding-agent) (pi coding agent CLI), orchestrated via terminal/process tools.
+
+## Prerequisites
+- pi installed: `npm install -g @earendil-works/pi-coding-agent` or `bun install -g --trust @earendil-works/pi-coding-agent`.
+- Provider auth configured in Nakama Settings → Provider. Nakama writes a temporary `models.json` (via `PI_CODING_AGENT_DIR`) that overrides the pi provider's `baseUrl` and `apiKey` so requests route through your configured provider.
+
+## Command Usage
+For non-interactive print mode tasks, Nakama passes `--provider` and `--model` from your configured provider:
+```bash
+pi --provider anthropic --model claude-sonnet-4-6 -p 'Add retry logic to API calls and update tests'
+```
+
+## Best Practices
+1. Scope tasks clearly to the target workspace/directory.
+2. Provide explicit constraints and implementation details.

--- a/packages/core/src/skills/bundled/create-automation.test.ts
+++ b/packages/core/src/skills/bundled/create-automation.test.ts
@@ -206,6 +206,7 @@ describe("ensureBundledSkillFiles", () => {
     expect(created).toContain("coding-backend-codex");
     expect(created).toContain("coding-backend-claude-code");
     expect(created).toContain("coding-backend-opencode");
+    expect(created).toContain("coding-backend-pi");
   });
 
   test("does not overwrite existing skill files", async () => {

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -169,7 +169,7 @@ export interface StoredWorkspaceSettingsRecord {
   orgId?: string | null;
 }
 
-export type StoredCodingAgentHarnessKind = "codex" | "claude_code" | "opencode";
+export type StoredCodingAgentHarnessKind = "codex" | "claude_code" | "opencode" | "pi";
 
 export interface StoredCodingAgentHarnessProbeCache {
   checkedAt: string;


### PR DESCRIPTION
## Summary
- Add `pi.dev` (pi) as a new coding agent harness kind alongside codex, claude_code, and opencode
- Provider passthrough maps Nakama provider types to pi.dev's provider system with correct env vars and CLI flags (`--provider`, `--model`)
- Custom base URLs (proxies/gateways) generate a "nakama" provider entry using `openai-completions` API format; default base URLs override built-in provider settings
- Model ID prefixes (e.g. `cx/`) are preserved for `openai_compatible` providers to avoid 404s from proxies
- Readiness check errors now include `combinedOutput` (stdout/stderr summary) for better debugging

#### Test plan
- [x] `bun test` for affected test files (coding-agent-command, coding-agent-spawn-env, coding-agent, create-automation) — 31 pass, 0 fail
- [x] Manual test: `pi -p "Reply with OK and nothing else."` with provider passthrough
- [x] Verified readiness check reports `ok: true`, `authenticated: true`, `ready: true`
- [x] Confirmed `--provider`, `--model`, and `spawn.env` are correctly set from Nakama routing