### PR TITLE
fix(email): OpenAI-compatible email tool schema

### DIFF
--- a/packages/core/src/tools/email.test.ts
+++ b/packages/core/src/tools/email.test.ts
@@ -49,6 +49,30 @@ describe("email tool", () => {
     }
   });
 
+  test("strips cross-action fields advertised by the flat LLM schema", async () => {
+    const sender = createFakeMailSender();
+
+    const result = await runEmailTool(
+      {
+        action: "send",
+        to: "recipient@example.com",
+        subject: "Hello",
+        text: "Body",
+        folder: "INBOX",
+        limit: 20,
+        uid: 99,
+        query: "noise",
+      },
+      {
+        loadConfig: async () => completeConfig,
+        createSender: () => sender,
+      },
+    );
+
+    expect("sent" in result && result.sent?.messageId).toBe("fake-message-id");
+    expect(sender.sent).toHaveLength(1);
+  });
+
   test("returns configuration error when mailbox is incomplete", async () => {
     const reader = createFakeMailReader();
     const sender = createFakeMailSender();

--- a/packages/core/src/tools/email.test.ts
+++ b/packages/core/src/tools/email.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import type { EmailConfigFile } from "../email-config";
-import { createFakeMailReader, createFakeMailSender, runEmailTool } from "./email";
+import {
+  createFakeMailReader,
+  createFakeMailSender,
+  emailParameters,
+  emailTool,
+  runEmailTool,
+} from "./email";
+import { builtinTools } from "./builtin";
 
 process.env.NAKAMA_EMAIL_ATTACHMENT_SECRET ??= "test-email-attachment-secret-32-chars";
 
@@ -18,6 +25,30 @@ const completeConfig: EmailConfigFile = {
 };
 
 describe("email tool", () => {
+  test("exposes an OpenAI-compatible object parameters schema", () => {
+    const parameters = emailParameters();
+    const schema = parameters as Record<string, unknown>;
+
+    expect(parameters.type).toBe("object");
+    expect(schema.oneOf).toBeUndefined();
+    expect(schema.anyOf).toBeUndefined();
+    expect(parameters.properties?.action).toEqual({
+      type: "string",
+      enum: ["list", "read", "search", "send"],
+    });
+    expect(parameters.required).toContain("action");
+    expect(emailTool.parameters).toEqual(parameters);
+  });
+
+  test("builtin tool schemas all declare type object for LLM providers", () => {
+    for (const tool of builtinTools) {
+      expect(tool.parameters?.type, `${tool.name} parameters.type`).toBe("object");
+      const schema = tool.parameters as Record<string, unknown> | undefined;
+      expect(schema?.oneOf, `${tool.name} oneOf`).toBeUndefined();
+      expect(schema?.anyOf, `${tool.name} anyOf`).toBeUndefined();
+    }
+  });
+
   test("returns configuration error when mailbox is incomplete", async () => {
     const reader = createFakeMailReader();
     const sender = createFakeMailSender();

--- a/packages/core/src/tools/email.ts
+++ b/packages/core/src/tools/email.ts
@@ -37,43 +37,35 @@ const limitSchema = z.preprocess(
   z.number().int().positive().max(100),
 );
 
-const emailListInputSchema = z
-  .object({
-    action: z.literal("list"),
-    folder: folderSchema,
-    limit: limitSchema,
-  })
-  .strict();
+const emailListInputSchema = z.object({
+  action: z.literal("list"),
+  folder: folderSchema,
+  limit: limitSchema,
+});
 
-const emailReadInputSchema = z
-  .object({
-    action: z.literal("read"),
-    folder: folderSchema,
-    uid: z
-      .number({ error: "uid is required." })
-      .int()
-      .positive({ error: "uid must be a positive integer." }),
-  })
-  .strict();
+const emailReadInputSchema = z.object({
+  action: z.literal("read"),
+  folder: folderSchema,
+  uid: z
+    .number({ error: "uid is required." })
+    .int()
+    .positive({ error: "uid must be a positive integer." }),
+});
 
-const emailSearchInputSchema = z
-  .object({
-    action: z.literal("search"),
-    folder: folderSchema,
-    query: z.string({ error: "query is required." }).trim().min(1),
-    limit: limitSchema,
-  })
-  .strict();
+const emailSearchInputSchema = z.object({
+  action: z.literal("search"),
+  folder: folderSchema,
+  query: z.string({ error: "query is required." }).trim().min(1),
+  limit: limitSchema,
+});
 
-const emailSendInputSchema = z
-  .object({
-    action: z.literal("send"),
-    to: z.string({ error: "to is required." }).trim().min(1),
-    subject: z.string({ error: "subject is required." }).trim().min(1),
-    text: z.string({ error: "text is required." }).trim().min(1),
-    html: z.string().trim().min(1).optional(),
-  })
-  .strict();
+const emailSendInputSchema = z.object({
+  action: z.literal("send"),
+  to: z.string({ error: "to is required." }).trim().min(1),
+  subject: z.string({ error: "subject is required." }).trim().min(1),
+  text: z.string({ error: "text is required." }).trim().min(1),
+  html: z.string().trim().min(1).optional(),
+});
 
 export const emailInputSchema = z.discriminatedUnion("action", [
   emailListInputSchema,

--- a/packages/core/src/tools/email.ts
+++ b/packages/core/src/tools/email.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { ToolContext, ToolDefinition } from "../contract";
+import type { JsonSchema, ToolContext, ToolDefinition } from "../contract";
 import {
   emailConfigToMailboxConfig,
   isEmailConfigComplete,
@@ -15,7 +15,7 @@ import {
   createAttachmentReference,
   getMailboxIdentity,
 } from "../mail/attachment-reference";
-import { jsonSchemaFromZod, parseToolInput } from "./schema";
+import { parseToolInput } from "./schema";
 
 const EMAIL_ADDRESS_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -85,8 +85,57 @@ export const emailInputSchema = z.discriminatedUnion("action", [
 export type EmailAction = z.infer<typeof emailInputSchema>["action"];
 export type EmailToolInput = z.infer<typeof emailInputSchema>;
 
-export function emailParameters() {
-  return jsonSchemaFromZod(emailInputSchema);
+/**
+ * OpenAI (and several OpenAI-compatible providers) require tool `parameters`
+ * to be a JSON Schema with top-level `type: "object"`. Zod's discriminated
+ * union emits `oneOf`/`anyOf` without that key, which providers reject with
+ * 400 invalid_function_parameters — blocking all chat when email is enabled.
+ * Keep `emailInputSchema` for runtime parsing; expose a flat object schema to LLMs.
+ */
+export function emailParameters(): JsonSchema {
+  return {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        enum: ["list", "read", "search", "send"],
+      },
+      folder: {
+        type: "string",
+        description: "Mail folder. Defaults to INBOX.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max messages to return (1-100). Defaults to 20.",
+      },
+      uid: {
+        type: "integer",
+        description: "Message UID. Required for action=read.",
+      },
+      query: {
+        type: "string",
+        description: "Search query. Required for action=search.",
+      },
+      to: {
+        type: "string",
+        description: "Recipient address. Required for action=send.",
+      },
+      subject: {
+        type: "string",
+        description: "Subject. Required for action=send.",
+      },
+      text: {
+        type: "string",
+        description: "Plain-text body. Required for action=send.",
+      },
+      html: {
+        type: "string",
+        description: "Optional HTML body for action=send.",
+      },
+    },
+    required: ["action"],
+    additionalProperties: false,
+  };
 }
 
 export interface EmailToolSuccess {


### PR DESCRIPTION
## Summary
With mailbox configured, OpenAI chat failed on every turn: the `email` tool schema used Zod’s discriminated union (`oneOf` without `type: object`), which OpenAI rejects. Chat with email enabled works again by exposing a flat `type: object` parameters schema to LLMs while keeping discriminated-union validation at runtime (extra cross-action keys are stripped).

Closes #153

## Test plan
- [x] `bun test packages/core/src/tools/email.test.ts`
- [x] Live OpenAI chat/completions with the fixed schema returns **200** (was **400** `invalid_function_parameters`)
- [x] Enable mailbox + email tool on a profile; send any web chat message via OpenAI — expect a normal reply, not a schema 400

## Known Residuals
- **P2** — Flat LLM schema only requires `action`; action-specific required fields (`uid`, `query`, `to`/`subject`/`text`) are documented in property descriptions and still enforced by Zod at runtime.
- **P2** — Hand-written `emailParameters()` can drift from `emailInputSchema`; no codegen alignment check yet.
- **P3** — Optional `html: ""` is allowed by the LLM schema but rejected by runtime `min(1)`.

## Post-Deploy Monitoring & Validation
- Watch chat/provider error logs for `invalid_function_parameters` / `Schema for function 'email'` after deploy.
- Healthy: OpenAI (and OpenAI-compatible) chats succeed on profiles with email assigned and mailbox configured.
- Failure: any recurrence of tool-schema 400s on email-enabled profiles — roll back this release or remove `email` from the profile as interim mitigation.
- Window: first 24h after deploy; owner: whoever ships the release.
