### PR TITLE
Fix Edit provider browse ignoring typed Base URL

### DIFF
--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -1603,7 +1603,11 @@ export class AgentService {
   async discoverModels(request: DiscoverModelsRequest): Promise<ModelsResponse> {
     const providerId = request.providerId?.trim();
     if (providerId) {
-      return this.discoverModelsForProvider(providerId);
+      return this.discoverModelsForProvider(providerId, {
+        baseUrl: request.baseUrl?.trim() || undefined,
+        apiKey: request.apiKey,
+        hostMode: request.hostMode,
+      });
     }
 
     if (request.provider === "fireworks") {
@@ -1670,7 +1674,14 @@ export class AgentService {
     };
   }
 
-  async discoverModelsForProvider(providerId: string): Promise<ModelsResponse> {
+  async discoverModelsForProvider(
+    providerId: string,
+    overrides?: {
+      baseUrl?: string;
+      apiKey?: string;
+      hostMode?: DiscoverModelsRequest["hostMode"];
+    },
+  ): Promise<ModelsResponse> {
     const instance = findProviderInstance(
       this.userConfig ?? { providers: [], defaultProviderId: null },
       providerId,
@@ -1682,8 +1693,11 @@ export class AgentService {
 
     if (instance.type === "ollama" || instance.type === "openai_compatible") {
       const hostMode =
-        instance.type === "ollama" ? resolveOllamaHostMode(instance) : undefined;
+        instance.type === "ollama"
+          ? (overrides?.hostMode ?? resolveOllamaHostMode(instance))
+          : undefined;
       const apiKey =
+        overrides?.apiKey?.trim() ||
         instance.apiKey.trim() ||
         (instance.type === "ollama"
           ? readEnvValue(process.env, apiKeyEnvVarForProvider("ollama") ?? "") || ""
@@ -1693,7 +1707,9 @@ export class AgentService {
         throw new Error("Add an API key before discovering Ollama Cloud models.");
       }
 
+      // Prefer an explicit baseUrl (e.g. unsaved Edit provider field) over the stored one.
       const baseUrl =
+        overrides?.baseUrl ||
         instance.baseUrl?.trim() ||
         (instance.type === "ollama" ? defaultOllamaBaseUrl(hostMode!) : "");
 
@@ -1705,7 +1721,7 @@ export class AgentService {
         instance.type === "ollama"
           ? await fetchOllamaModels(baseUrl, apiKey)
           : await fetchRemoteOpenAIModels(baseUrl, apiKey);
-      const remoteInstance = { ...instance, customModels: entries };
+      const remoteInstance = { ...instance, baseUrl, customModels: entries };
       const models = getModelsForProviderInstance(remoteInstance);
 
       return {

--- a/apps/web/src/components/RemoteModelsBrowseList.tsx
+++ b/apps/web/src/components/RemoteModelsBrowseList.tsx
@@ -45,9 +45,17 @@ export function RemoteModelsBrowseList({
       apiKey: apiKey.trim() ? "set" : "",
     }),
     queryFn: async () => {
+      // When providerId is set, still forward baseUrl so Edit provider can probe a
+      // typed (unsaved) URL while the server resolves stored credentials via id.
       const response = await client.discoverModels(
         providerId?.trim()
-          ? { providerId: providerId.trim() }
+          ? {
+              providerId: providerId.trim(),
+              ...(trimmedBaseUrl ? { baseUrl: trimmedBaseUrl } : {}),
+              ...(apiKey.trim() ? { apiKey } : {}),
+              ...(provider ? { provider } : {}),
+              ...(hostMode ? { hostMode } : {}),
+            }
           : {
               baseUrl: trimmedBaseUrl,
               apiKey,


### PR DESCRIPTION
## Summary
- Browse in **Edit provider** was probing the saved instance URL because `RemoteModelsBrowseList` sent `{ providerId }` alone whenever an instance id was present, ignoring the typed `baseUrl`.
- Forward the typed `baseUrl` (and optional key/hostMode) with `providerId`, and let the server prefer that URL while still loading stored credentials from the instance.
- **Manage models** is unchanged in behavior: Base URL is read-only and still probes the saved endpoint with stored credentials.

## Test plan
- [ ] Edit an Ollama / OpenAI-compatible provider, change Base URL without saving, click Browse — list/errors reflect the typed URL
- [ ] Same dialog with Base URL left unchanged — browse still works with stored credentials
- [ ] Manage models → Browse — still probes the saved Base URL
- [ ] Authenticated openai_compatible endpoint: browse against a typed URL still uses the stored API key

Closes #175

Made with [Cursor](https://cursor.com)