### PR TITLE
feat: Add Cursor Agent CLI coding backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ Path: `~/.nakama/orgs/{orgId}/profiles/{profileId}/` (`getProfileSoulDir`). Load
 | `search_files` / `ripgrep` | File/content search |
 | `bash` | Profile workspace shell — assign per profile; Super Bot by default |
 | `sub_agent` | Opt-in same-profile delegate (not repo coding) |
-| `coding-agent` | Codex / Claude Code / OpenCode via `bash` |
+| `coding-agent` | Codex / Claude Code / OpenCode / pi / Cursor Agent (`agent`) via `bash` |
 | `agent-browser` | Opt-in browser CLI; needs host install — `docs/website/agent-browser.md` |
 | `create-profile` | Super Bot only, confirm-first — `apps/server/src/tools/super-bot-tools.ts` |
 | `skill_manage` | Interactive web/cli with `manage-skills` — create/patch/edit/delete profile skills + supporting-file write/remove + auto-assign (`apps/server/src/tools/skill-manage-tool.ts`). When org/profile **write approval** is enabled, mutations stage as proposals for org-admin review instead of writing immediately. When present, file tools refuse any path under `skills/*/` (`forbidProfileSkillMarkdownWrites`). Not injected for automations or Telegram/WhatsApp/Discord. Opt-in **post-turn skill review** (`skills_post_turn_review`) may suggest or stage create/patch after complex turns without writing into model history. |

--- a/apps/server/src/services/agent-service.test.ts
+++ b/apps/server/src/services/agent-service.test.ts
@@ -350,6 +350,8 @@ describe("AgentService coding delegation context", () => {
 
     expect(context).toContain("No coding agent CLI is installed");
     expect(context).toContain("npm install -g");
+    expect(context).toContain("Cursor Agent CLI");
+    expect(context).toContain("cannot be auto-installed");
     expect(context).not.toContain("workspace settings");
     expect(context).not.toContain("delegate_coding_task");
   });

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -2828,6 +2828,8 @@ export class AgentService {
         `- Claude Code: \`${getCodingHarnessInstallCommand("claude_code")}\``,
         `- OpenCode: \`${getCodingHarnessInstallCommand("opencode")}\``,
         `- pi: \`${getCodingHarnessInstallCommand("pi")}\``,
+        "",
+        "Cursor Agent CLI (`agent`) cannot be auto-installed. Tell the user to install and authenticate it on the host themselves, then verify with `agent --version`.",
       ];
       return installLines.join("\n");
     }

