### PR TITLE
fix(openai): avoid tools + reasoning_effort 400 on gpt-5.4+

### DIFF
--- a/apps/server/src/providers/openai-compatible/index.test.ts
+++ b/apps/server/src/providers/openai-compatible/index.test.ts
@@ -129,6 +129,46 @@ describe("OpenAI-compatible provider", () => {
     expect(result.content).toBe("Answer");
   });
 
+  test("forces reasoning_effort none for gpt-5.6 tools even when thinking is off", async () => {
+    const fetchMock = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        reasoning?: unknown;
+        reasoning_effort?: string;
+        tools?: unknown[];
+      };
+      expect(body.tools).toHaveLength(1);
+      expect(body.reasoning).toBeUndefined();
+      expect(body.reasoning_effort).toBe("none");
+      return Response.json({
+        choices: [{ message: { content: "Answer" } }],
+      });
+    });
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = createOpenAICompatibleProvider({
+      apiKey: "sk-test",
+      baseUrl: "https://api.openai.com/v1",
+      model: "gpt-5.6-luna",
+      displayName: "OpenAI",
+      supportsThinking: true,
+    });
+
+    const result = await provider.generateChat({
+      system: "You are helpful.",
+      messages: [{ role: "user", content: "Search" }],
+      tools: [
+        {
+          name: "search_files",
+          description: "Search files",
+          parameters: { type: "object", properties: {} },
+        },
+      ],
+    });
+
+    expect(result.content).toBe("Answer");
+  });
+
   test("keeps reasoning_effort for non-OpenAI models with tools", async () => {
     const fetchMock = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
       const body = JSON.parse(String(init?.body ?? "{}")) as {

--- a/apps/server/src/providers/openai-compatible/index.test.ts
+++ b/apps/server/src/providers/openai-compatible/index.test.ts
@@ -88,6 +88,86 @@ describe("OpenAI-compatible provider", () => {
     expect(result.content).toBe("Answer");
   });
 
+  test("sets reasoning_effort to none for gpt-5.6 tools on chat completions", async () => {
+    const fetchMock = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        reasoning?: unknown;
+        reasoning_effort?: string;
+        tools?: unknown[];
+      };
+      expect(body.tools).toHaveLength(1);
+      expect(body.reasoning).toBeUndefined();
+      expect(body.reasoning_effort).toBe("none");
+      return Response.json({
+        choices: [{ message: { content: "Answer" } }],
+      });
+    });
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = createOpenAICompatibleProvider({
+      apiKey: "sk-test",
+      baseUrl: "https://api.openai.com/v1",
+      model: "gpt-5.6-luna",
+      displayName: "OpenAI",
+      supportsThinking: true,
+    });
+
+    const result = await provider.generateChat({
+      system: "You are helpful.",
+      messages: [{ role: "user", content: "Search" }],
+      tools: [
+        {
+          name: "search_files",
+          description: "Search files",
+          parameters: { type: "object", properties: {} },
+        },
+      ],
+      providerOptions: { thinking: { enabled: true, effort: "high" } },
+    });
+
+    expect(result.content).toBe("Answer");
+  });
+
+  test("keeps reasoning_effort for non-OpenAI models with tools", async () => {
+    const fetchMock = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        reasoning_effort?: string;
+        tools?: unknown[];
+      };
+      expect(body.tools).toHaveLength(1);
+      expect(body.reasoning_effort).toBe("high");
+      return Response.json({
+        choices: [{ message: { content: "Answer" } }],
+      });
+    });
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = createOpenAICompatibleProvider({
+      apiKey: "",
+      baseUrl: "https://api.example.com/v1",
+      model: "qwen3.6-35b",
+      displayName: "NetraRuntime",
+      supportsThinking: true,
+    });
+
+    const result = await provider.generateChat({
+      system: "You are helpful.",
+      messages: [{ role: "user", content: "Search" }],
+      tools: [
+        {
+          name: "search_files",
+          description: "Search files",
+          parameters: { type: "object", properties: {} },
+        },
+      ],
+      providerOptions: { thinking: { enabled: true, effort: "high" } },
+    });
+
+    expect(result.content).toBe("Answer");
+  });
+
   test("preserves leading spaces in streamed reasoning_content deltas", async () => {
     const fetchMock = mock(async () => {
       return new Response(

--- a/apps/server/src/providers/openai-compatible/index.ts
+++ b/apps/server/src/providers/openai-compatible/index.ts
@@ -26,6 +26,7 @@ import {
   toOpenAIMessages,
   toOpenAITools,
 } from "../openai";
+import { openAIModelRejectsChatToolsWithReasoning } from "../openai/thinking";
 
 export interface OpenAICompatibleProviderOptions {
   apiKey: string;
@@ -151,9 +152,17 @@ function readReasoningText(
   return trimmed ? trimmed : undefined;
 }
 
-function buildThinkingBody(thinking?: ProviderChatOptions["thinking"]) {
+function buildThinkingBody(
+  thinking: ProviderChatOptions["thinking"] | undefined,
+  options: { model: string; hasTools: boolean },
+) {
   if (!thinking?.enabled) {
     return {};
+  }
+
+  // OpenAI gpt-5.4+ chat/completions rejects tools + non-none reasoning_effort.
+  if (options.hasTools && openAIModelRejectsChatToolsWithReasoning(options.model)) {
+    return { reasoning_effort: "none" };
   }
 
   const effort = normalizeThinkingEffort(thinking.effort);
@@ -180,7 +189,10 @@ async function requestChatCompletion(
     const completion = await client.chat.completions.create({
       model: options.model,
       messages: await buildMessages(options.system, options.messages),
-      ...buildThinkingBody(options.thinking),
+      ...buildThinkingBody(options.thinking, {
+        model: options.model,
+        hasTools: Boolean(options.tools?.length),
+      }),
       ...(options.tools?.length
         ? {
             tools: toOpenAITools(options.tools),
@@ -238,7 +250,10 @@ async function streamChatCompletion(options: {
       stream: true,
       messages: await buildMessages(options.system, options.messages),
       stream_options: { include_usage: true },
-      ...buildThinkingBody(options.thinking),
+      ...buildThinkingBody(options.thinking, {
+        model: options.model,
+        hasTools: Boolean(options.tools?.length),
+      }),
       ...(options.tools?.length
         ? {
             tools: toOpenAITools(options.tools),

--- a/apps/server/src/providers/openai-compatible/index.ts
+++ b/apps/server/src/providers/openai-compatible/index.ts
@@ -156,13 +156,14 @@ function buildThinkingBody(
   thinking: ProviderChatOptions["thinking"] | undefined,
   options: { model: string; hasTools: boolean },
 ) {
-  if (!thinking?.enabled) {
-    return {};
-  }
-
-  // OpenAI gpt-5.4+ chat/completions rejects tools + non-none reasoning_effort.
+  // OpenAI gpt-5.4+ chat/completions rejects tools + non-none reasoning_effort
+  // (including when the API would default effort). Force none whenever tools are present.
   if (options.hasTools && openAIModelRejectsChatToolsWithReasoning(options.model)) {
     return { reasoning_effort: "none" };
+  }
+
+  if (!thinking?.enabled) {
+    return {};
   }
 
   const effort = normalizeThinkingEffort(thinking.effort);

--- a/apps/server/src/providers/openai/index.ts
+++ b/apps/server/src/providers/openai/index.ts
@@ -20,7 +20,7 @@ import {
   parseJsonRecord,
   readSseEvents,
 } from "../shared";
-import { openAIModelSupportsThinking, openAIModelRequiresResponsesApi } from "./thinking";
+import { openAIModelSupportsThinking, openAIModelRequiresResponsesApi, openAIModelRejectsChatToolsWithReasoning } from "./thinking";
 
 const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
 
@@ -155,6 +155,15 @@ function usesResponsesApi(
   }
 
   if (messagesIncludeUserDocuments(input.messages)) {
+    return true;
+  }
+
+  // gpt-5.4+ reject tools + reasoning_effort on chat/completions; Responses supports both.
+  if (
+    (input.tools?.length ?? 0) > 0 &&
+    (openAIModelRejectsChatToolsWithReasoning(model) ||
+      openAIModelSupportsThinking(model, customModels))
+  ) {
     return true;
   }
 
@@ -300,6 +309,8 @@ async function buildChatCompletionRequestBody(options: {
   streamOptions?: { includeUsage: boolean };
   provider?: ProviderName;
 }) {
+  const hasTools = Boolean(options.tools?.length);
+
   return {
     model: options.model,
     ...(options.stream ? { stream: true } : {}),
@@ -309,8 +320,15 @@ async function buildChatCompletionRequestBody(options: {
       options.messages,
       options.provider ?? "openai",
     ),
-    ...(options.tools?.length
-      ? { tools: toOpenAITools(options.tools), tool_choice: "auto" }
+    ...(hasTools
+      ? {
+          tools: toOpenAITools(options.tools),
+          tool_choice: "auto",
+          // Safety net if a caller still hits chat/completions for gpt-5.4+.
+          ...(openAIModelRejectsChatToolsWithReasoning(options.model)
+            ? { reasoning_effort: "none" }
+            : {}),
+        }
       : {}),
   };
 }

--- a/apps/server/src/providers/openai/thinking.test.ts
+++ b/apps/server/src/providers/openai/thinking.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test, mock, afterEach } from "bun:test";
-import { openAIModelRequiresResponsesApi, openAIModelSupportsThinking } from "./thinking";
+import {
+  openAIModelRejectsChatToolsWithReasoning,
+  openAIModelRequiresResponsesApi,
+  openAIModelSupportsThinking,
+} from "./thinking";
 import { createOpenAIProvider } from "./index";
 
 const originalFetch = globalThis.fetch;
@@ -36,6 +40,16 @@ describe("openAIModelRequiresResponsesApi", () => {
     expect(openAIModelRequiresResponsesApi("gpt-5.3-codex")).toBe(true);
     expect(openAIModelRequiresResponsesApi("GPT-5.3-Codex")).toBe(true);
     expect(openAIModelRequiresResponsesApi("gpt-5.4")).toBe(false);
+  });
+});
+
+describe("openAIModelRejectsChatToolsWithReasoning", () => {
+  test("flags gpt-5.4+ chat completions tool restriction", () => {
+    expect(openAIModelRejectsChatToolsWithReasoning("gpt-5.4")).toBe(true);
+    expect(openAIModelRejectsChatToolsWithReasoning("gpt-5.6-luna")).toBe(true);
+    expect(openAIModelRejectsChatToolsWithReasoning("GPT-5.6-Sol")).toBe(true);
+    expect(openAIModelRejectsChatToolsWithReasoning("gpt-5.3")).toBe(false);
+    expect(openAIModelRejectsChatToolsWithReasoning("gpt-4o-mini")).toBe(false);
   });
 });
 
@@ -81,6 +95,103 @@ describe("OpenAI codex vision routing", () => {
     });
 
     expect(result.content).toBe("A screenshot of settings.");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("OpenAI tools + reasoning routing", () => {
+  test("routes gpt-5.6-luna tool calls through responses even without thinking", async () => {
+    const fetchMock = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(String(input)).toBe("https://api.openai.com/v1/responses");
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        tools?: Array<{ type?: string; name?: string }>;
+        reasoning?: unknown;
+        reasoning_effort?: unknown;
+      };
+      expect(body.tools?.some((tool) => tool.name === "search_files")).toBe(true);
+      expect(body.reasoning).toBeUndefined();
+      expect(body.reasoning_effort).toBeUndefined();
+
+      return new Response(
+        JSON.stringify({
+          output: [
+            {
+              type: "message",
+              content: [{ type: "output_text", text: "Done." }],
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = createOpenAIProvider({
+      apiKey: "sk-test",
+      model: "gpt-5.6-luna",
+    });
+
+    const result = await provider.generateChat({
+      system: "You are helpful.",
+      messages: [{ role: "user", content: "Search for readme" }],
+      tools: [
+        {
+          name: "search_files",
+          description: "Search files",
+          parameters: { type: "object", properties: {} },
+        },
+      ],
+    });
+
+    expect(result.content).toBe("Done.");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("routes thinking + tools for gpt-5.4 through responses with reasoning", async () => {
+    const fetchMock = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(String(input)).toBe("https://api.openai.com/v1/responses");
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        tools?: unknown[];
+        reasoning?: { effort?: string };
+      };
+      expect(body.tools?.length).toBe(1);
+      expect(body.reasoning).toEqual({ effort: "high", summary: "auto" });
+
+      return new Response(
+        JSON.stringify({
+          output: [
+            {
+              type: "message",
+              content: [{ type: "output_text", text: "Done." }],
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = createOpenAIProvider({
+      apiKey: "sk-test",
+      model: "gpt-5.4",
+    });
+
+    const result = await provider.generateChat({
+      system: "You are helpful.",
+      messages: [{ role: "user", content: "Search" }],
+      tools: [
+        {
+          name: "search_files",
+          description: "Search files",
+          parameters: { type: "object", properties: {} },
+        },
+      ],
+      providerOptions: { thinking: { enabled: true, effort: "high" } },
+    });
+
+    expect(result.content).toBe("Done.");
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/server/src/providers/openai/thinking.ts
+++ b/apps/server/src/providers/openai/thinking.ts
@@ -46,3 +46,14 @@ export function openAIModelSupportsThinking(
 export function openAIModelRequiresResponsesApi(model: string): boolean {
   return model.trim().toLowerCase().includes("codex");
 }
+
+/**
+ * gpt-5.4+ (including gpt-5.6-luna / sol / terra) reject function tools combined
+ * with non-none `reasoning_effort` on `/v1/chat/completions`. Use `/v1/responses`
+ * or set `reasoning_effort` to `"none"`.
+ */
+export function openAIModelRejectsChatToolsWithReasoning(model: string): boolean {
+  const slug = model.trim().toLowerCase();
+  // gpt-5.4 … gpt-5.9, gpt-5.10+, gpt-5.6-luna, etc.
+  return /^gpt-5\.(?:[4-9]|\d{2,})/.test(slug);
+}


### PR DESCRIPTION
## Summary
- Route OpenAI gpt-5.4+ / thinking-capable models with function tools through `/v1/responses` so reasoning and tools can coexist.
- On chat/completions fallbacks (native safety net + openai-compatible), force `reasoning_effort: "none"` for gpt-5.4+ when tools are present — including when thinking is disabled — to avoid the OpenAI 400 for models like `gpt-5.6-luna`.
- Leave non-OpenAI compatible models (e.g. Qwen) free to keep sending reasoning with tools.

## Test plan
- [x] `bun test apps/server/src/providers/openai/thinking.test.ts apps/server/src/providers/openai/stream.test.ts apps/server/src/providers/openai-compatible/index.test.ts`
- [ ] Chat with OpenAI `gpt-5.6-luna` (or `gpt-5.4`) + tools + thinking on — should succeed via Responses
- [ ] Same with thinking off — should still succeed
- [ ] OpenAI-compatible local model (Qwen) with tools + thinking — still sends reasoning_effort

## Post-Deploy Monitoring & Validation
- Watch server logs for `Function tools with reasoning_effort` / `OpenAI request failed (400)` during chat with tools
- Healthy: tool-using OpenAI gpt-5.4+ turns complete without that 400; Responses path used when tools are present
- Failure signal: recurrence of the 400 → roll back this PR or temporarily disable thinking / switch model
- Validation window: first tool-using OpenAI chats after deploy

Made with [Cursor](https://cursor.com)