### PR TITLE
feat(discord): render and answer agent questionnaires

### DIFF
--- a/apps/platform/discord/src/chat-handler.test.ts
+++ b/apps/platform/discord/src/chat-handler.test.ts
@@ -218,3 +218,123 @@ describe("createChatHandler artifact delivery", () => {
     });
   });
 });
+
+describe("createChatHandler questionnaire delivery", () => {
+  const questionnaire = {
+    id: "qset_1",
+    title: "Need input",
+    questions: [
+      {
+        id: "how-to-run",
+        prompt: "How should I run this?",
+        choices: [
+          { id: "playwright", label: "Build Playwright e2e" },
+          { id: "manual", label: "Manual steps only" },
+        ],
+        allowCustomAnswer: true,
+      },
+    ],
+  };
+
+  test("posts the questionnaire when ask_user_question fires and skips empty reply", async () => {
+    await withTempHome(async (homeDir) => {
+      await writeDiscordConfigIni(homeDir, {
+        botToken: "discord-bot-token",
+        pairedUserIds: ["424242424242424242"],
+      });
+
+      const authStore = new DiscordAuthStore();
+      await authStore.reload();
+      const { client } = createMockClient({
+        onSendStream: async (_input, handlers) => {
+          handlers?.onQuestionnaireUpdated?.(questionnaire);
+          return "";
+        },
+      });
+      const sessionStore = new SessionStore(
+        path.join(homeDir, ".nakama", "discord", "chat-sessions.json"),
+      );
+      await sessionStore.load();
+      sessionStore.set("dm_channel_1", {
+        sessionId: "session_test",
+        profileId: "default",
+        updatedAt: new Date().toISOString(),
+      });
+      await sessionStore.save();
+      const orgStore = createTestOrgStore(homeDir);
+      await orgStore.load();
+      const { handleMessage } = createChatHandler({
+        client,
+        config: { botToken: "discord-bot-token", profileId: "default" },
+        authStore,
+        sessionStore,
+        orgStore,
+      });
+
+      const { message, sentMessages } = createDmMessage({
+        userId: "424242424242424242",
+        content: "help me ship this",
+      });
+      await handleMessage(message);
+
+      expect(sentMessages.some((reply) => reply.includes("Need input"))).toBe(true);
+      expect(sentMessages.some((reply) => reply.includes("a) Build Playwright e2e"))).toBe(true);
+      expect(sentMessages.some((reply) => reply.includes("(empty reply)"))).toBe(false);
+    });
+  });
+
+  test("maps the next Discord reply into Answers for the pending questionnaire", async () => {
+    await withTempHome(async (homeDir) => {
+      await writeDiscordConfigIni(homeDir, {
+        botToken: "discord-bot-token",
+        pairedUserIds: ["424242424242424242"],
+      });
+
+      const authStore = new DiscordAuthStore();
+      await authStore.reload();
+      const streamedInputs: unknown[] = [];
+      const { client } = createMockClient({
+        questionnaire,
+        onSendStream: async (input) => {
+          streamedInputs.push(input);
+          return "Got it.";
+        },
+      });
+      const sessionStore = new SessionStore(
+        path.join(homeDir, ".nakama", "discord", "chat-sessions.json"),
+      );
+      await sessionStore.load();
+      sessionStore.set("dm_channel_1", {
+        sessionId: "session_test",
+        profileId: "default",
+        updatedAt: new Date().toISOString(),
+      });
+      await sessionStore.save();
+      const orgStore = createTestOrgStore(homeDir);
+      await orgStore.load();
+      const { handleMessage } = createChatHandler({
+        client,
+        config: { botToken: "discord-bot-token", profileId: "default" },
+        authStore,
+        sessionStore,
+        orgStore,
+      });
+
+      const { message, sentMessages } = createDmMessage({
+        userId: "424242424242424242",
+        content: "a",
+      });
+      await handleMessage(message);
+
+      expect(streamedInputs[0]).toEqual({
+        message: [
+          "Answers",
+          "",
+          "Q: How should I run this?",
+          "A: Build Playwright e2e",
+        ].join("\n"),
+      });
+      expect(sentMessages).toContain("Got it.");
+    });
+  });
+});

