### PR TITLE
fix(chat): smooth streaming text with RAF coalesce and markdown seal

### DIFF
--- a/apps/web/src/components/chat/ThinkingReasoning.module.css
+++ b/apps/web/src/components/chat/ThinkingReasoning.module.css
@@ -112,7 +112,11 @@
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
-  animation: tr-sentence-in 420ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+/* Animate only newly appended sentences (not text growing in an existing line). */
+.sentence[data-fresh] {
+  animation: tr-sentence-in 280ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
 @keyframes tr-sentence-in {
@@ -186,6 +190,10 @@
   }
 
   .sentence {
+    animation: none;
+  }
+
+  .sentence[data-fresh] {
     animation: none;
   }
 

--- a/apps/web/src/components/chat/ThinkingReasoning.tsx
+++ b/apps/web/src/components/chat/ThinkingReasoning.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import styles from "./ThinkingReasoning.module.css";
 import { ThinkingState } from "@/components/chat/ThinkingState";
+import { useRafCoalescedValue } from "@/hooks/use-raf-coalesced-value";
 import { splitThinkingLines } from "@/lib/thinking-text";
 import { formatElapsedSeconds } from "@/lib/elapsed-time";
 import { cn } from "@/lib/utils";
@@ -115,7 +116,8 @@ function ThinkingReasoningViewport({
     >
       <div className={styles.stream}>
         {sentences.map((line, index) => (
-          <p key={`${index}:${line}`} className={styles.sentence}>
+          // Stable index keys: growing the last line must not remount + re-fade.
+          <p key={index} className={styles.sentence} data-fresh={index === sentences.length - 1 || undefined}>
             {line}
           </p>
         ))}
@@ -132,8 +134,9 @@ export function ThinkingReasoning({
   className,
   children,
 }: ThinkingReasoningProps) {
-  const trimmed = text.trim();
-  const sentences = useMemo(() => splitThinkingLines(text), [text]);
+  const displayText = useRafCoalescedValue(text, isThinkingStreaming);
+  const trimmed = displayText.trim();
+  const sentences = useMemo(() => splitThinkingLines(displayText), [displayText]);
   const hasBody = sentences.length > 0 || Boolean(children);
   const elapsedSeconds = useThinkingElapsed(isWorkActive, startedAt);
   const [done, setDone] = useState(!isWorkActive && hasBody);

--- a/apps/web/src/components/chat/ThinkingReasoning.tsx
+++ b/apps/web/src/components/chat/ThinkingReasoning.tsx
@@ -55,6 +55,20 @@ function ThinkingReasoningViewport({
   const viewportRef = useRef<HTMLDivElement | null>(null);
   const [fade, setFade] = useState({ top: false, bottom: false });
 
+  // Append-only stream: sealed lines keep a content-prefix key; the live tail
+  // keeps a fixed key so growing text does not remount / re-fade.
+  const items = useMemo(() => {
+    let sealedPrefix = "";
+    return sentences.map((text, index) => {
+      const isLiveTail = isWorkActive && index === sentences.length - 1;
+      if (isLiveTail) {
+        return { key: "live-tail", text, fresh: true as const };
+      }
+      sealedPrefix = `${sealedPrefix}\0${text}`;
+      return { key: `sealed:${sealedPrefix}`, text, fresh: false as const };
+    });
+  }, [sentences, isWorkActive]);
+
   const updateFade = () => {
     const element = viewportRef.current;
     if (!element) {
@@ -94,7 +108,7 @@ function ThinkingReasoningViewport({
     updateFade();
   };
 
-  if (sentences.length === 0) {
+  if (items.length === 0) {
     return null;
   }
 
@@ -115,10 +129,13 @@ function ThinkingReasoningViewport({
       onScroll={handleScroll}
     >
       <div className={styles.stream}>
-        {sentences.map((line, index) => (
-          // Stable index keys: growing the last line must not remount + re-fade.
-          <p key={index} className={styles.sentence} data-fresh={index === sentences.length - 1 || undefined}>
-            {line}
+        {items.map((item) => (
+          <p
+            key={item.key}
+            className={styles.sentence}
+            data-fresh={item.fresh || undefined}
+          >
+            {item.text}
           </p>
         ))}
       </div>

--- a/apps/web/src/components/chat/assistant-tool-group.tsx
+++ b/apps/web/src/components/chat/assistant-tool-group.tsx
@@ -27,7 +27,9 @@ import { WebFetchToolRow } from "@/components/chat/WebFetchToolRow";
 import { isArtifactMetaSidecarTool } from "@/lib/chat-artifacts";
 import { ThinkingReasoning } from "@/components/chat/ThinkingReasoning";
 import thinkingStyles from "@/components/chat/ThinkingReasoning.module.css";
+import { useRafCoalescedValue } from "@/hooks/use-raf-coalesced-value";
 import { formatElapsedSeconds, useElapsedSeconds } from "@/lib/elapsed-time";
+import { splitStreamingMarkdown } from "@/lib/streaming-markdown-seal";
 import { cn } from "@/lib/utils";
 
 import {
@@ -64,11 +66,38 @@ export function AssistantTurnSegmentView({
   );
 }
 
-function AssistantTextContent({ message }: { message: ChatListItem }) {
+function StreamingPlainTail({ text }: { text: string }) {
   return (
-    <MessageResponse isAnimating={Boolean(message.streaming && !message.thinkingStreaming)}>
-      {message.content || "…"}
-    </MessageResponse>
+    <div
+      className={cn(
+        "chat-markdown size-full whitespace-pre-wrap break-words text-foreground",
+        "[&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
+      )}
+    >
+      {text || "…"}
+    </div>
+  );
+}
+
+function AssistantTextContent({ message }: { message: ChatListItem }) {
+  const streaming = Boolean(message.streaming && !message.thinkingStreaming);
+  const content = useRafCoalescedValue(message.content, streaming);
+
+  if (!streaming) {
+    return <MessageResponse>{content || "…"}</MessageResponse>;
+  }
+
+  const { sealed, tail } = splitStreamingMarkdown(content);
+
+  return (
+    <div className="flex w-full min-w-0 flex-col gap-0">
+      {sealed ? (
+        <MessageResponse isAnimating={false} mode="streaming">
+          {sealed}
+        </MessageResponse>
+      ) : null}
+      {tail || !sealed ? <StreamingPlainTail text={tail} /> : null}
+    </div>
   );
 }
 

--- a/apps/web/src/hooks/use-raf-coalesced-value.ts
+++ b/apps/web/src/hooks/use-raf-coalesced-value.ts
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from "react";
-import { RafValueCoalescer } from "@/lib/raf-coalesced-value";
 
 /**
  * While `enabled`, propagates `value` at most once per animation frame.
@@ -7,24 +6,58 @@ import { RafValueCoalescer } from "@/lib/raf-coalesced-value";
  */
 export function useRafCoalescedValue<T>(value: T, enabled: boolean): T {
   const [display, setDisplay] = useState(value);
-  const coalescerRef = useRef<RafValueCoalescer<T> | null>(null);
-
-  if (coalescerRef.current === null) {
-    coalescerRef.current = new RafValueCoalescer(value, setDisplay);
-  }
+  const pendingRef = useRef(value);
+  const rafRef = useRef<number | null>(null);
+  const generationRef = useRef(0);
 
   useEffect(() => {
-    const coalescer = coalescerRef.current!;
     if (!enabled) {
-      coalescer.sync(value);
+      generationRef.current += 1;
+      if (rafRef.current != null && typeof cancelAnimationFrame === "function") {
+        cancelAnimationFrame(rafRef.current);
+      }
+      rafRef.current = null;
+      pendingRef.current = value;
+      setDisplay(value);
       return;
     }
-    coalescer.set(value);
+
+    pendingRef.current = value;
+    if (rafRef.current != null) {
+      return;
+    }
+
+    const generation = generationRef.current;
+    const run = () => {
+      if (generation !== generationRef.current) {
+        return;
+      }
+      rafRef.current = null;
+      setDisplay(pendingRef.current);
+    };
+
+    if (typeof requestAnimationFrame === "function") {
+      rafRef.current = requestAnimationFrame(run);
+      return;
+    }
+
+    // Mark scheduled without rAF so bursts in this turn still coalesce.
+    rafRef.current = -1;
+    queueMicrotask(() => {
+      if (rafRef.current !== -1) {
+        return;
+      }
+      run();
+    });
   }, [value, enabled]);
 
   useEffect(() => {
     return () => {
-      coalescerRef.current?.cancel();
+      generationRef.current += 1;
+      if (rafRef.current != null && rafRef.current >= 0 && typeof cancelAnimationFrame === "function") {
+        cancelAnimationFrame(rafRef.current);
+      }
+      rafRef.current = null;
     };
   }, []);
 

--- a/apps/web/src/hooks/use-raf-coalesced-value.ts
+++ b/apps/web/src/hooks/use-raf-coalesced-value.ts
@@ -13,12 +13,11 @@ export function useRafCoalescedValue<T>(value: T, enabled: boolean): T {
   useEffect(() => {
     if (!enabled) {
       generationRef.current += 1;
-      if (rafRef.current != null && typeof cancelAnimationFrame === "function") {
+      if (rafRef.current != null && rafRef.current >= 0 && typeof cancelAnimationFrame === "function") {
         cancelAnimationFrame(rafRef.current);
       }
       rafRef.current = null;
       pendingRef.current = value;
-      setDisplay(value);
       return;
     }
 

--- a/apps/web/src/hooks/use-raf-coalesced-value.ts
+++ b/apps/web/src/hooks/use-raf-coalesced-value.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef, useState } from "react";
+import { RafValueCoalescer } from "@/lib/raf-coalesced-value";
+
+/**
+ * While `enabled`, propagates `value` at most once per animation frame.
+ * When disabled, returns `value` immediately (catch-up on stream end).
+ */
+export function useRafCoalescedValue<T>(value: T, enabled: boolean): T {
+  const [display, setDisplay] = useState(value);
+  const coalescerRef = useRef<RafValueCoalescer<T> | null>(null);
+
+  if (coalescerRef.current === null) {
+    coalescerRef.current = new RafValueCoalescer(value, setDisplay);
+  }
+
+  useEffect(() => {
+    const coalescer = coalescerRef.current!;
+    if (!enabled) {
+      coalescer.sync(value);
+      return;
+    }
+    coalescer.set(value);
+  }, [value, enabled]);
+
+  useEffect(() => {
+    return () => {
+      coalescerRef.current?.cancel();
+    };
+  }, []);
+
+  return enabled ? display : value;
+}

--- a/apps/web/src/lib/raf-coalesced-value.test.ts
+++ b/apps/web/src/lib/raf-coalesced-value.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { RafValueCoalescer } from "./raf-coalesced-value";
+
+function flushCoalesceTurn(): Promise<void> {
+  if (typeof requestAnimationFrame === "function") {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+  return Promise.resolve(); // microtask fallback runs before the next await tick
+}
+
+describe("RafValueCoalescer", () => {
+  test("coalesces multiple set() calls into one flush", async () => {
+    const flushed: string[] = [];
+    const coalescer = new RafValueCoalescer("", (value) => {
+      flushed.push(value);
+    });
+
+    coalescer.set("a");
+    coalescer.set("ab");
+    coalescer.set("abc");
+
+    expect(flushed).toEqual([]);
+
+    await flushCoalesceTurn();
+
+    expect(flushed).toEqual(["abc"]);
+  });
+
+  test("sync publishes immediately and cancels a pending flush", async () => {
+    const flushed: string[] = [];
+    const coalescer = new RafValueCoalescer("", (value) => {
+      flushed.push(value);
+    });
+
+    coalescer.set("partial");
+    coalescer.sync("final");
+
+    expect(flushed).toEqual(["final"]);
+
+    await flushCoalesceTurn();
+
+    expect(flushed).toEqual(["final"]);
+  });
+
+  test("cancel drops a pending flush without publishing", async () => {
+    const flushed: string[] = [];
+    const coalescer = new RafValueCoalescer("", (value) => {
+      flushed.push(value);
+    });
+
+    coalescer.set("lost");
+    coalescer.cancel();
+
+    await flushCoalesceTurn();
+
+    expect(flushed).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/raf-coalesced-value.ts
+++ b/apps/web/src/lib/raf-coalesced-value.ts
@@ -1,0 +1,65 @@
+/**
+ * Coalesces rapid value updates into at most one paint per animation frame.
+ * While streaming, bursty token arrivals share a single flush; callers should
+ * call {@link RafValueCoalescer.sync} when streaming ends so the final value
+ * paints immediately.
+ *
+ * When `requestAnimationFrame` is unavailable (e.g. Bun tests), falls back to
+ * a microtask so same-turn bursts still coalesce.
+ */
+export class RafValueCoalescer<T> {
+  private pending: T;
+  private rafId: number | null = null;
+  private scheduled = false;
+  private generation = 0;
+
+  constructor(
+    initial: T,
+    private readonly onFlush: (value: T) => void,
+  ) {
+    this.pending = initial;
+  }
+
+  /** Queue `value` for the next animation frame (coalesced). */
+  set(value: T): void {
+    this.pending = value;
+    if (this.scheduled) {
+      return;
+    }
+
+    this.scheduled = true;
+    const generation = this.generation;
+
+    const run = () => {
+      if (generation !== this.generation) {
+        return;
+      }
+      this.scheduled = false;
+      this.rafId = null;
+      this.onFlush(this.pending);
+    };
+
+    if (typeof requestAnimationFrame === "function") {
+      this.rafId = requestAnimationFrame(run);
+      return;
+    }
+
+    queueMicrotask(run);
+  }
+
+  /** Cancel any pending frame and publish `value` immediately. */
+  sync(value: T): void {
+    this.cancel();
+    this.pending = value;
+    this.onFlush(value);
+  }
+
+  cancel(): void {
+    this.generation += 1;
+    this.scheduled = false;
+    if (this.rafId != null && typeof cancelAnimationFrame === "function") {
+      cancelAnimationFrame(this.rafId);
+    }
+    this.rafId = null;
+  }
+}

--- a/apps/web/src/lib/streaming-markdown-seal.test.ts
+++ b/apps/web/src/lib/streaming-markdown-seal.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { splitStreamingMarkdown } from "./streaming-markdown-seal";
+
+describe("splitStreamingMarkdown", () => {
+  test("keeps a single incomplete paragraph in the tail", () => {
+    expect(splitStreamingMarkdown("Hello world")).toEqual({
+      sealed: "",
+      tail: "Hello world",
+    });
+  });
+
+  test("seals completed paragraphs at blank-line boundaries", () => {
+    expect(splitStreamingMarkdown("First paragraph.\n\nSecond still typing")).toEqual({
+      sealed: "First paragraph.\n\n",
+      tail: "Second still typing",
+    });
+  });
+
+  test("does not seal blank lines inside an open code fence", () => {
+    const content = "Intro\n\n```js\nconst a = 1;\n\nconst b = 2;";
+    expect(splitStreamingMarkdown(content)).toEqual({
+      sealed: "Intro\n\n",
+      tail: "```js\nconst a = 1;\n\nconst b = 2;",
+    });
+  });
+
+  test("seals after a closed fence when a later blank line appears", () => {
+    const content = "Intro\n\n```js\nconst a = 1;\n\nconst b = 2;\n```\n\nAfter";
+    expect(splitStreamingMarkdown(content)).toEqual({
+      sealed: "Intro\n\n```js\nconst a = 1;\n\nconst b = 2;\n```\n\n",
+      tail: "After",
+    });
+  });
+
+  test("handles empty input", () => {
+    expect(splitStreamingMarkdown("")).toEqual({ sealed: "", tail: "" });
+  });
+});

--- a/apps/web/src/lib/streaming-markdown-seal.ts
+++ b/apps/web/src/lib/streaming-markdown-seal.ts
@@ -1,0 +1,65 @@
+/**
+ * Split streaming markdown into completed blocks (safe to render as markdown)
+ * and a trailing incomplete tail (render as plain text).
+ *
+ * Only treats blank lines outside fenced code blocks as seal boundaries, so a
+ * fence that contains blank lines stays in the tail until the fence closes.
+ */
+export function splitStreamingMarkdown(content: string): {
+  sealed: string;
+  tail: string;
+} {
+  if (!content) {
+    return { sealed: "", tail: "" };
+  }
+
+  let inFence = false;
+  let fenceChar: "`" | "~" | null = null;
+  let fenceLen = 0;
+  let lastSealedEnd = 0;
+
+  let index = 0;
+  const length = content.length;
+
+  while (index < length) {
+    const newlineAt = content.indexOf("\n", index);
+    const lineEnd = newlineAt === -1 ? length : newlineAt;
+    const line = content.slice(index, lineEnd);
+
+    const fence = line.match(/^(\s*)([`~]{3,})(.*)$/);
+    if (fence) {
+      const marker = fence[2]!;
+      const char = marker[0] as "`" | "~";
+      const info = fence[3] ?? "";
+      if (!inFence) {
+        inFence = true;
+        fenceChar = char;
+        fenceLen = marker.length;
+      } else if (
+        char === fenceChar &&
+        marker.length >= fenceLen &&
+        info.trim() === ""
+      ) {
+        inFence = false;
+        fenceChar = null;
+        fenceLen = 0;
+      }
+    } else if (!inFence && line.trim() === "" && index > 0) {
+      lastSealedEnd = newlineAt === -1 ? lineEnd : newlineAt + 1;
+    }
+
+    if (newlineAt === -1) {
+      break;
+    }
+    index = newlineAt + 1;
+  }
+
+  if (lastSealedEnd <= 0) {
+    return { sealed: "", tail: content };
+  }
+
+  return {
+    sealed: content.slice(0, lastSealedEnd),
+    tail: content.slice(lastSealedEnd),
+  };
+}


### PR DESCRIPTION
## Summary
- Coalesce streaming text paints to at most one update per animation frame so bursty tokens feel steadier
- Render incomplete paragraphs as plain text while streaming, then seal completed blocks (and the final reply) into Streamdown markdown — avoids mid-token AST remount flicker
- Stabilize thinking-line keys and only fade newly appended sentences so growing lines do not remount

## Test plan
- [ ] Send a long multi-paragraph assistant reply and confirm the active paragraph types smoothly without markdown flicker
- [ ] Confirm completed paragraphs format once sealed, and the full reply is markdown after the stream ends
- [ ] Confirm code fences with blank lines inside stay plain until closed, then seal cleanly
- [ ] Enable thinking and confirm growing lines do not flash/re-fade; new sentences still enter softly
- [ ] `bun test apps/web/src/lib/raf-coalesced-value.test.ts apps/web/src/lib/streaming-markdown-seal.test.ts`

