### PR TITLE
fix(discord): ignore messages in threads the bot did not start

### DIFF
--- a/apps/platform/discord/src/chat-handler.test.ts
+++ b/apps/platform/discord/src/chat-handler.test.ts
@@ -422,7 +422,7 @@ describe("createChatHandler questionnaire delivery", () => {
     });
   });
 
-  test("maps the next Discord reply into Answers for the pending questionnaire", async () => {
+  test("forwards the next Discord reply to the agent without parsing questionnaire answers", async () => {
     await withTempHome(async (homeDir) => {
       const streamedInputs: unknown[] = [];
       const { handleMessage, sessionStore } = await createPairedHandler(homeDir, {
@@ -445,15 +445,9 @@ describe("createChatHandler questionnaire delivery", () => {
       });
       await handleMessage(message);
 
-      expect(streamedInputs[0]).toEqual({
-        message: [
-          "Answers",
-          "",
-          "Q: How should I run this?",
-          "A: Build Playwright e2e",
-        ].join("\n"),
-      });
+      expect(streamedInputs[0]).toEqual({ message: "a" });
       expect(sentMessages).toContain("Got it.");
+      expect(sentMessages.some((reply) => reply.includes("Couldn't parse that"))).toBe(false);
     });
   });
 });

--- a/apps/platform/discord/src/chat-handler.test.ts
+++ b/apps/platform/discord/src/chat-handler.test.ts
@@ -518,15 +518,18 @@ describe("createChatHandler guild thread routing", () => {
     });
   });
 
