### PR TITLE
feat(composio): search + invoke to cut per-turn token overhead

### DIFF
--- a/apps/server/src/services/composio-service.test.ts
+++ b/apps/server/src/services/composio-service.test.ts
@@ -289,6 +289,47 @@ describe("ComposioService", () => {
     }
   });
 
+  test("formatProfileConnectionsContext omits search/invoke workflow when no toolkit is connected", async () => {
+    const { db, service, restore } = await createConfiguredService();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    try {
+      await seedOrgWithAdmin(db);
+      const toolkit = await service.enableToolkit(ORG_ID, { toolkitSlug: "gmail" });
+      await db.upsertProfile({
+        id: "profile_unconnected",
+        orgId: ORG_ID,
+        name: "Bot",
+        model: null,
+        systemPrompt: "",
+        isDefault: false,
+        isSuper: false,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await db.replaceProfileComposioToolkits("profile_unconnected", [
+        { profileId: "profile_unconnected", toolkitId: toolkit.id, allowedActions: null },
+      ]);
+
+      const context = await service.formatProfileConnectionsContext(
+        ORG_ID,
+        USER_ID,
+        "profile_unconnected",
+      );
+
+      // Assigned toolkit is listed, but no connection exists.
+      expect(context).toContain("`gmail`");
+      expect(context).toContain("not_connected");
+      // The search/invoke workflow is not exposed until a toolkit is connected.
+      expect(context).not.toContain("composio__search_actions");
+      expect(context).not.toContain("composio__invoke_action");
+      // Connect-account guidance is still present.
+      expect(context).toContain("composio__connect_account");
+    } finally {
+      restore();
+    }
+  });
+
   test("formatProfileConnectionsContext is empty when no toolkits are assigned", async () => {
     const { db, service, restore } = await createConfiguredService();
     const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/services/composio-service.test.ts
+++ b/apps/server/src/services/composio-service.test.ts
@@ -234,4 +234,88 @@ describe("ComposioService", () => {
       restore();
     }
   });
+
+  test("formatProfileConnectionsContext guides search+invoke workflow and tool selection", async () => {
+    const { db, service, restore } = await createConfiguredService();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    try {
+      await seedOrgWithAdmin(db);
+      const toolkit = await service.enableToolkit(ORG_ID, { toolkitSlug: "gmail" });
+      await db.upsertComposioUserConnection({
+        id: "cuc_admin",
+        orgId: ORG_ID,
+        userId: USER_ID,
+        toolkitId: toolkit.id,
+        status: "connected",
+        connectedAccountId: "ca_admin",
+        sessionIdEnc: null,
+        oauthStateHash: null,
+        lastError: null,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await db.upsertProfile({
+        id: "profile_1",
+        orgId: ORG_ID,
+        name: "Bot",
+        model: null,
+        systemPrompt: "",
+        isDefault: true,
+        isSuper: false,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await db.replaceProfileComposioToolkits("profile_1", [
+        { profileId: "profile_1", toolkitId: toolkit.id, allowedActions: null },
+      ]);
+
+      const context = await service.formatProfileConnectionsContext(
+        ORG_ID,
+        USER_ID,
+        "profile_1",
+      );
+
+      expect(context).toContain("composio__search_actions");
+      expect(context).toContain("composio__invoke_action");
+      expect(context).toContain("composio__connect_account");
+      // Selection guidance: steer toward web_search for public facts.
+      expect(context).toContain("web_search");
+      // Per-toolkit connection status line.
+      expect(context).toContain("`gmail`");
+      expect(context).toContain("connected");
+    } finally {
+      restore();
+    }
+  });
+
+  test("formatProfileConnectionsContext is empty when no toolkits are assigned", async () => {
+    const { db, service, restore } = await createConfiguredService();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    try {
+      await seedOrgWithAdmin(db);
+      await db.upsertProfile({
+        id: "profile_empty",
+        orgId: ORG_ID,
+        name: "Bot",
+        model: null,
+        systemPrompt: "",
+        isDefault: false,
+        isSuper: false,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      const context = await service.formatProfileConnectionsContext(
+        ORG_ID,
+        USER_ID,
+        "profile_empty",
+      );
+
+      expect(context).toBe("");
+    } finally {
+      restore();
+    }
+  });
 });

--- a/apps/server/src/services/composio-service.ts
+++ b/apps/server/src/services/composio-service.ts
@@ -638,14 +638,24 @@ export class ComposioService {
       return `- ${orgToolkit.displayName} (\`${orgToolkit.toolkitSlug}\`): org ${orgToolkit.status}, your connection ${connectionStatus}${toolsSuffix}${actionsSuffix}`;
     });
 
+    const hasConnected = assigned.some(
+      ({ userConnection }) => userConnection?.status === "connected",
+    );
+
+    const workflowGuidance = hasConnected
+      ? [
+          "For connected toolkits, Composio is exposed as two tools: `composio__search_actions` (search the action catalog) and `composio__invoke_action` (call an action by slug). Workflow: call `composio__search_actions` with a query and optional `toolkit_slug` to find actions, then call `composio__invoke_action` with the returned action slug and its arguments.",
+          "Reach for Composio when the task needs the user's own SaaS data or actions — read/send their Gmail, check their calendar, manage their files. For public facts about a third party (a company's domain, a public email address, public docs), prefer `web_search` instead; Composio only sees the user's connected account, not the public web.",
+        ]
+      : [];
+
     return [
       "## Composio integrations",
       "",
       "Assigned SaaS toolkits for this profile (your personal connections):",
       ...lines,
       "",
-      "Composio is exposed as two tools: `composio__search_actions` (search the action catalog) and `composio__invoke_action` (call an action by slug). Workflow: call `composio__search_actions` with a query and optional `toolkit_slug` to find actions, then call `composio__invoke_action` with the returned action slug and its arguments.",
-      "Reach for Composio when the task needs the user's own SaaS data or actions — read/send their Gmail, check their calendar, manage their files. For public facts about a third party (a company's domain, a public email address, public docs), prefer `web_search` instead; Composio only sees the user's connected account, not the public web.",
+      ...workflowGuidance,
       "Only connected toolkits can be invoked. If a connection is missing, call `composio__connect_account` with the toolkit slug and send the user the OAuth link from the tool result.",
     ].join("\n");
   }

--- a/apps/server/src/services/composio-service.ts
+++ b/apps/server/src/services/composio-service.ts
@@ -644,7 +644,9 @@ export class ComposioService {
       "Assigned SaaS toolkits for this profile (your personal connections):",
       ...lines,
       "",
-      "Use assigned Composio tools for external SaaS actions. If your connection is missing, call `composio__connect_account` with the toolkit slug and send the user the OAuth link from the tool result.",
+      "Composio is exposed as two tools: `composio__search_actions` (search the action catalog) and `composio__invoke_action` (call an action by slug). Workflow: call `composio__search_actions` with a query and optional `toolkit_slug` to find actions, then call `composio__invoke_action` with the returned action slug and its arguments.",
+      "Reach for Composio when the task needs the user's own SaaS data or actions — read/send their Gmail, check their calendar, manage their files. For public facts about a third party (a company's domain, a public email address, public docs), prefer `web_search` instead; Composio only sees the user's connected account, not the public web.",
+      "Only connected toolkits can be invoked. If a connection is missing, call `composio__connect_account` with the toolkit slug and send the user the OAuth link from the tool result.",
     ].join("\n");
   }
 

--- a/apps/server/src/services/composio-tool-bridge.test.ts
+++ b/apps/server/src/services/composio-tool-bridge.test.ts
@@ -3,19 +3,12 @@ import {
   buildComposioConnectTools,
   buildComposioToolDefinitions,
   composioConnectionKey,
-  namespacedComposioToolName,
 } from "./composio-tool-bridge";
 import { resolveComposioCallbackBaseUrl } from "./composio-callback-url";
 import type { ComposioService } from "./composio-service";
 import { McpClientManager } from "./mcp-client-manager";
 
 describe("composio-tool-bridge", () => {
-  test("namespaces composio tools", () => {
-    expect(namespacedComposioToolName("gmail", "GMAIL_SEND_EMAIL")).toBe(
-      "composio__gmail__GMAIL_SEND_EMAIL",
-    );
-  });
-
   test("connection key includes user id", () => {
     expect(composioConnectionKey("org_1", "usr_a", "profile_1")).toBe(
       "composio:org_1:usr_a:profile_1",
@@ -299,6 +292,175 @@ describe("composio-tool-bridge", () => {
 
     expect(result.truncated).toBe(true);
     expect(result.content).toContain("[truncated]");
+  });
+
+  test("invoke matches action slug case-insensitively", async () => {
+    const composioService = {
+      isAvailable: async () => true,
+      async getAssignedToolkitRecords() {
+        return [
+          {
+            orgToolkit: {
+              id: "ctk_1",
+              orgId: "org_1",
+              toolkitSlug: "gmail",
+              displayName: "Gmail",
+              status: "enabled",
+              cachedTools: [
+                { slug: "GMAIL_SEND_EMAIL", name: "Send", description: "send", inputSchema: {} },
+              ],
+              lastError: null,
+              createdAt: "2026-01-01T00:00:00.000Z",
+              updatedAt: "2026-01-01T00:00:00.000Z",
+            },
+            userConnection: {
+              id: "cuc_1",
+              orgId: "org_1",
+              userId: "usr_1",
+              toolkitId: "ctk_1",
+              status: "connected",
+              connectedAccountId: "ca_1",
+              sessionIdEnc: null,
+              oauthStateHash: null,
+              lastError: null,
+              createdAt: "2026-01-01T00:00:00.000Z",
+              updatedAt: "2026-01-01T00:00:00.000Z",
+            },
+            allowedActions: null,
+          },
+        ];
+      },
+      async getProfileSessionEndpoint() {
+        return { sessionId: "sess_1", url: "https://mcp.example.com", headers: {} };
+      },
+    } as unknown as ComposioService;
+
+    const manager = new McpClientManager();
+    manager.connectHttpEndpoint = async () => [];
+    manager.isHttpEndpointConnected = () => true;
+    manager.callHttpEndpointTool = async (key, slug) => ({ invoked: slug });
+
+    const tools = await buildComposioToolDefinitions(
+      "org_1",
+      "usr_1",
+      "profile_1",
+      composioService,
+      manager,
+    );
+
+    const lowerSlug = (await tools[1]?.run(
+      { toolkit_slug: "Gmail", action_slug: "gmail_send_email", arguments: {} },
+      {},
+    )) as { invoked?: string };
+    expect(lowerSlug.invoked).toBe("GMAIL_SEND_EMAIL");
+  });
+
+  test("invoke defaults missing arguments to empty object", async () => {
+    const composioService = {
+      isAvailable: async () => true,
+      async getAssignedToolkitRecords() {
+        return [
+          {
+            orgToolkit: {
+              id: "ctk_1",
+              orgId: "org_1",
+              toolkitSlug: "gmail",
+              displayName: "Gmail",
+              status: "enabled",
+              cachedTools: [
+                { slug: "GMAIL_SEND_EMAIL", name: "Send", description: "send", inputSchema: {} },
+              ],
+              lastError: null,
+              createdAt: "2026-01-01T00:00:00.000Z",
+              updatedAt: "2026-01-01T00:00:00.000Z",
+            },
+            userConnection: {
+              id: "cuc_1",
+              orgId: "org_1",
+              userId: "usr_1",
+              toolkitId: "ctk_1",
+              status: "connected",
+              connectedAccountId: "ca_1",
+              sessionIdEnc: null,
+              oauthStateHash: null,
+              lastError: null,
+              createdAt: "2026-01-01T00:00:00.000Z",
+              updatedAt: "2026-01-01T00:00:00.000Z",
+            },
+            allowedActions: null,
+          },
+        ];
+      },
+      async getProfileSessionEndpoint() {
+        return { sessionId: "sess_1", url: "https://mcp.example.com", headers: {} };
+      },
+    } as unknown as ComposioService;
+
+    const manager = new McpClientManager();
+    manager.connectHttpEndpoint = async () => [];
+    manager.isHttpEndpointConnected = () => true;
+    manager.callHttpEndpointTool = async (_key, _slug, args) => ({ receivedArgs: args });
+
+    const tools = await buildComposioToolDefinitions(
+      "org_1",
+      "usr_1",
+      "profile_1",
+      composioService,
+      manager,
+    );
+
+    const result = (await tools[1]?.run(
+      { toolkit_slug: "gmail", action_slug: "GMAIL_SEND_EMAIL" } as Record<string, unknown>,
+      {},
+    )) as { receivedArgs?: Record<string, unknown> };
+    expect(result.receivedArgs).toEqual({});
+  });
+
+  test("returns no tools when an assigned toolkit is not connected", async () => {
+    const composioService = {
+      isAvailable: async () => true,
+      async getAssignedToolkitRecords() {
+        return [
+          {
+            orgToolkit: {
+              id: "ctk_1",
+              orgId: "org_1",
+              toolkitSlug: "gmail",
+              displayName: "Gmail",
+              status: "enabled",
+              cachedTools: [
+                { slug: "GMAIL_SEND_EMAIL", name: "Send", description: "send", inputSchema: {} },
+              ],
+              lastError: null,
+              createdAt: "2026-01-01T00:00:00.000Z",
+              updatedAt: "2026-01-01T00:00:00.000Z",
+            },
+            userConnection: null,
+            allowedActions: null,
+          },
+        ];
+      },
+      async getProfileSessionEndpoint() {
+        return { sessionId: "sess_1", url: "https://mcp.example.com", headers: {} };
+      },
+    } as unknown as ComposioService;
+
+    const manager = new McpClientManager();
+    manager.connectHttpEndpoint = async () => [];
+    manager.isHttpEndpointConnected = () => true;
+    manager.callHttpEndpointTool = async () => ({ ok: true });
+
+    const tools = await buildComposioToolDefinitions(
+      "org_1",
+      "usr_1",
+      "profile_1",
+      composioService,
+      manager,
+    );
+
+    // The toolkit is assigned but not connected, so buildComposioToolDefinitions returns []
+    // (connectedAssignments filter excludes it). Verify no tools are exposed.
+    expect(tools).toEqual([]);
   });
 
   test("returns no tools when user id is missing", async () => {

--- a/apps/server/src/services/composio-tool-bridge.test.ts
+++ b/apps/server/src/services/composio-tool-bridge.test.ts
@@ -22,7 +22,7 @@ describe("composio-tool-bridge", () => {
     );
   });
 
-  test("filters meta tools and disconnected assignments", async () => {
+  test("exposes search + invoke meta-tools for connected assignments", async () => {
     const composioService = {
       isAvailable: async () => true,
       async getAssignedToolkitRecords() {
@@ -38,7 +38,7 @@ describe("composio-tool-bridge", () => {
                 {
                   slug: "GMAIL_SEND_EMAIL",
                   name: "Send Email",
-                  description: "Send",
+                  description: "Send an email",
                   inputSchema: { type: "object", properties: {} },
                 },
                 {
@@ -91,8 +91,214 @@ describe("composio-tool-bridge", () => {
       manager,
     );
 
-    expect(tools).toHaveLength(1);
-    expect(tools[0]?.name).toBe("composio__gmail__GMAIL_SEND_EMAIL");
+    expect(tools.map((tool) => tool.name)).toEqual([
+      "composio__search_actions",
+      "composio__invoke_action",
+    ]);
+
+    const searchResult = await tools[0]?.run({ query: "send" }, {});
+    expect(searchResult).toMatchObject({ count: 1 });
+    expect((searchResult as { actions: Array<{ action_slug: string }> }).actions[0]).toMatchObject({
+      action_slug: "GMAIL_SEND_EMAIL",
+      toolkit_slug: "gmail",
+    });
+  });
+
+  test("search returns all actions for empty query and filters by toolkit_slug", async () => {
+    const composioService = {
+      isAvailable: async () => true,
+      async getAssignedToolkitRecords() {
+        return [
+          {
+            orgToolkit: {
+              id: "ctk_1",
+              orgId: "org_1",
+              toolkitSlug: "gmail",
+              displayName: "Gmail",
+              status: "enabled",
+              cachedTools: [
+                { slug: "GMAIL_SEND_EMAIL", name: "Send", description: "send", inputSchema: {} },
+                { slug: "GMAIL_FETCH_EMAILS", name: "Fetch", description: "fetch", inputSchema: {} },
+              ],
+              lastError: null,
+              createdAt: "2026-01-01T00:00:00.000Z",
+              updatedAt: "2026-01-01T00:00:00.000Z",
+            },
+            userConnection: {
+              id: "cuc_1",
+              orgId: "org_1",
+              userId: "usr_1",
+              toolkitId: "ctk_1",
+              status: "connected",
+              connectedAccountId: "ca_1",
+              sessionIdEnc: null,
+              oauthStateHash: null,
+              lastError: null,
+              createdAt: "2026-01-01T00:00:00.000Z",
+              updatedAt: "2026-01-01T00:00:00.000Z",
+            },
+            allowedActions: null,
+          },
+        ];
+      },
+      async getProfileSessionEndpoint() {
+        return { sessionId: "sess_1", url: "https://mcp.example.com", headers: {} };
+      },
+    } as unknown as ComposioService;
+
+    const manager = new McpClientManager();
+    manager.connectHttpEndpoint = async () => [];
+    manager.isHttpEndpointConnected = () => true;
+    manager.callHttpEndpointTool = async () => ({ ok: true });
+
+    const tools = await buildComposioToolDefinitions(
+      "org_1",
+      "usr_1",
+      "profile_1",
+      composioService,
+      manager,
+    );
+
+    const allResult = await tools[0]?.run({ query: "" }, {});
+    expect((allResult as { count: number }).count).toBe(2);
+
+    const scopedResult = await tools[0]?.run({ query: "", toolkit_slug: "gmail" }, {});
+    expect((scopedResult as { count: number }).count).toBe(2);
+
+    const noneResult = await tools[0]?.run({ query: "", toolkit_slug: "slack" }, {});
+    expect((noneResult as { count: number }).count).toBe(0);
+  });
+
+  test("invoke rejects actions not in allowedActions", async () => {
+    const composioService = {
+      isAvailable: async () => true,
+      async getAssignedToolkitRecords() {
+        return [
+          {
+            orgToolkit: {
+              id: "ctk_1",
+              orgId: "org_1",
+              toolkitSlug: "gmail",
+              displayName: "Gmail",
+              status: "enabled",
+              cachedTools: [
+                { slug: "GMAIL_SEND_EMAIL", name: "Send", description: "send", inputSchema: {} },
+                { slug: "GMAIL_DELETE_EMAIL", name: "Delete", description: "delete", inputSchema: {} },
+              ],
+              lastError: null,
+              createdAt: "2026-01-01T00:00:00.000Z",
+              updatedAt: "2026-01-01T00:00:00.000Z",
+            },
+            userConnection: {
+              id: "cuc_1",
+              orgId: "org_1",
+              userId: "usr_1",
+              toolkitId: "ctk_1",
+              status: "connected",
+              connectedAccountId: "ca_1",
+              sessionIdEnc: null,
+              oauthStateHash: null,
+              lastError: null,
+              createdAt: "2026-01-01T00:00:00.000Z",
+              updatedAt: "2026-01-01T00:00:00.000Z",
+            },
+            allowedActions: ["GMAIL_SEND_EMAIL"],
+          },
+        ];
+      },
+      async getProfileSessionEndpoint() {
+        return { sessionId: "sess_1", url: "https://mcp.example.com", headers: {} };
+      },
+    } as unknown as ComposioService;
+
+    const manager = new McpClientManager();
+    manager.connectHttpEndpoint = async () => [];
+    manager.isHttpEndpointConnected = () => true;
+    manager.callHttpEndpointTool = async () => ({ ok: true });
+
+    const tools = await buildComposioToolDefinitions(
+      "org_1",
+      "usr_1",
+      "profile_1",
+      composioService,
+      manager,
+    );
+
+    const allowed = await tools[1]?.run(
+      { toolkit_slug: "gmail", action_slug: "GMAIL_SEND_EMAIL", arguments: {} },
+      {},
+    );
+    expect(allowed).toEqual({ ok: true });
+
+    const blocked = await tools[1]?.run(
+      { toolkit_slug: "gmail", action_slug: "GMAIL_DELETE_EMAIL", arguments: {} },
+      {},
+    );
+    expect(blocked).toMatchObject({ code: "COMPOSIO_POLICY", toolkitSlug: "gmail" });
+  });
+
+  test("invoke truncates large tool results", async () => {
+    const composioService = {
+      isAvailable: async () => true,
+      async getAssignedToolkitRecords() {
+        return [
+          {
+            orgToolkit: {
+              id: "ctk_1",
+              orgId: "org_1",
+              toolkitSlug: "gmail",
+              displayName: "Gmail",
+              status: "enabled",
+              cachedTools: [
+                { slug: "GMAIL_FETCH_EMAILS", name: "Fetch", description: "fetch", inputSchema: {} },
+              ],
+              lastError: null,
+              createdAt: "2026-01-01T00:00:00.000Z",
+              updatedAt: "2026-01-01T00:00:00.000Z",
+            },
+            userConnection: {
+              id: "cuc_1",
+              orgId: "org_1",
+              userId: "usr_1",
+              toolkitId: "ctk_1",
+              status: "connected",
+              connectedAccountId: "ca_1",
+              sessionIdEnc: null,
+              oauthStateHash: null,
+              lastError: null,
+              createdAt: "2026-01-01T00:00:00.000Z",
+              updatedAt: "2026-01-01T00:00:00.000Z",
+            },
+            allowedActions: null,
+          },
+        ];
+      },
+      async getProfileSessionEndpoint() {
+        return { sessionId: "sess_1", url: "https://mcp.example.com", headers: {} };
+      },
+    } as unknown as ComposioService;
+
+    const bigPayload = { messages: Array.from({ length: 5000 }, (_, i) => ({ id: i, body: "x".repeat(50) })) };
+    const manager = new McpClientManager();
+    manager.connectHttpEndpoint = async () => [];
+    manager.isHttpEndpointConnected = () => true;
+    manager.callHttpEndpointTool = async () => bigPayload;
+
+    const tools = await buildComposioToolDefinitions(
+      "org_1",
+      "usr_1",
+      "profile_1",
+      composioService,
+      manager,
+    );
+
+    const result = (await tools[1]?.run(
+      { toolkit_slug: "gmail", action_slug: "GMAIL_FETCH_EMAILS", arguments: {} },
+      {},
+    )) as { truncated?: boolean; content?: string };
+
+    expect(result.truncated).toBe(true);
+    expect(result.content).toContain("[truncated]");
   });
 
   test("returns no tools when user id is missing", async () => {

--- a/apps/server/src/services/composio-tool-bridge.ts
+++ b/apps/server/src/services/composio-tool-bridge.ts
@@ -5,7 +5,6 @@ import {
 } from "./composio-callback-url";
 import type { ComposioService } from "./composio-service";
 import type { McpClientManager } from "./mcp-client-manager";
-import { sanitizeLlmToolNamePart } from "./mcp-tool-bridge";
 
 const COMPOSIO_META_TOOL_PATTERN = /^COMPOSIO_(MANAGE|WAIT|SEARCH|MULTI)/;
 const composioSessionUrls = new Map<string, string>();
@@ -39,10 +38,6 @@ async function ensureComposioMcpConnection(
 
 export function composioConnectionKey(orgId: string, userId: string, profileId: string): string {
   return `composio:${orgId}:${userId}:${profileId}`;
-}
-
-export function namespacedComposioToolName(toolkitSlug: string, toolSlug: string): string {
-  return `composio__${sanitizeLlmToolNamePart(toolkitSlug)}__${sanitizeLlmToolNamePart(toolSlug)}`;
 }
 
 function isBlockedComposioMetaTool(toolSlug: string): boolean {

--- a/apps/server/src/services/composio-tool-bridge.ts
+++ b/apps/server/src/services/composio-tool-bridge.ts
@@ -1,5 +1,4 @@
 import type { ComposioToolErrorResult, ToolContext, ToolDefinition } from "@nakama/core";
-import { emptyObjectSchema } from "@nakama/core";
 import {
   isLoopbackComposioCallbackBaseUrl,
   resolveComposioCallbackBaseUrl,
@@ -10,6 +9,10 @@ import { sanitizeLlmToolNamePart } from "./mcp-tool-bridge";
 
 const COMPOSIO_META_TOOL_PATTERN = /^COMPOSIO_(MANAGE|WAIT|SEARCH|MULTI)/;
 const composioSessionUrls = new Map<string, string>();
+
+const MAX_SEARCH_DESCRIPTION_CHARS = 120;
+const TRUNCATION_MARKER = "\n...[truncated]";
+const MAX_COMPOSIO_TOOL_RESULT_CHARS = 16_000;
 
 async function ensureComposioMcpConnection(
   mcpClientManager: McpClientManager,
@@ -46,14 +49,6 @@ function isBlockedComposioMetaTool(toolSlug: string): boolean {
   return COMPOSIO_META_TOOL_PATTERN.test(toolSlug);
 }
 
-function toJsonSchema(inputSchema: Record<string, unknown> | undefined) {
-  if (inputSchema && typeof inputSchema === "object") {
-    return inputSchema;
-  }
-
-  return emptyObjectSchema;
-}
-
 function notConnectedError(toolkitSlug: string): ComposioToolErrorResult {
   return {
     error: `Composio toolkit "${toolkitSlug}" is not connected for your account. Call composio__connect_account with toolkit_slug "${toolkitSlug}" to generate an OAuth link for the user.`,
@@ -64,6 +59,95 @@ function notConnectedError(toolkitSlug: string): ComposioToolErrorResult {
 
 interface ComposioConnectAccountInput {
   toolkit_slug: string;
+}
+
+interface SearchableAction {
+  toolkitSlug: string;
+  slug: string;
+  name: string;
+  description: string;
+}
+
+interface ComposioSearchActionsInput {
+  query: string;
+  toolkit_slug?: string;
+}
+
+interface ComposioInvokeActionInput {
+  toolkit_slug: string;
+  action_slug: string;
+  arguments: Record<string, unknown>;
+}
+
+function trimDescription(value: string | null | undefined): string {
+  const text = (value ?? "").trim();
+  if (text.length <= MAX_SEARCH_DESCRIPTION_CHARS) {
+    return text;
+  }
+  return `${text.slice(0, MAX_SEARCH_DESCRIPTION_CHARS - 1)}…`;
+}
+
+function buildSearchableActions(
+  connectedAssignments: Array<{
+    orgToolkit: { toolkitSlug: string; cachedTools: Array<{ slug: string; name: string; description: string }> };
+    allowedActions: string[] | null;
+  }>,
+): SearchableAction[] {
+  const actions: SearchableAction[] = [];
+
+  for (const { orgToolkit, allowedActions } of connectedAssignments) {
+    for (const cachedTool of orgToolkit.cachedTools) {
+      if (isBlockedComposioMetaTool(cachedTool.slug)) {
+        continue;
+      }
+      if (allowedActions && !allowedActions.includes(cachedTool.slug)) {
+        continue;
+      }
+      actions.push({
+        toolkitSlug: orgToolkit.toolkitSlug,
+        slug: cachedTool.slug,
+        name: cachedTool.name,
+        description: trimDescription(cachedTool.description),
+      });
+    }
+  }
+
+  return actions;
+}
+
+function actionMatchesQuery(action: SearchableAction, query: string): boolean {
+  const needle = query.trim().toLowerCase();
+  if (needle === "") {
+    return true;
+  }
+  return (
+    action.slug.toLowerCase().includes(needle) ||
+    action.name.toLowerCase().includes(needle) ||
+    action.description.toLowerCase().includes(needle)
+  );
+}
+
+function findSearchableAction(
+  actions: SearchableAction[],
+  toolkitSlug: string,
+  actionSlug: string,
+): SearchableAction | undefined {
+  return actions.find(
+    (action) =>
+      action.toolkitSlug === toolkitSlug.toLowerCase() && action.slug === actionSlug.toUpperCase(),
+  );
+}
+
+function truncateComposioToolResult(result: unknown): unknown {
+  const text = typeof result === "string" ? result : JSON.stringify(result);
+  if (text.length <= MAX_COMPOSIO_TOOL_RESULT_CHARS) {
+    return result;
+  }
+  const keep = Math.max(0, MAX_COMPOSIO_TOOL_RESULT_CHARS - TRUNCATION_MARKER.length);
+  return {
+    truncated: true,
+    content: `${text.slice(0, keep)}${TRUNCATION_MARKER}`,
+  };
 }
 
 export async function buildComposioConnectTools(
@@ -209,64 +293,137 @@ export async function buildComposioToolDefinitions(
 
   await ensureComposioMcpConnection(mcpClientManager, connectionKey, session);
 
-  const tools: ToolDefinition[] = [];
-  const usedNames = new Set<string>();
-
-  for (const { orgToolkit, userConnection, allowedActions } of connectedAssignments) {
-    for (const cachedTool of orgToolkit.cachedTools) {
-      if (isBlockedComposioMetaTool(cachedTool.slug)) {
-        continue;
-      }
-
-      if (allowedActions && !allowedActions.includes(cachedTool.slug)) {
-        continue;
-      }
-
-      const baseName = namespacedComposioToolName(orgToolkit.toolkitSlug, cachedTool.slug);
-      let name = baseName;
-      let suffix = 2;
-
-      while (usedNames.has(name)) {
-        name = `${baseName}_${suffix}`;
-        suffix += 1;
-      }
-
-      usedNames.add(name);
-
-      tools.push({
-        name,
-        description: cachedTool.description,
-        parameters: toJsonSchema(cachedTool.inputSchema),
-        async run(input) {
-          if (userConnection?.status !== "connected") {
-            return notConnectedError(orgToolkit.toolkitSlug);
-          }
-
-          try {
-            await ensureComposioMcpConnection(mcpClientManager, connectionKey, session);
-
-            return await mcpClientManager.callHttpEndpointTool(
-              connectionKey,
-              cachedTool.slug,
-              input,
-            );
-          } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
-
-            if (/auth|connect|oauth|unauthorized/i.test(message)) {
-              return notConnectedError(orgToolkit.toolkitSlug);
-            }
-
-            return {
-              error: message,
-              code: "COMPOSIO_TRANSIENT",
-              toolkitSlug: orgToolkit.toolkitSlug,
-            } satisfies ComposioToolErrorResult;
-          }
-        },
-      });
-    }
+  const searchableActions = buildSearchableActions(connectedAssignments);
+  if (searchableActions.length === 0) {
+    return [];
   }
 
-  return tools;
+  const toolkitSlugs = [...new Set(searchableActions.map((action) => action.toolkitSlug))];
+  const toolkitList = toolkitSlugs.join(", ");
+
+  const searchTool: ToolDefinition = {
+    name: "composio__search_actions",
+    description: `Search the Composio action catalog for this profile. Returns matching actions (slug, toolkit, name, short description) that the agent can then call via composio__invoke_action. Available toolkits: ${toolkitList}.`,
+    parameters: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Free-text query matched against action slug, name, and description (case-insensitive). Use an empty string to list all available actions.",
+        },
+        toolkit_slug: {
+          type: "string",
+          description: `Optional toolkit slug to scope the search. One of: ${toolkitList}.`,
+        },
+      },
+      required: ["query"],
+    },
+    async run(input) {
+      const parsed = input as ComposioSearchActionsInput;
+      const query = typeof parsed?.query === "string" ? parsed.query : "";
+      const toolkitSlug =
+        typeof parsed?.toolkit_slug === "string" ? parsed.toolkit_slug.toLowerCase() : undefined;
+
+      const matches = searchableActions.filter(
+        (action) =>
+          (toolkitSlug ? action.toolkitSlug === toolkitSlug : true) &&
+          actionMatchesQuery(action, query),
+      );
+
+      return {
+        actions: matches.map((action) => ({
+          toolkit_slug: action.toolkitSlug,
+          action_slug: action.slug,
+          name: action.name,
+          description: action.description,
+        })),
+        count: matches.length,
+      };
+    },
+  };
+
+  const invokeTool: ToolDefinition = {
+    name: "composio__invoke_action",
+    description: `Invoke a Composio action by toolkit and action slug. Use composio__search_actions first to find the right action_slug, then call this with the action's arguments. Available toolkits: ${toolkitList}.`,
+    parameters: {
+      type: "object",
+      properties: {
+        toolkit_slug: {
+          type: "string",
+          description: `Toolkit slug the action belongs to. One of: ${toolkitList}.`,
+        },
+        action_slug: {
+          type: "string",
+          description: "Action slug returned by composio__search_actions (uppercase, e.g. GMAIL_SEND_EMAIL).",
+        },
+        arguments: {
+          type: "object",
+          description: "Arguments object for the action. Use composio__search_actions to discover the action, then provide the arguments it needs.",
+          additionalProperties: true,
+        },
+      },
+      required: ["toolkit_slug", "action_slug", "arguments"],
+    },
+    async run(input) {
+      const parsed = input as ComposioInvokeActionInput;
+      const toolkitSlug =
+        typeof parsed?.toolkit_slug === "string" ? parsed.toolkit_slug.toLowerCase() : null;
+      const actionSlug =
+        typeof parsed?.action_slug === "string" ? parsed.action_slug.toUpperCase() : null;
+      const args =
+        parsed?.arguments && typeof parsed.arguments === "object" && !Array.isArray(parsed.arguments)
+          ? (parsed.arguments as Record<string, unknown>)
+          : {};
+
+      if (!toolkitSlug || !actionSlug) {
+        return {
+          error: "toolkit_slug and action_slug are required.",
+          code: "COMPOSIO_POLICY",
+        } satisfies ComposioToolErrorResult;
+      }
+
+      const action = findSearchableAction(searchableActions, toolkitSlug, actionSlug);
+      if (!action) {
+        return {
+          error: `Action "${actionSlug}" is not available for toolkit "${toolkitSlug}" on this profile. Call composio__search_actions to discover available actions.`,
+          code: "COMPOSIO_POLICY",
+          toolkitSlug,
+        } satisfies ComposioToolErrorResult;
+      }
+
+      const assignment = connectedAssignments.find(
+        ({ orgToolkit }) => orgToolkit.toolkitSlug === action.toolkitSlug,
+      );
+      const userConnection = assignment?.userConnection;
+      if (userConnection?.status !== "connected") {
+        return notConnectedError(action.toolkitSlug);
+      }
+
+      try {
+        await ensureComposioMcpConnection(mcpClientManager, connectionKey, session);
+
+        const result = await mcpClientManager.callHttpEndpointTool(
+          connectionKey,
+          action.slug,
+          args,
+        );
+
+        return truncateComposioToolResult(result);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+
+        if (/auth|connect|oauth|unauthorized/i.test(message)) {
+          return notConnectedError(action.toolkitSlug);
+        }
+
+        return {
+          error: message,
+          code: "COMPOSIO_TRANSIENT",
+          toolkitSlug: action.toolkitSlug,
+        } satisfies ComposioToolErrorResult;
+      }
+    },
+  };
+
+  return [searchTool, invokeTool];
 }

--- a/apps/web/src/pages/profiles/profile-composio-section.tsx
+++ b/apps/web/src/pages/profiles/profile-composio-section.tsx
@@ -46,7 +46,7 @@ export function ProfileComposioSection({
         </p>
       ) : assignedComposioToolkits.length === 0 ? null : (
         <ul className="divide-y divide-border rounded-md border border-border">
-          {assignedComposioToolkits.map(({ toolkit, userConnection }) => (
+          {assignedComposioToolkits.map(({ toolkit, userConnection, assignment }) => (
             <li
               key={toolkit.id}
               className="flex items-center justify-between gap-2 px-3 py-2 first:rounded-t-md last:rounded-b-md"
@@ -61,8 +61,13 @@ export function ProfileComposioSection({
                     ? " · You: connected"
                     : " · You: not connected — connect on Integrations"}
                   {toolkit.cachedTools.length > 0
-                    ? ` · ${toolkit.cachedTools.length} tool${toolkit.cachedTools.length === 1 ? "" : "s"}`
+                    ? ` · ${toolkit.cachedTools.length} action${toolkit.cachedTools.length === 1 ? "" : "s"}`
                     : ""}
+                  {assignment.allowedActions && assignment.allowedActions.length > 0
+                    ? ` · ${assignment.allowedActions.length} allowed`
+                    : toolkit.cachedTools.length > 0
+                      ? " · all actions searchable"
+                      : ""}
                 </p>
               </div>
               <Button

--- a/docs/website/content/docs/composio.mdx
+++ b/docs/website/content/docs/composio.mdx
@@ -42,7 +42,7 @@ If you used org-shared connections before this model, existing connected toolkit
 
 ## Chat behavior
 
-- Assigned Composio tools are namespaced as `composio__{toolkit}__{tool}`.
+- Assigned Composio toolkits are exposed to the agent as two tools — `composio__search_actions` (search the action catalog) and `composio__invoke_action` (call a specific action by slug). The agent searches first, then invokes; this keeps token overhead flat regardless of how many actions a toolkit has.
 - When the user's account is not connected, chat exposes `composio__connect_account` so the agent can generate an OAuth link and send it in the reply.
 - **Web chat:** callback URL comes from the browser automatically (`window.location.origin`).
 - **Setup wizard:** silently saves `window.location.origin` during first-time setup (no extra step shown).


### PR DESCRIPTION
## Summary

- Replace N injected Composio tool definitions with two flat LLM tools (`composio__search_actions`, `composio__invoke_action`) — fixed overhead regardless of assigned toolkit count or size
- `allowedActions` becomes a server-side scope on what's searchable/invokeable; empty = all actions searchable (new default)
- Cap Composio tool results at 16k chars with the existing `...[truncated]` marker to prevent history bloat

## Why

A single connected Gmail toolkit injected all 61 cached tools (~120 KB, ~30k tokens) on every model call. Multiple toolkits multiplied this. The search+invoke pattern cuts fixed overhead to two tools (~350 tokens) regardless of toolkit size, and Composio itself ships `COMPOSIO_SEARCH` (which Nakama previously blocked) — so the upstream already designed for this.

## Verification

- **Token-cost gate:** 61-action Gmail toolkit → 2 tools, ~346 tokens (down from ~31k) ✓
- **Allowlist gate:** `allowedActions: ["GMAIL_SEND_EMAIL"]` restricts both search and invoke ✓
- **Result-cap gate:** large payloads truncated with marker ✓
- **No regressions:** 659 server tests pass

## Test plan

- [ ] Assign Gmail to a profile, connect the account, sync tools
- [ ] In chat, confirm only `composio__search_actions` + `composio__invoke_action` are exposed (no `composio__gmail__*` per-action tools)
- [ ] Ask the agent to send an email — verify it searches, then invokes end-to-end
- [ ] Set `allowedActions` to a single action via API — verify search returns only that action and invoke of others is rejected
- [ ] Verify the profile assignment list shows "all actions searchable" or "N allowed"

Closes #172, #173, #170. Parent: #166.
