### PR TITLE
feat(discord): route guild conversations into threads

### DIFF
--- a/apps/platform/discord/src/chat-handler.test.ts
+++ b/apps/platform/discord/src/chat-handler.test.ts
@@ -4,13 +4,54 @@ import type { ChatMessage } from "@nakama/core/contract";
 import { DiscordAuthStore } from "./auth-store";
 import { createChatHandler } from "./chat-handler";
 import { SessionStore } from "./session-store";
+import { ThreadStore } from "./thread-store";
 import {
   createDmMessage,
+  createGuildChatMessage,
   createMockClient,
+  createSlashInteraction,
   createTestOrgStore,
   withTempHome,
   writeDiscordConfigIni,
 } from "./test-helpers";
+
+async function createPairedHandler(
+  homeDir: string,
+  options: {
+    messages?: ChatMessage[];
+    onSendStream?: Parameters<typeof createMockClient>[0]["onSendStream"];
+    questionnaire?: Parameters<typeof createMockClient>[0]["questionnaire"];
+  } = {},
+) {
+  await writeDiscordConfigIni(homeDir, {
+    botToken: "discord-bot-token",
+    pairedUserIds: ["424242424242424242"],
+  });
+
+  const authStore = new DiscordAuthStore();
+  await authStore.reload();
+  const { client, calls } = createMockClient(options);
+  const sessionStore = new SessionStore(
+    path.join(homeDir, ".nakama", "discord", "chat-sessions.json"),
+  );
+  await sessionStore.load();
+  const threadStore = new ThreadStore(
+    path.join(homeDir, ".nakama", "discord", "chat-threads.json"),
+  );
+  await threadStore.load();
+  const orgStore = createTestOrgStore(homeDir);
+  await orgStore.load();
+  const handlers = createChatHandler({
+    client,
+    config: { botToken: "discord-bot-token", profileId: "default" },
+    authStore,
+    sessionStore,
+    threadStore,
+    orgStore,
+  });
+
+  return { ...handlers, client, calls, sessionStore, threadStore, orgStore };
+}
 
 describe("createChatHandler artifact delivery", () => {
   const metaJson = JSON.stringify({
@@ -60,33 +101,15 @@ describe("createChatHandler artifact delivery", () => {
 
   test("auto-uploads a small artifact after a paired save-artifact turn", async () => {
     await withTempHome(async (homeDir) => {
-      await writeDiscordConfigIni(homeDir, {
-        botToken: "discord-bot-token",
-        pairedUserIds: ["424242424242424242"],
+      const { handleMessage, calls, sessionStore } = await createPairedHandler(homeDir, {
+        messages: artifactMessages,
       });
-
-      const authStore = new DiscordAuthStore();
-      await authStore.reload();
-      const { client, calls } = createMockClient({ messages: artifactMessages });
-      const sessionStore = new SessionStore(
-        path.join(homeDir, ".nakama", "discord", "chat-sessions.json"),
-      );
-      await sessionStore.load();
       sessionStore.set("dm_channel_1", {
         sessionId: "session_test",
         profileId: "default",
         updatedAt: new Date().toISOString(),
       });
       await sessionStore.save();
-      const orgStore = createTestOrgStore(homeDir);
-      await orgStore.load();
-      const { handleMessage } = createChatHandler({
-        client,
-        config: { botToken: "discord-bot-token", profileId: "default" },
-        authStore,
-        sessionStore,
-        orgStore,
-      });
 
       const dm = createDmMessage({
         userId: "424242424242424242",
@@ -105,11 +128,6 @@ describe("createChatHandler artifact delivery", () => {
 
   test("falls back to a share link when the artifact exceeds the Discord attachment cap", async () => {
     await withTempHome(async (homeDir) => {
-      await writeDiscordConfigIni(homeDir, {
-        botToken: "discord-bot-token",
-        pairedUserIds: ["424242424242424242"],
-      });
-
       const oversizedMeta = JSON.stringify({
         mimeType: "video/mp4",
         savedAt: "2026-07-13T10:00:00.000Z",
@@ -154,28 +172,15 @@ describe("createChatHandler artifact delivery", () => {
         { role: "assistant", content: "Saved the clip." },
       ];
 
-      const authStore = new DiscordAuthStore();
-      await authStore.reload();
-      const { client, calls } = createMockClient({ messages: oversizedMessages });
-      const sessionStore = new SessionStore(
-        path.join(homeDir, ".nakama", "discord", "chat-sessions.json"),
-      );
-      await sessionStore.load();
+      const { handleMessage, calls, sessionStore } = await createPairedHandler(homeDir, {
+        messages: oversizedMessages,
+      });
       sessionStore.set("dm_channel_1", {
         sessionId: "session_test",
         profileId: "default",
         updatedAt: new Date().toISOString(),
       });
       await sessionStore.save();
-      const orgStore = createTestOrgStore(homeDir);
-      await orgStore.load();
-      const { handleMessage } = createChatHandler({
-        client,
-        config: { botToken: "discord-bot-token", profileId: "default" },
-        authStore,
-        sessionStore,
-        orgStore,
-      });
 
       const dm = createDmMessage({
         userId: "424242424242424242",
@@ -194,14 +199,7 @@ describe("createChatHandler artifact delivery", () => {
 
   test("does not publish when the turn has no sidecar pair", async () => {
     await withTempHome(async (homeDir) => {
-      await writeDiscordConfigIni(homeDir, {
-        botToken: "discord-bot-token",
-        pairedUserIds: ["424242424242424242"],
-      });
-
-      const authStore = new DiscordAuthStore();
-      await authStore.reload();
-      const { client, calls } = createMockClient({
+      const { handleMessage, calls, sessionStore } = await createPairedHandler(homeDir, {
         messages: [
           { role: "user", content: "save" },
           {
@@ -226,25 +224,12 @@ describe("createChatHandler artifact delivery", () => {
           },
         ],
       });
-      const sessionStore = new SessionStore(
-        path.join(homeDir, ".nakama", "discord", "chat-sessions.json"),
-      );
-      await sessionStore.load();
       sessionStore.set("dm_channel_1", {
         sessionId: "session_test",
         profileId: "default",
         updatedAt: new Date().toISOString(),
       });
       await sessionStore.save();
-      const orgStore = createTestOrgStore(homeDir);
-      await orgStore.load();
-      const { handleMessage } = createChatHandler({
-        client,
-        config: { botToken: "discord-bot-token", profileId: "default" },
-        authStore,
-        sessionStore,
-        orgStore,
-      });
 
       const { message, sentMessages } = createDmMessage({
         userId: "424242424242424242",
@@ -259,18 +244,7 @@ describe("createChatHandler artifact delivery", () => {
 
   test("sends a document when the user asks to attach a saved artifact", async () => {
     await withTempHome(async (homeDir) => {
-      await writeDiscordConfigIni(homeDir, {
-        botToken: "discord-bot-token",
-        pairedUserIds: ["424242424242424242"],
-      });
-
-      const authStore = new DiscordAuthStore();
-      await authStore.reload();
-      const { client, calls } = createMockClient();
-      const sessionStore = new SessionStore(
-        path.join(homeDir, ".nakama", "discord", "chat-sessions.json"),
-      );
-      await sessionStore.load();
+      const { handleMessage, calls, sessionStore } = await createPairedHandler(homeDir);
       sessionStore.set("dm_channel_1", {
         sessionId: "session_test",
         profileId: "default",
@@ -288,15 +262,6 @@ describe("createChatHandler artifact delivery", () => {
         ],
       });
       await sessionStore.save();
-      const orgStore = createTestOrgStore(homeDir);
-      await orgStore.load();
-      const { handleMessage } = createChatHandler({
-        client,
-        config: { botToken: "discord-bot-token", profileId: "default" },
-        authStore,
-        sessionStore,
-        orgStore,
-      });
 
       const dm = createDmMessage({
         userId: "424242424242424242",
@@ -329,39 +294,12 @@ describe("createChatHandler questionnaire delivery", () => {
 
   test("posts the questionnaire when ask_user_question fires and skips empty reply", async () => {
     await withTempHome(async (homeDir) => {
-      await writeDiscordConfigIni(homeDir, {
-        botToken: "discord-bot-token",
-        pairedUserIds: ["424242424242424242"],
-      });
-
-      const authStore = new DiscordAuthStore();
-      await authStore.reload();
-      const { client } = createMockClient({
+      const { handleMessage } = await createPairedHandler(homeDir, {
         onSendStream: async (_input, handlers) => {
           handlers?.onQuestionnaireUpdated?.(questionnaire);
           return "";
         },
       });
-      const sessionStore = new SessionStore(
-        path.join(homeDir, ".nakama", "discord", "chat-sessions.json"),
-      );
-      await sessionStore.load();
-      sessionStore.set("dm_channel_1", {
-        sessionId: "session_test",
-        profileId: "default",
-        updatedAt: new Date().toISOString(),
-      });
-      await sessionStore.save();
-      const orgStore = createTestOrgStore(homeDir);
-      await orgStore.load();
-      const { handleMessage } = createChatHandler({
-        client,
-        config: { botToken: "discord-bot-token", profileId: "default" },
-        authStore,
-        sessionStore,
-        orgStore,
-      });
-
       const { message, sentMessages } = createDmMessage({
         userId: "424242424242424242",
         content: "help me ship this",
@@ -376,40 +314,20 @@ describe("createChatHandler questionnaire delivery", () => {
 
   test("maps the next Discord reply into Answers for the pending questionnaire", async () => {
     await withTempHome(async (homeDir) => {
-      await writeDiscordConfigIni(homeDir, {
-        botToken: "discord-bot-token",
-        pairedUserIds: ["424242424242424242"],
-      });
-
-      const authStore = new DiscordAuthStore();
-      await authStore.reload();
       const streamedInputs: unknown[] = [];
-      const { client } = createMockClient({
+      const { handleMessage, sessionStore } = await createPairedHandler(homeDir, {
         questionnaire,
         onSendStream: async (input) => {
           streamedInputs.push(input);
           return "Got it.";
         },
       });
-      const sessionStore = new SessionStore(
-        path.join(homeDir, ".nakama", "discord", "chat-sessions.json"),
-      );
-      await sessionStore.load();
       sessionStore.set("dm_channel_1", {
         sessionId: "session_test",
         profileId: "default",
         updatedAt: new Date().toISOString(),
       });
       await sessionStore.save();
-      const orgStore = createTestOrgStore(homeDir);
-      await orgStore.load();
-      const { handleMessage } = createChatHandler({
-        client,
-        config: { botToken: "discord-bot-token", profileId: "default" },
-        authStore,
-        sessionStore,
-        orgStore,
-      });
 
       const { message, sentMessages } = createDmMessage({
         userId: "424242424242424242",
@@ -426,6 +344,157 @@ describe("createChatHandler questionnaire delivery", () => {
         ].join("\n"),
       });
       expect(sentMessages).toContain("Got it.");
+    });
+  });
+});
+
+describe("createChatHandler guild thread routing", () => {
+  test("mention in a guild channel creates a thread and replies inside it", async () => {
+    await withTempHome(async (homeDir) => {
+      const streamedInputs: unknown[] = [];
+      const { handleMessage, threadStore } = await createPairedHandler(homeDir, {
+        onSendStream: async (input) => {
+          streamedInputs.push(input);
+          return "Thread reply";
+        },
+      });
+
+      const guild = createGuildChatMessage({
+        content: "<@bot_id> summarize this",
+        mentionsBot: true,
+      });
+      await handleMessage(guild.message);
+
+      expect(guild.startThreadCalls).toBe(1);
+      expect(guild.lastThreadName).toBe("summarize this");
+      expect(guild.threadSentMessages).toContain("Thread reply");
+      expect(guild.channelSentMessages).not.toContain("Thread reply");
+      expect(threadStore.get("g:guild_channel_1:u:424242424242424242")).toBe(
+        guild.createdThreadId,
+      );
+      expect(streamedInputs[0]).toEqual({ message: "summarize this" });
+    });
+  });
+
+  test("second mention in the same channel reuses the existing thread", async () => {
+    await withTempHome(async (homeDir) => {
+      const { handleMessage, threadStore } = await createPairedHandler(homeDir, {
+        onSendStream: async () => "Again",
+      });
+
+      const first = createGuildChatMessage({
+        content: "<@bot_id> first question",
+        mentionsBot: true,
+      });
+      await handleMessage(first.message);
+      const threadId = first.createdThreadId;
+      expect(threadId).toBeTruthy();
+      expect(threadStore.get("g:guild_channel_1:u:424242424242424242")).toBe(threadId);
+
+      const existingThreads = new Map([
+        [threadId!, { id: threadId!, parentId: "guild_channel_1", archived: false }],
+      ]);
+
+      const second = createGuildChatMessage({
+        content: "<@bot_id> follow up",
+        mentionsBot: true,
+        existingThreads,
+      });
+      await handleMessage(second.message);
+
+      expect(second.startThreadCalls).toBe(0);
+      expect(second.threadSentMessages).toContain("Again");
+      expect(second.channelSentMessages).not.toContain("Again");
+    });
+  });
+
+  test("thread message without mention is answered in the thread", async () => {
+    await withTempHome(async (homeDir) => {
+      const streamedInputs: unknown[] = [];
+      const { handleMessage } = await createPairedHandler(homeDir, {
+        onSendStream: async (input) => {
+          streamedInputs.push(input);
+          return "In-thread answer";
+        },
+      });
+
+      const guild = createGuildChatMessage({
+        content: "keep going",
+        inThread: true,
+        threadId: "thread_42",
+        parentId: "guild_channel_1",
+      });
+      await handleMessage(guild.message);
+
+      expect(guild.startThreadCalls).toBe(0);
+      expect(guild.threadSentMessages).toContain("In-thread answer");
+      expect(streamedInputs[0]).toEqual({ message: "keep going" });
+    });
+  });
+
+  test("thread creation failure falls back to channel reply", async () => {
+    await withTempHome(async (homeDir) => {
+      const { handleMessage } = await createPairedHandler(homeDir, {
+        onSendStream: async (input) => {
+          // Fallback path still uses the public-channel prefix.
+          expect(input).toEqual({
+            message:
+              "[Discord channel — your reply is visible to everyone in this channel.]\nhello",
+          });
+          return "Channel fallback";
+        },
+      });
+
+      const guild = createGuildChatMessage({
+        content: "<@bot_id> hello",
+        mentionsBot: true,
+        startThreadError: new Error("Missing Permissions"),
+      });
+      await handleMessage(guild.message);
+
+      expect(guild.startThreadCalls).toBe(1);
+      expect(guild.channelSentMessages).toContain("Channel fallback");
+      expect(guild.threadSentMessages).toHaveLength(0);
+    });
+  });
+
+  test("slash commands in threads still clear and start new sessions", async () => {
+    await withTempHome(async (homeDir) => {
+      const { handleSlashCommand, sessionStore } = await createPairedHandler(homeDir);
+      const conversationKey = "g:guild_channel_1:t:thread_1";
+      sessionStore.set(conversationKey, {
+        sessionId: "session_test",
+        profileId: "default",
+        updatedAt: new Date().toISOString(),
+      });
+      await sessionStore.save();
+
+      const clearCmd = createSlashInteraction({
+        commandName: "clear",
+        inThread: true,
+        threadId: "thread_1",
+        parentId: "guild_channel_1",
+      });
+      await handleSlashCommand(clearCmd.interaction);
+      expect(clearCmd.replies).toContain("History cleared.");
+
+      const newCmd = createSlashInteraction({
+        commandName: "new",
+        inThread: true,
+        threadId: "thread_1",
+        parentId: "guild_channel_1",
+      });
+      await handleSlashCommand(newCmd.interaction);
+      expect(newCmd.replies).toContain("Started a new conversation.");
+
+      const stopCmd = createSlashInteraction({
+        commandName: "stop",
+        inThread: true,
+        threadId: "thread_1",
+        parentId: "guild_channel_1",
+      });
+      await handleSlashCommand(stopCmd.interaction);
+      expect(stopCmd.replies).toContain("Nothing to stop.");
     });
   });
 });

--- a/apps/platform/discord/src/chat-handler.test.ts
+++ b/apps/platform/discord/src/chat-handler.test.ts
@@ -9,6 +9,7 @@ import {
   createDmMessage,
   createGuildChatMessage,
   createMockClient,
+  createMultiTestOrgs,
   createSlashInteraction,
   createTestOrgStore,
   withTempHome,
@@ -21,6 +22,7 @@ async function createPairedHandler(
     messages?: ChatMessage[];
     onSendStream?: Parameters<typeof createMockClient>[0]["onSendStream"];
     questionnaire?: Parameters<typeof createMockClient>[0]["questionnaire"];
+    orgs?: Parameters<typeof createMockClient>[0]["orgs"];
   } = {},
 ) {
   await writeDiscordConfigIni(homeDir, {
@@ -429,6 +431,61 @@ describe("createChatHandler guild thread routing", () => {
       expect(guild.startThreadCalls).toBe(0);
       expect(guild.threadSentMessages).toContain("In-thread answer");
       expect(streamedInputs[0]).toEqual({ message: "keep going" });
+    });
+  });
+
+  test("thread messages reuse the parent channel org selection", async () => {
+    await withTempHome(async (homeDir) => {
+      const streamedInputs: unknown[] = [];
+      const { handleMessage, orgStore } = await createPairedHandler(homeDir, {
+        orgs: createMultiTestOrgs(),
+        onSendStream: async (input) => {
+          streamedInputs.push(input);
+          return "In-thread answer";
+        },
+      });
+
+      orgStore.set("g:guild_channel_1", "org_a");
+      await orgStore.save();
+
+      const guild = createGuildChatMessage({
+        content: "keep going",
+        inThread: true,
+        threadId: "thread_42",
+        parentId: "guild_channel_1",
+      });
+      await handleMessage(guild.message);
+
+      expect(guild.threadSentMessages.some((text) => text.includes("Choose an organization"))).toBe(
+        false,
+      );
+      expect(guild.threadSentMessages).toContain("In-thread answer");
+      expect(streamedInputs).toHaveLength(1);
+      expect(orgStore.get("g:thread_42")).toBeUndefined();
+      expect(orgStore.get("g:guild_channel_1")?.orgId).toBe("org_a");
+    });
+  });
+
+  test("slash commands in threads reuse the parent channel org selection", async () => {
+    await withTempHome(async (homeDir) => {
+      const { handleSlashCommand, orgStore } = await createPairedHandler(homeDir, {
+        orgs: createMultiTestOrgs(),
+      });
+
+      orgStore.set("g:guild_channel_1", "org_b");
+      await orgStore.save();
+
+      const clearCmd = createSlashInteraction({
+        commandName: "clear",
+        inThread: true,
+        threadId: "thread_1",
+        parentId: "guild_channel_1",
+      });
+      await handleSlashCommand(clearCmd.interaction);
+
+      expect(clearCmd.replies.some((text) => text.includes("Choose an organization"))).toBe(false);
+      expect(clearCmd.replies).toContain("History cleared.");
+      expect(orgStore.get("g:thread_1")).toBeUndefined();
     });
   });
 

--- a/apps/platform/discord/src/chat-handler.ts
+++ b/apps/platform/discord/src/chat-handler.ts
@@ -23,7 +23,12 @@ import {
   resolveProfileInScopes,
   type ProfileScope,
 } from "@nakama/core/profiles";
-import type { ChatInputCommandInteraction, Message, TextBasedChannel } from "discord.js";
+import type {
+  ChatInputCommandInteraction,
+  Message,
+  TextBasedChannel,
+  ThreadChannel,
+} from "discord.js";
 import {
   clearActiveStream,
   isAbortError,
@@ -43,6 +48,7 @@ import {
   resolveBotInfo,
   resolveChannelOrgKey,
   resolveConversationKey,
+  resolveThreadLookupKey,
   stripBotMention,
   type DiscordBotInfo,
 } from "./guild-message";
@@ -59,6 +65,7 @@ import {
 } from "./channel-artifact-flow";
 import { DiscordQuestionnaireMessage } from "./questionnaire-message";
 import type { SessionStore } from "./session-store";
+import type { ThreadStore } from "./thread-store";
 import { DiscordTodoStatusMessage } from "./todo-status-message";
 import { createTypingLoop } from "./typing-indicator";
 
@@ -86,13 +93,21 @@ export interface ChatHandlerDeps {
   config: DiscordBridgeConfig;
   authStore: DiscordAuthStore;
   sessionStore: SessionStore;
+  threadStore: ThreadStore;
   orgStore: ChannelOrgStore;
   getBotInfo?: () => DiscordBotInfo | undefined;
 }
 
 export function createChatHandler(deps: ChatHandlerDeps) {
-  const { client, config, authStore, sessionStore, orgStore, getBotInfo = () => undefined } =
-    deps;
+  const {
+    client,
+    config,
+    authStore,
+    sessionStore,
+    threadStore,
+    orgStore,
+    getBotInfo = () => undefined,
+  } = deps;
 
   return {
     handleMessage,
@@ -120,8 +135,16 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     const channelOrgKey = resolveChannelOrgKey(channelId, userId, isGuild);
     const conversationKey = resolveConversationKey(message, channelId, isGuild);
     const isThread = isDiscordThreadMessage(message);
+    const parentChannelId =
+      isGuild && isThread
+        ? (message.channel.isThread() ? (message.channel.parentId ?? channelId) : channelId)
+        : channelId;
+    // Serialize per user+parent channel so thread create/reuse and in-thread chat don't race.
+    const lockKey = isGuild
+      ? resolveThreadLookupKey(parentChannelId, userId)
+      : conversationKey;
 
-    await withChatLock(conversationKey, async () => {
+    await withChatLock(lockKey, async () => {
       await authStore.reload();
       const isAuthorized = authStore.isAuthorized(userId);
 
@@ -178,14 +201,84 @@ export function createChatHandler(deps: ChatHandlerDeps) {
         return;
       }
 
+      let replyChannel = channel;
+      let replyConversationKey = conversationKey;
+      let replyMessenger = messenger;
+      let replyIsThread = isThread;
+
+      const shouldRouteToThread =
+        isGuild &&
+        !isThread &&
+        (groupDecision?.reason === "bot-mention" || groupDecision?.reason === "reply-to-bot");
+
+      if (shouldRouteToThread) {
+        const thread = await resolveOrCreateGuildThread(
+          message,
+          channelId,
+          userId,
+          messageText,
+        );
+
+        if (thread) {
+          replyChannel = thread;
+          replyConversationKey = `g:${channelId}:t:${thread.id}`;
+          replyMessenger = createDiscordMessenger(thread);
+          replyIsThread = true;
+        }
+      }
+
       await handleChatMessage(
-        channel,
-        conversationKey,
-        messenger,
+        replyChannel,
+        replyConversationKey,
+        replyMessenger,
         messageText,
         isGuild,
+        replyIsThread,
       );
     });
+  }
+
+  async function resolveOrCreateGuildThread(
+    message: Message,
+    parentChannelId: string,
+    userId: string,
+    messageText: string,
+  ): Promise<ThreadChannel | null> {
+    const lookupKey = resolveThreadLookupKey(parentChannelId, userId);
+    // Re-check after the chat lock so concurrent mentions do not create duplicate threads.
+    const existingThreadId = threadStore.get(lookupKey);
+
+    if (existingThreadId) {
+      try {
+        const fetched = await message.client.channels.fetch(existingThreadId);
+
+        if (fetched?.isThread()) {
+          if (fetched.archived) {
+            await fetched.setArchived(false);
+          }
+
+          return fetched;
+        }
+      } catch (error) {
+        console.warn(
+          `Stored Discord thread ${existingThreadId} is unavailable; creating a new one.`,
+          error,
+        );
+      }
+    }
+
+    try {
+      const thread = await message.startThread({
+        name: deriveThreadName(messageText),
+        autoArchiveDuration: 1440,
+      });
+      threadStore.set(lookupKey, thread.id);
+      await threadStore.save();
+      return thread;
+    } catch (error) {
+      console.error("Failed to create Discord thread; falling back to channel reply:", error);
+      return null;
+    }
   }
 
   async function handleSlashCommand(interaction: ChatInputCommandInteraction): Promise<void> {
@@ -359,6 +452,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     messenger: DiscordMessenger,
     attachUserText: string,
     isGuild: boolean,
+    isThread: boolean,
   ): Promise<void> {
     const session = await resolveSession(conversationKey);
     const profileId = sessionStore.get(conversationKey)?.profileId;
@@ -380,6 +474,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
       session,
       attachUserText,
       isGuild,
+      isThread,
       messenger,
     );
 
@@ -484,12 +579,13 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     session: RemoteChatSession,
     userText: string,
     isGuild: boolean,
+    isThread: boolean,
     messenger: DiscordMessenger,
   ): Promise<SendMessageInput | null> {
     const pending = await resolvePendingQuestionnaire(conversationKey, session);
 
     if (!pending) {
-      return withGroupContext({ message: userText }, isGuild);
+      return withGroupContext({ message: userText }, isGuild, isThread);
     }
 
     const answers = tryParseChannelQuestionnaireAnswers(pending, userText);
@@ -504,6 +600,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     return withGroupContext(
       { message: formatAgentQuestionnaireAnswersMessage(answers) },
       isGuild,
+      isThread,
     );
   }
 
@@ -816,8 +913,13 @@ export function createChatHandler(deps: ChatHandlerDeps) {
   }
 }
 
-function withGroupContext(input: SendMessageInput, isGroup: boolean): SendMessageInput {
-  if (!isGroup) {
+function withGroupContext(
+  input: SendMessageInput,
+  isGuild: boolean,
+  isThread: boolean,
+): SendMessageInput {
+  // Threads are a private-ish conversation surface — skip the public-channel warning.
+  if (!isGuild || isThread) {
     return input;
   }
 
@@ -828,6 +930,28 @@ function withGroupContext(input: SendMessageInput, isGroup: boolean): SendMessag
   }
 
   return { ...input, message: GROUP_MESSAGE_PREFIX.trim() };
+}
+
+function deriveThreadName(messageText: string): string {
+  const cleaned = messageText.replace(/\s+/g, " ").trim();
+
+  if (!cleaned) {
+    return "Nakama chat";
+  }
+
+  // Discord thread names are capped at 100 characters.
+  if (cleaned.length <= 100) {
+    return cleaned;
+  }
+
+  const sliced = cleaned.slice(0, 100);
+  const lastSpace = sliced.lastIndexOf(" ");
+
+  if (lastSpace > 40) {
+    return sliced.slice(0, lastSpace);
+  }
+
+  return sliced;
 }
 
 function getOrgSelection(

--- a/apps/platform/discord/src/chat-handler.ts
+++ b/apps/platform/discord/src/chat-handler.ts
@@ -48,6 +48,7 @@ import {
   resolveBotInfo,
   resolveChannelOrgKey,
   resolveConversationKey,
+  resolveOrgChannelId,
   resolveThreadLookupKey,
   stripBotMention,
   type DiscordBotInfo,
@@ -132,13 +133,11 @@ export function createChatHandler(deps: ChatHandlerDeps) {
       return;
     }
 
-    const channelOrgKey = resolveChannelOrgKey(channelId, userId, isGuild);
-    const conversationKey = resolveConversationKey(message, channelId, isGuild);
     const isThread = isDiscordThreadMessage(message);
-    const parentChannelId =
-      isGuild && isThread
-        ? (message.channel.isThread() ? (message.channel.parentId ?? channelId) : channelId)
-        : channelId;
+    const parentChannelId = resolveOrgChannelId(message, channelId, isGuild);
+    // Threads share the parent channel's org selection — do not key by thread id.
+    const channelOrgKey = resolveChannelOrgKey(parentChannelId, userId, isGuild);
+    const conversationKey = resolveConversationKey(message, channelId, isGuild);
     // Serialize per user+parent channel so thread create/reuse and in-thread chat don't race.
     const lockKey = isGuild
       ? resolveThreadLookupKey(parentChannelId, userId)
@@ -288,7 +287,11 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     const userId = interaction.user.id;
     const channelId = interaction.channelId;
     const isGuild = !interaction.channel?.isDMBased();
-    const channelOrgKey = resolveChannelOrgKey(channelId, userId, isGuild);
+    const orgChannelId =
+      isGuild && interaction.channel?.isThread()
+        ? (interaction.channel.parentId ?? channelId)
+        : channelId;
+    const channelOrgKey = resolveChannelOrgKey(orgChannelId, userId, isGuild);
     const conversationKey = isGuild
       ? interaction.channel?.isThread()
         ? `g:${interaction.channel.parentId ?? channelId}:t:${interaction.channel.id}`

--- a/apps/platform/discord/src/guild-message.test.ts
+++ b/apps/platform/discord/src/guild-message.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   explainGuildMessageHandling,
   resolveConversationKey,
+  resolveOrgChannelId,
   resolveThreadLookupKey,
   stripBotMention,
 } from "./guild-message";
@@ -112,11 +113,23 @@ describe("resolveConversationKey", () => {
   test("uses thread suffix for thread channels", () => {
     const key = resolveConversationKey(
       createGuildMessage({ thread: true, parentId: "parent_1" }),
-      "parent_1",
+      "thread_1",
       true,
     );
 
     expect(key).toBe("g:parent_1:t:thread_1");
+  });
+});
+
+describe("resolveOrgChannelId", () => {
+  test("uses parent channel id for guild threads", () => {
+    const message = createGuildMessage({ thread: true, parentId: "parent_1" });
+    expect(resolveOrgChannelId(message, "thread_1", true)).toBe("parent_1");
+  });
+
+  test("uses channel id for plain guild channels", () => {
+    const message = createGuildMessage({ content: "hi" });
+    expect(resolveOrgChannelId(message, "channel_1", true)).toBe("channel_1");
   });
 });
 

--- a/apps/platform/discord/src/guild-message.test.ts
+++ b/apps/platform/discord/src/guild-message.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   explainGuildMessageHandling,
   resolveConversationKey,
+  resolveThreadLookupKey,
   stripBotMention,
 } from "./guild-message";
 
@@ -71,6 +72,40 @@ describe("explainGuildMessageHandling", () => {
     expect(decision.shouldHandle).toBe(true);
     expect(decision.reason).toBe("reply-to-bot");
   });
+
+  test("handles thread messages without mention", () => {
+    const decision = explainGuildMessageHandling(
+      createGuildMessage({ content: "continue here", thread: true }),
+      BOT_INFO,
+    );
+
+    expect(decision.shouldHandle).toBe(true);
+    expect(decision.reason).toBe("in-thread");
+  });
+
+  test("handles thread messages that also mention the bot as in-thread", () => {
+    const decision = explainGuildMessageHandling(
+      createGuildMessage({
+        content: "<@999000111222333444> still in thread",
+        mentionsBot: true,
+        thread: true,
+      }),
+      BOT_INFO,
+    );
+
+    expect(decision.shouldHandle).toBe(true);
+    expect(decision.reason).toBe("in-thread");
+  });
+
+  test("still requires a trigger in plain channels", () => {
+    const decision = explainGuildMessageHandling(
+      createGuildMessage({ content: "" }),
+      BOT_INFO,
+    );
+
+    expect(decision.shouldHandle).toBe(false);
+    expect(decision.reason).toBe("no-text");
+  });
 });
 
 describe("resolveConversationKey", () => {
@@ -82,6 +117,12 @@ describe("resolveConversationKey", () => {
     );
 
     expect(key).toBe("g:parent_1:t:thread_1");
+  });
+});
+
+describe("resolveThreadLookupKey", () => {
+  test("maps channel and user to a stable lookup key", () => {
+    expect(resolveThreadLookupKey("channel_1", "user_1")).toBe("g:channel_1:u:user_1");
   });
 });
 

--- a/apps/platform/discord/src/guild-message.ts
+++ b/apps/platform/discord/src/guild-message.ts
@@ -10,6 +10,7 @@ export interface GuildMessageHandlingDecision {
   reason:
     | "slash-command"
     | "missing-bot-info"
+    | "in-thread"
     | "reply-to-bot"
     | "bot-mention"
     | "no-text"
@@ -38,6 +39,11 @@ export function resolveConversationKey(message: Message, channelId: string, isGu
   }
 
   return channelId;
+}
+
+/** Persisted mapping key: one chat thread per user in a parent guild channel. */
+export function resolveThreadLookupKey(channelId: string, userId: string): string {
+  return `g:${channelId}:u:${userId}`;
 }
 
 export function isDiscordThreadMessage(message: Message): boolean {
@@ -78,6 +84,11 @@ export function explainGuildMessageHandling(
 
   if (!botInfo) {
     return { shouldHandle: false, reason: "missing-bot-info" };
+  }
+
+  // Inside a bot-owned conversation thread, any message is handled — no mention required.
+  if (message.channel.isThread()) {
+    return { shouldHandle: true, reason: "in-thread" };
   }
 
   if (isReplyToBot(message, botInfo.id)) {

--- a/apps/platform/discord/src/guild-message.ts
+++ b/apps/platform/discord/src/guild-message.ts
@@ -29,6 +29,19 @@ export function resolveChannelOrgKey(
   return isGuild ? `g:${channelId}` : `u:${userId}`;
 }
 
+/** Parent guild channel for org selection — threads inherit the parent's org. */
+export function resolveOrgChannelId(message: Message, channelId: string, isGuild: boolean): string {
+  if (!isGuild) {
+    return channelId;
+  }
+
+  if (message.channel.isThread()) {
+    return message.channel.parentId ?? channelId;
+  }
+
+  return channelId;
+}
+
 export function resolveConversationKey(message: Message, channelId: string, isGuild: boolean): string {
   if (!isGuild) {
     return channelId;

--- a/apps/platform/discord/src/index.ts
+++ b/apps/platform/discord/src/index.ts
@@ -13,6 +13,7 @@ import { DiscordAuthStore } from "./auth-store";
 import { createBot } from "./bot";
 import { loadConfig } from "./config";
 import { SessionStore } from "./session-store";
+import { ThreadStore } from "./thread-store";
 
 let spawnedChild: Bun.Subprocess | null = null;
 let clientStop: (() => void) | null = null;
@@ -74,6 +75,9 @@ try {
   const sessionStore = new SessionStore();
   await sessionStore.load();
 
+  const threadStore = new ThreadStore();
+  await threadStore.load();
+
   const orgStore = new ChannelOrgStore(getChannelOrgSelectionPath("discord"));
   await orgStore.load();
 
@@ -84,6 +88,7 @@ try {
     client,
     authStore,
     sessionStore,
+    threadStore,
     orgStore,
   });
 

--- a/apps/platform/discord/src/test-helpers.ts
+++ b/apps/platform/discord/src/test-helpers.ts
@@ -196,6 +196,234 @@ export function createDmMessage(options: {
   };
 }
 
+export interface MockGuildChatMessage {
+  message: Message;
+  channelSentMessages: string[];
+  threadSentMessages: string[];
+  startThreadCalls: number;
+  createdThreadId: string | null;
+  channelFileSendCalls: number;
+  threadFileSendCalls: number;
+  lastThreadName: string | null;
+}
+
+export function createGuildChatMessage(options: {
+  userId?: string;
+  channelId?: string;
+  threadId?: string;
+  parentId?: string;
+  content?: string;
+  mentionsBot?: boolean;
+  replyToBot?: boolean;
+  inThread?: boolean;
+  startThreadError?: Error;
+  existingThreads?: Map<
+    string,
+    {
+      id: string;
+      archived?: boolean;
+      parentId?: string;
+    }
+  >;
+}): MockGuildChatMessage {
+  const channelSentMessages: string[] = [];
+  const threadSentMessages: string[] = [];
+  let startThreadCalls = 0;
+  let createdThreadId: string | null = null;
+  let lastThreadName: string | null = null;
+  let channelFileSendCalls = 0;
+  let threadFileSendCalls = 0;
+
+  const userId = options.userId ?? "424242424242424242";
+  const channelId = options.channelId ?? "guild_channel_1";
+  const threadId = options.threadId ?? "thread_1";
+  const parentId = options.parentId ?? channelId;
+  const botId = "bot_id";
+  const existingThreads = options.existingThreads ?? new Map();
+
+  const messages = new Map<string, { author: { id: string } }>();
+  if (options.replyToBot) {
+    messages.set("reply_1", { author: { id: botId } });
+  }
+
+  function createThreadChannel(id: string, parent: string, archived = false) {
+    return {
+      id,
+      parentId: parent,
+      archived,
+      isDMBased: () => false,
+      isTextBased: () => true,
+      isThread: () => true,
+      setArchived: async (value: boolean) => {
+        archived = value;
+        return createThreadChannel(id, parent, archived);
+      },
+      send: async (payload: string | { files: unknown[] }) => {
+        if (typeof payload === "string") {
+          threadSentMessages.push(payload);
+          return { id: `tmsg_${threadSentMessages.length}` };
+        }
+
+        threadFileSendCalls += 1;
+        return { id: `tfile_${threadFileSendCalls}` };
+      },
+      sendTyping: async () => {},
+      messages: {
+        cache: messages,
+        fetch: async () => ({
+          edit: async () => {},
+        }),
+      },
+    };
+  }
+
+  const parentChannel = {
+    id: channelId,
+    parentId: null as string | null,
+    isDMBased: () => false,
+    isTextBased: () => true,
+    isThread: () => false,
+    send: async (payload: string | { files: unknown[] }) => {
+      if (typeof payload === "string") {
+        channelSentMessages.push(payload);
+        return { id: `cmsg_${channelSentMessages.length}` };
+      }
+
+      channelFileSendCalls += 1;
+      return { id: `cfile_${channelFileSendCalls}` };
+    },
+    sendTyping: async () => {},
+    messages: {
+      cache: messages,
+      fetch: async () => ({
+        edit: async () => {},
+      }),
+    },
+  };
+
+  const channel = options.inThread
+    ? createThreadChannel(threadId, parentId, false)
+    : parentChannel;
+
+  const clientChannels = {
+    fetch: async (id: string) => {
+      const known = existingThreads.get(id);
+      if (known) {
+        return createThreadChannel(known.id, known.parentId ?? parentId, known.archived ?? false);
+      }
+
+      if (createdThreadId && id === createdThreadId) {
+        return createThreadChannel(createdThreadId, channelId, false);
+      }
+
+      throw new Error(`Unknown channel ${id}`);
+    },
+  };
+
+  const message = {
+    author: { id: userId, bot: false },
+    content: options.content ?? "",
+    mentions: {
+      users: {
+        has: (id: string) => (options.mentionsBot ? id === botId : false),
+      },
+    },
+    reference: options.replyToBot ? { messageId: "reply_1" } : null,
+    channel,
+    client: {
+      user: { id: botId, username: "nakamabot" },
+      channels: clientChannels,
+    },
+    startThread: async ({ name }: { name: string }) => {
+      startThreadCalls += 1;
+      lastThreadName = name;
+      if (options.startThreadError) {
+        throw options.startThreadError;
+      }
+
+      createdThreadId = `created_thread_${startThreadCalls}`;
+      const thread = createThreadChannel(createdThreadId, channelId, false);
+      existingThreads.set(createdThreadId, {
+        id: createdThreadId,
+        parentId: channelId,
+        archived: false,
+      });
+      return thread;
+    },
+  } as unknown as Message;
+
+  return {
+    message,
+    channelSentMessages,
+    threadSentMessages,
+    get startThreadCalls() {
+      return startThreadCalls;
+    },
+    get createdThreadId() {
+      return createdThreadId;
+    },
+    get lastThreadName() {
+      return lastThreadName;
+    },
+    get channelFileSendCalls() {
+      return channelFileSendCalls;
+    },
+    get threadFileSendCalls() {
+      return threadFileSendCalls;
+    },
+  };
+}
+
+export function createSlashInteraction(options: {
+  userId?: string;
+  channelId?: string;
+  commandName: string;
+  inThread?: boolean;
+  parentId?: string;
+  threadId?: string;
+}): {
+  interaction: import("discord.js").ChatInputCommandInteraction;
+  replies: string[];
+} {
+  const replies: string[] = [];
+  const userId = options.userId ?? "424242424242424242";
+  const channelId = options.channelId ?? "guild_channel_1";
+  const threadId = options.threadId ?? "thread_1";
+  const parentId = options.parentId ?? channelId;
+
+  const channel = options.inThread
+    ? {
+        id: threadId,
+        parentId,
+        isDMBased: () => false,
+        isThread: () => true,
+      }
+    : {
+        id: channelId,
+        parentId: null,
+        isDMBased: () => false,
+        isThread: () => false,
+      };
+
+  const interaction = {
+    user: { id: userId },
+    channelId: options.inThread ? threadId : channelId,
+    channel,
+    commandName: options.commandName,
+    reply: async ({ content }: { content: string }) => {
+      replies.push(content);
+    },
+    followUp: async ({ content }: { content: string }) => {
+      replies.push(content);
+    },
+    editReply: async ({ content }: { content: string }) => {
+      replies.push(content);
+    },
+  } as unknown as import("discord.js").ChatInputCommandInteraction;
+
+  return { interaction, replies };
+}
+
 export async function writeDiscordConfigIni(
   homeDir: string,
   config: {

--- a/apps/platform/discord/src/test-helpers.ts
+++ b/apps/platform/discord/src/test-helpers.ts
@@ -27,6 +27,28 @@ export function createDefaultTestOrgs(): UserOrgSummary[] {
   ];
 }
 
+export function createMultiTestOrgs(): UserOrgSummary[] {
+  const now = new Date().toISOString();
+  return [
+    {
+      id: "org_a",
+      name: "Personal",
+      slug: "helipod",
+      role: "admin",
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: "org_b",
+      name: "Tinyclaw",
+      slug: "tinyclaw",
+      role: "member",
+      createdAt: now,
+      updatedAt: now,
+    },
+  ];
+}
+
 export function createMockClient(
   options: {
     messages?: ChatMessage[];

--- a/apps/platform/discord/src/thread-store.ts
+++ b/apps/platform/discord/src/thread-store.ts
@@ -1,0 +1,62 @@
+import { readTextOrNull, writePrivateTextFile } from "@nakama/core/fs";
+import { getDiscordConfigDir } from "@nakama/core/discord-config";
+import { join } from "node:path";
+
+type ThreadMap = Record<string, string>;
+
+export class ThreadStore {
+  private readonly path: string;
+  private map: ThreadMap = {};
+
+  constructor(path = getThreadMapPath()) {
+    this.path = path;
+  }
+
+  async load(): Promise<void> {
+    const raw = await readTextOrNull(this.path);
+
+    if (raw === null) {
+      this.map = {};
+      return;
+    }
+
+    const parsed = JSON.parse(raw) as unknown;
+
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      this.map = {};
+      return;
+    }
+
+    const next: ThreadMap = {};
+
+    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof value === "string" && value.trim()) {
+        next[key] = value;
+      }
+    }
+
+    this.map = next;
+  }
+
+  get(lookupKey: string): string | undefined {
+    return this.map[lookupKey];
+  }
+
+  set(lookupKey: string, threadId: string): void {
+    this.map[lookupKey] = threadId;
+  }
+
+  delete(lookupKey: string): void {
+    delete this.map[lookupKey];
+  }
+
+  async save(): Promise<void> {
+    await writePrivateTextFile(this.path, `${JSON.stringify(this.map, null, 2)}\n`, {
+      ensureDir: getDiscordConfigDir(),
+    });
+  }
+}
+
+function getThreadMapPath(): string {
+  return join(getDiscordConfigDir(), "chat-threads.json");
+}


### PR DESCRIPTION
## Summary
- Guild channel mentions/replies create or reuse a per-user Discord thread; agent replies (typing, todos, questionnaires, artifacts, final text) go into the thread.
- Messages already in a thread are handled without a mention (`in-thread` trigger); public-channel group prefix is skipped for thread conversations.
- Persist `channel+user → threadId` in `chat-threads.json`; fall back to in-channel replies when thread create/fetch fails.

Closes #186

## Test plan
- [x] `bun test` in `apps/platform/discord`
- [x] `bun run build` in `apps/platform/discord`
- [x] `bun test` at repo root
- [ ] In a live guild: mention bot → thread created, reply inside thread
- [ ] Mention again in same channel → same thread reused
- [ ] Plain message in that thread (no mention) → answered
- [ ] Bot without Create Public Threads permission → channel fallback, no crash
- [ ] `/clear`, `/new`, `/stop` inside a thread still work


Made with [Cursor](https://cursor.com)