-  test("thread message without mention is answered in the thread", async () => {
+  test("thread message without mention is answered in a bot-owned thread", async () => {
     await withTempHome(async (homeDir) => {
       const streamedInputs: unknown[] = [];
-      const { handleMessage } = await createPairedHandler(homeDir, {
+      const { handleMessage, threadStore } = await createPairedHandler(homeDir, {
         onSendStream: async (input) => {
           streamedInputs.push(input);
           return "In-thread answer";
         },
       });
+
+      threadStore.set("g:guild_channel_1:u:424242424242424242", "thread_42");
+      await threadStore.save();
 
       const guild = createGuildChatMessage({
         content: "keep going",
@@ -542,10 +545,36 @@ describe("createChatHandler guild thread routing", () => {
     });
   });
 
+  test("ignores messages in threads the agent did not start", async () => {
+    await withTempHome(async (homeDir) => {
+      const streamedInputs: unknown[] = [];
+      const { handleMessage } = await createPairedHandler(homeDir, {
+        onSendStream: async (input) => {
+          streamedInputs.push(input);
+          return "Should not reply";
+        },
+      });
+
+      const guild = createGuildChatMessage({
+        content: "<@bot_id> please join this thread",
+        mentionsBot: true,
+        inThread: true,
+        threadId: "user_thread_9",
+        parentId: "guild_channel_1",
+      });
+      await handleMessage(guild.message);
+
+      expect(guild.startThreadCalls).toBe(0);
+      expect(guild.threadSentMessages).toHaveLength(0);
+      expect(guild.channelSentMessages).toHaveLength(0);
+      expect(streamedInputs).toHaveLength(0);
+    });
+  });
+
   test("thread messages reuse the parent channel org selection", async () => {
     await withTempHome(async (homeDir) => {
       const streamedInputs: unknown[] = [];
-      const { handleMessage, orgStore } = await createPairedHandler(homeDir, {
+      const { handleMessage, orgStore, threadStore } = await createPairedHandler(homeDir, {
         orgs: createMultiTestOrgs(),
         onSendStream: async (input) => {
           streamedInputs.push(input);
@@ -555,6 +584,8 @@ describe("createChatHandler guild thread routing", () => {
 
       orgStore.set("g:guild_channel_1", "org_a");
       await orgStore.save();
+      threadStore.set("g:guild_channel_1:u:424242424242424242", "thread_42");
+      await threadStore.save();
 
       const guild = createGuildChatMessage({
         content: "keep going",

--- a/apps/platform/discord/src/chat-handler.test.ts
+++ b/apps/platform/discord/src/chat-handler.test.ts
@@ -693,4 +693,50 @@ describe("createChatHandler guild thread routing", () => {
       expect(stopCmd.replies).toContain("Nothing to stop.");
     });
   });
+
+  test("close archives a bot-owned thread and clears the mapping", async () => {
+    await withTempHome(async (homeDir) => {
+      const { handleSlashCommand, threadStore } = await createPairedHandler(homeDir);
+      threadStore.set("g:guild_channel_1:u:424242424242424242", "thread_1");
+      await threadStore.save();
+
+      const closeCmd = createSlashInteraction({
+        commandName: "close",
+        inThread: true,
+        threadId: "thread_1",
+        parentId: "guild_channel_1",
+      });
+      await handleSlashCommand(closeCmd.interaction);
+
+      expect(closeCmd.replies).toContain("Thread closed.");
+      expect((closeCmd.interaction.channel as { archived?: boolean }).archived).toBe(true);
+      expect(threadStore.get("g:guild_channel_1:u:424242424242424242")).toBeUndefined();
+      expect(threadStore.hasThreadId("thread_1")).toBe(false);
+    });
+  });
+
+  test("close rejects non-thread channels and foreign threads", async () => {
+    await withTempHome(async (homeDir) => {
+      const { handleSlashCommand, threadStore } = await createPairedHandler(homeDir);
+      threadStore.set("g:guild_channel_1:u:424242424242424242", "thread_owned");
+      await threadStore.save();
+
+      const channelClose = createSlashInteraction({
+        commandName: "close",
+        channelId: "guild_channel_1",
+      });
+      await handleSlashCommand(channelClose.interaction);
+      expect(channelClose.replies).toContain("Use /close inside a bot conversation thread.");
+
+      const foreignClose = createSlashInteraction({
+        commandName: "close",
+        inThread: true,
+        threadId: "user_thread_9",
+        parentId: "guild_channel_1",
+      });
+      await handleSlashCommand(foreignClose.interaction);
+      expect(foreignClose.replies).toContain("I can only close threads I started.");
+      expect(threadStore.hasThreadId("thread_owned")).toBe(true);
+    });
+  });
 });

--- a/apps/platform/discord/src/chat-handler.ts
+++ b/apps/platform/discord/src/chat-handler.ts
@@ -129,14 +129,16 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     const channelId = message.channel.id;
     const text = message.content?.trim();
     const isGuild = isDiscordGuildMessage(message);
+    const isThread = isDiscordThreadMessage(message);
     const botInfo = resolveBotInfo(message, getBotInfo());
-    const groupDecision = isGuild ? explainGuildMessageHandling(message, botInfo) : null;
+    const botOwnsThread = isThread ? threadStore.hasThreadId(channelId) : false;
+    const groupDecision = isGuild
+      ? explainGuildMessageHandling(message, botInfo, { botOwnsThread })
+      : null;
 
     if (groupDecision && !groupDecision.shouldHandle) {
       return;
     }
-
-    const isThread = isDiscordThreadMessage(message);
     const parentChannelId = resolveOrgChannelId(message, channelId, isGuild);
     // Threads share the parent channel's org selection — do not key by thread id.
     const channelOrgKey = resolveChannelOrgKey(parentChannelId, userId, isGuild);

--- a/apps/platform/discord/src/chat-handler.ts
+++ b/apps/platform/discord/src/chat-handler.ts
@@ -375,6 +375,11 @@ export function createChatHandler(deps: ChatHandlerDeps) {
         return;
       }
 
+      if (interaction.commandName === "close") {
+        await handleCloseThread(interaction, conversationKey, messenger);
+        return;
+      }
+
       const orgReady = await ensureOrgReady(messenger, channelOrgKey, undefined);
       if (!orgReady) {
         return;
@@ -404,10 +409,6 @@ export function createChatHandler(deps: ChatHandlerDeps) {
           pendingQuestionnaires.delete(conversationKey);
           await createAndBindSession(conversationKey);
           await messenger.send("Started a new conversation.");
-          return;
-        }
-        case "close": {
-          await handleCloseThread(interaction, conversationKey, messenger);
           return;
         }
         case "status":

--- a/apps/platform/discord/src/chat-handler.ts
+++ b/apps/platform/discord/src/chat-handler.ts
@@ -285,6 +285,42 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     }
   }
 
+  async function handleCloseThread(
+    interaction: ChatInputCommandInteraction,
+    conversationKey: string,
+    messenger: DiscordMessenger,
+  ): Promise<void> {
+    const channel = interaction.channel;
+
+    if (!channel?.isThread()) {
+      await messenger.send("Use /close inside a bot conversation thread.");
+      return;
+    }
+
+    if (!threadStore.hasThreadId(channel.id)) {
+      await messenger.send("I can only close threads I started.");
+      return;
+    }
+
+    stopActiveStream(conversationKey);
+    pendingQuestionnaires.delete(conversationKey);
+
+    if (threadStore.deleteByThreadId(channel.id)) {
+      await threadStore.save();
+    }
+
+    await messenger.send("Thread closed.");
+
+    try {
+      if (!channel.archived) {
+        await channel.setArchived(true);
+      }
+    } catch (error) {
+      console.error("Failed to archive Discord thread after /close:", error);
+      await messenger.send("Couldn't archive the thread. Check the bot's Manage Threads permission.");
+    }
+  }
+
   async function handleSlashCommand(interaction: ChatInputCommandInteraction): Promise<void> {
     // Caller (bot.ts) already deferred — do not wait on withChatLock here.
     // Agent replies hold that lock for a long time and would leave commands stuck.
@@ -368,6 +404,10 @@ export function createChatHandler(deps: ChatHandlerDeps) {
           pendingQuestionnaires.delete(conversationKey);
           await createAndBindSession(conversationKey);
           await messenger.send("Started a new conversation.");
+          return;
+        }
+        case "close": {
+          await handleCloseThread(interaction, conversationKey, messenger);
           return;
         }
         case "status":

--- a/apps/platform/discord/src/chat-handler.ts
+++ b/apps/platform/discord/src/chat-handler.ts
@@ -1,10 +1,5 @@
 import type { NakamaClient, RemoteChatSession } from "@nakama/client";
-import {
-  formatAgentQuestionnaireAnswersMessage,
-  formatAgentQuestionnaireMessage,
-  hasActiveAgentQuestionnaire,
-  tryParseChannelQuestionnaireAnswers,
-} from "@nakama/core/agent-questionnaire";
+import { hasActiveAgentQuestionnaire } from "@nakama/core/agent-questionnaire";
 import type { AgentQuestionnaire, SendMessageInput } from "@nakama/core/contract";
 import {
   findOrgBySelectionInput,
@@ -518,18 +513,8 @@ export function createChatHandler(deps: ChatHandlerDeps) {
       });
     }
 
-    const streamInput = await resolveQuestionnaireStreamInput(
-      conversationKey,
-      session,
-      attachUserText,
-      isGuild,
-      isThread,
-      messenger,
-    );
-
-    if (!streamInput) {
-      return;
-    }
+    // Forward free text to the agent — do not gate Discord replies on questionnaire parsing.
+    const streamInput = withGroupContext({ message: attachUserText }, isGuild, isThread);
 
     const signal = registerActiveStream(conversationKey);
     const typingLoop = createTypingLoop(messenger);
@@ -631,61 +616,6 @@ export function createChatHandler(deps: ChatHandlerDeps) {
         messenger,
       });
     }
-  }
-
-  async function resolveQuestionnaireStreamInput(
-    conversationKey: string,
-    session: RemoteChatSession,
-    userText: string,
-    isGuild: boolean,
-    isThread: boolean,
-    messenger: DiscordMessenger,
-  ): Promise<SendMessageInput | null> {
-    const pending = await resolvePendingQuestionnaire(conversationKey, session);
-
-    if (!pending) {
-      return withGroupContext({ message: userText }, isGuild, isThread);
-    }
-
-    const answers = tryParseChannelQuestionnaireAnswers(pending, userText);
-
-    if (!answers) {
-      await messenger.send(formatAgentQuestionnaireMessage(pending));
-      await messenger.send("Couldn't parse that. Reply using the format above.");
-      return null;
-    }
-
-    pendingQuestionnaires.delete(conversationKey);
-    return withGroupContext(
-      { message: formatAgentQuestionnaireAnswersMessage(answers) },
-      isGuild,
-      isThread,
-    );
-  }
-
-  async function resolvePendingQuestionnaire(
-    conversationKey: string,
-    session: RemoteChatSession,
-  ): Promise<AgentQuestionnaire | null> {
-    const cached = pendingQuestionnaires.get(conversationKey);
-
-    if (hasActiveAgentQuestionnaire(cached)) {
-      return cached ?? null;
-    }
-
-    try {
-      const { questionnaire } = await client.getSessionMessages(session.id);
-
-      if (hasActiveAgentQuestionnaire(questionnaire)) {
-        pendingQuestionnaires.set(conversationKey, questionnaire!);
-        return questionnaire;
-      }
-    } catch {
-      // Best-effort; continue without a pending questionnaire.
-    }
-
-    pendingQuestionnaires.delete(conversationKey);
-    return null;
   }
 
   async function ensureOrgReady(

--- a/apps/platform/discord/src/format.ts
+++ b/apps/platform/discord/src/format.ts
@@ -121,6 +121,7 @@ export const HELP_TEXT = `Nakama Discord commands:
 /clear — clear chat history
 /compact — compact conversation history
 /new — start a new conversation
+/close — close this bot conversation thread
 /org — choose or switch organization (send as text)
 /profile — choose or switch bot profile (send as text)
 /status — server and model status

--- a/apps/platform/discord/src/guild-message.test.ts
+++ b/apps/platform/discord/src/guild-message.test.ts
@@ -74,17 +74,18 @@ describe("explainGuildMessageHandling", () => {
     expect(decision.reason).toBe("reply-to-bot");
   });
 
-  test("handles thread messages without mention", () => {
+  test("handles messages in bot-owned threads without mention", () => {
     const decision = explainGuildMessageHandling(
       createGuildMessage({ content: "continue here", thread: true }),
       BOT_INFO,
+      { botOwnsThread: true },
     );
 
     expect(decision.shouldHandle).toBe(true);
     expect(decision.reason).toBe("in-thread");
   });
 
-  test("handles thread messages that also mention the bot as in-thread", () => {
+  test("handles messages in bot-owned threads that also mention the bot as in-thread", () => {
     const decision = explainGuildMessageHandling(
       createGuildMessage({
         content: "<@999000111222333444> still in thread",
@@ -92,10 +93,37 @@ describe("explainGuildMessageHandling", () => {
         thread: true,
       }),
       BOT_INFO,
+      { botOwnsThread: true },
     );
 
     expect(decision.shouldHandle).toBe(true);
     expect(decision.reason).toBe("in-thread");
+  });
+
+  test("ignores messages in threads the agent did not start", () => {
+    const decision = explainGuildMessageHandling(
+      createGuildMessage({ content: "continue here", thread: true }),
+      BOT_INFO,
+      { botOwnsThread: false },
+    );
+
+    expect(decision.shouldHandle).toBe(false);
+    expect(decision.reason).toBe("foreign-thread");
+  });
+
+  test("ignores mentions inside threads the agent did not start", () => {
+    const decision = explainGuildMessageHandling(
+      createGuildMessage({
+        content: "<@999000111222333444> please join",
+        mentionsBot: true,
+        thread: true,
+      }),
+      BOT_INFO,
+      { botOwnsThread: false },
+    );
+
+    expect(decision.shouldHandle).toBe(false);
+    expect(decision.reason).toBe("foreign-thread");
   });
 
   test("still requires a trigger in plain channels", () => {

--- a/apps/platform/discord/src/guild-message.ts
+++ b/apps/platform/discord/src/guild-message.ts
@@ -11,10 +11,16 @@ export interface GuildMessageHandlingDecision {
     | "slash-command"
     | "missing-bot-info"
     | "in-thread"
+    | "foreign-thread"
     | "reply-to-bot"
     | "bot-mention"
     | "no-text"
     | "no-trigger";
+}
+
+export interface GuildMessageHandlingOptions {
+  /** True when the message is in a thread the Discord agent started and tracks. */
+  botOwnsThread?: boolean;
 }
 
 export function isDiscordGuildMessage(message: Message): boolean {
@@ -80,13 +86,15 @@ export function resolveBotInfo(
 export function shouldHandleGuildMessage(
   message: Message,
   storedBotInfo?: DiscordBotInfo,
+  options?: GuildMessageHandlingOptions,
 ): boolean {
-  return explainGuildMessageHandling(message, storedBotInfo).shouldHandle;
+  return explainGuildMessageHandling(message, storedBotInfo, options).shouldHandle;
 }
 
 export function explainGuildMessageHandling(
   message: Message,
   storedBotInfo?: DiscordBotInfo,
+  options?: GuildMessageHandlingOptions,
 ): GuildMessageHandlingDecision {
   const text = message.content?.trim() ?? "";
   const botInfo = resolveBotInfo(message, storedBotInfo);
@@ -99,8 +107,11 @@ export function explainGuildMessageHandling(
     return { shouldHandle: false, reason: "missing-bot-info" };
   }
 
-  // Inside a bot-owned conversation thread, any message is handled — no mention required.
+  // Only continue conversations in threads the agent started — ignore user-created threads.
   if (message.channel.isThread()) {
+    if (!options?.botOwnsThread) {
+      return { shouldHandle: false, reason: "foreign-thread" };
+    }
     return { shouldHandle: true, reason: "in-thread" };
   }
 

--- a/apps/platform/discord/src/slash-commands.ts
+++ b/apps/platform/discord/src/slash-commands.ts
@@ -6,7 +6,7 @@ import {
   type Client,
 } from "discord.js";
 
-const COMMAND_NAMES = ["start", "help", "stop", "clear", "compact", "new", "status"] as const;
+const COMMAND_NAMES = ["start", "help", "stop", "clear", "compact", "new", "close", "status"] as const;
 
 export function buildSlashCommands(): SlashCommandBuilder[] {
   const descriptions: Record<(typeof COMMAND_NAMES)[number], string> = {
@@ -16,6 +16,7 @@ export function buildSlashCommands(): SlashCommandBuilder[] {
     clear: "Clear chat history",
     compact: "Compact conversation history",
     new: "Start a new conversation",
+    close: "Close this bot conversation thread",
     status: "Show server and model status",
   };
 

--- a/apps/platform/discord/src/test-helpers.ts
+++ b/apps/platform/discord/src/test-helpers.ts
@@ -416,8 +416,13 @@ export function createSlashInteraction(options: {
     ? {
         id: threadId,
         parentId,
+        archived: false,
         isDMBased: () => false,
         isThread: () => true,
+        setArchived: async (value: boolean) => {
+          channel.archived = value;
+          return channel;
+        },
       }
     : {
         id: channelId,

--- a/apps/platform/discord/src/thread-store.ts
+++ b/apps/platform/discord/src/thread-store.ts
@@ -42,6 +42,16 @@ export class ThreadStore {
     return this.map[lookupKey];
   }
 
+  /** True when this thread id was created/tracked by the Discord agent. */
+  hasThreadId(threadId: string): boolean {
+    for (const stored of Object.values(this.map)) {
+      if (stored === threadId) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   set(lookupKey: string, threadId: string): void {
     this.map[lookupKey] = threadId;
   }

--- a/apps/platform/discord/src/thread-store.ts
+++ b/apps/platform/discord/src/thread-store.ts
@@ -60,6 +60,18 @@ export class ThreadStore {
     delete this.map[lookupKey];
   }
 
+  /** Drop every mapping that points at this Discord thread id. */
+  deleteByThreadId(threadId: string): boolean {
+    let removed = false;
+    for (const [key, value] of Object.entries(this.map)) {
+      if (value === threadId) {
+        delete this.map[key];
+        removed = true;
+      }
+    }
+    return removed;
+  }
+
   async save(): Promise<void> {
     await writePrivateTextFile(this.path, `${JSON.stringify(this.map, null, 2)}\n`, {
       ensureDir: dirname(this.path),

--- a/docs/website/content/docs/discord.mdx
+++ b/docs/website/content/docs/discord.mdx
@@ -50,6 +50,7 @@ This toggle is required. Without it, the bridge worker logs `Used disallowed int
    - **Send Messages**
    - **Read Message History**
    - **Send Messages in Threads** (recommended if you use threads)
+   - **Manage Threads** (recommended so `/close` can archive bot conversation threads)
 4. Copy the generated URL, open it, pick a server, and approve
 
 You can also use the **Invite bot to server** link on **Integrations → Discord** after saving your token — Nakama generates an invite with the right permissions.
@@ -129,6 +130,8 @@ In Discord threads, each thread keeps its own Nakama session.
 - new threads use the default Discord profile until you switch them
 - `/profile` in the main channel changes the channel-level profile
 - `/org` stays channel-level, so switch org first if a thread needs a profile from another org
+- `/close` inside a bot-started thread archives it and frees the slot so the next @mention opens a new one
+- the bot ignores messages in threads it did not start, including @mentions
 
 Replies in server channels are visible to everyone in that channel. Nakama prefixes those messages so the agent knows the reply is public.
 
@@ -144,6 +147,7 @@ Session control uses Discord slash commands. Org and profile switching use text 
 | `/clear` | Slash | Clear chat history |
 | `/compact` | Slash | Compact conversation history |
 | `/new` | Slash | Start a new conversation |
+| `/close` | Slash | Close (archive) the bot conversation thread |
 | `/status` | Slash | Show server and model status |
 | `/org` | Text | Choose or switch organization |
 | `/profile` | Text | Choose or switch profile |

--- a/packages/core/src/agent-questionnaire.test.ts
+++ b/packages/core/src/agent-questionnaire.test.ts
@@ -53,7 +53,7 @@ describe("formatAgentQuestionnaireMessage", () => {
     expect(text).toContain("a) Build Playwright e2e");
     expect(text).toContain("b) Manual steps only");
     expect(text).toContain("Or reply with your own answer.");
-    expect(text).toContain("Reply with a letter/number");
+    expect(text).toContain("Reply with your answer in chat.");
   });
 });
 

--- a/packages/core/src/agent-questionnaire.ts
+++ b/packages/core/src/agent-questionnaire.ts
@@ -38,11 +38,9 @@ export function formatAgentQuestionnaireMessage(questionnaire: AgentQuestionnair
   });
 
   if (questionnaire.questions.length === 1) {
-    lines.push("Reply with a letter/number, a choice label, or your answer.");
+    lines.push("Reply with your answer in chat.");
   } else {
-    lines.push("Reply with one line per question, e.g.:");
-    lines.push("1. a");
-    lines.push("2. your answer");
+    lines.push("Reply with your answers in chat.");
   }
 
   return lines.join("\n").trimEnd();


### PR DESCRIPTION
## Summary
Before this change, Nakama answered any message posted inside a Discord thread — including threads someone else created, and even plain follow-ups with no @mention. That pulled the bot into unrelated conversations.

It now only continues chat in threads it started and tracks. Mentions in a parent channel still create or reuse the bot’s thread as before; messages (including @mentions) in foreign threads are ignored.

Paired users can also run `/close` inside a bot-started thread to archive it and free the slot so the next @mention opens a fresh thread.

## Test plan
- [x] `bun test apps/platform/discord/src/guild-message.test.ts apps/platform/discord/src/chat-handler.test.ts apps/platform/discord/src/format.test.ts`
- [ ] In a guild channel, @mention the bot and confirm it replies in its own thread
- [ ] Reply in that bot-created thread without a mention and confirm it still answers
- [ ] @mention the bot inside a user-created thread and confirm it stays silent
- [ ] Run `/close` in the bot thread and confirm it archives; @mention again opens a new thread
- [ ] Confirm bot has **Manage Threads** in the server invite permissions