### PR TITLE
feat(discord): auto-upload small artifacts on turn delivery

### DIFF
--- a/apps/platform/discord/src/channel-artifact-flow.ts
+++ b/apps/platform/discord/src/channel-artifact-flow.ts
@@ -6,10 +6,14 @@ import {
   isAttachIntent,
   mintDeliverableArtifacts,
   pushDeliverableArtifact,
+  type DeliverableChannelArtifact,
 } from "@nakama/core";
 import type { TextBasedChannel } from "discord.js";
 import type { SessionStore } from "./session-store";
-import { sendDiscordArtifactAttachment } from "./send-artifact-attachment";
+import {
+  DISCORD_ARTIFACT_ATTACHMENT_MAX_BYTES,
+  sendDiscordArtifactAttachment,
+} from "./send-artifact-attachment";
 import type { DiscordMessenger } from "./messenger";
 
 export async function maybeSendRequestedDiscordArtifactAttachment(input: {
@@ -43,6 +47,7 @@ export async function maybeSendRequestedDiscordArtifactAttachment(input: {
 }
 
 export async function deliverDiscordTurnArtifactShares(input: {
+  channel: TextBasedChannel;
   client: NakamaClient;
   session: RemoteChatSession;
   conversationKey: string;
@@ -83,11 +88,54 @@ export async function deliverDiscordTurnArtifactShares(input: {
   });
   await input.sessionStore.save();
 
-  const footer = formatArtifactShareFooter(delivered, {
+  const fallbackArtifacts: DeliverableChannelArtifact[] = [];
+
+  for (const artifact of delivered) {
+    const uploaded = await tryUploadDiscordArtifact({
+      channel: input.channel,
+      client: input.client,
+      profileId: input.profileId,
+      artifact,
+    });
+
+    if (!uploaded) {
+      fallbackArtifacts.push(artifact);
+    }
+  }
+
+  const footer = formatArtifactShareFooter(fallbackArtifacts, {
     webPublicUrlConfigured,
   });
 
   if (footer.trim()) {
     await input.messenger.send(footer);
+  }
+}
+
+async function tryUploadDiscordArtifact(input: {
+  channel: TextBasedChannel;
+  client: NakamaClient;
+  profileId: string;
+  artifact: DeliverableChannelArtifact;
+}): Promise<boolean> {
+  if (input.artifact.sizeBytes > DISCORD_ARTIFACT_ATTACHMENT_MAX_BYTES) {
+    return false;
+  }
+
+  try {
+    const { data } = await input.client.readProfileArtifactContent(input.profileId, input.artifact.path);
+    const bytes = new Uint8Array(data);
+    if (bytes.byteLength > DISCORD_ARTIFACT_ATTACHMENT_MAX_BYTES) {
+      return false;
+    }
+
+    const result = await sendDiscordArtifactAttachment(input.channel, {
+      filename: input.artifact.filename,
+      bytes,
+    });
+
+    return result.ok;
+  } catch {
+    return false;
   }
 }

--- a/apps/platform/discord/src/chat-handler.test.ts
+++ b/apps/platform/discord/src/chat-handler.test.ts
@@ -88,16 +88,16 @@ describe("createChatHandler artifact delivery", () => {
         orgStore,
       });
 
-      const { message, sentMessages, fileSendCalls } = createDmMessage({
+      const dm = createDmMessage({
         userId: "424242424242424242",
         content: "thanks",
       });
-      await handleMessage(message);
+      await handleMessage(dm.message);
 
       expect(calls.publishProfileArtifactShare).toBe(1);
       expect(calls.readProfileArtifactContent).toBe(1);
-      expect(fileSendCalls).toBe(1);
-      expect(sentMessages.some((reply) => reply.includes("https://app.example/s/tok_test"))).toBe(
+      expect(dm.fileSendCalls).toBe(1);
+      expect(dm.sentMessages.some((reply) => reply.includes("https://app.example/s/tok_test"))).toBe(
         false,
       );
     });
@@ -177,16 +177,16 @@ describe("createChatHandler artifact delivery", () => {
         orgStore,
       });
 
-      const { message, sentMessages, fileSendCalls } = createDmMessage({
+      const dm = createDmMessage({
         userId: "424242424242424242",
         content: "thanks",
       });
-      await handleMessage(message);
+      await handleMessage(dm.message);
 
       expect(calls.publishProfileArtifactShare).toBe(1);
       expect(calls.readProfileArtifactContent).toBe(0);
-      expect(fileSendCalls).toBe(0);
-      expect(sentMessages.some((reply) => reply.includes("https://app.example/s/tok_test"))).toBe(
+      expect(dm.fileSendCalls).toBe(0);
+      expect(dm.sentMessages.some((reply) => reply.includes("https://app.example/s/tok_test"))).toBe(
         true,
       );
     });

--- a/apps/platform/discord/src/chat-handler.test.ts
+++ b/apps/platform/discord/src/chat-handler.test.ts
@@ -58,7 +58,7 @@ describe("createChatHandler artifact delivery", () => {
     { role: "assistant", content: "Saved the report." },
   ];
 
-  test("posts a publish share link after a paired save-artifact turn", async () => {
+  test("auto-uploads a small artifact after a paired save-artifact turn", async () => {
     await withTempHome(async (homeDir) => {
       await writeDiscordConfigIni(homeDir, {
         botToken: "discord-bot-token",
@@ -88,13 +88,104 @@ describe("createChatHandler artifact delivery", () => {
         orgStore,
       });
 
-      const { message, sentMessages } = createDmMessage({
+      const { message, sentMessages, fileSendCalls } = createDmMessage({
         userId: "424242424242424242",
         content: "thanks",
       });
       await handleMessage(message);
 
       expect(calls.publishProfileArtifactShare).toBe(1);
+      expect(calls.readProfileArtifactContent).toBe(1);
+      expect(fileSendCalls).toBe(1);
+      expect(sentMessages.some((reply) => reply.includes("https://app.example/s/tok_test"))).toBe(
+        false,
+      );
+    });
+  });
+
+  test("falls back to a share link when the artifact exceeds the Discord attachment cap", async () => {
+    await withTempHome(async (homeDir) => {
+      await writeDiscordConfigIni(homeDir, {
+        botToken: "discord-bot-token",
+        pairedUserIds: ["424242424242424242"],
+      });
+
+      const oversizedMeta = JSON.stringify({
+        mimeType: "video/mp4",
+        savedAt: "2026-07-13T10:00:00.000Z",
+        sizeBytes: 9 * 1024 * 1024,
+      });
+      const oversizedMessages: ChatMessage[] = [
+        { role: "user", content: "save video" },
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [
+            {
+              id: "tool_1",
+              name: "write_file",
+              arguments: { path: "artifacts/clip.mp4", content: "binary" },
+            },
+            {
+              id: "tool_2",
+              name: "write_file",
+              arguments: { path: "artifacts/clip.mp4.nakama-meta.json", content: oversizedMeta },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          toolCallId: "tool_1",
+          name: "write_file",
+          content: JSON.stringify({
+            path: "/home/.nakama/orgs/org/profiles/default/artifacts/clip.mp4",
+            bytesWritten: 9 * 1024 * 1024,
+          }),
+        },
+        {
+          role: "tool",
+          toolCallId: "tool_2",
+          name: "write_file",
+          content: JSON.stringify({
+            path: "/home/.nakama/orgs/org/profiles/default/artifacts/clip.mp4.nakama-meta.json",
+            bytesWritten: oversizedMeta.length,
+          }),
+        },
+        { role: "assistant", content: "Saved the clip." },
+      ];
+
+      const authStore = new DiscordAuthStore();
+      await authStore.reload();
+      const { client, calls } = createMockClient({ messages: oversizedMessages });
+      const sessionStore = new SessionStore(
+        path.join(homeDir, ".nakama", "discord", "chat-sessions.json"),
+      );
+      await sessionStore.load();
+      sessionStore.set("dm_channel_1", {
+        sessionId: "session_test",
+        profileId: "default",
+        updatedAt: new Date().toISOString(),
+      });
+      await sessionStore.save();
+      const orgStore = createTestOrgStore(homeDir);
+      await orgStore.load();
+      const { handleMessage } = createChatHandler({
+        client,
+        config: { botToken: "discord-bot-token", profileId: "default" },
+        authStore,
+        sessionStore,
+        orgStore,
+      });
+
+      const { message, sentMessages, fileSendCalls } = createDmMessage({
+        userId: "424242424242424242",
+        content: "thanks",
+      });
+      await handleMessage(message);
+
+      expect(calls.publishProfileArtifactShare).toBe(1);
+      expect(calls.readProfileArtifactContent).toBe(0);
+      expect(fileSendCalls).toBe(0);
       expect(sentMessages.some((reply) => reply.includes("https://app.example/s/tok_test"))).toBe(
         true,
       );

--- a/apps/platform/discord/src/chat-handler.ts
+++ b/apps/platform/discord/src/chat-handler.ts
@@ -468,6 +468,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
 
     if (profileId) {
       await deliverDiscordTurnArtifactShares({
+        channel,
         client,
         session,
         conversationKey,

--- a/apps/platform/discord/src/test-helpers.ts
+++ b/apps/platform/discord/src/test-helpers.ts
@@ -40,6 +40,7 @@ export function createMockClient(
     }>;
     orgs?: UserOrgSummary[];
     onSendStream?: (input: unknown, handlers?: StreamHandlers) => Promise<string>;
+    artifactContentBytes?: Uint8Array;
   } = {},
 ) {
   const calls = {
@@ -128,9 +129,10 @@ export function createMockClient(
     },
     readProfileArtifactContent: async () => {
       calls.readProfileArtifactContent += 1;
+      const data = options.artifactContentBytes ?? new TextEncoder().encode("# Report");
       return {
         contentType: "text/markdown",
-        data: new TextEncoder().encode("# Report").buffer,
+        data: data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength),
       };
     },
   } as unknown as NakamaClient;


### PR DESCRIPTION
## Summary
Discord previously only posted share links after an artifact save, so small deliverables (like e2e videos under 8 MB) never landed in the channel unless the user asked to attach a file. Turn delivery now uploads those files automatically and keeps the share-link footer as the fallback when a file is over the 8 MB Discord attachment cap or upload fails.

## Test plan
- [ ] `cd apps/platform/discord && bun test`
- [ ] In a Discord DM/channel with a paired bot, ask an agent to `write_file` a small file under `artifacts/` with a metadata sidecar
- [ ] Confirm the bot uploads the file after the turn (no share-link footer for that file)
- [ ] Repeat with an artifact whose sidecar `sizeBytes` is > 8 MB and confirm only the share link is posted
- [ ] Confirm “send me the file” still attaches the most recent deliverable


Made with [Cursor](https://cursor.com)