### PR TITLE
Fix model catalog browse blocked by CSP

### DIFF
--- a/apps/server/src/http/routes/models.ts
+++ b/apps/server/src/http/routes/models.ts
@@ -50,6 +50,10 @@ import { requireOrgAdminFromContext } from "../org-guards";
 import { installCodingAgentHarness } from "../../services/coding-agent-harness-service";
 import { installAgentBrowser } from "../../services/agent-browser-service";
 import { streamAgentBrowserInstall, streamCodingHarnessInstall } from "../coding-harness-install-stream";
+import {
+  getExternalModelCatalog,
+  isExternalModelCatalogId,
+} from "../../services/external-model-catalog-service";
 
 export function registerModelRoutes(app: HonoApp, options: ServerOptions): void {
   const { agent, workerManager, databaseAdapter } = options;
@@ -136,7 +140,30 @@ export function registerModelRoutes(app: HonoApp, options: ServerOptions): void 
   const updateComposioRequestSchema = z.object({}).passthrough().openapi("UpdateComposioSettingsRequest");
   const updateWhatsappRequestSchema = z.object({}).passthrough().openapi("UpdateWhatsAppSettingsRequest");
   const modelQuerySchema = z.object({ source: z.enum(["catalog", "remote"]).optional() });
+  const externalModelCatalogParam = z.object({
+    catalogId: z.string().openapi({ param: { name: "catalogId", in: "path" } }),
+  });
+  const externalModelCatalogResponseSchema = z
+    .object({})
+    .passthrough()
+    .openapi("ExternalModelCatalogResponse");
 
+  app.openAPIRegistry.registerPath(createRoute({
+    method: "get",
+    path: "/v1/model-catalogs/{catalogId}",
+    tags: ["Models"],
+    summary: "Fetch a public upstream model catalog",
+    operationId: "getExternalModelCatalog",
+    request: { params: externalModelCatalogParam },
+    responses: {
+      200: {
+        description: "Upstream model catalog payload",
+        content: { "application/json": { schema: externalModelCatalogResponseSchema } },
+      },
+      400: { description: "Error", content: { "application/json": { schema: errorSchema } } },
+      502: { description: "Upstream error", content: { "application/json": { schema: errorSchema } } },
+    },
+  }));
   app.openAPIRegistry.registerPath(createRoute({
     method: "get",
     path: "/v1/models",
@@ -495,6 +522,22 @@ export function registerModelRoutes(app: HonoApp, options: ServerOptions): void 
     operationId: "reconnectWhatsApp",
     responses: { 200: { description: "WhatsApp settings", content: { "application/json": { schema: whatsappSettingsSchema } } }, 400: { description: "Error", content: { "application/json": { schema: errorSchema } } } },
   }));
+
+  app.get("/v1/model-catalogs/:catalogId", async (c) => {
+    getRequestAuth(c);
+    const catalogId = decodeURIComponent(c.req.param("catalogId"));
+
+    if (!isExternalModelCatalogId(catalogId)) {
+      return errorResponse("Unknown model catalog.", 400);
+    }
+
+    try {
+      return json(await getExternalModelCatalog(catalogId));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return errorResponse(message, 502);
+    }
+  });
 
   app.get("/v1/models", async (c) => {
     getRequestAuth(c);

--- a/apps/server/src/services/external-model-catalog-service.test.ts
+++ b/apps/server/src/services/external-model-catalog-service.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  getExternalModelCatalog,
+  isExternalModelCatalogId,
+} from "./external-model-catalog-service";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("isExternalModelCatalogId", () => {
+  test("accepts supported catalog ids", () => {
+    expect(isExternalModelCatalogId("models-dev")).toBe(true);
+    expect(isExternalModelCatalogId("openrouter")).toBe(true);
+    expect(isExternalModelCatalogId("cerebras")).toBe(true);
+  });
+
+  test("rejects unknown catalog ids", () => {
+    expect(isExternalModelCatalogId("unknown")).toBe(false);
+  });
+});
+
+describe("getExternalModelCatalog", () => {
+  test("fetches and returns catalog payload", async () => {
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ openai: { models: {} } }), { status: 200 });
+
+    await expect(getExternalModelCatalog("models-dev")).resolves.toEqual({
+      openai: { models: {} },
+    });
+  });
+
+  test("throws when upstream request fails", async () => {
+    globalThis.fetch = async () => new Response("nope", { status: 502 });
+
+    await expect(getExternalModelCatalog("openrouter")).rejects.toThrow(
+      "Failed to fetch model catalog (502)",
+    );
+  });
+});