--- a/apps/platform/discord/src/chat-handler.ts
+++ b/apps/platform/discord/src/chat-handler.ts
@@ -246,6 +246,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
       switch (interaction.commandName) {
         case "clear": {
           stopActiveStream(conversationKey);
+          pendingQuestionnaires.delete(conversationKey);
           const session = await resolveSession(conversationKey);
           await session.clear();
           clearSessionArtifactState(conversationKey);
@@ -263,6 +264,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
         }
         case "new": {
           stopActiveStream(conversationKey);
+          pendingQuestionnaires.delete(conversationKey);
           await createAndBindSession(conversationKey);
           await messenger.send("Started a new conversation.");
           return;
@@ -600,6 +602,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     client.setOrgId(picked.id);
 
     if (previousOrgId && previousOrgId !== picked.id) {
+      pendingQuestionnaires.delete(conversationKey);
       sessionStore.delete(conversationKey);
       await sessionStore.save();
     }
@@ -671,6 +674,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     const { scope, profile: picked } = resolved;
 
     if (scope.orgId !== currentOrgId) {
+      pendingQuestionnaires.delete(conversationKey);
       orgStore.set(channelOrgKey, scope.orgId);
       await orgStore.save();
       client.setOrgId(scope.orgId);

--- a/apps/platform/discord/src/chat-handler.ts
+++ b/apps/platform/discord/src/chat-handler.ts
@@ -769,6 +769,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     chatId: string,
     profileId?: string,
   ): Promise<RemoteChatSession> {
+    pendingQuestionnaires.delete(chatId);
     const resolvedProfileId = profileId ?? (await resolveSessionProfileId(chatId));
     const session = await client.createSession("discord", {
       profileId: resolvedProfileId,

--- a/apps/platform/discord/src/chat-handler.ts
+++ b/apps/platform/discord/src/chat-handler.ts
@@ -1,5 +1,11 @@
 import type { NakamaClient, RemoteChatSession } from "@nakama/client";
-import type { SendMessageInput } from "@nakama/core/contract";
+import {
+  formatAgentQuestionnaireAnswersMessage,
+  formatAgentQuestionnaireMessage,
+  hasActiveAgentQuestionnaire,
+  tryParseChannelQuestionnaireAnswers,
+} from "@nakama/core/agent-questionnaire";
+import type { AgentQuestionnaire, SendMessageInput } from "@nakama/core/contract";
 import {
   findOrgBySelectionInput,
   formatOrgSelectionPrompt,
@@ -51,11 +57,13 @@ import {
   deliverDiscordTurnArtifactShares,
   maybeSendRequestedDiscordArtifactAttachment,
 } from "./channel-artifact-flow";
+import { DiscordQuestionnaireMessage } from "./questionnaire-message";
 import type { SessionStore } from "./session-store";
 import { DiscordTodoStatusMessage } from "./todo-status-message";
 import { createTypingLoop } from "./typing-indicator";
 
 const chatLocks = new Map<string, Promise<void>>();
+const pendingQuestionnaires = new Map<string, AgentQuestionnaire>();
 
 const GROUP_MESSAGE_PREFIX =
   "[Discord channel — your reply is visible to everyone in this channel.]\n";
@@ -172,10 +180,10 @@ export function createChatHandler(deps: ChatHandlerDeps) {
 
       await handleChatMessage(
         channel,
-        withGroupContext({ message: messageText }, isGuild),
         conversationKey,
         messenger,
         messageText,
+        isGuild,
       );
     });
   }
@@ -345,10 +353,10 @@ export function createChatHandler(deps: ChatHandlerDeps) {
 
   async function handleChatMessage(
     channel: TextBasedChannel,
-    input: SendMessageInput,
     conversationKey: string,
     messenger: DiscordMessenger,
     attachUserText: string,
+    isGuild: boolean,
   ): Promise<void> {
     const session = await resolveSession(conversationKey);
     const profileId = sessionStore.get(conversationKey)?.profileId;
@@ -365,16 +373,30 @@ export function createChatHandler(deps: ChatHandlerDeps) {
       });
     }
 
+    const streamInput = await resolveQuestionnaireStreamInput(
+      conversationKey,
+      session,
+      attachUserText,
+      isGuild,
+      messenger,
+    );
+
+    if (!streamInput) {
+      return;
+    }
+
     const signal = registerActiveStream(conversationKey);
     const typingLoop = createTypingLoop(messenger);
     const todoStatus = new DiscordTodoStatusMessage(messenger);
+    const questionnaireStatus = new DiscordQuestionnaireMessage(messenger);
     typingLoop.start();
 
     let reply = "";
+    let postedQuestionnaire = false;
 
     try {
       reply = await session.sendStream(
-        input,
+        streamInput,
         {
           onThinking: () => {
             typingLoop.ping();
@@ -391,6 +413,17 @@ export function createChatHandler(deps: ChatHandlerDeps) {
           onTodosUpdated: (todos) => {
             typingLoop.ping();
             void todoStatus.update(todos);
+          },
+          onQuestionnaireUpdated: (questionnaire) => {
+            typingLoop.ping();
+            if (hasActiveAgentQuestionnaire(questionnaire)) {
+              postedQuestionnaire = true;
+              pendingQuestionnaires.set(conversationKey, questionnaire!);
+              void questionnaireStatus.update(questionnaire);
+            } else {
+              pendingQuestionnaires.delete(conversationKey);
+              questionnaireStatus.clear();
+            }
           },
         },
         { signal },
@@ -427,7 +460,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
 
     if (reply.trim()) {
       await replyAsChat(messenger, reply);
-    } else {
+    } else if (!postedQuestionnaire) {
       await messenger.send("(empty reply)");
     }
 
@@ -441,6 +474,59 @@ export function createChatHandler(deps: ChatHandlerDeps) {
         messenger,
       });
     }
+  }
+
+  async function resolveQuestionnaireStreamInput(
+    conversationKey: string,
+    session: RemoteChatSession,
+    userText: string,
+    isGuild: boolean,
+    messenger: DiscordMessenger,
+  ): Promise<SendMessageInput | null> {
+    const pending = await resolvePendingQuestionnaire(conversationKey, session);
+
+    if (!pending) {
+      return withGroupContext({ message: userText }, isGuild);
+    }
+
+    const answers = tryParseChannelQuestionnaireAnswers(pending, userText);
+
+    if (!answers) {
+      await messenger.send(formatAgentQuestionnaireMessage(pending));
+      await messenger.send("Couldn't parse that. Reply using the format above.");
+      return null;
+    }
+
+    pendingQuestionnaires.delete(conversationKey);
+    return withGroupContext(
+      { message: formatAgentQuestionnaireAnswersMessage(answers) },
+      isGuild,
+    );
+  }
+
+  async function resolvePendingQuestionnaire(
+    conversationKey: string,
+    session: RemoteChatSession,
+  ): Promise<AgentQuestionnaire | null> {
+    const cached = pendingQuestionnaires.get(conversationKey);
+
+    if (hasActiveAgentQuestionnaire(cached)) {
+      return cached ?? null;
+    }
+
+    try {
+      const { questionnaire } = await client.getSessionMessages(session.id);
+
+      if (hasActiveAgentQuestionnaire(questionnaire)) {
+        pendingQuestionnaires.set(conversationKey, questionnaire!);
+        return questionnaire;
+      }
+    } catch {
+      // Best-effort; continue without a pending questionnaire.
+    }
+
+    pendingQuestionnaires.delete(conversationKey);
+    return null;
   }
 
   async function ensureOrgReady(

--- a/apps/platform/discord/src/questionnaire-message.ts
+++ b/apps/platform/discord/src/questionnaire-message.ts
@@ -1,0 +1,56 @@
+import type { AgentQuestionnaire } from "@nakama/core/contract";
+import type { DiscordMessenger } from "./messenger";
+import { formatAgentQuestionnaireMessage } from "@nakama/core/agent-questionnaire";
+
+export class DiscordQuestionnaireMessage {
+  private messageId: string | null = null;
+  private lastRendered = "";
+  private pending = Promise.resolve();
+  private active: AgentQuestionnaire | null = null;
+
+  constructor(private readonly messenger: DiscordMessenger) {}
+
+  getActive(): AgentQuestionnaire | null {
+    return this.active;
+  }
+
+  async update(questionnaire: AgentQuestionnaire | null): Promise<void> {
+    this.active = questionnaire && questionnaire.questions.length > 0 ? questionnaire : null;
+
+    if (!this.active) {
+      return;
+    }
+
+    await this.enqueueRender(this.active);
+  }
+
+  clear(): void {
+    this.active = null;
+  }
+
+  private async enqueueRender(questionnaire: AgentQuestionnaire): Promise<void> {
+    this.pending = this.pending.then(() => this.render(questionnaire));
+    await this.pending;
+  }
+
+  private async render(questionnaire: AgentQuestionnaire): Promise<void> {
+    const next = formatAgentQuestionnaireMessage(questionnaire);
+
+    if (next === this.lastRendered) {
+      return;
+    }
+
+    try {
+      if (this.messageId === null) {
+        const message = await this.messenger.send(next);
+        this.messageId = message?.id ?? null;
+      } else {
+        await this.messenger.edit(this.messageId, next);
+      }
+
+      this.lastRendered = next;
+    } catch {
+      // Questionnaire delivery is best-effort only.
+    }
+  }
+}

--- a/apps/platform/discord/src/test-helpers.ts
+++ b/apps/platform/discord/src/test-helpers.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import * as os from "node:os";
 import path from "node:path";
 import { spyOn } from "bun:test";
-import type { ChatMessage } from "@nakama/core/contract";
+import type { AgentQuestionnaire, ChatMessage } from "@nakama/core/contract";
 import type { UserOrgSummary } from "@nakama/core/contract";
 import {
   assertBridgeClientMethods,
@@ -10,7 +10,7 @@ import {
   parseListUserOrgsResponse,
 } from "@nakama/core/bridge-api";
 import { ChannelOrgStore } from "@nakama/core/channel-org";
-import type { NakamaClient } from "@nakama/client";
+import type { NakamaClient, StreamHandlers } from "@nakama/client";
 import type { Message } from "discord.js";
 
 export function createDefaultTestOrgs(): UserOrgSummary[] {

--- a/apps/platform/discord/src/test-helpers.ts
+++ b/apps/platform/discord/src/test-helpers.ts
@@ -30,6 +30,7 @@ export function createDefaultTestOrgs(): UserOrgSummary[] {
 export function createMockClient(
   options: {
     messages?: ChatMessage[];
+    questionnaire?: AgentQuestionnaire | null;
     profiles?: Array<{
       id: string;
       name?: string;
@@ -38,17 +39,22 @@ export function createMockClient(
       isSuper?: boolean;
     }>;
     orgs?: UserOrgSummary[];
+    onSendStream?: (input: unknown, handlers?: StreamHandlers) => Promise<string>;
   } = {},
 ) {
   const calls = {
     createSession: 0,
     sendStream: 0,
+    getSessionMessages: 0,
     publishProfileArtifactShare: 0,
     readProfileArtifactContent: 0,
   };
 
-  const sendStream = async () => {
+  const sendStream = async (input: unknown, handlers?: StreamHandlers) => {
     calls.sendStream += 1;
+    if (options.onSendStream) {
+      return options.onSendStream(input, handlers);
+    }
     return "Agent reply";
   };
 
@@ -77,6 +83,16 @@ export function createMockClient(
       return session;
     },
     createChatSession: () => session,
+    getSessionMessages: async () => {
+      calls.getSessionMessages += 1;
+      return {
+        channel: "discord" as const,
+        messages: options.messages ?? [],
+        messageMeta: [],
+        todos: [],
+        questionnaire: options.questionnaire ?? null,
+      };
+    },
     health: async () => ({ ok: true, providerConfigured: false }),
     listProfiles: async () =>
       parseListProfilesResponse({

--- a/apps/server/src/services/composio-api-client.ts
+++ b/apps/server/src/services/composio-api-client.ts
@@ -20,7 +20,7 @@ export interface ComposioSessionMcpEndpoint {
 }
 
 export interface ComposioApiClient {
-  listCatalogToolkits(): Promise<ComposioCatalogToolkit[]>;
+  listCatalogToolkits(options?: { limit?: number }): Promise<ComposioCatalogToolkit[]>;
   linkToolkitAccount(
     userId: string,
     toolkitSlug: string,
@@ -223,8 +223,9 @@ export class SdkComposioApiClient implements ComposioApiClient {
     this.composio = new Composio({ apiKey });
   }
 
-  async listCatalogToolkits(): Promise<ComposioCatalogToolkit[]> {
-    const response = await this.composio.toolkits.getToolkits({ limit: 200 });
+  async listCatalogToolkits(options?: { limit?: number }): Promise<ComposioCatalogToolkit[]> {
+    const limit = options?.limit ?? 200;
+    const response = await this.composio.toolkits.getToolkits({ limit });
     const items = extractComposioListItems(response);
 
     return items

--- a/apps/server/src/services/composio-service.test.ts
+++ b/apps/server/src/services/composio-service.test.ts
@@ -174,6 +174,86 @@ describe("ComposioService", () => {
     }
   });
 
+  test("isReachable probes with limit 1 and caches the result", async () => {
+    const { service, restore } = await createConfiguredService();
+    let calls = 0;
+    let lastLimit: number | undefined;
+
+    injectMockComposioClient(service, {
+      ...createMockClient(),
+      async listCatalogToolkits(options) {
+        calls += 1;
+        lastLimit = options?.limit;
+        return [{ slug: "gmail", name: "Gmail", description: null, logoUrl: null }];
+      },
+    });
+
+    try {
+      expect(await service.isReachable()).toBe(true);
+      expect(await service.isReachable()).toBe(true);
+      expect(calls).toBe(1);
+      expect(lastLimit).toBe(1);
+
+      (
+        service as unknown as {
+          reachabilityCache: { value: boolean; expiresAt: number } | null;
+        }
+      ).reachabilityCache = { value: true, expiresAt: Date.now() - 1 };
+
+      // Stale cache returns immediately and refreshes in the background.
+      expect(await service.isReachable()).toBe(true);
+      expect(calls).toBe(1);
+      const inflight = (
+        service as unknown as { reachabilityInflight: Promise<boolean> | null }
+      ).reachabilityInflight;
+      expect(inflight).not.toBeNull();
+      await inflight;
+      expect(calls).toBe(2);
+
+      service.reloadConfiguration();
+      injectMockComposioClient(service, {
+        ...createMockClient(),
+        async listCatalogToolkits(options) {
+          calls += 1;
+          lastLimit = options?.limit;
+          return [];
+        },
+      });
+      expect(await service.isReachable()).toBe(true);
+      expect(calls).toBe(3);
+      expect(lastLimit).toBe(1);
+    } finally {
+      restore();
+    }
+  });
+
+  test("isReachable coalesces concurrent probes", async () => {
+    const { service, restore } = await createConfiguredService();
+    let calls = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    injectMockComposioClient(service, {
+      ...createMockClient(),
+      async listCatalogToolkits() {
+        calls += 1;
+        await gate;
+        return [];
+      },
+    });
+
+    try {
+      const pending = Promise.all([service.isReachable(), service.isReachable(), service.isReachable()]);
+      release();
+      expect(await pending).toEqual([true, true, true]);
+      expect(calls).toBe(1);
+    } finally {
+      restore();
+    }
+  });
+
   test("resolveComposioActingUserId maps local client to earliest human admin", async () => {
     const { db, service, restore } = await createConfiguredService();
 

--- a/apps/server/src/services/composio-service.ts
+++ b/apps/server/src/services/composio-service.ts
@@ -75,7 +75,11 @@ function titleCaseToolkit(slug: string): string {
 }
 
 export class ComposioService {
+  private static readonly REACHABILITY_TTL_MS = 30_000;
+
   private apiClientCache: { key: string; client: ComposioApiClient } | null = null;
+  private reachabilityCache: { value: boolean; expiresAt: number } | null = null;
+  private reachabilityInflight: Promise<boolean> | null = null;
   private readonly profileSessionCache = new Map<
     string,
     { fingerprint: string; endpoint: ComposioSessionMcpEndpoint }
@@ -88,6 +92,8 @@ export class ComposioService {
 
   reloadConfiguration(): void {
     this.apiClientCache = null;
+    this.reachabilityCache = null;
+    this.reachabilityInflight = null;
   }
 
   /**
@@ -138,17 +144,56 @@ export class ComposioService {
   }
 
   async isReachable(): Promise<boolean> {
+    const cached = this.reachabilityCache;
+    const now = Date.now();
+
+    if (cached) {
+      if (cached.expiresAt > now) {
+        return cached.value;
+      }
+
+      // Stale-while-revalidate: status polls every 10s — never block on a warm cache.
+      if (!this.reachabilityInflight) {
+        this.reachabilityInflight = this.probeReachability().finally(() => {
+          this.reachabilityInflight = null;
+        });
+      }
+      return cached.value;
+    }
+
+    if (this.reachabilityInflight) {
+      return this.reachabilityInflight;
+    }
+
+    this.reachabilityInflight = this.probeReachability().finally(() => {
+      this.reachabilityInflight = null;
+    });
+    return this.reachabilityInflight;
+  }
+
+  private async probeReachability(): Promise<boolean> {
     const apiClient = await this.getApiClient();
     if (!apiClient) {
+      this.cacheReachability(false);
       return false;
     }
 
     try {
-      await apiClient.listCatalogToolkits();
+      // Limit 1: reachability only — full catalog fetch is ~1s and used by listToolkits.
+      await apiClient.listCatalogToolkits({ limit: 1 });
+      this.cacheReachability(true);
       return true;
     } catch {
+      this.cacheReachability(false);
       return false;
     }
+  }
+
+  private cacheReachability(value: boolean): void {
+    this.reachabilityCache = {
+      value,
+      expiresAt: Date.now() + ComposioService.REACHABILITY_TTL_MS,
+    };
   }
 
   async validateConfiguration(apiKey?: string): Promise<void> {
@@ -163,7 +208,7 @@ export class ComposioService {
     }
 
     try {
-      await client.listCatalogToolkits();
+      await client.listCatalogToolkits({ limit: 1 });
     } catch (error) {
       throw new NakamaApiError(
         error instanceof Error ? error.message : "Failed to validate Composio API key.",

--- a/apps/web/src/components/WorkerActionBar.tsx
+++ b/apps/web/src/components/WorkerActionBar.tsx
@@ -79,8 +79,9 @@ export function WorkerActionBar({
           <>
             <Button
               type="button"
-              variant="destructive"
+              variant="outline"
               size="sm"
+              className="border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
               disabled={isBusy}
               aria-busy={stopping || undefined}
               onClick={() => stopWorker.mutate(workerName)}

--- a/apps/web/src/components/WorkerActionBar.tsx
+++ b/apps/web/src/components/WorkerActionBar.tsx
@@ -6,6 +6,9 @@ import { useRestartWorker, useStartWorker, useStopWorker } from "@/hooks/use-wor
 import { WorkerLogDialog } from "@/components/WorkerLogDialog";
 import { cn } from "@/lib/utils";
 
+const glyphTransition =
+  "absolute inset-0 size-3.5 transition-[opacity,transform,filter] duration-200 ease-[cubic-bezier(0.2,0,0,1)]";
+
 function ActionGlyph({
   icon: Icon,
   busy,
@@ -16,11 +19,11 @@ function ActionGlyph({
   iconClassName?: string;
 }) {
   return (
-    <span className="relative inline-flex size-3.5 shrink-0 items-center justify-center">
+    <span className="relative size-3.5 shrink-0" aria-hidden={!busy}>
       <Icon
         className={cn(
-          "absolute size-3.5 transition-[opacity,transform,filter] duration-200 ease-[cubic-bezier(0.2,0,0,1)]",
-          busy ? "opacity-0 scale-25 blur-[4px]" : "opacity-100 scale-100 blur-0",
+          glyphTransition,
+          busy ? "scale-[0.25] opacity-0 blur-[4px]" : "scale-100 opacity-100 blur-0",
           iconClassName,
         )}
         strokeWidth={2}
@@ -28,14 +31,13 @@ function ActionGlyph({
       />
       <Loader2Icon
         className={cn(
-          "absolute size-3.5 animate-spin transition-[opacity,transform,filter] duration-200 ease-[cubic-bezier(0.2,0,0,1)]",
-          busy ? "opacity-100 scale-100 blur-0" : "opacity-0 scale-25 blur-[4px]",
+          glyphTransition,
+          "animate-spin",
+          busy ? "scale-100 opacity-100 blur-0" : "scale-[0.25] opacity-0 blur-[4px]",
         )}
         strokeWidth={2}
         aria-hidden={!busy}
-        {...(busy
-          ? { role: "status" as const, "aria-label": "Loading" }
-          : {})}
+        {...(busy ? { role: "status" as const, "aria-label": "Loading" } : {})}
       />
     </span>
   );

--- a/apps/web/src/components/WorkerActionBar.tsx
+++ b/apps/web/src/components/WorkerActionBar.tsx
@@ -1,9 +1,45 @@
 import { useState } from "react";
+import type { LucideIcon } from "lucide-react";
+import { Loader2Icon, PlayIcon, RotateCcwIcon, ScrollTextIcon, SquareIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Spinner } from "@/components/ui/spinner";
 import { useRestartWorker, useStartWorker, useStopWorker } from "@/hooks/use-worker-actions";
 import { WorkerLogDialog } from "@/components/WorkerLogDialog";
 import { cn } from "@/lib/utils";
+
+function ActionGlyph({
+  icon: Icon,
+  busy,
+  iconClassName,
+}: {
+  icon: LucideIcon;
+  busy: boolean;
+  iconClassName?: string;
+}) {
+  return (
+    <span className="relative inline-flex size-3.5 shrink-0 items-center justify-center">
+      <Icon
+        className={cn(
+          "absolute size-3.5 transition-[opacity,transform,filter] duration-200 ease-[cubic-bezier(0.2,0,0,1)]",
+          busy ? "opacity-0 scale-25 blur-[4px]" : "opacity-100 scale-100 blur-0",
+          iconClassName,
+        )}
+        strokeWidth={2}
+        aria-hidden
+      />
+      <Loader2Icon
+        className={cn(
+          "absolute size-3.5 animate-spin transition-[opacity,transform,filter] duration-200 ease-[cubic-bezier(0.2,0,0,1)]",
+          busy ? "opacity-100 scale-100 blur-0" : "opacity-0 scale-25 blur-[4px]",
+        )}
+        strokeWidth={2}
+        aria-hidden={!busy}
+        {...(busy
+          ? { role: "status" as const, "aria-label": "Loading" }
+          : {})}
+      />
+    </span>
+  );
+}
 
 export function WorkerActionBar({
   running,
@@ -21,10 +57,10 @@ export function WorkerActionBar({
   const stopWorker = useStopWorker();
   const restartWorker = useRestartWorker();
 
-  const isLoading =
-    (startWorker.isPending && startWorker.variables === workerName) ||
-    (stopWorker.isPending && stopWorker.variables === workerName) ||
-    (restartWorker.isPending && restartWorker.variables === workerName);
+  const starting = startWorker.isPending && startWorker.variables === workerName;
+  const stopping = stopWorker.isPending && stopWorker.variables === workerName;
+  const restarting = restartWorker.isPending && restartWorker.variables === workerName;
+  const isBusy = starting || stopping || restarting;
 
   if (!pm2Managed) {
     return (
@@ -34,27 +70,29 @@ export function WorkerActionBar({
 
   return (
     <>
-      <div className={cn("flex flex-wrap items-center gap-2", className)}>
+      <div className={cn("flex flex-wrap items-center gap-1.5", className)}>
         {running ? (
           <>
             <Button
               type="button"
-              variant="outline"
+              variant="destructive"
               size="sm"
-              disabled={isLoading}
+              disabled={isBusy}
+              aria-busy={stopping || undefined}
               onClick={() => stopWorker.mutate(workerName)}
             >
-              {isLoading ? <Spinner className="size-3" /> : null}
+              <ActionGlyph icon={SquareIcon} busy={stopping} />
               Stop
             </Button>
             <Button
               type="button"
               variant="outline"
               size="sm"
-              disabled={isLoading}
+              disabled={isBusy}
+              aria-busy={restarting || undefined}
               onClick={() => restartWorker.mutate(workerName)}
             >
-              {isLoading ? <Spinner className="size-3" /> : null}
+              <ActionGlyph icon={RotateCcwIcon} busy={restarting} />
               Restart
             </Button>
           </>
@@ -63,10 +101,11 @@ export function WorkerActionBar({
             type="button"
             variant="outline"
             size="sm"
-            disabled={isLoading}
+            disabled={isBusy}
+            aria-busy={starting || undefined}
             onClick={() => startWorker.mutate(workerName)}
           >
-            {isLoading ? <Spinner className="size-3" /> : null}
+            <ActionGlyph icon={PlayIcon} busy={starting} iconClassName="translate-x-px" />
             Start
           </Button>
         )}
@@ -74,8 +113,10 @@ export function WorkerActionBar({
           type="button"
           variant="ghost"
           size="sm"
+          className="ml-auto"
           onClick={() => setLogDialogOpen(true)}
         >
+          <ScrollTextIcon className="size-3.5" strokeWidth={2} aria-hidden />
           View logs
         </Button>
       </div>

--- a/apps/web/src/components/WorkerActionBar.tsx
+++ b/apps/web/src/components/WorkerActionBar.tsx
@@ -48,11 +48,13 @@ export function WorkerActionBar({
   pm2Managed,
   workerName,
   className,
+  showLogs = true,
 }: {
   running: boolean;
   pm2Managed: boolean;
   workerName: string;
   className?: string;
+  showLogs?: boolean;
 }) {
   const [logDialogOpen, setLogDialogOpen] = useState(false);
   const startWorker = useStartWorker();
@@ -111,17 +113,51 @@ export function WorkerActionBar({
             Start
           </Button>
         )}
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="ml-auto"
-          onClick={() => setLogDialogOpen(true)}
-        >
-          <ScrollTextIcon className="size-3.5" strokeWidth={2} aria-hidden />
-          View logs
-        </Button>
+        {showLogs ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="ml-auto"
+            onClick={() => setLogDialogOpen(true)}
+          >
+            <ScrollTextIcon className="size-3.5" strokeWidth={2} aria-hidden />
+            View logs
+          </Button>
+        ) : null}
       </div>
+      {showLogs ? (
+        <WorkerLogDialog
+          workerName={workerName}
+          open={logDialogOpen}
+          onOpenChange={setLogDialogOpen}
+        />
+      ) : null}
+    </>
+  );
+}
+
+export function WorkerViewLogsButton({
+  workerName,
+  className,
+}: {
+  workerName: string;
+  className?: string;
+}) {
+  const [logDialogOpen, setLogDialogOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className={cn("text-muted-foreground", className)}
+        onClick={() => setLogDialogOpen(true)}
+      >
+        <ScrollTextIcon className="size-3.5" strokeWidth={2} aria-hidden />
+        View logs
+      </Button>
       <WorkerLogDialog
         workerName={workerName}
         open={logDialogOpen}

--- a/apps/web/src/pages/StatusPage.tsx
+++ b/apps/web/src/pages/StatusPage.tsx
@@ -130,14 +130,16 @@ function StatusDashboard({
       </div>
 
       <div className="overflow-x-auto">
-        <table className="w-full min-w-[40rem] border-collapse text-left text-sm">
+        <table className="w-full min-w-[32rem] border-collapse text-left text-sm">
           <thead className="text-xs text-muted-foreground">
             <tr>
               <th className="border-b border-border px-5 py-2.5 font-medium">Service</th>
               <th className="border-b border-border px-5 py-2.5 font-medium">Status</th>
-              <th className="border-b border-border px-5 py-2.5 font-medium">Resources</th>
               <th className="border-b border-border px-5 py-2.5 font-medium">
                 {canManageWorkers ? "Actions" : <span className="sr-only">Actions</span>}
+              </th>
+              <th className="border-b border-border px-5 py-2.5 font-medium">
+                {canManageWorkers ? "Logs" : <span className="sr-only">Logs</span>}
               </th>
             </tr>
           </thead>
@@ -533,41 +535,28 @@ function QuickStat({
 
 type ServiceStatusTone = "ok" | "warn" | "bad" | "muted";
 
-function statusToneClass(tone: ServiceStatusTone): string {
-  return cn(
-    tone === "ok" && "text-emerald-700 dark:text-emerald-300",
-    tone === "warn" && "text-amber-700 dark:text-amber-300",
-    tone === "bad" && "text-destructive",
-    tone === "muted" && "text-muted-foreground",
-  );
-}
-
-function MetricsDisplay({
-  cpuPercent,
-  memoryMb,
+function ServiceStatusBadge({
+  status,
+  tone,
 }: {
-  cpuPercent: number | null | undefined;
-  memoryMb: number | null | undefined;
+  status: string;
+  tone: ServiceStatusTone;
 }) {
-  if (cpuPercent == null && memoryMb == null) {
-    return <span className="text-xs text-muted-foreground">—</span>;
-  }
-
   return (
-    <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-      {cpuPercent != null ? (
-        <span className="inline-flex items-center gap-1 text-xs tabular-nums text-muted-foreground">
-          <ZapIcon className="size-3" aria-hidden />
-          CPU: {cpuPercent.toFixed(1)}%
-        </span>
-      ) : null}
-      {memoryMb != null ? (
-        <span className="inline-flex items-center gap-1 text-xs tabular-nums text-muted-foreground">
-          <ServerIcon className="size-3" aria-hidden />
-          Mem: {memoryMb < 1 ? `${(memoryMb * 1024).toFixed(0)} KB` : `${memoryMb.toFixed(1)} MB`}
-        </span>
-      ) : null}
-    </div>
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center rounded-full border px-2.5 py-0.5 text-xs font-medium",
+        tone === "ok" &&
+          "border-emerald-200 bg-emerald-50 text-emerald-800 dark:border-emerald-800/60 dark:bg-emerald-950/40 dark:text-emerald-200",
+        tone === "warn" &&
+          "border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-800/50 dark:bg-amber-950/30 dark:text-amber-100",
+        tone === "bad" &&
+          "border-destructive/30 bg-destructive/10 text-destructive",
+        tone === "muted" && "border-border bg-muted text-muted-foreground",
+      )}
+    >
+      {status}
+    </span>
   );
 }
 
@@ -590,31 +579,23 @@ function WorkerServiceRow({
   canManage: boolean;
   footerLink?: { label: string; to: string };
 }) {
+  const pm2Managed = worker.process?.managed ?? false;
+
   return (
     <tr className="last:[&>td]:border-b-0">
       <td className="border-b border-border px-5 py-3">
-        <div className="flex min-w-0 items-center gap-3">
-          <span
-            className={cn(
-              iconTileClass,
-              "size-8",
-              tone === "bad" && "bg-destructive/5",
-            )}
-          >
-            <Icon className="size-4 text-foreground" aria-hidden />
-          </span>
+        <div className="flex min-w-0 items-center gap-2.5">
+          <Icon className="size-4 shrink-0 text-muted-foreground" aria-hidden />
           <span className="truncate font-medium text-foreground">{title}</span>
         </div>
       </td>
       <td className="border-b border-border px-5 py-3">
-        <div className="space-y-1">
-          <p className={cn("text-xs font-medium leading-none", statusToneClass(tone))}>
-            {status}
-          </p>
+        <div className="flex flex-wrap items-center gap-2">
+          <ServiceStatusBadge status={status} tone={tone} />
           {footerLink ? (
             <Link
               to={footerLink.to}
-              className="inline-flex text-xs font-medium text-primary underline underline-offset-4 hover:text-primary/90"
+              className="text-xs font-medium text-primary underline underline-offset-4 hover:text-primary/90"
             >
               {footerLink.label}
             </Link>
@@ -622,19 +603,21 @@ function WorkerServiceRow({
         </div>
       </td>
       <td className="border-b border-border px-5 py-3">
-        <MetricsDisplay
-          cpuPercent={worker.process?.cpuPercent}
-          memoryMb={worker.process?.memoryMb}
-        />
-      </td>
-      <td className="border-b border-border px-5 py-3">
         {canManage ? (
           <WorkerActionBar
             className="w-fit"
             running={worker.running}
-            pm2Managed={worker.process?.managed ?? false}
+            pm2Managed={pm2Managed}
             workerName={workerName}
+            showLogs={false}
           />
+        ) : (
+          <span className="text-xs text-muted-foreground">—</span>
+        )}
+      </td>
+      <td className="border-b border-border px-5 py-3">
+        {canManage && pm2Managed ? (
+          <WorkerViewLogsButton workerName={workerName} />
         ) : (
           <span className="text-xs text-muted-foreground">—</span>
         )}

--- a/apps/web/src/pages/StatusPage.tsx
+++ b/apps/web/src/pages/StatusPage.tsx
@@ -5,7 +5,6 @@ import {
   CheckCircle2Icon,
   ClockIcon,
   CoinsIcon,
-  ServerIcon,
   SparklesIcon,
   XCircleIcon,
   ZapIcon,
@@ -15,7 +14,7 @@ import { useMemo, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 import type { LlmUsageStatus, SystemStatusResponse } from "@nakama/core/contract";
 import { Button } from "@/components/ui/button";
-import { WorkerActionBar } from "@/components/WorkerActionBar";
+import { WorkerActionBar, WorkerViewLogsButton } from "@/components/WorkerActionBar";
 import { buildServiceColumns, deriveSummary, type StatusTone } from "@/pages/status-page.shared";
 import { useAuth } from "@/context/use-auth";
 import { useRefreshSystemStatus, useSystemStatusQuery } from "@/hooks/use-system-status";
@@ -27,7 +26,6 @@ import { cn } from "@/lib/utils";
 const sectionClass = "rounded-md border border-border bg-card";
 const iconTileClass =
   "flex size-10 shrink-0 items-center justify-center rounded-md border border-border bg-muted/40";
-const iconClass = "size-5 text-foreground";
 
 export function StatusPage({ embedded = false }: { embedded?: boolean } = {}) {
   const { data: status, error, isLoading } = useSystemStatusQuery();
@@ -90,6 +88,32 @@ function StatusDashboard({
   const services = useMemo(() => buildServiceColumns(status), [status]);
   const { automationWorker, telegramWorker, whatsappWorker, discordWorker } = status;
 
+  const workerByTitle: Record<
+    string,
+    {
+      worker: Pick<SystemStatusResponse["automationWorker"], "running" | "process">;
+      workerName: string;
+      footerLink?: { label: string; to: string };
+    }
+  > = {
+    Automation: { worker: automationWorker, workerName: "automation" },
+    Telegram: { worker: telegramWorker, workerName: "telegram" },
+    WhatsApp: {
+      worker: whatsappWorker,
+      workerName: "whatsapp",
+      footerLink:
+        whatsappWorker.configured && whatsappWorker.running && !whatsappWorker.paired
+          ? { label: "Scan QR in Settings", to: PAGE_PATHS.settings }
+          : undefined,
+    },
+    Discord: { worker: discordWorker, workerName: "discord" },
+  };
+
+  const workerRows = services.map((service) => ({
+    ...service,
+    ...workerByTitle[service.title],
+  }));
+
   return (
     <section
       className={cn("min-w-0 overflow-hidden", !embedded && sectionClass)}
@@ -105,77 +129,34 @@ function StatusDashboard({
         />
       </div>
 
-      <div className="grid grid-cols-1 divide-y divide-border lg:grid-cols-2 lg:divide-x lg:divide-y-0 xl:grid-cols-4">
-        {services.map((service) => {
-          if (service.title === "Automation") {
-            return (
-              <WorkerServiceColumn
-                key={service.title}
-                icon={service.icon}
-                title={service.title}
-                status={service.status}
-                tone={service.tone}
-                worker={automationWorker}
-                workerName="automation"
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[40rem] border-collapse text-left text-sm">
+          <thead className="text-xs text-muted-foreground">
+            <tr>
+              <th className="border-b border-border px-5 py-2.5 font-medium">Service</th>
+              <th className="border-b border-border px-5 py-2.5 font-medium">Status</th>
+              <th className="border-b border-border px-5 py-2.5 font-medium">Resources</th>
+              <th className="border-b border-border px-5 py-2.5 font-medium">
+                {canManageWorkers ? "Actions" : <span className="sr-only">Actions</span>}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {workerRows.map((row) => (
+              <WorkerServiceRow
+                key={row.title}
+                icon={row.icon}
+                title={row.title}
+                status={row.status}
+                tone={row.tone}
+                worker={row.worker}
+                workerName={row.workerName}
                 canManage={canManageWorkers}
+                footerLink={row.footerLink}
               />
-            );
-          }
-
-          if (service.title === "Telegram") {
-            return (
-              <WorkerServiceColumn
-                key={service.title}
-                icon={service.icon}
-                title={service.title}
-                status={service.status}
-                tone={service.tone}
-                worker={telegramWorker}
-                workerName="telegram"
-                canManage={canManageWorkers}
-              />
-            );
-          }
-
-          if (service.title === "WhatsApp") {
-            return (
-              <WorkerServiceColumn
-                key={service.title}
-                icon={service.icon}
-                title={service.title}
-                status={service.status}
-                tone={service.tone}
-                worker={whatsappWorker}
-                workerName="whatsapp"
-                canManage={canManageWorkers}
-                footerLink={
-                  whatsappWorker.configured &&
-                  whatsappWorker.running &&
-                  !whatsappWorker.paired
-                    ? { label: "Scan QR in Settings", to: PAGE_PATHS.settings }
-                    : undefined
-                }
-              />
-            );
-          }
-
-          if (service.title === "Discord") {
-            return (
-              <WorkerServiceColumn
-                key={service.title}
-                icon={service.icon}
-                title={service.title}
-                status={service.status}
-                tone={service.tone}
-                worker={discordWorker}
-                workerName="discord"
-                canManage={canManageWorkers}
-              />
-            );
-          }
-
-          return <ServiceColumn key={service.title} {...service} />;
-        })}
+            ))}
+          </tbody>
+        </table>
       </div>
     </section>
   );
@@ -552,42 +533,12 @@ function QuickStat({
 
 type ServiceStatusTone = "ok" | "warn" | "bad" | "muted";
 
-function ServiceColumn({
-  icon: Icon,
-  title,
-  status,
-  tone,
-}: {
-  icon: LucideIcon;
-  title: string;
-  status: string;
-  tone: ServiceStatusTone;
-}) {
-  return (
-    <div className="flex min-w-0 items-center gap-3 p-5">
-      <span
-        className={cn(
-          iconTileClass,
-          tone === "bad" && "bg-destructive/5",
-        )}
-      >
-        <Icon className={iconClass} aria-hidden />
-      </span>
-      <div className="min-w-0 flex-1">
-        <h2 className="type-section-title leading-tight">{title}</h2>
-        <p
-          className={cn(
-            "mt-1 text-xs font-medium leading-none",
-            tone === "ok" && "text-emerald-700 dark:text-emerald-300",
-            tone === "warn" && "text-amber-700 dark:text-amber-300",
-            tone === "bad" && "text-destructive",
-            tone === "muted" && "text-muted-foreground",
-          )}
-        >
-          {status}
-        </p>
-      </div>
-    </div>
+function statusToneClass(tone: ServiceStatusTone): string {
+  return cn(
+    tone === "ok" && "text-emerald-700 dark:text-emerald-300",
+    tone === "warn" && "text-amber-700 dark:text-amber-300",
+    tone === "bad" && "text-destructive",
+    tone === "muted" && "text-muted-foreground",
   );
 }
 
@@ -598,18 +549,20 @@ function MetricsDisplay({
   cpuPercent: number | null | undefined;
   memoryMb: number | null | undefined;
 }) {
-  if (cpuPercent == null && memoryMb == null) return null;
+  if (cpuPercent == null && memoryMb == null) {
+    return <span className="text-xs text-muted-foreground">—</span>;
+  }
 
   return (
-    <div className="flex items-center gap-3 border-t border-border px-5 py-2">
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
       {cpuPercent != null ? (
-        <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+        <span className="inline-flex items-center gap-1 text-xs tabular-nums text-muted-foreground">
           <ZapIcon className="size-3" aria-hidden />
           CPU: {cpuPercent.toFixed(1)}%
         </span>
       ) : null}
       {memoryMb != null ? (
-        <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+        <span className="inline-flex items-center gap-1 text-xs tabular-nums text-muted-foreground">
           <ServerIcon className="size-3" aria-hidden />
           Mem: {memoryMb < 1 ? `${(memoryMb * 1024).toFixed(0)} KB` : `${memoryMb.toFixed(1)} MB`}
         </span>
@@ -618,7 +571,7 @@ function MetricsDisplay({
   );
 }
 
-function WorkerServiceColumn({
+function WorkerServiceRow({
   icon: Icon,
   title,
   status,
@@ -638,54 +591,55 @@ function WorkerServiceColumn({
   footerLink?: { label: string; to: string };
 }) {
   return (
-    <div className="flex flex-col">
-      <div className="flex min-w-0 items-center gap-3 p-5">
-        <span
-          className={cn(
-            iconTileClass,
-            tone === "bad" && "bg-destructive/5",
-          )}
-        >
-          <Icon className={iconClass} aria-hidden />
-        </span>
-        <div className="min-w-0 flex-1">
-          <h2 className="type-section-title leading-tight">{title}</h2>
-          <p
+    <tr className="last:[&>td]:border-b-0">
+      <td className="border-b border-border px-5 py-3">
+        <div className="flex min-w-0 items-center gap-3">
+          <span
             className={cn(
-              "mt-1 text-xs font-medium leading-none",
-              tone === "ok" && "text-emerald-700 dark:text-emerald-300",
-              tone === "warn" && "text-amber-700 dark:text-amber-300",
-              tone === "bad" && "text-destructive",
-              tone === "muted" && "text-muted-foreground",
+              iconTileClass,
+              "size-8",
+              tone === "bad" && "bg-destructive/5",
             )}
           >
+            <Icon className="size-4 text-foreground" aria-hidden />
+          </span>
+          <span className="truncate font-medium text-foreground">{title}</span>
+        </div>
+      </td>
+      <td className="border-b border-border px-5 py-3">
+        <div className="space-y-1">
+          <p className={cn("text-xs font-medium leading-none", statusToneClass(tone))}>
             {status}
           </p>
+          {footerLink ? (
+            <Link
+              to={footerLink.to}
+              className="inline-flex text-xs font-medium text-primary underline underline-offset-4 hover:text-primary/90"
+            >
+              {footerLink.label}
+            </Link>
+          ) : null}
         </div>
-      </div>
-      {canManage ? (
-        <WorkerActionBar
-          className="border-t border-border px-5 py-2"
-          running={worker.running}
-          pm2Managed={worker.process?.managed ?? false}
-          workerName={workerName}
+      </td>
+      <td className="border-b border-border px-5 py-3">
+        <MetricsDisplay
+          cpuPercent={worker.process?.cpuPercent}
+          memoryMb={worker.process?.memoryMb}
         />
-      ) : null}
-      {footerLink ? (
-        <div className="border-t border-border px-5 py-2">
-          <Link
-            to={footerLink.to}
-            className="text-xs font-medium text-primary underline underline-offset-4 hover:text-primary/90"
-          >
-            {footerLink.label}
-          </Link>
-        </div>
-      ) : null}
-      <MetricsDisplay
-        cpuPercent={worker.process?.cpuPercent}
-        memoryMb={worker.process?.memoryMb}
-      />
-    </div>
+      </td>
+      <td className="border-b border-border px-5 py-3">
+        {canManage ? (
+          <WorkerActionBar
+            className="w-fit"
+            running={worker.running}
+            pm2Managed={worker.process?.managed ?? false}
+            workerName={workerName}
+          />
+        ) : (
+          <span className="text-xs text-muted-foreground">—</span>
+        )}
+      </td>
+    </tr>
   );
 }
 

--- a/packages/core/src/agent-questionnaire.test.ts
+++ b/packages/core/src/agent-questionnaire.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentQuestionnaire } from "./contract";
+import {
+  formatAgentQuestionnaireAnswersMessage,
+  formatAgentQuestionnaireMessage,
+  tryParseChannelQuestionnaireAnswers,
+} from "./agent-questionnaire";
+
+const singleQuestion: AgentQuestionnaire = {
+  id: "qset_1",
+  title: "Need input",
+  questions: [
+    {
+      id: "how-to-run",
+      prompt: "How should I run this?",
+      choices: [
+        { id: "playwright", label: "Build Playwright e2e" },
+        { id: "manual", label: "Manual steps only" },
+      ],
+      allowCustomAnswer: true,
+    },
+  ],
+};
+
+const multiQuestion: AgentQuestionnaire = {
+  id: "qset_2",
+  title: "Two questions",
+  questions: [
+    {
+      id: "q1",
+      prompt: "Pick a color",
+      choices: [
+        { id: "red", label: "Red" },
+        { id: "blue", label: "Blue" },
+      ],
+      allowCustomAnswer: false,
+    },
+    {
+      id: "q2",
+      prompt: "Any notes?",
+      choices: [],
+      allowCustomAnswer: true,
+    },
+  ],
+};
+
+describe("formatAgentQuestionnaireMessage", () => {
+  test("renders title, numbered questions, and reply hint", () => {
+    const text = formatAgentQuestionnaireMessage(singleQuestion);
+
+    expect(text).toContain("Need input");
+    expect(text).toContain("1. How should I run this?");
+    expect(text).toContain("a) Build Playwright e2e");
+    expect(text).toContain("b) Manual steps only");
+    expect(text).toContain("Or reply with your own answer.");
+    expect(text).toContain("Reply with a letter/number");
+  });
+});
+
+describe("tryParseChannelQuestionnaireAnswers", () => {
+  test("parses single-question letter, number, label, and free text", () => {
+    expect(tryParseChannelQuestionnaireAnswers(singleQuestion, "a")).toEqual([
+      {
+        questionId: "how-to-run",
+        prompt: "How should I run this?",
+        answer: "Build Playwright e2e",
+      },
+    ]);
+    expect(tryParseChannelQuestionnaireAnswers(singleQuestion, "2")?.[0]?.answer).toBe(
+      "Manual steps only",
+    );
+    expect(
+      tryParseChannelQuestionnaireAnswers(singleQuestion, "Build Playwright e2e")?.[0]?.answer,
+    ).toBe("Build Playwright e2e");
+    expect(tryParseChannelQuestionnaireAnswers(singleQuestion, "ffmpeg pipeline")?.[0]?.answer).toBe(
+      "ffmpeg pipeline",
+    );
+  });
+
+  test("parses multi-question numbered lines into Answers payload shape", () => {
+    const answers = tryParseChannelQuestionnaireAnswers(
+      multiQuestion,
+      ["1. a", "2. keep it short"].join("\n"),
+    );
+
+    expect(answers).toEqual([
+      { questionId: "q1", prompt: "Pick a color", answer: "Red" },
+      { questionId: "q2", prompt: "Any notes?", answer: "keep it short" },
+    ]);
+    expect(formatAgentQuestionnaireAnswersMessage(answers!)).toContain("Answers");
+  });
+});

--- a/packages/core/src/agent-questionnaire.ts
+++ b/packages/core/src/agent-questionnaire.ts
@@ -20,6 +20,116 @@ export function formatAgentQuestionnaireAnswersMessage(
   return lines.join("\n");
 }
 
+export function formatAgentQuestionnaireMessage(questionnaire: AgentQuestionnaire): string {
+  const lines = [questionnaire.title.trim(), ""];
+
+  questionnaire.questions.forEach((question, questionIndex) => {
+    lines.push(`${questionIndex + 1}. ${question.prompt.trim()}`);
+
+    question.choices.forEach((choice, choiceIndex) => {
+      lines.push(`   ${choiceLetter(choiceIndex)}) ${choice.label.trim()}`);
+    });
+
+    if (question.allowCustomAnswer) {
+      lines.push("   Or reply with your own answer.");
+    }
+
+    lines.push("");
+  });
+
+  if (questionnaire.questions.length === 1) {
+    lines.push("Reply with a letter/number, a choice label, or your answer.");
+  } else {
+    lines.push("Reply with one line per question, e.g.:");
+    lines.push("1. a");
+    lines.push("2. your answer");
+  }
+
+  return lines.join("\n").trimEnd();
+}
+
+export function tryParseChannelQuestionnaireAnswers(
+  questionnaire: AgentQuestionnaire,
+  text: string,
+): AgentQuestionAnswer[] | null {
+  const trimmed = text.trim();
+
+  if (!trimmed || questionnaire.questions.length === 0) {
+    return null;
+  }
+
+  if (questionnaire.questions.length === 1) {
+    const question = questionnaire.questions[0]!;
+    const answer = resolveQuestionAnswer(question, trimmed);
+
+    if (!answer) {
+      return null;
+    }
+
+    return [
+      {
+        questionId: question.id,
+        prompt: question.prompt,
+        answer,
+      },
+    ];
+  }
+
+  const byIndex = new Map<number, string>();
+
+  for (const rawLine of trimmed.split(/\r?\n/)) {
+    const line = rawLine.trim();
+
+    if (!line) {
+      continue;
+    }
+
+    const match = line.match(/^(\d+)\s*[.):\-]\s*(.+)$/);
+
+    if (!match) {
+      return null;
+    }
+
+    const index = Number(match[1]);
+    const value = match[2]?.trim() ?? "";
+
+    if (!Number.isInteger(index) || index < 1 || !value) {
+      return null;
+    }
+
+    byIndex.set(index, value);
+  }
+
+  if (byIndex.size !== questionnaire.questions.length) {
+    return null;
+  }
+
+  const answers: AgentQuestionAnswer[] = [];
+
+  for (let index = 0; index < questionnaire.questions.length; index += 1) {
+    const question = questionnaire.questions[index]!;
+    const raw = byIndex.get(index + 1);
+
+    if (!raw) {
+      return null;
+    }
+
+    const answer = resolveQuestionAnswer(question, raw);
+
+    if (!answer) {
+      return null;
+    }
+
+    answers.push({
+      questionId: question.id,
+      prompt: question.prompt,
+      answer,
+    });
+  }
+
+  return answers;
+}
+
 export function parseAgentQuestionnaireAnswersMessage(
   value: string,
 ): AgentQuestionAnswer[] | null {
@@ -77,4 +187,52 @@ export function parseAgentQuestionnaireAnswersMessage(
   }
 
   return answers.length > 0 ? answers : null;
+}
+
+function resolveQuestionAnswer(
+  question: AgentQuestionnaire["questions"][number],
+  raw: string,
+): string | null {
+  const trimmed = raw.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  const byNumber = trimmed.match(/^(\d+)$/);
+  if (byNumber) {
+    const index = Number(byNumber[1]) - 1;
+    const choice = question.choices[index];
+    if (choice) {
+      return choice.label;
+    }
+  }
+
+  const byLetter = trimmed.match(/^([a-z])$/i);
+  if (byLetter) {
+    const index = byLetter[1]!.toLowerCase().charCodeAt(0) - "a".charCodeAt(0);
+    const choice = question.choices[index];
+    if (choice) {
+      return choice.label;
+    }
+  }
+
+  const labelMatch = question.choices.find(
+    (choice) => choice.label.trim().toLowerCase() === trimmed.toLowerCase(),
+  );
+  if (labelMatch) {
+    return labelMatch.label;
+  }
+
+  if (question.allowCustomAnswer || question.choices.length === 0) {
+    return trimmed;
+  }
+
+  // Channel chats: accept free text even when choices exist so Discord/Telegram
+  // users are not stuck without buttons.
+  return trimmed;
+}
+
+function choiceLetter(index: number): string {
+  return String.fromCharCode("a".charCodeAt(0) + index);
 }


### PR DESCRIPTION
## Summary

Before this change, when an agent called `ask_user_question` on Discord, the bridge ignored the questionnaire event — users often only saw `(empty reply)`, and their next message was never turned into structured answers. Discord now posts the questionnaire as a readable text prompt (choices + reply hint) and maps the next reply (`a` / `1` / label / free text, or numbered lines for multi-question) into the same `Answers` format the web UI uses.

## Test plan

- [x] `bun test packages/core/src/agent-questionnaire.test.ts apps/platform/discord/src/chat-handler.test.ts`
- [ ] Restart Discord worker, trigger a question in Discord, confirm the prompt posts instead of `(empty reply)`
- [ ] Reply with a letter/number and confirm the agent continues with the chosen answer

---

🔬 *This PR was created with [Compound Engineering](https://ai.ashbyhq.com/compound)*
