### PR TITLE
fix(history): show Discord sessions on the history page

### DIFF
--- a/apps/web/src/lib/chat-history-route.test.ts
+++ b/apps/web/src/lib/chat-history-route.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import {
+  HISTORY_SESSION_CHANNELS,
   buildChatPath,
   buildNewChatPath,
   chatProfileIdFromPath,
+  formatSessionChannelLabel,
   isChatSessionPath,
+  isReadOnlySessionChannel,
   parseChatRouteParams,
   readRequestedDraftFromNewChatSearch,
   readRequestedDraftKeyFromNewChatSearch,
@@ -212,5 +215,11 @@ describe("chat history route helpers", () => {
     const profiles = [{ id: "default" }, { id: "super" }];
     expect(pickKnownProfileId(profiles, "missing", "super")).toBe("super");
     expect(pickKnownProfileId(profiles, "missing")).toBeNull();
+  });
+
+  test("history lists discord sessions as read-only channel chats", () => {
+    expect(HISTORY_SESSION_CHANNELS).toContain("discord");
+    expect(isReadOnlySessionChannel("discord")).toBe(true);
+    expect(formatSessionChannelLabel("discord")).toBe("Discord");
   });
 });

--- a/apps/web/src/lib/chat-history.ts
+++ b/apps/web/src/lib/chat-history.ts
@@ -277,10 +277,10 @@ export function sessionStorageKey(profileId: string): string {
   return `nakama:session:${profileId}`;
 }
 
-export const HISTORY_SESSION_CHANNELS = ["web", "telegram", "whatsapp"] as const satisfies readonly AgentChannel[];
+export const HISTORY_SESSION_CHANNELS = ["web", "telegram", "whatsapp", "discord"] as const satisfies readonly AgentChannel[];
 
 export function isReadOnlySessionChannel(channel: AgentChannel): boolean {
-  return channel === "telegram" || channel === "whatsapp";
+  return channel === "telegram" || channel === "whatsapp" || channel === "discord";
 }
 
 export function formatSessionChannelLabel(channel: AgentChannel): string {
@@ -289,6 +289,8 @@ export function formatSessionChannelLabel(channel: AgentChannel): string {
       return "Telegram";
     case "whatsapp":
       return "WhatsApp";
+    case "discord":
+      return "Discord";
     case "web":
       return "Web";
     default:


### PR DESCRIPTION
## Summary

Before this change, Discord conversations for a profile never appeared on History even when they were saved in the database. Opening `/history?profile=…` after chatting on Discord now lists those sessions alongside web/Telegram/WhatsApp, labeled Discord and opened as view-only (reply from Discord).

## Test plan

- [x] `bun test apps/web/src/lib/chat-history-route.test.ts apps/web/src/lib/chat-history.test.ts`
- [ ] Reload `/history?profile=<profile-with-discord-session>` and confirm a Discord-labeled chat appears
- [ ] Open it and confirm the composer stays view-only

---

🔬 *This PR was created with [Compound Engineering](https://ai.ashbyhq.com/compound)*