--- a/apps/server/src/services/external-model-catalog-service.ts
+++ b/apps/server/src/services/external-model-catalog-service.ts
@@ -1,0 +1,36 @@
+const CATALOG_URLS = {
+  "models-dev": "https://models.dev/api.json",
+  openrouter: "https://openrouter.ai/api/v1/models?output_modalities=text",
+  cerebras: "https://api.cerebras.ai/public/v1/models",
+} as const;
+
+export type ExternalModelCatalogId = keyof typeof CATALOG_URLS;
+
+const CACHE_TTL_MS = 1000 * 60 * 30;
+
+type CacheEntry = {
+  fetchedAt: number;
+  payload: unknown;
+};
+
+const cache = new Map<ExternalModelCatalogId, CacheEntry>();
+
+export function isExternalModelCatalogId(value: string): value is ExternalModelCatalogId {
+  return value in CATALOG_URLS;
+}
+
+export async function getExternalModelCatalog(catalogId: ExternalModelCatalogId): Promise<unknown> {
+  const cached = cache.get(catalogId);
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.payload;
+  }
+
+  const response = await fetch(CATALOG_URLS[catalogId]);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch model catalog (${response.status})`);
+  }
+
+  const payload = await response.json();
+  cache.set(catalogId, { fetchedAt: Date.now(), payload });
+  return payload;
+}

--- a/apps/web/src/hooks/use-cerebras-models.ts
+++ b/apps/web/src/hooks/use-cerebras-models.ts
@@ -1,24 +1,19 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import {
   CEREBRAS_FALLBACK_MODELS,
-  CEREBRAS_MODELS_URL,
   normalizeCerebrasModels,
   type CerebrasModelRow,
   type CerebrasModelsApiResponse,
 } from "@/lib/cerebras-models";
 import { queryKeys } from "@/lib/query-keys";
+import { client } from "@/lib/client";
 
 async function fetchCerebrasModels(): Promise<{
   rows: CerebrasModelRow[];
   usedFallback: boolean;
 }> {
   try {
-    const res = await fetch(CEREBRAS_MODELS_URL);
-    if (!res.ok) {
-      throw new Error(`HTTP ${res.status}`);
-    }
-
-    const data = (await res.json()) as CerebrasModelsApiResponse;
+    const data = (await client.getExternalModelCatalog("cerebras")) as CerebrasModelsApiResponse;
     const rows = normalizeCerebrasModels(data);
     if (rows.length === 0) {
       return { rows: CEREBRAS_FALLBACK_MODELS, usedFallback: true };

--- a/apps/web/src/hooks/use-models-dev.ts
+++ b/apps/web/src/hooks/use-models-dev.ts
@@ -1,5 +1,6 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { queryKeys } from "@/lib/query-keys";
+import { client } from "@/lib/client";
 import type { SelectedProvider } from "@/lib/models";
 
 export interface ModelsDevRow {
@@ -66,10 +67,7 @@ function resolvenakamaProvider(
 }
 
 async function fetchModelsDev(): Promise<ModelsDevRow[]> {
-  const res = await fetch("https://models.dev/api.json");
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-
-  const data = (await res.json()) as Record<string, unknown>;
+  const data = (await client.getExternalModelCatalog("models-dev")) as Record<string, unknown>;
   const rows: ModelsDevRow[] = [];
 
   for (const [providerId, p] of Object.entries(data)) {

--- a/apps/web/src/hooks/use-openrouter-models.ts
+++ b/apps/web/src/hooks/use-openrouter-models.ts
@@ -5,17 +5,10 @@ import {
   type OpenRouterModelsApiResponse,
 } from "@/lib/openrouter-models";
 import { queryKeys } from "@/lib/query-keys";
-
-const OPENROUTER_MODELS_URL =
-  "https://openrouter.ai/api/v1/models?output_modalities=text";
+import { client } from "@/lib/client";
 
 async function fetchOpenRouterModels(): Promise<OpenRouterModelRow[]> {
-  const res = await fetch(OPENROUTER_MODELS_URL);
-  if (!res.ok) {
-    throw new Error(`HTTP ${res.status}`);
-  }
-
-  const data = (await res.json()) as OpenRouterModelsApiResponse;
+  const data = (await client.getExternalModelCatalog("openrouter")) as OpenRouterModelsApiResponse;
   return normalizeOpenRouterModels(data);
 }
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -321,6 +321,12 @@ export class NakamaClient {
     return this.request<ModelsResponse>(`/v1/models${query}`);
   }
 
+  async getExternalModelCatalog(
+    catalogId: "models-dev" | "openrouter" | "cerebras",
+  ): Promise<unknown> {
+    return this.request(`/v1/model-catalogs/${encodeURIComponent(catalogId)}`);
+  }
+
   async discoverModels(request: {
     baseUrl?: string;
     apiKey?: string;


### PR DESCRIPTION
## Summary
- Proxy external model catalogs (models.dev, OpenRouter, Cerebras) through a new authenticated `/v1/model-catalogs/:catalogId` server endpoint
- Update web hooks and client to fetch catalogs via Nakama API instead of direct browser requests blocked by `connect-src 'self'`
- Add server-side caching (30 min TTL) and unit tests for catalog fetching

## Test plan
- [x] `bun test apps/server/src/services/external-model-catalog-service.test.ts`
- [ ] Sign in and open provider setup → Browse models.dev; catalog loads without CSP errors
- [ ] Verify OpenRouter and Cerebras browse lists still load in provider settings