--- a/apps/server/src/services/coding-agent-bash-env.test.ts
+++ b/apps/server/src/services/coding-agent-bash-env.test.ts
@@ -184,7 +184,7 @@ describe("enrichCodingAgentBashInput", () => {
 
     const enriched = (await enrichCodingAgentBashInput(
       db,
-      { command: "echo -p 'task' --output-format stream-json --yolo", codingAgent: true },
+      { command: "echo -p 'task' --output-format text --yolo", codingAgent: true },
       { orgId: "org_test", profileId: "profile_test" },
       {
         providers: [anthropicProvider],

--- a/apps/server/src/services/coding-agent-bash-env.test.ts
+++ b/apps/server/src/services/coding-agent-bash-env.test.ts
@@ -150,4 +150,50 @@ describe("enrichCodingAgentBashInput", () => {
       ),
     ).rejects.toThrow(/known coding-agent CLI/);
   });
+
+  test("does not merge provider credentials for Cursor Agent when routing is active", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    await db.upsertWorkspaceSettings({
+      id: "workspace-settings",
+      visionModel: null,
+      transcriptionModel: null,
+      codingAgentHarnesses: [
+        {
+          id: "coding-harness-cursor-agent",
+          kind: "cursor_agent",
+          name: "Cursor Agent",
+          command: "echo",
+          args: [],
+          enabled: true,
+        },
+      ],
+      selectedCodingAgentHarness: null,
+      updatedAt: new Date().toISOString(),
+    });
+    await db.upsertProfile({
+      id: "profile_test",
+      orgId: "org_test",
+      name: "Test",
+      systemPrompt: "test",
+      model: "anthropic:claude-sonnet-4-6",
+      isDefault: true,
+      isSuper: false,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const enriched = (await enrichCodingAgentBashInput(
+      db,
+      { command: "echo -p 'task' --output-format stream-json --yolo", codingAgent: true },
+      { orgId: "org_test", profileId: "profile_test" },
+      {
+        providers: [anthropicProvider],
+        defaultProviderId: anthropicProvider.id,
+      },
+    )) as { env?: Record<string, string>; codingAgent?: boolean };
+
+    expect(enriched.codingAgent).toBe(true);
+    expect(enriched.env?.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(enriched.env?.OPENAI_API_KEY).toBeUndefined();
+  });
 });

--- a/apps/server/src/services/coding-agent-bash-env.ts
+++ b/apps/server/src/services/coding-agent-bash-env.ts
@@ -46,7 +46,7 @@ export async function enrichCodingAgentBashInput(
 
   if (codingAgentRequested && !inferredKind) {
     throw new Error(
-      "codingAgent was set but the bash command does not start with a known coding-agent CLI (codex, claude, opencode, or pi). Use the harness binary as argv0 so Nakama can merge the correct provider passthrough env.",
+      "codingAgent was set but the bash command does not start with a known coding-agent CLI (codex, claude, opencode, pi, or agent). Use the harness binary as argv0 so Nakama can merge the correct provider passthrough env.",
     );
   }
 

--- a/apps/server/src/services/coding-agent-command.test.ts
+++ b/apps/server/src/services/coding-agent-command.test.ts
@@ -89,7 +89,7 @@ describe("buildCodingAgentCommandTemplate", () => {
     expect(template.command).toContain("'Fix lint errors'");
   });
 
-  test("builds Cursor Agent print command with stream-json and yolo", async () => {
+  test("builds Cursor Agent print command with text output and yolo", async () => {
     const template = await buildCodingAgentCommandTemplate(
       {
         kind: "cursor_agent",
@@ -109,7 +109,8 @@ describe("buildCodingAgentCommandTemplate", () => {
     expect(template.command).toContain("agent");
     expect(template.command).toContain("-p");
     expect(template.command).toContain("--output-format");
-    expect(template.command).toContain("stream-json");
+    expect(template.command).toContain("text");
+    expect(template.command).not.toContain("stream-json");
     expect(template.command).toContain("--yolo");
     expect(template.command).toContain("'Where are the built-in skills'");
     expect(template.spawnEnv).toEqual({});
@@ -192,7 +193,9 @@ describe("formatCodingAgentCommandContext", () => {
     );
 
     expect(context).toContain("host auth");
+    expect(context).toContain("cwd");
     expect(context).not.toContain("When Nakama provider passthrough is active");
     expect(context).toContain("--yolo");
+    expect(context).toContain("--output-format text");
   });
 });

--- a/apps/server/src/services/coding-agent-command.test.ts
+++ b/apps/server/src/services/coding-agent-command.test.ts
@@ -89,6 +89,32 @@ describe("buildCodingAgentCommandTemplate", () => {
     expect(template.command).toContain("'Fix lint errors'");
   });
 
+  test("builds Cursor Agent print command with stream-json and yolo", async () => {
+    const template = await buildCodingAgentCommandTemplate(
+      {
+        kind: "cursor_agent",
+        name: "Cursor Agent",
+        command: "agent",
+        args: [],
+      },
+      "Where are the built-in skills",
+      "/tmp/workspace",
+      {
+        userConfig: anthropicUserConfig,
+        profileModel: "claude-sonnet-4-6",
+      },
+    );
+
+    expect(template.backend).toBe("cursor_agent");
+    expect(template.command).toContain("agent");
+    expect(template.command).toContain("-p");
+    expect(template.command).toContain("--output-format");
+    expect(template.command).toContain("stream-json");
+    expect(template.command).toContain("--yolo");
+    expect(template.command).toContain("'Where are the built-in skills'");
+    expect(template.spawnEnv).toEqual({});
+  });
+
   test("reflects custom harness command from workspace settings", async () => {
     const template = await buildCodingAgentCommandTemplate(
       {
@@ -145,5 +171,28 @@ describe("formatCodingAgentCommandContext", () => {
     expect(context).toContain("Nakama provider passthrough");
     expect(context).not.toContain("sk-ant-test");
     expect(context).toContain('"***"');
+  });
+
+  test("does not claim provider passthrough for Cursor Agent", async () => {
+    const context = formatCodingAgentCommandContext(
+      await buildCodingAgentCommandTemplate(
+        {
+          kind: "cursor_agent",
+          name: "Cursor Agent",
+          command: "agent",
+          args: [],
+        },
+        "Ship feature",
+        "/tmp/workspace",
+        {
+          userConfig: anthropicUserConfig,
+          profileModel: "claude-sonnet-4-6",
+        },
+      ),
+    );
+
+    expect(context).toContain("host auth");
+    expect(context).not.toContain("When Nakama provider passthrough is active");
+    expect(context).toContain("--yolo");
   });
 });

--- a/apps/server/src/services/coding-agent-command.ts
+++ b/apps/server/src/services/coding-agent-command.ts
@@ -177,9 +177,10 @@ export async function buildCodingAgentCommandTemplate(
       ].join(" "),
       notes: [
         "Cursor Agent uses host Cursor authentication — Nakama does not inject provider credentials.",
+        "Before coding: ensure the target repo exists in the profile workspace; git clone it there if missing, then run from that folder.",
         "Use --yolo so unattended background runs do not block on permission prompts.",
         "Summarize the final outcome from stream-json output; do not dump the full event stream to the user.",
-        "Run from the profile workspace cwd unless the user specifies another path inside it.",
+        "Run from the repo checkout inside the profile workspace unless the user specifies another path inside it.",
       ],
     };
   }

--- a/apps/server/src/services/coding-agent-command.ts
+++ b/apps/server/src/services/coding-agent-command.ts
@@ -62,6 +62,17 @@ export function buildHarnessNonInteractiveArgs(
     ];
   }
 
+  if (kind === "cursor_agent") {
+    return [
+      ...baseArgs,
+      "-p",
+      prompt,
+      "--output-format",
+      "stream-json",
+      "--yolo",
+    ];
+  }
+
   if (kind === "pi") {
     const piArgs = [...baseArgs];
 
@@ -153,6 +164,26 @@ export async function buildCodingAgentCommandTemplate(
     };
   }
 
+  if (harness.kind === "cursor_agent") {
+    return {
+      ...shared,
+      command: [
+        baseCommand,
+        "-p",
+        escapedTask,
+        "--output-format",
+        "stream-json",
+        "--yolo",
+      ].join(" "),
+      notes: [
+        "Cursor Agent uses host Cursor authentication — Nakama does not inject provider credentials.",
+        "Use --yolo so unattended background runs do not block on permission prompts.",
+        "Summarize the final outcome from stream-json output; do not dump the full event stream to the user.",
+        "Run from the profile workspace cwd unless the user specifies another path inside it.",
+      ],
+    };
+  }
+
   if (harness.kind === "pi") {
     const piProvider = routing.providerType ? mapNakamaProviderToPi(routing.providerType, routing.baseUrl) : null;
     const piModel = routing.model
@@ -206,7 +237,9 @@ export function formatCodingAgentCommandContext(
   const lines = [
     "# Coding Agent Harness",
     `Selected backend: ${template.harnessName} (${template.backend}).`,
-    "Run the coding agent via the `bash` tool. Set `codingAgent: true` so Nakama merges spawn env for this harness, or rely on auto-detection when the command starts with the harness binary.",
+    template.backend === "cursor_agent"
+      ? "Run the coding agent via the `bash` tool. Cursor Agent uses host auth — Nakama does not merge provider credentials. You may set `codingAgent: true` or rely on argv0 auto-detection for the `agent` binary."
+      : "Run the coding agent via the `bash` tool. Set `codingAgent: true` so Nakama merges spawn env for this harness, or rely on auto-detection when the command starts with the harness binary.",
     "",
     "```bash",
     template.command,
@@ -236,7 +269,12 @@ export function formatCodingAgentCommandContext(
 
 function getBackendSkillName(
   backend: StoredCodingAgentHarnessKind,
-): "coding-backend-codex" | "coding-backend-claude-code" | "coding-backend-opencode" | "coding-backend-pi" {
+):
+  | "coding-backend-codex"
+  | "coding-backend-claude-code"
+  | "coding-backend-opencode"
+  | "coding-backend-pi"
+  | "coding-backend-cursor" {
   if (backend === "codex") {
     return "coding-backend-codex";
   }
@@ -247,6 +285,10 @@ function getBackendSkillName(
 
   if (backend === "pi") {
     return "coding-backend-pi";
+  }
+
+  if (backend === "cursor_agent") {
+    return "coding-backend-cursor";
   }
 
   return "coding-backend-opencode";

--- a/apps/server/src/services/coding-agent-command.ts
+++ b/apps/server/src/services/coding-agent-command.ts
@@ -68,7 +68,7 @@ export function buildHarnessNonInteractiveArgs(
       "-p",
       prompt,
       "--output-format",
-      "stream-json",
+      "text",
       "--yolo",
     ];
   }
@@ -172,15 +172,16 @@ export async function buildCodingAgentCommandTemplate(
         "-p",
         escapedTask,
         "--output-format",
-        "stream-json",
+        "text",
         "--yolo",
       ].join(" "),
       notes: [
         "Cursor Agent uses host Cursor authentication — Nakama does not inject provider credentials.",
-        "Before coding: ensure the target repo exists in the profile workspace; git clone it there if missing, then run from that folder.",
+        "Before coding: ensure the target repo exists in the profile workspace; git clone it there if missing.",
+        "Set bash cwd to the repo directory and keep argv0 as `agent` (do not prefix with cd && — codingAgent requires the harness binary first).",
+        "Prefer --output-format text so bash stdout stays under Nakama's output cap; avoid stream-json for orchestration.",
         "Use --yolo so unattended background runs do not block on permission prompts.",
-        "Summarize the final outcome from stream-json output; do not dump the full event stream to the user.",
-        "Run from the repo checkout inside the profile workspace unless the user specifies another path inside it.",
+        "After the run: summarize the final text. If output looks truncated or unclear, verify with git status / git diff --stat in the repo.",
       ],
     };
   }
@@ -239,7 +240,7 @@ export function formatCodingAgentCommandContext(
     "# Coding Agent Harness",
     `Selected backend: ${template.harnessName} (${template.backend}).`,
     template.backend === "cursor_agent"
-      ? "Run the coding agent via the `bash` tool. Cursor Agent uses host auth — Nakama does not merge provider credentials. You may set `codingAgent: true` or rely on argv0 auto-detection for the `agent` binary."
+      ? "Run via the `bash` tool with cwd set to the repo checkout and codingAgent: true (or argv0 `agent`). Cursor uses host auth — Nakama does not merge provider credentials. Do not use `cd … && agent`."
       : "Run the coding agent via the `bash` tool. Set `codingAgent: true` so Nakama merges spawn env for this harness, or rely on auto-detection when the command starts with the harness binary.",
     "",
     "```bash",

--- a/apps/server/src/services/coding-agent-command.ts
+++ b/apps/server/src/services/coding-agent-command.ts
@@ -179,9 +179,9 @@ export async function buildCodingAgentCommandTemplate(
         "Cursor Agent uses host Cursor authentication — Nakama does not inject provider credentials.",
         "Before coding: ensure the target repo exists in the profile workspace; git clone it there if missing.",
         "Set bash cwd to the repo directory and keep argv0 as `agent` (do not prefix with cd && — codingAgent requires the harness binary first).",
-        "Prefer --output-format text so bash stdout stays under Nakama's output cap; avoid stream-json for orchestration.",
+        "Prefer --output-format text for a short final answer. If stream-json is used, Nakama summarizes it and saves the full log under artifacts/coding-agent-runs/.",
         "Use --yolo so unattended background runs do not block on permission prompts.",
-        "After the run: summarize the final text. If output looks truncated or unclear, verify with git status / git diff --stat in the repo.",
+        "After the run: summarize the returned stdout for the user. If unclear, verify with git status / git diff --stat in the repo (full raw log path is included when present).",
       ],
     };
   }

--- a/apps/server/src/services/coding-agent-harness-service.test.ts
+++ b/apps/server/src/services/coding-agent-harness-service.test.ts
@@ -25,10 +25,12 @@ describe("coding-agent harness resolution", () => {
     const harnesses = [
       { kind: "claude_code" as const, command: "claude", enabled: true },
       { kind: "codex" as const, command: "codex", enabled: true },
+      { kind: "cursor_agent" as const, command: "agent", enabled: true },
     ];
 
     expect(inferCodingAgentHarnessKind("codex exec 'task'", harnesses)).toBe("codex");
     expect(inferCodingAgentHarnessKind("claude -p 'task'", harnesses)).toBe("claude_code");
+    expect(inferCodingAgentHarnessKind("agent -p 'task' --yolo", harnesses)).toBe("cursor_agent");
     expect(inferCodingAgentHarnessKind("npm install -g @openai/codex", harnesses)).toBeNull();
   });
 
@@ -38,6 +40,37 @@ describe("coding-agent harness resolution", () => {
       args: ["install", "-g", "--trust", "opencode-ai"],
       displayCommand: "bun install -g --trust opencode-ai",
     });
+  });
+
+  test("refuses auto-install plan for Cursor Agent", () => {
+    expect(() => buildCodingHarnessInstallPlan("cursor_agent", "npm")).toThrow(/cannot be auto-installed/i);
+  });
+
+  test("marks Cursor Agent ready when installed without provider passthrough", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    await db.upsertWorkspaceSettings({
+      id: "workspace-settings",
+      visionModel: null,
+      transcriptionModel: null,
+      codingAgentHarnesses: [
+        {
+          id: "coding-harness-cursor-agent",
+          kind: "cursor_agent",
+          name: "Cursor Agent",
+          command: "echo",
+          args: [],
+          enabled: true,
+        },
+      ],
+      selectedCodingAgentHarness: null,
+      updatedAt: new Date().toISOString(),
+    });
+
+    const statuses = await listCodingAgentHarnessStatuses(db);
+    const cursor = statuses.find((harness) => harness.id === "coding-harness-cursor-agent");
+    expect(cursor?.installed).toBe(true);
+    expect(cursor?.ready).toBe(true);
+    expect(cursor?.statusMessage).toMatch(/host Cursor auth/i);
   });
 
   test("refreshCodingAgentHarnessProbe persists cached readiness", async () => {

--- a/apps/server/src/services/coding-agent-harness-service.ts
+++ b/apps/server/src/services/coding-agent-harness-service.ts
@@ -28,7 +28,7 @@ interface CodingAgentInstallPlan {
   displayCommand: string;
 }
 
-const HARNESS_PACKAGES: Record<StoredCodingAgentHarnessKind, string> = {
+const HARNESS_PACKAGES: Partial<Record<StoredCodingAgentHarnessKind, string>> = {
   codex: "@openai/codex",
   claude_code: "@anthropic-ai/claude-code",
   opencode: "opencode-ai",
@@ -52,6 +52,14 @@ export function buildCodingHarnessInstallPlan(
   packageManager: "npm" | "bun" = detectCodingHarnessPackageManager(),
 ): CodingAgentInstallPlan {
   const pkg = HARNESS_PACKAGES[kind];
+
+  if (!pkg) {
+    throw new Error(
+      kind === "cursor_agent"
+        ? "Cursor Agent CLI cannot be auto-installed. Install and authenticate it on the host yourself (verify with `agent --version`)."
+        : `No auto-install package is configured for coding harness kind ${kind}.`,
+    );
+  }
 
   if (packageManager === "bun") {
     return {
@@ -124,6 +132,14 @@ const DEFAULT_HARNESSES: StoredCodingAgentHarnessRecord[] = [
     kind: "pi",
     name: "pi.dev",
     command: "pi",
+    args: [],
+    enabled: true,
+  },
+  {
+    id: "coding-harness-cursor-agent",
+    kind: "cursor_agent",
+    name: "Cursor Agent",
+    command: "agent",
     args: [],
     enabled: true,
   },
@@ -685,6 +701,10 @@ export function getCodingHarnessInstallCommand(kind: StoredCodingAgentHarnessKin
 }
 
 export function getCodingHarnessInstallHint(kind: StoredCodingAgentHarnessKind): string {
+  if (kind === "cursor_agent") {
+    return "Install and authenticate Cursor Agent CLI on this machine yourself (verify with `agent --version`), then check again.";
+  }
+
   if (kind === "codex") {
     return "Install the Codex CLI on this machine, then check again.";
   }
@@ -758,6 +778,15 @@ async function probeHarnessLight(
   nextStep: "retry" | null;
   statusMessage: string | null;
 }> {
+  if (harness.kind === "cursor_agent") {
+    return {
+      authenticated: null,
+      ready: true,
+      nextStep: null,
+      statusMessage: `${harness.name} is installed. Uses host Cursor auth (no Nakama provider passthrough).`,
+    };
+  }
+
   const { routing } = await resolveCodingAgentSpawnBundle({
     userConfig: probeContext?.userConfig,
     profileModel: probeContext?.profileModel ?? null,
@@ -792,6 +821,15 @@ async function probeHarnessExec(
   nextStep: "retry" | null;
   statusMessage: string | null;
 }> {
+  if (harness.kind === "cursor_agent") {
+    return {
+      authenticated: null,
+      ready: true,
+      nextStep: null,
+      statusMessage: `${harness.name} is installed. Uses host Cursor auth (no Nakama provider passthrough).`,
+    };
+  }
+
   const { spawn, routing } = await resolveCodingAgentSpawnBundle({
     userConfig: probeContext?.userConfig,
     profileModel: probeContext?.profileModel ?? null,

--- a/apps/server/src/services/coding-agent-provider-routing.test.ts
+++ b/apps/server/src/services/coding-agent-provider-routing.test.ts
@@ -26,6 +26,11 @@ const geminiProvider: ProviderInstance = {
 };
 
 describe("coding-agent provider routing", () => {
+  test("Cursor Agent is never provider-compatible", () => {
+    expect(isProviderCompatibleWithHarness("anthropic", "cursor_agent")).toBe(false);
+    expect(isProviderCompatibleWithHarness("openai", "cursor_agent")).toBe(false);
+  });
+
   test("anthropic provider routes to Claude Code with Anthropic base URL", () => {
     const routing = resolveCodingAgentProviderRouting({
       userConfig: {

--- a/apps/server/src/services/coding-agent-provider-routing.ts
+++ b/apps/server/src/services/coding-agent-provider-routing.ts
@@ -71,6 +71,11 @@ export function isProviderCompatibleWithHarness(
   providerType: ProviderName,
   harnessKind: StoredCodingAgentHarnessKind,
 ): boolean {
+  // Cursor Agent uses host Cursor auth — never Nakama provider passthrough.
+  if (harnessKind === "cursor_agent") {
+    return false;
+  }
+
   if (harnessKind === "claude_code") {
     return CLAUDE_CODE_PROVIDER_TYPES.has(providerType);
   }

--- a/apps/server/src/services/coding-agent-spawn-env.test.ts
+++ b/apps/server/src/services/coding-agent-spawn-env.test.ts
@@ -3,6 +3,7 @@ import {
   buildClaudeCodeSpawnEnv,
   buildCodexSpawnEnv,
   buildPiSpawnEnv,
+  buildSpawnEnvForHarness,
   mergeCodingAgentSpawnEnv,
   normalizeCodingAgentModel,
   redactSpawnEnvForPrompt,
@@ -18,6 +19,19 @@ describe("coding-agent spawn env", () => {
 
   test("returns no env overrides when routing is inactive", () => {
     expect(buildClaudeCodeSpawnEnv(inactiveRouting)).toEqual({});
+  });
+
+  test("returns empty spawn env for Cursor Agent even when routing is active", async () => {
+    const spawn = await buildSpawnEnvForHarness(
+      "cursor_agent",
+      activeAnthropicRouting({
+        model: "anthropic:claude-opus-4-6",
+      }),
+      "anthropic",
+    );
+
+    expect(spawn.env).toEqual({});
+    expect(spawn.cleanup).toBeUndefined();
   });
 
   test("builds Claude Code provider passthrough env", () => {

--- a/apps/server/src/services/coding-agent-spawn-env.ts
+++ b/apps/server/src/services/coding-agent-spawn-env.ts
@@ -259,6 +259,11 @@ export async function buildSpawnEnvForHarness(
   routing: CodingAgentProviderRouting,
   providerType: ProviderName = "openai",
 ): Promise<CodingAgentSpawnEnvResult> {
+  // Cursor Agent uses host Cursor auth — never merge Nakama provider credentials.
+  if (kind === "cursor_agent") {
+    return { env: {} };
+  }
+
   if (!routing.active) {
     return { env: {} };
   }

--- a/apps/server/src/tools/bash.test.ts
+++ b/apps/server/src/tools/bash.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, realpath, rm } from "node:fs/promises";
+import { chmod, mkdtemp, mkdir, readFile, readdir, realpath, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
@@ -87,5 +87,74 @@ describe("bash tool", () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toBe("http://127.0.0.1:4310");
+  });
+
+  test("summarizes Cursor stream-json for coding-agent runs and saves a full log", async () => {
+    workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "nakama-bash-"));
+    const agentPath = path.join(workspaceRoot, "agent");
+    const stream = [
+      '{"type":"system","subtype":"init","model":"composer-2","cwd":"/tmp/repo"}',
+      ...Array.from({ length: 80 }, (_, i) =>
+        JSON.stringify({
+          type: "tool_call",
+          subtype: "started",
+          tool_call: { readToolCall: { args: { path: `pad-${i}.ts` } } },
+        }),
+      ),
+      '{"type":"assistant","message":{"content":[{"type":"text","text":"Patched the flaky test."}]}}',
+      '{"type":"result","subtype":"success","result":"All checks passed.","duration_ms":42}',
+      "",
+    ].join("\n");
+
+    await writeFile(
+      agentPath,
+      `#!/bin/bash\ncat <<'EOF'\n${stream}EOF\n`,
+      "utf8",
+    );
+    await chmod(agentPath, 0o755);
+
+    const result = await runBash(
+      {
+        command: "./agent -p 'fix the flaky test' --output-format stream-json --yolo",
+        codingAgent: true,
+      },
+      { orgId: "org_test", profileId: "profile_test" },
+      { workspaceRoot },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("# Cursor Agent result");
+    expect(result.stdout).toContain("Patched the flaky test.");
+    expect(result.stdout).toContain("All checks passed.");
+    expect(result.stdout).toContain("Full coding-agent log: artifacts/coding-agent-runs/");
+    expect(result.stdout).not.toContain("...[truncated]\n{\"type\":\"system\"");
+
+    const logDir = path.join(workspaceRoot, "artifacts", "coding-agent-runs");
+    const logs = await readdir(logDir);
+    expect(logs.length).toBe(1);
+    const logBody = await readFile(path.join(logDir, logs[0]!), "utf8");
+    expect(logBody).toContain('"type":"result"');
+    expect(logBody).toContain("All checks passed.");
+  });
+
+  test("keep-tails long plain coding-agent stdout instead of head-truncating", async () => {
+    workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "nakama-bash-"));
+    const agentPath = path.join(workspaceRoot, "agent");
+    const body = `${"n".repeat(40_000)}TAIL_MARKER_OK`;
+    await writeFile(agentPath, `#!/bin/bash\ncat <<'EOF'\n${body}EOF\n`, "utf8");
+    await chmod(agentPath, 0o755);
+
+    const result = await runBash(
+      {
+        command: "./agent -p 'hello' --output-format text --yolo",
+        codingAgent: true,
+      },
+      { orgId: "org_test", profileId: "profile_test" },
+      { workspaceRoot },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("TAIL_MARKER_OK");
+    expect(result.stdout).toContain("Full coding-agent log:");
   });
 });

--- a/apps/server/src/tools/bash.ts
+++ b/apps/server/src/tools/bash.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
-import { realpath } from "node:fs/promises";
+import { mkdir, realpath, writeFile } from "node:fs/promises";
+import path from "node:path";
 import {
   getProfileSoulDir,
   guardFilePath,
@@ -7,10 +8,16 @@ import {
   type ToolDefinition,
 } from "@nakama/core";
 import { mergeCodingAgentSpawnEnv } from "../services/coding-agent-spawn-env";
+import {
+  commandLooksLikeCursorAgent,
+  formatCodingAgentBashStdout,
+} from "./cursor-agent-output";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const MAX_TIMEOUT_MS = 30 * 60_000;
 const MAX_OUTPUT_CHARS = 32_000;
+/** In-memory capture for coding-agent runs before summarize / keep-tail. */
+const CODING_AGENT_MAX_CAPTURE_CHARS = 5_000_000;
 
 export interface BashInput {
   command: string;
@@ -29,6 +36,11 @@ export interface BashOutput {
 
 interface BashRunOptions {
   workspaceRoot?: string;
+}
+
+interface ShellRunOptions {
+  codingAgentMode: boolean;
+  workspaceRoot: string;
 }
 
 export const bashTool: ToolDefinition<BashInput, BashOutput> = {
@@ -100,8 +112,13 @@ export async function runBash(
     : workspaceRoot;
   const timeoutMs = readTimeout(readOptionalNumber(input, "timeoutMs"));
   const env = readStringRecord(readOptionalRecord(input, "env"));
+  const codingAgentMode =
+    readOptionalBoolean(input, "codingAgent") === true || commandLooksLikeCursorAgent(command);
 
-  return runShellCommand(command, cwd, timeoutMs, env);
+  return runShellCommand(command, cwd, timeoutMs, env, {
+    codingAgentMode,
+    workspaceRoot,
+  });
 }
 
 function runShellCommand(
@@ -109,6 +126,7 @@ function runShellCommand(
   cwd: string,
   timeoutMs: number,
   envOverrides: Record<string, string> = {},
+  options: ShellRunOptions,
 ): Promise<BashOutput> {
   return new Promise((resolve, reject) => {
     const child = spawn("/bin/bash", ["-lc", command], {
@@ -120,6 +138,8 @@ function runShellCommand(
     let stdout = "";
     let stderr = "";
     let timedOut = false;
+    let stdoutOverflow = false;
+    let stderrOverflow = false;
 
     const timeoutId = setTimeout(() => {
       timedOut = true;
@@ -127,10 +147,24 @@ function runShellCommand(
     }, timeoutMs);
 
     child.stdout?.on("data", (chunk: Buffer | string) => {
+      if (options.codingAgentMode) {
+        const next = appendCodingAgentCapture(stdout, String(chunk));
+        stdout = next.value;
+        stdoutOverflow = stdoutOverflow || next.overflowed;
+        return;
+      }
+
       stdout = appendOutput(stdout, String(chunk));
     });
 
     child.stderr?.on("data", (chunk: Buffer | string) => {
+      if (options.codingAgentMode) {
+        const next = appendCodingAgentCapture(stderr, String(chunk));
+        stderr = next.value;
+        stderrOverflow = stderrOverflow || next.overflowed;
+        return;
+      }
+
       stderr = appendOutput(stderr, String(chunk));
     });
 
@@ -141,14 +175,88 @@ function runShellCommand(
 
     child.on("close", (exitCode) => {
       clearTimeout(timeoutId);
-      resolve({
-        exitCode,
+
+      void finalizeCodingAgentOutput({
+        codingAgentMode: options.codingAgentMode,
+        workspaceRoot: options.workspaceRoot,
         stdout,
         stderr,
+        stdoutOverflow,
+        stderrOverflow,
+        exitCode,
         timedOut,
-      });
+      })
+        .then(resolve)
+        .catch(reject);
     });
   });
+}
+
+async function finalizeCodingAgentOutput(args: {
+  codingAgentMode: boolean;
+  workspaceRoot: string;
+  stdout: string;
+  stderr: string;
+  stdoutOverflow: boolean;
+  stderrOverflow: boolean;
+  exitCode: number | null;
+  timedOut: boolean;
+}): Promise<BashOutput> {
+  if (!args.codingAgentMode) {
+    return {
+      exitCode: args.exitCode,
+      stdout: args.stdout,
+      stderr: args.stderr,
+      timedOut: args.timedOut,
+    };
+  }
+
+  const logPath = await writeCodingAgentLog(args.workspaceRoot, args.stdout, args.stderr);
+  let stdout = formatCodingAgentBashStdout(args.stdout, {
+    logPath,
+    exitCode: args.exitCode,
+  });
+  if (args.stdoutOverflow) {
+    stdout = `${stdout}\n\n(stdout capture hit ${CODING_AGENT_MAX_CAPTURE_CHARS} char limit; see full log)`;
+  }
+
+  let stderr = keepTail(args.stderr, MAX_OUTPUT_CHARS);
+  if (args.stderrOverflow) {
+    stderr = `${stderr}\n\n(stderr capture hit ${CODING_AGENT_MAX_CAPTURE_CHARS} char limit; see full log)`;
+  }
+
+  return {
+    exitCode: args.exitCode,
+    stdout,
+    stderr,
+    timedOut: args.timedOut,
+  };
+}
+
+async function writeCodingAgentLog(
+  workspaceRoot: string,
+  stdout: string,
+  stderr: string,
+): Promise<string | null> {
+  try {
+    const dir = path.join(workspaceRoot, "artifacts", "coding-agent-runs");
+    await mkdir(dir, { recursive: true });
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const fileName = `${stamp}-${Math.random().toString(36).slice(2, 8)}.log`;
+    const absolutePath = path.join(dir, fileName);
+    const body = [
+      "=== stdout ===",
+      stdout,
+      "",
+      "=== stderr ===",
+      stderr,
+      "",
+    ].join("\n");
+    await writeFile(absolutePath, body, "utf8");
+    return path.join("artifacts", "coding-agent-runs", fileName);
+  } catch {
+    return null;
+  }
 }
 
 function appendOutput(current: string, chunk: string): string {
@@ -159,6 +267,33 @@ function appendOutput(current: string, chunk: string): string {
   }
 
   return combined.slice(0, MAX_OUTPUT_CHARS) + "\n...[truncated]";
+}
+
+function appendCodingAgentCapture(
+  current: string,
+  chunk: string,
+): { value: string; overflowed: boolean } {
+  if (current.length >= CODING_AGENT_MAX_CAPTURE_CHARS) {
+    return { value: current, overflowed: true };
+  }
+
+  const remaining = CODING_AGENT_MAX_CAPTURE_CHARS - current.length;
+  if (chunk.length <= remaining) {
+    return { value: current + chunk, overflowed: false };
+  }
+
+  return {
+    value: current + chunk.slice(0, remaining),
+    overflowed: true,
+  };
+}
+
+function keepTail(value: string, maxChars: number): string {
+  if (value.length <= maxChars) {
+    return value;
+  }
+
+  return `...[truncated]\n${value.slice(value.length - maxChars)}`;
 }
 
 async function resolveWorkspaceRoot(rawWorkspaceRoot: string): Promise<string> {
@@ -178,6 +313,14 @@ function readTimeout(value: unknown): number {
 }
 
 function readOptionalNumber(input: unknown, key: string): unknown {
+  if (typeof input !== "object" || input === null || !(key in input)) {
+    return undefined;
+  }
+
+  return (input as Record<string, unknown>)[key];
+}
+
+function readOptionalBoolean(input: unknown, key: string): unknown {
   if (typeof input !== "object" || input === null || !(key in input)) {
     return undefined;
   }

--- a/apps/server/src/tools/cursor-agent-output.test.ts
+++ b/apps/server/src/tools/cursor-agent-output.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import {
+  commandLooksLikeCursorAgent,
+  formatCodingAgentBashStdout,
+  looksLikeCursorAgentStreamJson,
+  summarizeCursorAgentStreamJson,
+} from "./cursor-agent-output";
+
+describe("cursor-agent-output", () => {
+  test("detects Cursor stream-json NDJSON", () => {
+    const sample = [
+      '{"type":"system","subtype":"init","model":"composer-2","cwd":"/tmp/repo"}',
+      '{"type":"assistant","message":{"content":[{"type":"text","text":"Looking at the repo."}]}}',
+    ].join("\n");
+
+    expect(looksLikeCursorAgentStreamJson(sample)).toBe(true);
+    expect(looksLikeCursorAgentStreamJson("plain text answer")).toBe(false);
+  });
+
+  test("summarizes assistant text, tools, and result from the end of a long stream", () => {
+    const noise = Array.from({ length: 200 }, (_, i) =>
+      JSON.stringify({
+        type: "tool_call",
+        subtype: "started",
+        tool_call: {
+          readToolCall: { args: { path: `noise/file-${i}.ts` } },
+        },
+      }),
+    ).join("\n");
+
+    const stdout = [
+      '{"type":"system","subtype":"init","model":"composer-2","cwd":"/tmp/repo","apiKeySource":"login"}',
+      noise,
+      '{"type":"assistant","message":{"content":[{"type":"text","text":"I fixed the bug in auth.ts."}]}}',
+      '{"type":"tool_call","subtype":"completed","tool_call":{"editToolCall":{"args":{"path":"src/auth.ts"}}}}',
+      '{"type":"result","subtype":"success","result":"Updated auth.ts and verified tests.","duration_ms":1234}',
+    ].join("\n");
+
+    const summary = summarizeCursorAgentStreamJson(stdout, 0);
+
+    expect(summary).toContain("# Cursor Agent result");
+    expect(summary).toContain("model=composer-2");
+    expect(summary).toContain("exitCode=0");
+    expect(summary).toContain("I fixed the bug in auth.ts.");
+    expect(summary).toContain("src/auth.ts");
+    expect(summary).toContain("Updated auth.ts and verified tests.");
+    expect(summary).toContain("durationMs=1234");
+    expect(summary.length).toBeLessThan(stdout.length);
+  });
+
+  test("formatCodingAgentBashStdout appends log path and keep-tails plain text", () => {
+    const longText = `${"x".repeat(30_000)}FINAL_ANSWER`;
+    const formatted = formatCodingAgentBashStdout(longText, {
+      logPath: "artifacts/coding-agent-runs/run.log",
+      exitCode: 0,
+    });
+
+    expect(formatted).toContain("FINAL_ANSWER");
+    expect(formatted).toContain("Full coding-agent log: artifacts/coding-agent-runs/run.log");
+    expect(formatted.startsWith("...[truncated]")).toBe(true);
+  });
+
+  test("commandLooksLikeCursorAgent matches argv0 agent paths", () => {
+    expect(commandLooksLikeCursorAgent("agent -p 'hi' --yolo")).toBe(true);
+    expect(commandLooksLikeCursorAgent("./agent -p hi")).toBe(true);
+    expect(commandLooksLikeCursorAgent("/usr/local/bin/agent -p hi")).toBe(true);
+    expect(commandLooksLikeCursorAgent("cd repo && agent -p hi")).toBe(false);
+    expect(commandLooksLikeCursorAgent("codex exec 'hi'")).toBe(false);
+  });
+});

--- a/apps/server/src/tools/cursor-agent-output.ts
+++ b/apps/server/src/tools/cursor-agent-output.ts
@@ -1,0 +1,294 @@
+/**
+ * Turn Cursor Agent CLI stream-json (NDJSON) stdout into a short, readable
+ * summary for the parent Nakama agent. Bash truncates at 32k from the head by
+ * default — stream-json puts the useful result at the end — so coding-agent
+ * runs should summarize instead of returning the raw firehose.
+ */
+
+const MAX_SUMMARY_CHARS = 24_000;
+const MAX_ASSISTANT_CHARS = 12_000;
+const MAX_TOOL_LINES = 40;
+
+export function looksLikeCursorAgentStreamJson(stdout: string): boolean {
+  const sample = stdout.slice(0, 4_000);
+  if (!sample.includes('"type"')) {
+    return false;
+  }
+
+  return (
+    sample.includes('"type":"system"') ||
+    sample.includes('"type": "system"') ||
+    sample.includes('"type":"assistant"') ||
+    sample.includes('"type": "assistant"') ||
+    sample.includes('"type":"tool_call"') ||
+    sample.includes('"type": "tool_call"') ||
+    sample.includes('"type":"result"') ||
+    sample.includes('"type": "result"')
+  );
+}
+
+export function formatCodingAgentBashStdout(
+  stdout: string,
+  options: { logPath?: string | null; exitCode?: number | null } = {},
+): string {
+  const trimmed = stdout.trim();
+  if (!trimmed) {
+    return appendLogFooter("", options.logPath);
+  }
+
+  if (looksLikeCursorAgentStreamJson(trimmed)) {
+    return appendLogFooter(summarizeCursorAgentStreamJson(trimmed, options.exitCode), options.logPath);
+  }
+
+  return appendLogFooter(capText(trimmed, MAX_SUMMARY_CHARS, "tail"), options.logPath);
+}
+
+export function summarizeCursorAgentStreamJson(
+  stdout: string,
+  exitCode?: number | null,
+): string {
+  const assistantChunks: string[] = [];
+  const toolLines: string[] = [];
+  let resultLine: string | null = null;
+  let initLine: string | null = null;
+  let parseErrors = 0;
+  let eventCount = 0;
+
+  for (const line of stdout.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) {
+      continue;
+    }
+
+    let event: Record<string, unknown>;
+    try {
+      event = JSON.parse(trimmed) as Record<string, unknown>;
+    } catch {
+      parseErrors += 1;
+      continue;
+    }
+
+    eventCount += 1;
+    const type = typeof event.type === "string" ? event.type : "";
+
+    if (type === "system" && event.subtype === "init") {
+      const model = typeof event.model === "string" ? event.model : null;
+      const cwd = typeof event.cwd === "string" ? event.cwd : null;
+      const bits = [
+        model ? `model=${model}` : null,
+        cwd ? `cwd=${cwd}` : null,
+        typeof event.apiKeySource === "string" ? `auth=${event.apiKeySource}` : null,
+      ].filter(Boolean);
+      initLine = bits.length > 0 ? bits.join(", ") : "Cursor Agent started";
+      continue;
+    }
+
+    if (type === "assistant") {
+      const text = extractAssistantText(event);
+      if (text) {
+        assistantChunks.push(text);
+      }
+      continue;
+    }
+
+    if (type === "tool_call") {
+      const lineText = formatToolCallLine(event);
+      if (lineText) {
+        toolLines.push(lineText);
+      }
+      continue;
+    }
+
+    if (type === "result") {
+      resultLine = formatResultLine(event);
+    }
+  }
+
+  const sections: string[] = ["# Cursor Agent result"];
+
+  if (initLine) {
+    sections.push("", initLine);
+  }
+
+  if (exitCode != null) {
+    sections.push("", `exitCode=${exitCode}`);
+  }
+
+  const assistantText = joinAssistantChunks(assistantChunks);
+  if (assistantText) {
+    sections.push("", "## Assistant", assistantText);
+  }
+
+  if (toolLines.length > 0) {
+    const omitted = Math.max(0, toolLines.length - MAX_TOOL_LINES);
+    const shown = omitted > 0 ? toolLines.slice(-MAX_TOOL_LINES) : toolLines;
+    sections.push("", "## Tools");
+    if (omitted > 0) {
+      sections.push(`- …${omitted} earlier tool calls omitted`);
+    }
+    sections.push(...shown.map((line) => `- ${line}`));
+  }
+
+  if (resultLine) {
+    sections.push("", "## Result", resultLine);
+  } else if (eventCount > 0 && !assistantText) {
+    sections.push(
+      "",
+      "## Result",
+      "No final result event in captured stream. Check git status in the repo cwd or the full log.",
+    );
+  }
+
+  if (parseErrors > 0) {
+    sections.push("", `(ignored ${parseErrors} non-JSON stream lines)`);
+  }
+
+  if (eventCount === 0) {
+    return capText(stdout, MAX_SUMMARY_CHARS, "tail");
+  }
+
+  return capText(sections.join("\n"), MAX_SUMMARY_CHARS, "tail");
+}
+
+function extractAssistantText(event: Record<string, unknown>): string | null {
+  const message = event.message;
+  if (!message || typeof message !== "object") {
+    return null;
+  }
+
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === "string" && content.trim()) {
+    return content.trim();
+  }
+
+  if (!Array.isArray(content)) {
+    return null;
+  }
+
+  const parts: string[] = [];
+  for (const part of content) {
+    if (!part || typeof part !== "object") {
+      continue;
+    }
+    const text = (part as { text?: unknown }).text;
+    if (typeof text === "string" && text.trim()) {
+      parts.push(text.trim());
+    }
+  }
+
+  return parts.length > 0 ? parts.join("\n") : null;
+}
+
+function joinAssistantChunks(chunks: string[]): string {
+  if (chunks.length === 0) {
+    return "";
+  }
+
+  // Prefer later turns — early ones are often "I'll read X next".
+  const merged = chunks.join("\n\n").trim();
+  return capText(merged, MAX_ASSISTANT_CHARS, "tail");
+}
+
+function formatToolCallLine(event: Record<string, unknown>): string | null {
+  const subtype = typeof event.subtype === "string" ? event.subtype : "";
+  const toolCall = event.tool_call;
+  if (!toolCall || typeof toolCall !== "object") {
+    return subtype ? `tool_call ${subtype}` : null;
+  }
+
+  const call = toolCall as Record<string, unknown>;
+  for (const [key, value] of Object.entries(call)) {
+    if (!key.endsWith("ToolCall") || !value || typeof value !== "object") {
+      continue;
+    }
+    const name = key.replace(/ToolCall$/, "");
+    const args = (value as { args?: Record<string, unknown> }).args;
+    const detail = summarizeToolArgs(name, args);
+    return `${subtype || "tool"} ${name}${detail ? `: ${detail}` : ""}`;
+  }
+
+  return `tool_call ${subtype || "unknown"}`.trim();
+}
+
+function summarizeToolArgs(name: string, args: Record<string, unknown> | undefined): string {
+  if (!args) {
+    return "";
+  }
+
+  const path =
+    (typeof args.path === "string" && args.path) ||
+    (typeof args.file_path === "string" && args.file_path) ||
+    (typeof args.target_notebook === "string" && args.target_notebook) ||
+    null;
+  if (path) {
+    return path;
+  }
+
+  if (typeof args.command === "string") {
+    return capText(args.command, 120, "head");
+  }
+
+  if (typeof args.pattern === "string") {
+    return capText(args.pattern, 80, "head");
+  }
+
+  if (name.toLowerCase().includes("write") || name.toLowerCase().includes("edit")) {
+    return "(edit)";
+  }
+
+  return "";
+}
+
+function formatResultLine(event: Record<string, unknown>): string {
+  const subtype = typeof event.subtype === "string" ? event.subtype : null;
+  const bits: string[] = [];
+  if (subtype) {
+    bits.push(subtype);
+  }
+  if (typeof event.result === "string" && event.result.trim()) {
+    bits.push(capText(event.result.trim(), 4_000, "tail"));
+  } else if (typeof event.message === "string" && event.message.trim()) {
+    bits.push(capText(event.message.trim(), 4_000, "tail"));
+  }
+  if (typeof event.duration_ms === "number") {
+    bits.push(`durationMs=${event.duration_ms}`);
+  }
+  return bits.length > 0 ? bits.join("\n") : "result event received";
+}
+
+function appendLogFooter(body: string, logPath?: string | null): string {
+  if (!logPath) {
+    return body;
+  }
+
+  const footer = `\n\nFull coding-agent log: ${logPath}`;
+  if (!body) {
+    return footer.trim();
+  }
+
+  return `${body}${footer}`;
+}
+
+function capText(value: string, maxChars: number, mode: "head" | "tail"): string {
+  if (value.length <= maxChars) {
+    return value;
+  }
+
+  if (mode === "tail") {
+    return `...[truncated]\n${value.slice(value.length - maxChars)}`;
+  }
+
+  return `${value.slice(0, maxChars)}\n...[truncated]`;
+}
+
+export function commandLooksLikeCursorAgent(command: string): boolean {
+  const trimmed = command.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  // First argv token; allow absolute/relative paths ending in `agent`.
+  const first = trimmed.split(/\s+/, 1)[0] ?? "";
+  const base = first.split(/[/\\]/).pop() ?? first;
+  return base === "agent";
+}

--- a/docs/website/content/docs/builtin-tools.mdx
+++ b/docs/website/content/docs/builtin-tools.mdx
@@ -106,7 +106,7 @@ Legacy `.doc` (Word 97–2003) is not supported for generation or preview. Binar
 
 ## Coding agent
 
-Repo coding work is not a separate builtin. Profiles with the `coding-agent` skill invoke Codex, Claude Code, or OpenCode through `bash`. See [Coding agent](/coding-agent) for skill-driven install, multi-CLI choice, provider passthrough, and runtime behavior.
+Repo coding work is not a separate builtin. Profiles with the `coding-agent` skill invoke Codex, Claude Code, OpenCode, pi, or Cursor Agent through `bash`. See [Coding agent](/coding-agent) for skill-driven install, multi-CLI choice, provider passthrough, and runtime behavior.
 
 ## Tool reference
 
@@ -304,7 +304,7 @@ Run a one-off shell command in the profile workspace and return stdout, stderr, 
 
 **Returns:** `{ exitCode, stdout, stderr, timedOut }`
 
-**Coding-agent spawn env:** When the command starts with a known harness binary (`codex`, `claude`, `opencode`, or `pi`), or when `codingAgent: true` is set with such a command, Nakama merges provider passthrough env vars on the server before spawn. `codingAgent: true` without a known binary fails closed. See [Coding agent — Provider passthrough](/coding-agent#provider-passthrough). Optional `env` keys are merged on top (credential keys cannot override passthrough).
+**Coding-agent spawn env:** When the command starts with a known harness binary (`codex`, `claude`, `opencode`, `pi`, or `agent`), or when `codingAgent: true` is set with such a command, Nakama merges provider passthrough env vars on the server before spawn. `codingAgent: true` without a known binary fails closed. See [Coding agent — Provider passthrough](/coding-agent#provider-passthrough). Optional `env` keys are merged on top (credential keys cannot override passthrough).
 
 **Scope:** Profile workspace only. Do not use `bash` to create persistent tools or `.sh` wrappers — register JavaScript tools under `~/.nakama/tools/` instead.
 
@@ -410,7 +410,7 @@ All builtin tool IDs are protected and cannot be deleted from the dashboard.
 
 - [Org memory](/org-memory) — shared facts, admin UI, and API
 - [Skills](/skills) — bundled system skills and reusable profile procedures
-- [Coding agent](/coding-agent) — hand repo work to Codex, Claude Code, or OpenCode via `bash`
+- [Coding agent](/coding-agent) — hand repo work to Codex, Claude Code, OpenCode, pi, or Cursor Agent via `bash`
 - [Agent browser](/agent-browser) — interactive browsing via `bash` and the `agent-browser` skill
 - [Agent prompts](/agent-prompt) — how bundled system skills appear in the chat wrapper
 - [MCP servers](/mcp) — extend a profile with external tools via the Model Context Protocol

--- a/docs/website/content/docs/cli.mdx
+++ b/docs/website/content/docs/cli.mdx
@@ -84,5 +84,5 @@ Workers reload from disk on the next request. Restart platform workers if anythi
 ## Next steps
 
 - [Quickstart](/quickstart) — install and open the dashboard
-- [Coding agent](/coding-agent) — Codex, Claude Code, OpenCode from chat
+- [Coding agent](/coding-agent) — Codex, Claude Code, OpenCode, pi, or Cursor Agent from chat
 - [Telegram](/telegram) — add a messaging channel

--- a/docs/website/content/docs/coding-agent.mdx
+++ b/docs/website/content/docs/coding-agent.mdx
@@ -57,7 +57,7 @@ Nakama supports CLI-backed backends on the machine running the server:
 | **Claude Code** | `claude` | Anthropic Claude Code print mode (`-p`) |
 | **OpenCode** | `opencode` | Provider-agnostic OpenCode `run` |
 | **pi** | `pi` | pi coding agent CLI |
-| **Cursor Agent** | `agent` | Cursor Agent print mode (`-p`) with `stream-json` output for unattended runs |
+| **Cursor Agent** | `agent` | Cursor Agent print mode (`-p`) with text output + `--yolo`; set bash `cwd` to the repo checkout |
 
 ## Setup
 

--- a/docs/website/content/docs/coding-agent.mdx
+++ b/docs/website/content/docs/coding-agent.mdx
@@ -57,7 +57,7 @@ Nakama supports CLI-backed backends on the machine running the server:
 | **Claude Code** | `claude` | Anthropic Claude Code print mode (`-p`) |
 | **OpenCode** | `opencode` | Provider-agnostic OpenCode `run` |
 | **pi** | `pi` | pi coding agent CLI |
-| **Cursor Agent** | `agent` | Cursor Agent print mode (`-p`) with text output + `--yolo`; set bash `cwd` to the repo checkout |
+| **Cursor Agent** | `agent` | Cursor Agent print mode (`-p`) with text output + `--yolo`; set bash `cwd` to the repo checkout. If `stream-json` is used, Nakama summarizes the NDJSON and keeps a full log under the profile `artifacts/coding-agent-runs/` folder |
 
 ## Setup
 

--- a/docs/website/content/docs/coding-agent.mdx
+++ b/docs/website/content/docs/coding-agent.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Coding Agent"
-description: "Hand off coding tasks to Codex, Claude Code, or OpenCode from Nakama chat, with optional provider passthrough from your Nakama LLM provider."
+description: "Hand off coding tasks to Codex, Claude Code, OpenCode, pi, or Cursor Agent from Nakama chat, with optional provider passthrough where the harness supports it."
 ---
 
-A Nakama profile is a general-purpose agent: it chats, explains, uses file tools, and follows your soul and skills. For **real coding work** — multi-file features, refactors, test fixes, repo-wide changes — a dedicated **coding agent** (Codex, Claude Code, or OpenCode) usually does better.
+A Nakama profile is a general-purpose agent: it chats, explains, uses file tools, and follows your soul and skills. For **real coding work** — multi-file features, refactors, test fixes, repo-wide changes — a dedicated **coding agent** (Codex, Claude Code, OpenCode, pi, or Cursor Agent) usually does better.
 
 Nakama keeps you in the same chat while handing those tasks to a CLI on the server. The Nakama agent orchestrates; the coding agent executes.
 
@@ -14,9 +14,9 @@ The mental model:
 - Nakama runs a coding-agent CLI through the `bash` tool
 - Nakama summarizes stdout/stderr and continues the conversation
 
-There is no separate delegate builtin for **repo coding work**. That workflow is **`bash` + the `coding-agent` skill**. Setup happens in chat: the agent can install missing CLIs and asks which backend to use when more than one is available.
+There is no separate delegate builtin for **repo coding work**. That workflow is **`bash` + the `coding-agent` skill**. Setup happens in chat: the agent can install missing npm-based CLIs (or tell you to install Cursor Agent yourself) and asks which backend to use when more than one is available.
 
-For **general in-process delegation** (research, review, planning), Nakama also offers the optional [`sub_agent`](/builtin-tools#sub_agent) tool — a same-profile sub-agent that returns a structured result. It does not spawn external CLIs and is not a substitute for Codex / Claude Code / OpenCode on large repo changes.
+For **general in-process delegation** (research, review, planning), Nakama also offers the optional [`sub_agent`](/builtin-tools#sub_agent) tool — a same-profile sub-agent that returns a structured result. It does not spawn external CLIs and is not a substitute for dedicated coding CLIs on large repo changes.
 
 ## Why use a coding agent
 
@@ -25,7 +25,7 @@ Nakama can edit files with `read_file`, `write_file`, and `edit_file`, but that 
 Dedicated coding agents are built for that job. Nakama adds this feature so you do not have to choose between "stay in Nakama" and "use a real coding CLI":
 
 - **Nakama** stays the conversation owner, permission boundary, and summarizer
-- **Coding agent** (Codex, Claude Code, or OpenCode) runs the heavy repo work on the server
+- **Coding agent** (Codex, Claude Code, OpenCode, pi, or Cursor Agent) runs the heavy repo work on the server
 - **Super Bot** is the default profile with `bash` and the `coding-agent` skill; other profiles can opt in
 
 ## How the pieces fit together
@@ -35,7 +35,7 @@ Dedicated coding agents are built for that job. Nakama adds this feature so you 
 | **`coding-agent` skill** | Teaches when to invoke a coding agent, how to install CLIs, when to ask which backend, and how to summarize results |
 | **`bash` tool** | Runs the coding-agent CLI in the profile workspace |
 | **Runtime discovery** | Nakama detects which CLIs are on the server `PATH` and injects harness context for the turn |
-| **Backend guidance** | Runtime-only bundled skills (`coding-backend-codex`, `coding-backend-claude-code`, `coding-backend-opencode`) injected on matched turns |
+| **Backend guidance** | Runtime-only bundled skills (`coding-backend-codex`, `coding-backend-claude-code`, `coding-backend-opencode`, `coding-backend-pi`, `coding-backend-cursor`) injected on matched turns |
 
 ```text
 User message (coding task)
@@ -57,6 +57,7 @@ Nakama supports CLI-backed backends on the machine running the server:
 | **Claude Code** | `claude` | Anthropic Claude Code print mode (`-p`) |
 | **OpenCode** | `opencode` | Provider-agnostic OpenCode `run` |
 | **pi** | `pi` | pi coding agent CLI |
+| **Cursor Agent** | `agent` | Cursor Agent print mode (`-p`) with `stream-json` output for unattended runs |
 
 ## Setup
 
@@ -69,13 +70,14 @@ Nakama supports CLI-backed backends on the machine running the server:
 
 You can assign `coding-agent` without pre-installing a CLI. The first coding turn installs or chooses a backend as needed.
 
-Assigning **`bash` + `coding-agent`** means the agent can run global package installs on the **server host**. On shared servers, treat that assignment as host-install capability.
+Assigning **`bash` + `coding-agent`** means the agent can run global package installs on the **server host** for Codex / Claude Code / OpenCode / pi. **Cursor Agent** is not auto-installed — install and authenticate it on the host yourself (`agent --version`). On shared servers, treat bash assignment as host-install capability for the npm-based CLIs.
+
 
 ### 2. Chat from a profile with coding-agent access
 
 When the user's message looks like a code-change request, the skill matcher attaches the full `coding-agent` body plus harness context for that turn:
 
-- **No CLI installed** — context lists install commands; the agent can install via `bash`, then retry
+- **No CLI installed** — context lists install commands for npm-based CLIs; Cursor Agent must be installed by the operator
 - **One CLI installed** — context includes that backend's command template
 - **Multiple CLIs installed** — the agent asks which one to use (per conversation) before running
 
@@ -90,6 +92,7 @@ Nakama injects your configured LLM provider credentials at coding-agent spawn ti
 | Claude Code | `ANTHROPIC_BASE_URL`, `ANTHROPIC_API_KEY`, model tier env vars |
 | Codex | `OPENAI_BASE_URL`, `OPENAI_API_KEY`, `OPENAI_MODEL` (or temp `config.toml` + `CODEX_HOME`) |
 | OpenCode | Temp `opencode.json` via `XDG_CONFIG_HOME` |
+| Cursor Agent | None — uses host Cursor authentication; Nakama does not inject provider credentials |
 
 **Requirements:**
 
@@ -98,10 +101,10 @@ Nakama injects your configured LLM provider credentials at coding-agent spawn ti
 
 The `bash` tool merges spawn env when:
 
-- the command starts with a known harness binary (`codex`, `claude`, `opencode`, or `pi`), or
+- the command starts with a known harness binary (`codex`, `claude`, `opencode`, `pi`, or `agent`), or
 - `codingAgent: true` is set **and** the command starts with a known harness binary
 
-If `codingAgent: true` is set but the command does not start with a known binary, Nakama fails closed (no provider env merge) so the wrong credentials are never applied.
+If `codingAgent: true` is set but the command does not start with a known binary, Nakama fails closed (no provider env merge) so the wrong credentials are never applied. For Cursor Agent (`agent`), spawn env stays empty even when a Nakama provider is configured.
 
 Passthrough follows the **binary in the command**, not a dashboard selection.
 
@@ -165,7 +168,8 @@ Tool and skill assignment remain per profile.
 
 | Symptom | What to check |
 |---------|----------------|
-| Agent offers to install a CLI | Expected when none are on the server `PATH` — approve global install only if you operate that host |
+| Agent offers to install a CLI | Expected for Codex/Claude/OpenCode/pi when none are on `PATH` — approve global install only if you operate that host. For Cursor Agent, install it yourself on the host |
+| Cursor Agent missing / auth fails | Install and authenticate Cursor Agent CLI on the server host; verify with `agent --version` |
 | Nakama asks which coding agent to use | Multiple CLIs are installed; answer for this conversation |
 | Nakama explains instead of coding | Message may not match the skill; ask for an explicit repo change |
 | Claude Code asks for `/login` | Provider passthrough not applied — ensure Settings → Provider is compatible and the bash command starts with `claude` |

--- a/docs/website/content/docs/docs.mdx
+++ b/docs/website/content/docs/docs.mdx
@@ -59,7 +59,7 @@ Then open the dashboard, complete the setup wizard, and send your first message.
 - [Skills](/skills) — reusable workflows including memory, artifacts, and automations
 - [Self-improving skills](/self-improving-skills) — agents save workflows as skills; optional admin approval
 - [Integrations](/integrations) — dashboard settings for channels and external providers
-- [Coding agent](/coding-agent) — Codex, Claude Code, or OpenCode from chat
+- [Coding agent](/coding-agent) — Codex, Claude Code, OpenCode, pi, or Cursor Agent from chat
 - [Agent browser](/agent-browser) — interactive browser automation for login-walled sites
 - [MCP servers](/mcp) — connect external tool providers
 - [Composio](/composio) — SaaS OAuth and toolkit assignment

--- a/packages/core/src/skills/bundled-names.ts
+++ b/packages/core/src/skills/bundled-names.ts
@@ -14,6 +14,7 @@ export const RUNTIME_ONLY_BUNDLED_SKILL_NAMES = [
   "coding-backend-claude-code",
   "coding-backend-opencode",
   "coding-backend-pi",
+  "coding-backend-cursor",
 ] as const;
 
 /** Bundled skills that install/sync but are never auto-assigned (manual opt-in). */

--- a/packages/core/src/skills/bundled/coding-agent.test.ts
+++ b/packages/core/src/skills/bundled/coding-agent.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { matchSkillsForMessage } from "../match";
@@ -59,5 +59,26 @@ describe("ensureBundledSkillFiles for coding agent", () => {
     expect(created).toContain("coding-backend-opencode");
     expect(created).toContain("coding-backend-pi");
     expect(created).toContain("coding-backend-cursor");
+  });
+
+  test("force-refreshes coding-agent and coding-backend-cursor when installed copies are stale", async () => {
+    const codingAgentPath = join(configDir, "agent", "skills", "coding-agent", "SKILL.md");
+    const cursorPath = join(configDir, "agent", "skills", "coding-backend-cursor", "SKILL.md");
+    await mkdir(join(configDir, "agent", "skills", "coding-agent"), { recursive: true });
+    await mkdir(join(configDir, "agent", "skills", "coding-backend-cursor"), { recursive: true });
+    await Bun.write(codingAgentPath, "---\nname: coding-agent\ndescription: stale\n---\n");
+    await Bun.write(cursorPath, "---\nname: coding-backend-cursor\ndescription: stale\n---\n");
+
+    const created = await ensureBundledSkillFiles();
+    const codingAgent = await readFile(codingAgentPath, "utf8");
+    const cursor = await readFile(cursorPath, "utf8");
+
+    expect(created).toContain("coding-agent");
+    expect(created).toContain("coding-backend-cursor");
+    expect(codingAgent).toContain("gh pr create");
+    expect(codingAgent).not.toContain("description: stale");
+    expect(cursor).toContain("Commits and pull requests");
+    expect(cursor).toContain("open a PR with gh");
+    expect(cursor).not.toContain("description: stale");
   });
 });

--- a/packages/core/src/skills/bundled/coding-agent.test.ts
+++ b/packages/core/src/skills/bundled/coding-agent.test.ts
@@ -58,5 +58,6 @@ describe("ensureBundledSkillFiles for coding agent", () => {
     expect(created).toContain("coding-backend-claude-code");
     expect(created).toContain("coding-backend-opencode");
     expect(created).toContain("coding-backend-pi");
+    expect(created).toContain("coding-backend-cursor");
   });
 });

--- a/packages/core/src/skills/bundled/coding-agent/SKILL.md
+++ b/packages/core/src/skills/bundled/coding-agent/SKILL.md
@@ -57,4 +57,5 @@ After the coding agent returns:
 - Summarize what changed in plain language using stdout/stderr from the bash result.
 - Mention what was verified.
 - Call out any remaining risks, gaps, or follow-up work.
+- If the user asked to resolve an issue / ship / open a PR, the coding brief should have required branch + commit + push + `gh pr create` (see backend guidance, especially Cursor). Confirm the PR URL before treating the task as done.
 - If the coding agent run failed (non-zero exit, timeout, or empty useful output), explain the failure clearly and decide whether to retry, adjust the prompt, or ask the user.

--- a/packages/core/src/skills/bundled/coding-agent/SKILL.md
+++ b/packages/core/src/skills/bundled/coding-agent/SKILL.md
@@ -50,7 +50,7 @@ When repo work should run on a coding agent, use the `bash` tool to run the CLI:
 5. Call `bash` with `codingAgent: true` **and** a command that starts with the harness binary (`codex`, `claude`, `opencode`, `pi`, or `agent`) so Nakama can recognize the harness. For Codex/Claude/OpenCode/pi, Nakama may merge provider passthrough spawn env. For **Cursor Agent**, spawn env stays empty — host Cursor auth is used instead. Use an explicit `timeoutMs` suited to the task — use 600000–1800000 ms (10–30 minutes) for substantial coding runs; keep shorter timeouts for quick checks.
 6. Prefer precise change requests over broad open-ended prompts.
 7. If the user names a preferred backend, use that CLI.
-8. For Cursor Agent, the required shape is `agent -p '<task>' --output-format stream-json --yolo` (see backend guidance). Summarize the outcome; do not dump the full stream-json log.
+8. For Cursor Agent: ensure the target repo exists in the profile workspace (clone with `git clone` if missing), then run from that folder with `agent -p '<task>' --output-format stream-json --yolo` (see backend guidance). Summarize the outcome; do not dump the full stream-json log.
 
 After the coding agent returns:
 

--- a/packages/core/src/skills/bundled/coding-agent/SKILL.md
+++ b/packages/core/src/skills/bundled/coding-agent/SKILL.md
@@ -50,7 +50,7 @@ When repo work should run on a coding agent, use the `bash` tool to run the CLI:
 5. Call `bash` with `codingAgent: true` **and** a command that starts with the harness binary (`codex`, `claude`, `opencode`, `pi`, or `agent`) so Nakama can recognize the harness. For Codex/Claude/OpenCode/pi, Nakama may merge provider passthrough spawn env. For **Cursor Agent**, spawn env stays empty — host Cursor auth is used instead. Use an explicit `timeoutMs` suited to the task — use 600000–1800000 ms (10–30 minutes) for substantial coding runs; keep shorter timeouts for quick checks.
 6. Prefer precise change requests over broad open-ended prompts.
 7. If the user names a preferred backend, use that CLI.
-8. For Cursor Agent: ensure the target repo exists in the profile workspace (clone if missing), set bash cwd to that repo, run `agent -p '<task>' --output-format text --yolo` with codingAgent true (argv0 must be `agent`, not `cd && agent`). Prefer text over stream-json. If output looks truncated, verify with git status/diff. See backend guidance.
+8. For Cursor Agent: ensure the target repo exists in the profile workspace (clone if missing), set bash cwd to that repo, run `agent -p '<task>' --output-format text --yolo` with codingAgent true (argv0 must be `agent`, not `cd && agent`). Prefer text; stream-json is summarized automatically with a full log under `artifacts/coding-agent-runs/`. See backend guidance.
 
 After the coding agent returns:
 

--- a/packages/core/src/skills/bundled/coding-agent/SKILL.md
+++ b/packages/core/src/skills/bundled/coding-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coding-agent
-description: Invoke a dedicated coding agent (Codex, Claude Code, or OpenCode) for bug fixes, feature implementation, file edits, repository changes, or targeted validation when the user wants changes made in the current project. Nakama handles ordinary explanation, brainstorming, and non-editing chat; use this skill when repo work is better done by a coding agent.
+description: Invoke a dedicated coding agent (Codex, Claude Code, OpenCode, pi, or Cursor Agent) for bug fixes, feature implementation, file edits, repository changes, or targeted validation when the user wants changes made in the current project. Nakama handles ordinary explanation, brainstorming, and non-editing chat; use this skill when repo work is better done by a coding agent.
 include-body-on-match: true
 ---
 
@@ -15,9 +15,9 @@ Keep ordinary conversation local:
 ## Prerequisites
 
 - This profile must have the **`bash`** tool assigned.
-- A coding agent CLI must be installed on the **Nakama server host** (Codex, Claude Code, OpenCode, or pi).
+- A coding agent CLI must be installed on the **Nakama server host** (Codex, Claude Code, OpenCode, pi, or Cursor Agent).
 
-Install with `bash` when missing (global installs affect the whole host — confirm with the operator on shared servers):
+Install with `bash` when missing for npm-based CLIs (global installs affect the whole host — confirm with the operator on shared servers):
 
 ```bash
 npm install -g @openai/codex
@@ -28,6 +28,8 @@ npm install -g @earendil-works/pi-coding-agent
 
 (or the equivalent `bun install -g --trust …` if npm is unavailable)
 
+**Cursor Agent** (`agent`) cannot be auto-installed by Nakama. If it is missing, tell the user to install and authenticate Cursor Agent CLI on the host themselves, then verify with `agent --version`. Do not attempt `npm install -g` for Cursor.
+
 If the injected **Coding Agent Harness** context lists install commands, follow those. After install, retry the coding task.
 
 ## Choosing a backend
@@ -35,7 +37,7 @@ If the injected **Coding Agent Harness** context lists install commands, follow 
 1. Read the injected **Coding Agent Harness** context.
 2. If it says **multiple** CLIs are installed, **ask the user which one to use** before running. Do not pick silently. Remember their choice for this conversation only.
 3. If exactly one CLI is available (or the context includes a single command template), use that backend.
-4. If none are installed, install via bash (above), then continue.
+4. If none are installed, install via bash for Codex/Claude/OpenCode/pi when appropriate, or tell the user to install Cursor Agent themselves when that is the desired backend.
 
 ## Coding agent workflow
 
@@ -45,9 +47,10 @@ When repo work should run on a coding agent, use the `bash` tool to run the CLI:
 2. Summarize the coding task in one concrete instruction block.
 3. Include only the context the coding agent needs: target behavior, affected files or areas when known, constraints, and what should be verified.
 4. Build the shell command from the template (or backend guidance), substituting your task prompt. Escape quotes carefully or use a heredoc when the prompt is multi-line.
-5. Call `bash` with `codingAgent: true` **and** a command that starts with the harness binary (`codex`, `claude`, `opencode`, or `pi`) so Nakama merges provider passthrough spawn env. Use an explicit `timeoutMs` suited to the task — use 600000–1800000 ms (10–30 minutes) for substantial coding runs; keep shorter timeouts for quick checks.
+5. Call `bash` with `codingAgent: true` **and** a command that starts with the harness binary (`codex`, `claude`, `opencode`, `pi`, or `agent`) so Nakama can recognize the harness. For Codex/Claude/OpenCode/pi, Nakama may merge provider passthrough spawn env. For **Cursor Agent**, spawn env stays empty — host Cursor auth is used instead. Use an explicit `timeoutMs` suited to the task — use 600000–1800000 ms (10–30 minutes) for substantial coding runs; keep shorter timeouts for quick checks.
 6. Prefer precise change requests over broad open-ended prompts.
 7. If the user names a preferred backend, use that CLI.
+8. For Cursor Agent, the required shape is `agent -p '<task>' --output-format stream-json --yolo` (see backend guidance). Summarize the outcome; do not dump the full stream-json log.
 
 After the coding agent returns:
 

--- a/packages/core/src/skills/bundled/coding-agent/SKILL.md
+++ b/packages/core/src/skills/bundled/coding-agent/SKILL.md
@@ -50,7 +50,7 @@ When repo work should run on a coding agent, use the `bash` tool to run the CLI:
 5. Call `bash` with `codingAgent: true` **and** a command that starts with the harness binary (`codex`, `claude`, `opencode`, `pi`, or `agent`) so Nakama can recognize the harness. For Codex/Claude/OpenCode/pi, Nakama may merge provider passthrough spawn env. For **Cursor Agent**, spawn env stays empty — host Cursor auth is used instead. Use an explicit `timeoutMs` suited to the task — use 600000–1800000 ms (10–30 minutes) for substantial coding runs; keep shorter timeouts for quick checks.
 6. Prefer precise change requests over broad open-ended prompts.
 7. If the user names a preferred backend, use that CLI.
-8. For Cursor Agent: ensure the target repo exists in the profile workspace (clone with `git clone` if missing), then run from that folder with `agent -p '<task>' --output-format stream-json --yolo` (see backend guidance). Summarize the outcome; do not dump the full stream-json log.
+8. For Cursor Agent: ensure the target repo exists in the profile workspace (clone if missing), set bash cwd to that repo, run `agent -p '<task>' --output-format text --yolo` with codingAgent true (argv0 must be `agent`, not `cd && agent`). Prefer text over stream-json. If output looks truncated, verify with git status/diff. See backend guidance.
 
 After the coding agent returns:
 

--- a/packages/core/src/skills/bundled/coding-backend-cursor/SKILL.md
+++ b/packages/core/src/skills/bundled/coding-backend-cursor/SKILL.md
@@ -16,31 +16,37 @@ You are preparing a coding agent run for Cursor Agent CLI (`agent`), orchestrate
 
 ## Repo setup (do this before coding)
 
-Bash runs in the **profile workspace**. Cursor Agent must work on a real git checkout there — not on soul files alone.
+Bash defaults to the **profile workspace**. Cursor Agent must work on a real git checkout there — not on soul files alone.
 
 1. Identify the target repo (URL or folder name from the user). If unclear, ask once.
-2. Check whether that repo already exists under the workspace (e.g. `ls`, or `test -d <dir>/.git`).
-3. If it is missing, clone it into the workspace with `bash` (`git clone <url> <dir>`), then continue.
-4. Run Cursor Agent **inside that repo folder** (`cd <dir> && …` or `agent --workspace <dir> …`).
+2. Check whether that repo already exists under the workspace (`ls`, or `test -d <dir>/.git`).
+3. If it is missing, clone it into the workspace (`git clone <url> <dir>`), then continue.
+4. Hand off soon: give Cursor a short brief (issue URL + goal + constraints). Do not fully re-solve the bug with file tools first.
 
 Do not invent a repo URL. Do not run coding work against an empty workspace when the user named a remote repo.
 
 ## Command (required shape)
 
-Non-interactive print mode for unattended background runs from Nakama (from the repo directory):
+Set bash **`cwd`** to the repo directory. Keep argv0 as **`agent`** — never `cd … && agent` (with `codingAgent: true`, Nakama requires the harness binary first).
 
 ```bash
-cd <repo-dir> && agent -p 'Implement the requested change and summarize what you verified' --output-format stream-json --yolo
+agent -p 'Implement the requested change and summarize what you verified' --output-format text --yolo
 ```
 
-- `-p` / `--print` — non-interactive one-shot
-- `--output-format stream-json` — machine-readable event stream on stdout
-- `--yolo` — required for Nakama background dispatch so the CLI does not wait on interactive permission prompts
+bash args:
 
-Use an explicit bash `timeoutMs` suited to the task (often 600000–1800000 ms). Prefer `codingAgent: true` or a command that starts with `agent` so Nakama recognizes the harness binary (spawn env stays empty for Cursor).
+- `cwd`: absolute path to the repo checkout inside the profile workspace
+- `codingAgent: true`
+- `timeoutMs`: often 600000–1800000 for substantial runs
+
+Flags:
+
+- `-p` / `--print` — non-interactive one-shot
+- `--output-format text` — short final answer for Nakama (prefer this; avoid `stream-json`, which blows bash's stdout cap and looks truncated mid-run)
+- `--yolo` — required for unattended background dispatch
 
 ## After the run
 
-- Summarize the final outcome in plain language for the user.
-- Do **not** dump the full stream-json event log into the chat.
+- Summarize the final text for the user.
+- If stdout looks truncated (`...[truncated]`) or unclear, verify completion with `git status` / `git diff --stat` in the repo (via bash `cwd`), then report what changed.
 - If the run failed (non-zero exit, timeout, auth error, or empty useful output), explain clearly and ask the user to fix host install/auth when that is the cause.

--- a/packages/core/src/skills/bundled/coding-backend-cursor/SKILL.md
+++ b/packages/core/src/skills/bundled/coding-backend-cursor/SKILL.md
@@ -42,11 +42,11 @@ bash args:
 Flags:
 
 - `-p` / `--print` — non-interactive one-shot
-- `--output-format text` — short final answer for Nakama (prefer this; avoid `stream-json`, which blows bash's stdout cap and looks truncated mid-run)
+- `--output-format text` — short final answer for Nakama (preferred). `stream-json` also works: Nakama summarizes the NDJSON into assistant/tools/result and saves the full log under `artifacts/coding-agent-runs/`.
 - `--yolo` — required for unattended background dispatch
 
 ## After the run
 
-- Summarize the final text for the user.
-- If stdout looks truncated (`...[truncated]`) or unclear, verify completion with `git status` / `git diff --stat` in the repo (via bash `cwd`), then report what changed.
+- Summarize the returned stdout for the user (already summarized if stream-json was used).
+- If the result is unclear, verify completion with `git status` / `git diff --stat` in the repo (via bash `cwd`), then report what changed. Use the full log path from stdout when you need raw events.
 - If the run failed (non-zero exit, timeout, auth error, or empty useful output), explain clearly and ask the user to fix host install/auth when that is the cause.

--- a/packages/core/src/skills/bundled/coding-backend-cursor/SKILL.md
+++ b/packages/core/src/skills/bundled/coding-backend-cursor/SKILL.md
@@ -45,8 +45,34 @@ Flags:
 - `--output-format text` — short final answer for Nakama (preferred). `stream-json` also works: Nakama summarizes the NDJSON into assistant/tools/result and saves the full log under `artifacts/coding-agent-runs/`.
 - `--yolo` — required for unattended background dispatch
 
+## Commits and pull requests
+
+Cursor Agent can create branches, commit, push, and open GitHub PRs with `git` + `gh` on the host (same capabilities as a local checkout). Include that in the `-p` brief when the user wants an issue resolved, a fix shipped, or a PR opened — do not stop at uncommitted edits on `main`.
+
+When shipping / opening a PR, put this in the agent prompt (adapt issue number, title, and scope):
+
+```bash
+agent -p 'Fix issue #175: <short problem + required changes>.
+
+When done:
+1. Create a feature branch off the default branch (do not commit on main).
+2. Commit with a clear message focused on why.
+3. Push the branch and open a PR with gh (link Fixes #175 in the body).
+4. Reply with the PR URL, what changed, and what you verified.
+
+Do not force-push. Do not skip hooks.' --output-format text --yolo
+```
+
+Rules:
+
+- Only require commit/push/PR when user intent includes shipping (fix an issue, open a PR, ship, create a PR). For local-only exploration or “just look”, skip git publish steps.
+- Prefer one coding-agent run that implements **and** opens the PR. If the first run left uncommitted work, follow up with another `agent -p` (or bash `gh`/`git`) in the same repo `cwd` to finish ship — verify with `git status` / `gh pr view` first.
+- Host needs `gh` authenticated for the target remote. If push/PR fails on auth, tell the user to fix host `gh auth` / git credentials, then retry.
+- Never invent a PR URL. Confirm from agent stdout or `gh pr list` / `gh pr view`.
+
 ## After the run
 
 - Summarize the returned stdout for the user (already summarized if stream-json was used).
 - If the result is unclear, verify completion with `git status` / `git diff --stat` in the repo (via bash `cwd`), then report what changed. Use the full log path from stdout when you need raw events.
+- If a PR was requested: confirm branch is pushed and report the PR URL (from stdout or `gh pr view --json url -q .url`). If changes exist but no PR, finish shipping — do not claim the issue is done.
 - If the run failed (non-zero exit, timeout, auth error, or empty useful output), explain clearly and ask the user to fix host install/auth when that is the cause.

--- a/packages/core/src/skills/bundled/coding-backend-cursor/SKILL.md
+++ b/packages/core/src/skills/bundled/coding-backend-cursor/SKILL.md
@@ -14,12 +14,23 @@ You are preparing a coding agent run for Cursor Agent CLI (`agent`), orchestrate
 - Nakama does **not** auto-install Cursor Agent and does **not** inject Nakama provider credentials. Host Cursor auth is required.
 - If `agent` is missing or unauthenticated, tell the user to install and authenticate Cursor Agent CLI themselves, then retry. Do not run `npm install -g` for this backend.
 
+## Repo setup (do this before coding)
+
+Bash runs in the **profile workspace**. Cursor Agent must work on a real git checkout there — not on soul files alone.
+
+1. Identify the target repo (URL or folder name from the user). If unclear, ask once.
+2. Check whether that repo already exists under the workspace (e.g. `ls`, or `test -d <dir>/.git`).
+3. If it is missing, clone it into the workspace with `bash` (`git clone <url> <dir>`), then continue.
+4. Run Cursor Agent **inside that repo folder** (`cd <dir> && …` or `agent --workspace <dir> …`).
+
+Do not invent a repo URL. Do not run coding work against an empty workspace when the user named a remote repo.
+
 ## Command (required shape)
 
-Non-interactive print mode for unattended background runs from Nakama:
+Non-interactive print mode for unattended background runs from Nakama (from the repo directory):
 
 ```bash
-agent -p 'Implement the requested change and summarize what you verified' --output-format stream-json --yolo
+cd <repo-dir> && agent -p 'Implement the requested change and summarize what you verified' --output-format stream-json --yolo
 ```
 
 - `-p` / `--print` — non-interactive one-shot

--- a/packages/core/src/skills/bundled/coding-backend-cursor/SKILL.md
+++ b/packages/core/src/skills/bundled/coding-backend-cursor/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: coding-backend-cursor
+description: Runtime prompt layer for Cursor Agent CLI coding agent runs.
+disable-model-invocation: true
+include-body-on-match: true
+---
+
+You are preparing a coding agent run for Cursor Agent CLI (`agent`), orchestrated via the `bash` tool.
+
+## Prerequisites
+
+- Cursor Agent CLI must already be installed and authenticated **on the Nakama server host**.
+- Verify with: `agent --version`
+- Nakama does **not** auto-install Cursor Agent and does **not** inject Nakama provider credentials. Host Cursor auth is required.
+- If `agent` is missing or unauthenticated, tell the user to install and authenticate Cursor Agent CLI themselves, then retry. Do not run `npm install -g` for this backend.
+
+## Command (required shape)
+
+Non-interactive print mode for unattended background runs from Nakama:
+
+```bash
+agent -p 'Implement the requested change and summarize what you verified' --output-format stream-json --yolo
+```
+
+- `-p` / `--print` — non-interactive one-shot
+- `--output-format stream-json` — machine-readable event stream on stdout
+- `--yolo` — required for Nakama background dispatch so the CLI does not wait on interactive permission prompts
+
+Use an explicit bash `timeoutMs` suited to the task (often 600000–1800000 ms). Prefer `codingAgent: true` or a command that starts with `agent` so Nakama recognizes the harness binary (spawn env stays empty for Cursor).
+
+## After the run
+
+- Summarize the final outcome in plain language for the user.
+- Do **not** dump the full stream-json event log into the chat.
+- If the run failed (non-zero exit, timeout, auth error, or empty useful output), explain clearly and ask the user to fix host install/auth when that is the cause.

--- a/packages/core/src/skills/bundled/create-automation.test.ts
+++ b/packages/core/src/skills/bundled/create-automation.test.ts
@@ -207,6 +207,7 @@ describe("ensureBundledSkillFiles", () => {
     expect(created).toContain("coding-backend-claude-code");
     expect(created).toContain("coding-backend-opencode");
     expect(created).toContain("coding-backend-pi");
+    expect(created).toContain("coding-backend-cursor");
   });
 
   test("does not overwrite existing skill files", async () => {

--- a/packages/core/src/skills/bundled/install.ts
+++ b/packages/core/src/skills/bundled/install.ts
@@ -5,7 +5,11 @@ import { getGlobalSkillsDir, SKILL_FILE_NAME } from "../paths";
 import { BUNDLED_SKILL_NAMES, readBundledSkillMarkdown } from "./index";
 
 /** Bundled skills whose installed SKILL.md must be overwritten on startup (content drift). */
-const FORCE_REFRESH_BUNDLED_SKILL_NAMES = new Set<string>(["manage-skills"]);
+const FORCE_REFRESH_BUNDLED_SKILL_NAMES = new Set<string>([
+  "manage-skills",
+  "coding-agent",
+  "coding-backend-cursor",
+]);
 
 const RENAMED_BUNDLED_SKILL_DIRS = [["coding-delegation", "coding-agent"]] as const;
 

--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -3092,7 +3092,13 @@ function parseCodingAgentHarnesses(
         return [];
       }
 
-      if (kind !== "codex" && kind !== "claude_code" && kind !== "opencode") {
+      if (
+        kind !== "codex" &&
+        kind !== "claude_code" &&
+        kind !== "opencode" &&
+        kind !== "pi" &&
+        kind !== "cursor_agent"
+      ) {
         return [];
       }
 

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -169,7 +169,12 @@ export interface StoredWorkspaceSettingsRecord {
   orgId?: string | null;
 }
 
-export type StoredCodingAgentHarnessKind = "codex" | "claude_code" | "opencode" | "pi";
+export type StoredCodingAgentHarnessKind =
+  | "codex"
+  | "claude_code"
+  | "opencode"
+  | "pi"
+  | "cursor_agent";
 
 export interface StoredCodingAgentHarnessProbeCache {
   checkedAt: string;


### PR DESCRIPTION
## Summary
- Register Cursor Agent (`agent`) as a coding-agent harness with PATH discovery, ready-when-installed (host Cursor auth), and no Nakama provider passthrough or auto-install
- Add runtime skill `coding-backend-cursor` and update `coding-agent` to invoke `agent -p … --output-format stream-json --yolo` via `bash`
- Document Cursor in coding-agent / builtin-tools docs and AGENTS.md

## Test plan
- [x] `bun test` coding-agent harness/command/spawn/bash/provider + bundled skill + agent-service tests
- [ ] Smoke: with `agent` on PATH, coding turn injects Cursor template; bash run uses `-p`, `stream-json`, `--yolo`
- [ ] Smoke: without `agent`, context tells user to install Cursor themselves (no npm install for Cursor)


Made with [Cursor](https://cursor.com)