### PR TITLE
feat(discord): allow starting a new guild thread while another is active

### DIFF
--- a/apps/platform/discord/src/chat-handler.test.ts
+++ b/apps/platform/discord/src/chat-handler.test.ts
@@ -480,10 +480,14 @@ describe("createChatHandler guild thread routing", () => {
     });
   });
 
-  test("second mention in the same channel reuses the existing thread", async () => {
+  test("second mention in the same channel creates a distinct thread", async () => {
     await withTempHome(async (homeDir) => {
-      const { handleMessage, threadStore } = await createPairedHandler(homeDir, {
-        onSendStream: async () => "Again",
+      const streamedInputs: unknown[] = [];
+      const { handleMessage, threadStore, sessionStore } = await createPairedHandler(homeDir, {
+        onSendStream: async (input) => {
+          streamedInputs.push(input);
+          return "Again";
+        },
       });
 
       const first = createGuildChatMessage({
@@ -491,24 +495,150 @@ describe("createChatHandler guild thread routing", () => {
         mentionsBot: true,
       });
       await handleMessage(first.message);
-      const threadId = first.createdThreadId;
-      expect(threadId).toBeTruthy();
-      expect(threadStore.get("g:guild_channel_1:u:424242424242424242")).toBe(threadId);
-
-      const existingThreads = new Map([
-        [threadId!, { id: threadId!, parentId: "guild_channel_1", archived: false }],
-      ]);
+      const firstThreadId = first.createdThreadId;
+      expect(firstThreadId).toBeTruthy();
+      expect(threadStore.get("g:guild_channel_1:u:424242424242424242")).toBe(firstThreadId);
+      expect(sessionStore.get(`g:guild_channel_1:t:${firstThreadId}`)).toBeTruthy();
 
       const second = createGuildChatMessage({
-        content: "<@bot_id> follow up",
+        content: "<@bot_id> new topic",
         mentionsBot: true,
-        existingThreads,
+      });
+      await handleMessage(second.message);
+      const secondThreadId = second.createdThreadId;
+
+      expect(second.startThreadCalls).toBe(1);
+      expect(secondThreadId).toBeTruthy();
+      expect(secondThreadId).not.toBe(firstThreadId);
+      expect(threadStore.list("g:guild_channel_1:u:424242424242424242")).toEqual([
+        firstThreadId!,
+        secondThreadId!,
+      ]);
+      expect(threadStore.hasThreadId(firstThreadId!)).toBe(true);
+      expect(threadStore.hasThreadId(secondThreadId!)).toBe(true);
+      expect(second.threadSentMessages).toContain("Again");
+      expect(streamedInputs).toHaveLength(2);
+
+      // Old thread session remains independent of the new one.
+      expect(sessionStore.get(`g:guild_channel_1:t:${firstThreadId}`)?.sessionId).toBe(
+        "session_test",
+      );
+      expect(sessionStore.get(`g:guild_channel_1:t:${secondThreadId}`)?.sessionId).toBe(
+        "session_test",
+      );
+    });
+  });
+
+  test("old bot-owned thread still accepts follow-ups after a newer parent mention", async () => {
+    await withTempHome(async (homeDir) => {
+      const streamedByKey: string[] = [];
+      const { handleMessage, threadStore } = await createPairedHandler(homeDir, {
+        onSendStream: async (input) => {
+          streamedByKey.push(String((input as { message?: string }).message ?? ""));
+          return "Follow-up ok";
+        },
+      });
+
+      const first = createGuildChatMessage({
+        content: "<@bot_id> topic one",
+        mentionsBot: true,
+      });
+      await handleMessage(first.message);
+      const oldThreadId = first.createdThreadId!;
+
+      const second = createGuildChatMessage({
+        content: "<@bot_id> topic two",
+        mentionsBot: true,
       });
       await handleMessage(second.message);
 
-      expect(second.startThreadCalls).toBe(0);
-      expect(second.threadSentMessages).toContain("Again");
-      expect(second.channelSentMessages).not.toContain("Again");
+      const followUp = createGuildChatMessage({
+        content: "continue topic one",
+        inThread: true,
+        threadId: oldThreadId,
+        parentId: "guild_channel_1",
+      });
+      await handleMessage(followUp.message);
+
+      expect(threadStore.hasThreadId(oldThreadId)).toBe(true);
+      expect(followUp.threadSentMessages).toContain("Follow-up ok");
+      expect(streamedByKey.at(-1)).toBe("continue topic one");
+    });
+  });
+
+  test("concurrent parent mentions run in parallel on distinct threads", async () => {
+    await withTempHome(async (homeDir) => {
+      let releaseFirst!: () => void;
+      const firstGate = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      let firstStarted = false;
+      const startedOrder: string[] = [];
+
+      const { handleMessage, threadStore } = await createPairedHandler(homeDir, {
+        onSendStream: async (input) => {
+          const text = String((input as { message?: string }).message ?? "");
+          startedOrder.push(text);
+          if (text === "slow") {
+            firstStarted = true;
+            await firstGate;
+            return "Slow done";
+          }
+          return "Fast done";
+        },
+      });
+
+      const slow = createGuildChatMessage({
+        content: "<@bot_id> slow",
+        mentionsBot: true,
+      });
+      const fast = createGuildChatMessage({
+        content: "<@bot_id> fast",
+        mentionsBot: true,
+      });
+
+      const slowPromise = handleMessage(slow.message);
+      await Bun.sleep(20);
+      expect(firstStarted).toBe(true);
+
+      const fastPromise = handleMessage(fast.message);
+      await Bun.sleep(20);
+      // Fast should start while slow still holds its own thread lock.
+      expect(startedOrder).toContain("fast");
+
+      releaseFirst();
+      await Promise.all([slowPromise, fastPromise]);
+
+      expect(slow.startThreadCalls).toBe(1);
+      expect(fast.startThreadCalls).toBe(1);
+      expect(slow.createdThreadId).not.toBe(fast.createdThreadId);
+      expect(threadStore.list("g:guild_channel_1:u:424242424242424242")).toHaveLength(2);
+      expect(slow.threadSentMessages).toContain("Slow done");
+      expect(fast.threadSentMessages).toContain("Fast done");
+    });
+  });
+
+  test("/new from a parent channel creates a fresh Discord thread", async () => {
+    await withTempHome(async (homeDir) => {
+      const { handleSlashCommand, threadStore, sessionStore } = await createPairedHandler(homeDir);
+
+      threadStore.set("g:guild_channel_1:u:424242424242424242", "thread_old");
+      await threadStore.save();
+
+      const newCmd = createSlashInteraction({
+        commandName: "new",
+        channelId: "guild_channel_1",
+      });
+      await handleSlashCommand(newCmd.interaction);
+
+      expect(newCmd.startThreadCalls).toBe(1);
+      expect(newCmd.createdThreadId).toBeTruthy();
+      expect(newCmd.replies.some((text) => text.includes(`<#${newCmd.createdThreadId}>`))).toBe(
+        true,
+      );
+      expect(threadStore.hasThreadId("thread_old")).toBe(true);
+      expect(threadStore.hasThreadId(newCmd.createdThreadId!)).toBe(true);
+      expect(sessionStore.get(`g:guild_channel_1:t:${newCmd.createdThreadId}`)).toBeTruthy();
     });
   });
 

--- a/apps/platform/discord/src/chat-handler.ts
+++ b/apps/platform/discord/src/chat-handler.ts
@@ -138,12 +138,29 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     // Threads share the parent channel's org selection — do not key by thread id.
     const channelOrgKey = resolveChannelOrgKey(parentChannelId, userId, isGuild);
     const conversationKey = resolveConversationKey(message, channelId, isGuild);
-    // Serialize per user+parent channel so thread create/reuse and in-thread chat don't race.
-    const lockKey = isGuild
-      ? resolveThreadLookupKey(parentChannelId, userId)
-      : conversationKey;
+    const shouldRouteToThread =
+      isGuild &&
+      !isThread &&
+      (groupDecision?.reason === "bot-mention" || groupDecision?.reason === "reply-to-bot");
 
-    await withChatLock(lockKey, async () => {
+    // Parent-channel mentions create a NEW thread, then lock per that thread so
+    // concurrent agent runs in other threads for the same user are allowed.
+    if (shouldRouteToThread) {
+      await handleGuildParentMention({
+        message,
+        channel,
+        messenger,
+        userId,
+        parentChannelId,
+        channelOrgKey,
+        botInfo,
+        text,
+      });
+      return;
+    }
+
+    // DMs and in-thread follow-ups serialize per conversation/thread key.
+    await withChatLock(conversationKey, async () => {
       await authStore.reload();
       const isAuthorized = authStore.isAuthorized(userId);
 
@@ -200,82 +217,138 @@ export function createChatHandler(deps: ChatHandlerDeps) {
         return;
       }
 
-      let replyChannel = channel;
-      let replyConversationKey = conversationKey;
-      let replyMessenger = messenger;
-      let replyIsThread = isThread;
+      await handleChatMessage(
+        channel,
+        conversationKey,
+        messenger,
+        messageText,
+        isGuild,
+        isThread,
+      );
+    });
+  }
 
-      const shouldRouteToThread =
-        isGuild &&
-        !isThread &&
-        (groupDecision?.reason === "bot-mention" || groupDecision?.reason === "reply-to-bot");
+  async function handleGuildParentMention(options: {
+    message: Message;
+    channel: TextBasedChannel;
+    messenger: DiscordMessenger;
+    userId: string;
+    parentChannelId: string;
+    channelOrgKey: string;
+    botInfo: DiscordBotInfo | undefined;
+    text: string | undefined;
+  }): Promise<void> {
+    const {
+      message,
+      channel,
+      messenger,
+      userId,
+      parentChannelId,
+      channelOrgKey,
+      botInfo,
+      text,
+    } = options;
 
-      if (shouldRouteToThread) {
-        const thread = await resolveOrCreateGuildThread(
-          message,
-          channelId,
-          userId,
-          messageText,
-        );
+    await authStore.reload();
 
-        if (thread) {
-          replyChannel = thread;
-          replyConversationKey = `g:${channelId}:t:${thread.id}`;
-          replyMessenger = createDiscordMessenger(thread);
-          replyIsThread = true;
-        }
-      }
+    if (!authStore.isAuthorized(userId)) {
+      await messenger.send(LINK_IN_PRIVATE_REPLY);
+      return;
+    }
 
+    if (text && looksLikeHandshakeAttempt(text)) {
+      await messenger.send(LINK_IN_PRIVATE_REPLY);
+      return;
+    }
+
+    const orgGateText = text && botInfo ? stripBotMention(text, botInfo) : text;
+    const orgReady = await ensureOrgReady(messenger, channelOrgKey, orgGateText);
+    if (!orgReady) {
+      return;
+    }
+
+    if (!text) {
+      await messenger.send("Text messages only.");
+      return;
+    }
+
+    const messageText = botInfo ? stripBotMention(text, botInfo) : text;
+
+    if (!messageText) {
+      return;
+    }
+
+    const thread = await createGuildThread(message, parentChannelId, userId, messageText);
+
+    if (!thread) {
+      await withChatLock(parentChannelId, async () => {
+        await handleChatMessage(channel, parentChannelId, messenger, messageText, true, false);
+      });
+      return;
+    }
+
+    const replyConversationKey = `g:${parentChannelId}:t:${thread.id}`;
+    const replyChannel = thread as TextBasedChannel;
+    const replyMessenger = createDiscordMessenger(replyChannel);
+
+    await withChatLock(replyConversationKey, async () => {
       await handleChatMessage(
         replyChannel,
         replyConversationKey,
         replyMessenger,
         messageText,
-        isGuild,
-        replyIsThread,
+        true,
+        true,
       );
     });
   }
 
-  async function resolveOrCreateGuildThread(
+  /** Always start a fresh Discord thread from a parent-channel mention/reply. */
+  async function createGuildThread(
     message: Message,
     parentChannelId: string,
     userId: string,
     messageText: string,
   ): Promise<ThreadChannel | null> {
     const lookupKey = resolveThreadLookupKey(parentChannelId, userId);
-    // Re-check after the chat lock so concurrent mentions do not create duplicate threads.
-    const existingThreadId = threadStore.get(lookupKey);
-
-    if (existingThreadId) {
-      try {
-        const fetched = await message.client.channels.fetch(existingThreadId);
-
-        if (fetched?.isThread()) {
-          if (fetched.archived) {
-            await fetched.setArchived(false);
-          }
-
-          return fetched;
-        }
-      } catch (error) {
-        console.warn(
-          `Stored Discord thread ${existingThreadId} is unavailable; creating a new one.`,
-          error,
-        );
-      }
-    }
 
     try {
       const thread = await message.startThread({
         name: deriveThreadName(messageText),
         autoArchiveDuration: 1440,
       });
-      threadStore.set(lookupKey, thread.id);
+      threadStore.add(lookupKey, thread.id);
       await threadStore.save();
       return thread;
     } catch (error) {
       console.error("Failed to create Discord thread; falling back to channel reply:", error);
+      return null;
+    }
+  }
+
+  async function createGuildThreadFromChannel(
+    channel: TextBasedChannel,
+    parentChannelId: string,
+    userId: string,
+    threadName = "Nakama chat",
+  ): Promise<ThreadChannel | null> {
+    if (!("threads" in channel) || typeof channel.threads?.create !== "function") {
+      return null;
+    }
+
+    const lookupKey = resolveThreadLookupKey(parentChannelId, userId);
+
+    try {
+      const thread = await channel.threads.create({
+        name: threadName.slice(0, 100),
+        autoArchiveDuration: 1440,
+        reason: "Nakama /new conversation",
+      });
+      threadStore.add(lookupKey, thread.id);
+      await threadStore.save();
+      return thread;
+    } catch (error) {
+      console.error("Failed to create Discord thread for /new:", error);
       return null;
     }
   }
@@ -314,6 +387,40 @@ export function createChatHandler(deps: ChatHandlerDeps) {
       console.error("Failed to archive Discord thread after /close:", error);
       await messenger.send("Couldn't archive the thread. Check the bot's Manage Threads permission.");
     }
+  }
+
+  async function handleNewFromParentChannel(
+    interaction: ChatInputCommandInteraction,
+    parentChannelId: string,
+    userId: string,
+    messenger: DiscordMessenger,
+  ): Promise<void> {
+    const channel = interaction.channel;
+
+    if (!channel || channel.isDMBased() || channel.isThread()) {
+      await messenger.send("Use /new in a server channel to open a new bot thread.");
+      return;
+    }
+
+    const thread = await createGuildThreadFromChannel(
+      channel,
+      parentChannelId,
+      userId,
+      "Nakama chat",
+    );
+
+    if (!thread) {
+      await messenger.send(
+        "Couldn't create a thread. Check the bot's Create Public Threads permission.",
+      );
+      return;
+    }
+
+    const conversationKey = `g:${parentChannelId}:t:${thread.id}`;
+    stopActiveStream(conversationKey);
+    pendingQuestionnaires.delete(conversationKey);
+    await createAndBindSession(conversationKey);
+    await messenger.send(`Started a new conversation in <#${thread.id}>.`);
   }
 
   async function handleSlashCommand(interaction: ChatInputCommandInteraction): Promise<void> {
@@ -400,6 +507,11 @@ export function createChatHandler(deps: ChatHandlerDeps) {
           return;
         }
         case "new": {
+          if (isGuild && !interaction.channel?.isThread()) {
+            await handleNewFromParentChannel(interaction, orgChannelId, userId, messenger);
+            return;
+          }
+
           stopActiveStream(conversationKey);
           pendingQuestionnaires.delete(conversationKey);
           await createAndBindSession(conversationKey);

--- a/apps/platform/discord/src/format.ts
+++ b/apps/platform/discord/src/format.ts
@@ -120,10 +120,10 @@ export const HELP_TEXT = `Nakama Discord commands:
 /stop — stop the agent's current reply
 /clear — clear chat history
 /compact — compact conversation history
-/new — start a new conversation
+/new — start a new conversation (in a server channel: opens a new thread)
 /close — close this bot conversation thread
 /org — choose or switch organization (send as text)
 /profile — choose or switch bot profile (send as text)
 /status — server and model status
 
-In servers, @mention the bot or reply to it to chat. Pair in a DM first.`;
+In servers, @mention the bot or reply to it to open a new thread. Follow up inside that thread. Pair in a DM first.`;

--- a/apps/platform/discord/src/guild-message.ts
+++ b/apps/platform/discord/src/guild-message.ts
@@ -60,7 +60,11 @@ export function resolveConversationKey(message: Message, channelId: string, isGu
   return channelId;
 }
 
-/** Persisted mapping key: one chat thread per user in a parent guild channel. */
+/**
+ * Persisted ownership key for bot-started threads in a parent guild channel.
+ * Values may be one thread id (legacy) or several — each @mention from the
+ * parent channel adds a new thread without dropping ownership of older ones.
+ */
 export function resolveThreadLookupKey(channelId: string, userId: string): string {
   return `g:${channelId}:u:${userId}`;
 }

--- a/apps/platform/discord/src/slash-commands.ts
+++ b/apps/platform/discord/src/slash-commands.ts
@@ -15,7 +15,7 @@ export function buildSlashCommands(): SlashCommandBuilder[] {
     stop: "Stop the current agent reply",
     clear: "Clear chat history",
     compact: "Compact conversation history",
-    new: "Start a new conversation",
+    new: "Start a new conversation (opens a new thread in server channels)",
     close: "Close this bot conversation thread",
     status: "Show server and model status",
   };

--- a/apps/platform/discord/src/test-helpers.ts
+++ b/apps/platform/discord/src/test-helpers.ts
@@ -228,6 +228,8 @@ export interface MockGuildChatMessage {
   lastThreadName: string | null;
 }
 
+let guildThreadSeq = 0;
+
 export function createGuildChatMessage(options: {
   userId?: string;
   channelId?: string;
@@ -320,6 +322,25 @@ export function createGuildChatMessage(options: {
         edit: async () => {},
       }),
     },
+    threads: {
+      create: async ({ name }: { name: string }) => {
+        startThreadCalls += 1;
+        lastThreadName = name;
+        if (options.startThreadError) {
+          throw options.startThreadError;
+        }
+
+        guildThreadSeq += 1;
+        createdThreadId = `created_thread_${guildThreadSeq}`;
+        const thread = createThreadChannel(createdThreadId, channelId, false);
+        existingThreads.set(createdThreadId, {
+          id: createdThreadId,
+          parentId: channelId,
+          archived: false,
+        });
+        return thread;
+      },
+    },
   };
 
   const channel = options.inThread
@@ -362,7 +383,8 @@ export function createGuildChatMessage(options: {
         throw options.startThreadError;
       }
 
-      createdThreadId = `created_thread_${startThreadCalls}`;
+      guildThreadSeq += 1;
+      createdThreadId = `created_thread_${guildThreadSeq}`;
       const thread = createThreadChannel(createdThreadId, channelId, false);
       existingThreads.set(createdThreadId, {
         id: createdThreadId,
@@ -402,15 +424,20 @@ export function createSlashInteraction(options: {
   inThread?: boolean;
   parentId?: string;
   threadId?: string;
+  startThreadError?: Error;
 }): {
   interaction: import("discord.js").ChatInputCommandInteraction;
   replies: string[];
+  createdThreadId: string | null;
+  startThreadCalls: number;
 } {
   const replies: string[] = [];
   const userId = options.userId ?? "424242424242424242";
   const channelId = options.channelId ?? "guild_channel_1";
   const threadId = options.threadId ?? "thread_1";
   const parentId = options.parentId ?? channelId;
+  let createdThreadId: string | null = null;
+  let startThreadCalls = 0;
 
   const channel = options.inThread
     ? {
@@ -429,6 +456,22 @@ export function createSlashInteraction(options: {
         parentId: null,
         isDMBased: () => false,
         isThread: () => false,
+        threads: {
+          create: async ({ name }: { name: string }) => {
+            startThreadCalls += 1;
+            if (options.startThreadError) {
+              throw options.startThreadError;
+            }
+            createdThreadId = `slash_thread_${startThreadCalls}`;
+            return {
+              id: createdThreadId,
+              parentId: channelId,
+              name,
+              isThread: () => true,
+              isDMBased: () => false,
+            };
+          },
+        },
       };
 
   const interaction = {
@@ -447,7 +490,16 @@ export function createSlashInteraction(options: {
     },
   } as unknown as import("discord.js").ChatInputCommandInteraction;
 
-  return { interaction, replies };
+  return {
+    interaction,
+    replies,
+    get createdThreadId() {
+      return createdThreadId;
+    },
+    get startThreadCalls() {
+      return startThreadCalls;
+    },
+  };
 }
 
 export async function writeDiscordConfigIni(

--- a/apps/platform/discord/src/thread-store.test.ts
+++ b/apps/platform/discord/src/thread-store.test.ts
@@ -1,0 +1,50 @@
+import path from "node:path";
+import { describe, expect, test } from "bun:test";
+import { ThreadStore } from "./thread-store";
+import { withTempHome } from "./test-helpers";
+
+describe("ThreadStore multi-thread ownership", () => {
+  test("loads legacy string mappings and keeps older threads when adding", async () => {
+    await withTempHome(async (homeDir) => {
+      const storePath = path.join(homeDir, ".nakama", "discord", "chat-threads.json");
+      await Bun.write(
+        storePath,
+        `${JSON.stringify({ "g:channel_1:u:user_1": "thread_old" }, null, 2)}\n`,
+      );
+
+      const store = new ThreadStore(storePath);
+      await store.load();
+
+      expect(store.get("g:channel_1:u:user_1")).toBe("thread_old");
+      expect(store.hasThreadId("thread_old")).toBe(true);
+
+      store.add("g:channel_1:u:user_1", "thread_new");
+      await store.save();
+
+      expect(store.list("g:channel_1:u:user_1")).toEqual(["thread_old", "thread_new"]);
+      expect(store.get("g:channel_1:u:user_1")).toBe("thread_new");
+      expect(store.hasThreadId("thread_old")).toBe(true);
+      expect(store.hasThreadId("thread_new")).toBe(true);
+
+      const reloaded = new ThreadStore(storePath);
+      await reloaded.load();
+      expect(reloaded.list("g:channel_1:u:user_1")).toEqual(["thread_old", "thread_new"]);
+    });
+  });
+
+  test("deleteByThreadId removes one thread without dropping siblings", async () => {
+    await withTempHome(async (homeDir) => {
+      const store = new ThreadStore(
+        path.join(homeDir, ".nakama", "discord", "chat-threads.json"),
+      );
+      await store.load();
+
+      store.add("g:channel_1:u:user_1", "thread_a");
+      store.add("g:channel_1:u:user_1", "thread_b");
+      expect(store.deleteByThreadId("thread_a")).toBe(true);
+      expect(store.list("g:channel_1:u:user_1")).toEqual(["thread_b"]);
+      expect(store.hasThreadId("thread_a")).toBe(false);
+      expect(store.hasThreadId("thread_b")).toBe(true);
+    });
+  });
+});

--- a/apps/platform/discord/src/thread-store.ts
+++ b/apps/platform/discord/src/thread-store.ts
@@ -2,7 +2,9 @@ import { readTextOrNull, writePrivateTextFile } from "@nakama/core/fs";
 import { getDiscordConfigDir } from "@nakama/core/discord-config";
 import { dirname, join } from "node:path";
 
-type ThreadMap = Record<string, string>;
+/** Legacy entries are a single thread id string; multi-thread entries are arrays. */
+type ThreadMapValue = string | string[];
+type ThreadMap = Record<string, ThreadMapValue>;
 
 export class ThreadStore {
   private readonly path: string;
@@ -30,43 +32,71 @@ export class ThreadStore {
     const next: ThreadMap = {};
 
     for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
-      if (typeof value === "string" && value.trim()) {
-        next[key] = value;
+      const normalized = normalizeThreadIds(value);
+      if (normalized.length === 1) {
+        next[key] = normalized[0]!;
+      } else if (normalized.length > 1) {
+        next[key] = normalized;
       }
     }
 
     this.map = next;
   }
 
+  /** Latest mapped thread for this lookup key, if any. */
   get(lookupKey: string): string | undefined {
-    return this.map[lookupKey];
+    const ids = this.list(lookupKey);
+    return ids[ids.length - 1];
+  }
+
+  /** All bot-owned threads registered under this lookup key (oldest → newest). */
+  list(lookupKey: string): string[] {
+    return normalizeThreadIds(this.map[lookupKey]);
   }
 
   /** True when this thread id was created/tracked by the Discord agent. */
   hasThreadId(threadId: string): boolean {
     for (const stored of Object.values(this.map)) {
-      if (stored === threadId) {
+      if (normalizeThreadIds(stored).includes(threadId)) {
         return true;
       }
     }
     return false;
   }
 
+  /**
+   * Register a bot-owned thread. Appends without dropping prior threads so
+   * in-thread follow-ups keep working after a newer parent-channel mention.
+   */
+  add(lookupKey: string, threadId: string): void {
+    const existing = this.list(lookupKey).filter((id) => id !== threadId);
+    existing.push(threadId);
+    this.map[lookupKey] = serializeThreadIds(existing);
+  }
+
+  /** Alias for add — kept for call sites that previously replaced the sole mapping. */
   set(lookupKey: string, threadId: string): void {
-    this.map[lookupKey] = threadId;
+    this.add(lookupKey, threadId);
   }
 
   delete(lookupKey: string): void {
     delete this.map[lookupKey];
   }
 
-  /** Drop every mapping that points at this Discord thread id. */
+  /** Drop this Discord thread id from every mapping (other threads stay owned). */
   deleteByThreadId(threadId: string): boolean {
     let removed = false;
     for (const [key, value] of Object.entries(this.map)) {
-      if (value === threadId) {
+      const ids = normalizeThreadIds(value);
+      const next = ids.filter((id) => id !== threadId);
+      if (next.length === ids.length) {
+        continue;
+      }
+      removed = true;
+      if (next.length === 0) {
         delete this.map[key];
-        removed = true;
+      } else {
+        this.map[key] = serializeThreadIds(next);
       }
     }
     return removed;
@@ -77,6 +107,29 @@ export class ThreadStore {
       ensureDir: dirname(this.path),
     });
   }
+}
+
+function normalizeThreadIds(value: unknown): string[] {
+  if (typeof value === "string" && value.trim()) {
+    return [value];
+  }
+
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const ids: string[] = [];
+  for (const entry of value) {
+    if (typeof entry === "string" && entry.trim() && !ids.includes(entry)) {
+      ids.push(entry);
+    }
+  }
+  return ids;
+}
+
+/** Persist a single id as a string for backwards-compatible chat-threads.json. */
+function serializeThreadIds(ids: string[]): ThreadMapValue {
+  return ids.length === 1 ? ids[0]! : ids;
 }
 
 function getThreadMapPath(): string {

--- a/docs/website/content/docs/discord.mdx
+++ b/docs/website/content/docs/discord.mdx
@@ -126,11 +126,16 @@ This keeps server channels usable without making the bot noisy.
 
 In Discord threads, each thread keeps its own Nakama session.
 
+- each `@mention` (or reply to the bot) from a **parent channel** opens a **new** Discord thread — you are not forced back into a previous one
+- follow-ups inside a thread continue that thread’s session (no mention needed)
+- agent runs in **different** threads can run at the same time; messages in the **same** thread still queue
+- `/new` in a parent channel opens a fresh Discord thread and starts a new session there
+- `/new` inside a thread starts a new Nakama session but stays in that Discord thread
 - `/profile` inside a thread changes only that thread
 - new threads use the default Discord profile until you switch them
 - `/profile` in the main channel changes the channel-level profile
-- `/org` stays channel-level, so switch org first if a thread needs a profile from another org
-- `/close` inside a bot-started thread archives it and frees the slot so the next @mention opens a new one
+- `/org` stays channel-level (inherited by threads from the parent channel), so switch org first if a thread needs a profile from another org
+- `/close` inside a bot-started thread archives it; other open threads for the same user keep working
 - the bot ignores messages in threads it did not start, including @mentions
 
 Replies in server channels are visible to everyone in that channel. Nakama prefixes those messages so the agent knows the reply is public.
@@ -146,13 +151,13 @@ Session control uses Discord slash commands. Org and profile switching use text 
 | `/stop` | Slash | Stop the current in-progress reply |
 | `/clear` | Slash | Clear chat history |
 | `/compact` | Slash | Compact conversation history |
-| `/new` | Slash | Start a new conversation |
+| `/new` | Slash | Start a new conversation (opens a new thread from a server channel) |
 | `/close` | Slash | Close (archive) the bot conversation thread |
 | `/status` | Slash | Show server and model status |
 | `/org` | Text | Choose or switch organization |
 | `/profile` | Text | Choose or switch profile |
 
-In servers, `@mention` the bot or reply to it to chat. Complete DM pairing first.
+In servers, `@mention` the bot or reply to it to open a new thread. Complete DM pairing first.
 
 ## Reply formatting
 


### PR DESCRIPTION
## Summary
- Parent-channel `@mention` / reply-to-bot always creates a **new** Discord thread instead of reusing the mapped one; prior threads stay owned so in-thread follow-ups keep working.
- Chat locks are now per conversation/thread (`g:parent:t:threadId`), so the same user can run agents in two threads of one parent channel concurrently; same-thread messages still queue.
- `/new` in a parent channel creates a fresh Discord thread and session; `/new` inside a thread still only resets the Nakama session.
- `chat-threads.json` stays backwards compatible (legacy string values); multiple owned threads serialize as arrays.

Tracks #188 (does not close the issue).

## Test plan
- [x] `bun test apps/platform/discord/src/` (47 pass)
- [ ] In a guild channel: `@bot first topic` → thread A
- [ ] While A is running (or after): `@bot second topic` → distinct thread B
- [ ] Message in thread A still gets a reply with A’s session
- [ ] `/new` in the parent channel opens another thread and remaps ownership
- [ ] `/new` inside a thread stays in that Discord thread
- [ ] Org selection still comes from the parent channel


Made with [Cursor](https://cursor.com)