### PR TITLE
fix: browse edited base URL in Edit provider dialog

### DIFF
--- a/apps/server/src/services/agent-service.test.ts
+++ b/apps/server/src/services/agent-service.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -9,6 +9,7 @@ import {
   WORKSPACE_SETTINGS_ID,
 } from "@nakama/db";
 import type { StoredProfileRecord } from "@nakama/db";
+import * as providers from "../providers";
 import { AgentService } from "./agent-service";
 import { SkillsService } from "./skills-service";
 
@@ -451,6 +452,82 @@ describe("AgentService skill_manage injection", () => {
       includeAutomationTools: false,
     });
     expect(automationTools.some((tool) => tool.name === "skill_manage")).toBe(false);
+  });
+});
+
+describe("AgentService discoverModels baseUrl override", () => {
+  const storedBaseUrl = "https://stored.example/v1";
+  const editedBaseUrl = "https://edited.example/v1";
+  let fetchSpy: ReturnType<typeof spyOn<typeof providers, "fetchRemoteOpenAIModels">> | null =
+    null;
+  let probed: string[] = [];
+
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+    fetchSpy = null;
+    probed = [];
+  });
+
+  function createService() {
+    const db = createInMemoryDatabaseAdapter();
+    return new AgentService(
+      {
+        defaultProviderId: "compat-1",
+        providers: [
+          {
+            id: "compat-1",
+            type: "openai_compatible",
+            label: "Compat",
+            apiKey: "secret",
+            baseUrl: storedBaseUrl,
+            customModels: [],
+            createdAt: new Date().toISOString(),
+          },
+        ],
+      },
+      null,
+      db,
+    );
+  }
+
+  function stubFetch() {
+    probed = [];
+    fetchSpy = spyOn(providers, "fetchRemoteOpenAIModels").mockImplementation(async (baseUrl) => {
+      probed.push(baseUrl);
+      return [{ id: "model-a", name: "model-a" }];
+    });
+  }
+
+  test("override differing from stored probes the override URL", async () => {
+    stubFetch();
+    const result = await createService().discoverModels({
+      providerId: "compat-1",
+      baseUrl: editedBaseUrl,
+    });
+
+    expect(probed).toEqual([editedBaseUrl]);
+    expect(result.baseUrl).toBe(editedBaseUrl);
+  });
+
+  test("override equal to stored probes the stored URL", async () => {
+    stubFetch();
+    const result = await createService().discoverModels({
+      providerId: "compat-1",
+      baseUrl: storedBaseUrl,
+    });
+
+    expect(probed).toEqual([storedBaseUrl]);
+    expect(result.baseUrl).toBe(storedBaseUrl);
+  });
+
+  test("no override probes the stored URL", async () => {
+    stubFetch();
+    const result = await createService().discoverModels({
+      providerId: "compat-1",
+    });
+
+    expect(probed).toEqual([storedBaseUrl]);
+    expect(result.baseUrl).toBe(storedBaseUrl);
   });
 });
 

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -1603,7 +1603,11 @@ export class AgentService {
   async discoverModels(request: DiscoverModelsRequest): Promise<ModelsResponse> {
     const providerId = request.providerId?.trim();
     if (providerId) {
-      return this.discoverModelsForProvider(providerId);
+      const baseUrlOverride = request.baseUrl?.trim();
+      return this.discoverModelsForProvider(
+        providerId,
+        baseUrlOverride ? baseUrlOverride : undefined,
+      );
     }
 
     if (request.provider === "fireworks") {
@@ -1670,7 +1674,10 @@ export class AgentService {
     };
   }
 
-  async discoverModelsForProvider(providerId: string): Promise<ModelsResponse> {
+  async discoverModelsForProvider(
+    providerId: string,
+    baseUrlOverride?: string,
+  ): Promise<ModelsResponse> {
     const instance = findProviderInstance(
       this.userConfig ?? { providers: [], defaultProviderId: null },
       providerId,
@@ -1693,9 +1700,12 @@ export class AgentService {
         throw new Error("Add an API key before discovering Ollama Cloud models.");
       }
 
-      const baseUrl =
+      const resolvedBaseUrl =
         instance.baseUrl?.trim() ||
         (instance.type === "ollama" ? defaultOllamaBaseUrl(hostMode!) : "");
+      const override = baseUrlOverride?.trim();
+      const baseUrl =
+        override && override !== resolvedBaseUrl ? override : resolvedBaseUrl;
 
       if (!baseUrl) {
         throw new Error("A base URL is required to discover models.");

--- a/apps/web/src/components/RemoteModelsBrowseList.tsx
+++ b/apps/web/src/components/RemoteModelsBrowseList.tsx
@@ -47,7 +47,7 @@ export function RemoteModelsBrowseList({
     queryFn: async () => {
       const response = await client.discoverModels(
         providerId?.trim()
-          ? { providerId: providerId.trim() }
+          ? { providerId: providerId.trim(), baseUrl: trimmedBaseUrl || undefined }
           : {
               baseUrl: trimmedBaseUrl,
               apiKey,


### PR DESCRIPTION
## Summary
- Fixes #175: Edit provider Browse was discovering against the saved Base URL and ignoring the field being edited.
- Client now sends `{ providerId, baseUrl }` when browsing an existing provider; server probes the override when it differs from the stored URL (same apiKey/type/hostMode).
- Adds unit tests for override / equal / no-override probe behavior.

## Test plan
- [x] `cd apps/server && bun test src/services/agent-service.test.ts`
- [x] `cd apps/server && bun test` (666 pass)
- [x] `cd apps/web && bunx tsc --noEmit`
- [ ] Manually: System → Providers → Edit a remote provider → change Base URL → Browse → confirm models load from the edited URL (not the saved one)
- [ ] Manually: Manage models dialog (read-only Base URL) still browses the stored endpoint


Made with [Cursor](https://cursor.com)