### PR TITLE
feat(discord): always start a new guild thread on parent mention

### DIFF
--- a/apps/platform/discord/src/chat-handler.test.ts
+++ b/apps/platform/discord/src/chat-handler.test.ts
@@ -473,14 +473,12 @@ describe("createChatHandler guild thread routing", () => {
       expect(guild.lastThreadName).toBe("summarize this");
       expect(guild.threadSentMessages).toContain("Thread reply");
       expect(guild.channelSentMessages).not.toContain("Thread reply");
-      expect(threadStore.get("g:guild_channel_1:u:424242424242424242")).toBe(
-        guild.createdThreadId,
-      );
+      expect(threadStore.hasThreadId(guild.createdThreadId!)).toBe(true);
       expect(streamedInputs[0]).toEqual({ message: "summarize this" });
     });
   });
 
-  test("second mention in the same channel reuses the existing thread", async () => {
+  test("second mention in the same channel creates a new thread", async () => {
     await withTempHome(async (homeDir) => {
       const { handleMessage, threadStore } = await createPairedHandler(homeDir, {
         onSendStream: async () => "Again",
@@ -491,24 +489,109 @@ describe("createChatHandler guild thread routing", () => {
         mentionsBot: true,
       });
       await handleMessage(first.message);
-      const threadId = first.createdThreadId;
-      expect(threadId).toBeTruthy();
-      expect(threadStore.get("g:guild_channel_1:u:424242424242424242")).toBe(threadId);
-
-      const existingThreads = new Map([
-        [threadId!, { id: threadId!, parentId: "guild_channel_1", archived: false }],
-      ]);
+      const firstThreadId = first.createdThreadId;
+      expect(firstThreadId).toBeTruthy();
+      expect(first.startThreadCalls).toBe(1);
+      expect(threadStore.hasThreadId(firstThreadId!)).toBe(true);
 
       const second = createGuildChatMessage({
-        content: "<@bot_id> follow up",
+        content: "<@bot_id> follow up topic",
         mentionsBot: true,
-        existingThreads,
       });
       await handleMessage(second.message);
 
-      expect(second.startThreadCalls).toBe(0);
+      expect(second.startThreadCalls).toBe(1);
+      const secondThreadId = second.createdThreadId;
+      expect(secondThreadId).toBeTruthy();
+      expect(secondThreadId).not.toBe(firstThreadId);
+      expect(threadStore.hasThreadId(firstThreadId!)).toBe(true);
+      expect(threadStore.hasThreadId(secondThreadId!)).toBe(true);
       expect(second.threadSentMessages).toContain("Again");
       expect(second.channelSentMessages).not.toContain("Again");
+    });
+  });
+
+  test("first thread stays independent after a second mention creates another thread", async () => {
+    await withTempHome(async (homeDir) => {
+      const streamedByThread: string[] = [];
+      const { handleMessage, threadStore, sessionStore } = await createPairedHandler(homeDir, {
+        onSendStream: async (input) => {
+          streamedByThread.push(String((input as { message?: string }).message ?? ""));
+          return "ok";
+        },
+      });
+
+      const first = createGuildChatMessage({
+        content: "<@bot_id> topic one",
+        mentionsBot: true,
+      });
+      await handleMessage(first.message);
+      const firstThreadId = first.createdThreadId!;
+
+      const second = createGuildChatMessage({
+        content: "<@bot_id> topic two",
+        mentionsBot: true,
+      });
+      await handleMessage(second.message);
+
+      const followUp = createGuildChatMessage({
+        content: "continue topic one",
+        inThread: true,
+        threadId: firstThreadId,
+        parentId: "guild_channel_1",
+      });
+      await handleMessage(followUp.message);
+
+      expect(followUp.startThreadCalls).toBe(0);
+      expect(followUp.threadSentMessages).toContain("ok");
+      expect(threadStore.hasThreadId(firstThreadId)).toBe(true);
+      expect(sessionStore.get(`g:guild_channel_1:t:${firstThreadId}`)).toBeTruthy();
+      expect(streamedByThread).toContain("continue topic one");
+    });
+  });
+
+  test("overlapping parent mentions run agent turns concurrently", async () => {
+    await withTempHome(async (homeDir) => {
+      let releaseFirst!: () => void;
+      const firstGate = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      let entered = 0;
+      let maxInFlight = 0;
+      let inFlight = 0;
+
+      const { handleMessage } = await createPairedHandler(homeDir, {
+        onSendStream: async () => {
+          entered += 1;
+          inFlight += 1;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          if (entered === 1) {
+            await firstGate;
+          }
+          inFlight -= 1;
+          return "done";
+        },
+      });
+
+      const first = createGuildChatMessage({
+        content: "<@bot_id> slow",
+        mentionsBot: true,
+      });
+      const second = createGuildChatMessage({
+        content: "<@bot_id> fast",
+        mentionsBot: true,
+      });
+
+      const firstTurn = handleMessage(first.message);
+      await Bun.sleep(20);
+      const secondTurn = handleMessage(second.message);
+      await Bun.sleep(20);
+
+      expect(entered).toBe(2);
+      expect(maxInFlight).toBeGreaterThanOrEqual(2);
+
+      releaseFirst();
+      await Promise.all([firstTurn, secondTurn]);
     });
   });
 
@@ -522,7 +605,7 @@ describe("createChatHandler guild thread routing", () => {
         },
       });
 
-      threadStore.set("g:guild_channel_1:u:424242424242424242", "thread_42");
+      threadStore.add("thread_42");
       await threadStore.save();
 
       const guild = createGuildChatMessage({
@@ -578,7 +661,7 @@ describe("createChatHandler guild thread routing", () => {
 
       orgStore.set("g:guild_channel_1", "org_a");
       await orgStore.save();
-      threadStore.set("g:guild_channel_1:u:424242424242424242", "thread_42");
+      threadStore.add("thread_42");
       await threadStore.save();
 
       const guild = createGuildChatMessage({
@@ -688,10 +771,11 @@ describe("createChatHandler guild thread routing", () => {
     });
   });
 
-  test("close archives a bot-owned thread and clears the mapping", async () => {
+  test("close archives a bot-owned thread and clears ownership for that thread only", async () => {
     await withTempHome(async (homeDir) => {
-      const { handleSlashCommand, threadStore } = await createPairedHandler(homeDir);
-      threadStore.set("g:guild_channel_1:u:424242424242424242", "thread_1");
+      const { handleSlashCommand, threadStore, handleMessage } = await createPairedHandler(homeDir);
+      threadStore.add("thread_1");
+      threadStore.add("thread_sibling");
       await threadStore.save();
 
       const closeCmd = createSlashInteraction({
@@ -704,15 +788,24 @@ describe("createChatHandler guild thread routing", () => {
 
       expect(closeCmd.replies).toContain("Thread closed.");
       expect((closeCmd.interaction.channel as { archived?: boolean }).archived).toBe(true);
-      expect(threadStore.get("g:guild_channel_1:u:424242424242424242")).toBeUndefined();
       expect(threadStore.hasThreadId("thread_1")).toBe(false);
+      expect(threadStore.hasThreadId("thread_sibling")).toBe(true);
+
+      const sibling = createGuildChatMessage({
+        content: "still here",
+        inThread: true,
+        threadId: "thread_sibling",
+        parentId: "guild_channel_1",
+      });
+      await handleMessage(sibling.message);
+      expect(sibling.threadSentMessages.length).toBeGreaterThan(0);
     });
   });
 
   test("close rejects non-thread channels and foreign threads", async () => {
     await withTempHome(async (homeDir) => {
       const { handleSlashCommand, threadStore } = await createPairedHandler(homeDir);
-      threadStore.set("g:guild_channel_1:u:424242424242424242", "thread_owned");
+      threadStore.add("thread_owned");
       await threadStore.save();
 
       const channelClose = createSlashInteraction({

--- a/apps/platform/discord/src/chat-handler.ts
+++ b/apps/platform/discord/src/chat-handler.ts
@@ -44,7 +44,6 @@ import {
   resolveChannelOrgKey,
   resolveConversationKey,
   resolveOrgChannelId,
-  resolveThreadLookupKey,
   stripBotMention,
   type DiscordBotInfo,
 } from "./guild-message";
@@ -67,6 +66,7 @@ import { createTypingLoop } from "./typing-indicator";
 
 const chatLocks = new Map<string, Promise<void>>();
 const pendingQuestionnaires = new Map<string, AgentQuestionnaire>();
+const THREAD_OWNERSHIP_LOCK_KEY = "__discord_thread_ownership__";
 
 const GROUP_MESSAGE_PREFIX =
   "[Discord channel — your reply is visible to everyone in this channel.]\n";
@@ -138,94 +138,91 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     // Threads share the parent channel's org selection — do not key by thread id.
     const channelOrgKey = resolveChannelOrgKey(parentChannelId, userId, isGuild);
     const conversationKey = resolveConversationKey(message, channelId, isGuild);
-    // Serialize per user+parent channel so thread create/reuse and in-thread chat don't race.
-    const lockKey = isGuild
-      ? resolveThreadLookupKey(parentChannelId, userId)
-      : conversationKey;
 
-    await withChatLock(lockKey, async () => {
-      await authStore.reload();
-      const isAuthorized = authStore.isAuthorized(userId);
+    // Auth/org/thread-create run without the agent-stream lock so parallel parent mentions
+    // can each open a thread. Agent work locks per conversation/thread key below.
+    await authStore.reload();
+    const isAuthorized = authStore.isAuthorized(userId);
 
-      if (!isAuthorized) {
-        if (isGuild) {
-          await messenger.send(LINK_IN_PRIVATE_REPLY);
-          return;
-        }
-
-        if (!text) {
-          await messenger.send("Send your pairing code as text to link this chat.");
-          return;
-        }
-
-        await handlePairing(text, userId, messenger);
-        return;
-      }
-
-      if (isGuild && text && looksLikeHandshakeAttempt(text)) {
+    if (!isAuthorized) {
+      if (isGuild) {
         await messenger.send(LINK_IN_PRIVATE_REPLY);
         return;
       }
 
-      const command = text?.startsWith("/") ? parseTextCommand(text) : null;
-      const bypassOrgGate = command === "/help" || command === "/start" || command === "/org";
-
-      if (!bypassOrgGate) {
-        const orgGateText =
-          isGuild && text && botInfo ? stripBotMention(text, botInfo) : text;
-        const orgReady = await ensureOrgReady(messenger, channelOrgKey, orgGateText);
-        if (!orgReady) {
-          return;
-        }
-      }
-
       if (!text) {
-        await messenger.send("Text messages only.");
+        await messenger.send("Send your pairing code as text to link this chat.");
         return;
       }
 
-      if (command === "/org" || command === "/profile") {
+      await withChatLock(conversationKey, async () => {
+        await handlePairing(text, userId, messenger);
+      });
+      return;
+    }
+
+    if (isGuild && text && looksLikeHandshakeAttempt(text)) {
+      await messenger.send(LINK_IN_PRIVATE_REPLY);
+      return;
+    }
+
+    const command = text?.startsWith("/") ? parseTextCommand(text) : null;
+    const bypassOrgGate = command === "/help" || command === "/start" || command === "/org";
+
+    if (!bypassOrgGate) {
+      const orgGateText =
+        isGuild && text && botInfo ? stripBotMention(text, botInfo) : text;
+      const orgReady = await ensureOrgReady(messenger, channelOrgKey, orgGateText);
+      if (!orgReady) {
+        return;
+      }
+    }
+
+    if (!text) {
+      await messenger.send("Text messages only.");
+      return;
+    }
+
+    if (command === "/org" || command === "/profile") {
+      await withChatLock(conversationKey, async () => {
         await handleTextCommand(text, command, conversationKey, channelOrgKey, isThread, messenger);
-        return;
+      });
+      return;
+    }
+
+    if (text.startsWith("/")) {
+      await messenger.send("Use slash commands from Discord's command menu for session control.");
+      return;
+    }
+
+    const messageText = isGuild && botInfo ? stripBotMention(text, botInfo) : text;
+
+    if (!messageText) {
+      return;
+    }
+
+    let replyChannel = channel;
+    let replyConversationKey = conversationKey;
+    let replyMessenger = messenger;
+    let replyIsThread = isThread;
+
+    const shouldRouteToThread =
+      isGuild &&
+      !isThread &&
+      (groupDecision?.reason === "bot-mention" || groupDecision?.reason === "reply-to-bot");
+
+    if (shouldRouteToThread) {
+      const thread = await createGuildThread(message, messageText);
+
+      if (thread) {
+        replyChannel = thread;
+        replyConversationKey = `g:${channelId}:t:${thread.id}`;
+        replyMessenger = createDiscordMessenger(thread);
+        replyIsThread = true;
       }
+    }
 
-      if (text.startsWith("/")) {
-        await messenger.send("Use slash commands from Discord's command menu for session control.");
-        return;
-      }
-
-      const messageText = isGuild && botInfo ? stripBotMention(text, botInfo) : text;
-
-      if (!messageText) {
-        return;
-      }
-
-      let replyChannel = channel;
-      let replyConversationKey = conversationKey;
-      let replyMessenger = messenger;
-      let replyIsThread = isThread;
-
-      const shouldRouteToThread =
-        isGuild &&
-        !isThread &&
-        (groupDecision?.reason === "bot-mention" || groupDecision?.reason === "reply-to-bot");
-
-      if (shouldRouteToThread) {
-        const thread = await resolveOrCreateGuildThread(
-          message,
-          channelId,
-          userId,
-          messageText,
-        );
-
-        if (thread) {
-          replyChannel = thread;
-          replyConversationKey = `g:${channelId}:t:${thread.id}`;
-          replyMessenger = createDiscordMessenger(thread);
-          replyIsThread = true;
-        }
-      }
-
+    await withChatLock(replyConversationKey, async () => {
       await handleChatMessage(
         replyChannel,
         replyConversationKey,
@@ -237,42 +234,20 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     });
   }
 
-  async function resolveOrCreateGuildThread(
+  async function createGuildThread(
     message: Message,
-    parentChannelId: string,
-    userId: string,
     messageText: string,
   ): Promise<ThreadChannel | null> {
-    const lookupKey = resolveThreadLookupKey(parentChannelId, userId);
-    // Re-check after the chat lock so concurrent mentions do not create duplicate threads.
-    const existingThreadId = threadStore.get(lookupKey);
-
-    if (existingThreadId) {
-      try {
-        const fetched = await message.client.channels.fetch(existingThreadId);
-
-        if (fetched?.isThread()) {
-          if (fetched.archived) {
-            await fetched.setArchived(false);
-          }
-
-          return fetched;
-        }
-      } catch (error) {
-        console.warn(
-          `Stored Discord thread ${existingThreadId} is unavailable; creating a new one.`,
-          error,
-        );
-      }
-    }
-
     try {
       const thread = await message.startThread({
         name: deriveThreadName(messageText),
         autoArchiveDuration: 1440,
       });
-      threadStore.set(lookupKey, thread.id);
-      await threadStore.save();
+      // Brief lock so concurrent ownership saves do not drop a newly created id.
+      await withChatLock(THREAD_OWNERSHIP_LOCK_KEY, async () => {
+        threadStore.add(thread.id);
+        await threadStore.save();
+      });
       return thread;
     } catch (error) {
       console.error("Failed to create Discord thread; falling back to channel reply:", error);

--- a/apps/platform/discord/src/chat-handler.ts
+++ b/apps/platform/discord/src/chat-handler.ts
@@ -275,9 +275,11 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     stopActiveStream(conversationKey);
     pendingQuestionnaires.delete(conversationKey);
 
-    if (threadStore.deleteByThreadId(channel.id)) {
-      await threadStore.save();
-    }
+    await withChatLock(THREAD_OWNERSHIP_LOCK_KEY, async () => {
+      if (threadStore.deleteByThreadId(channel.id)) {
+        await threadStore.save();
+      }
+    });
 
     await messenger.send("Thread closed.");
 

--- a/apps/platform/discord/src/format.ts
+++ b/apps/platform/discord/src/format.ts
@@ -126,4 +126,4 @@ export const HELP_TEXT = `Nakama Discord commands:
 /profile — choose or switch bot profile (send as text)
 /status — server and model status
 
-In servers, @mention the bot or reply to it to chat. Pair in a DM first.`;
+In servers, @mention the bot or reply to it to chat — each mention in a parent channel opens a new thread. Pair in a DM first.`;

--- a/apps/platform/discord/src/guild-message.test.ts
+++ b/apps/platform/discord/src/guild-message.test.ts
@@ -3,7 +3,6 @@ import {
   explainGuildMessageHandling,
   resolveConversationKey,
   resolveOrgChannelId,
-  resolveThreadLookupKey,
   stripBotMention,
 } from "./guild-message";
 
@@ -158,12 +157,6 @@ describe("resolveOrgChannelId", () => {
   test("uses channel id for plain guild channels", () => {
     const message = createGuildMessage({ content: "hi" });
     expect(resolveOrgChannelId(message, "channel_1", true)).toBe("channel_1");
-  });
-});
-
-describe("resolveThreadLookupKey", () => {
-  test("maps channel and user to a stable lookup key", () => {
-    expect(resolveThreadLookupKey("channel_1", "user_1")).toBe("g:channel_1:u:user_1");
   });
 });
 

--- a/apps/platform/discord/src/guild-message.ts
+++ b/apps/platform/discord/src/guild-message.ts
@@ -60,11 +60,6 @@ export function resolveConversationKey(message: Message, channelId: string, isGu
   return channelId;
 }
 
-/** Persisted mapping key: one chat thread per user in a parent guild channel. */
-export function resolveThreadLookupKey(channelId: string, userId: string): string {
-  return `g:${channelId}:u:${userId}`;
-}
-
 export function isDiscordThreadMessage(message: Message): boolean {
   return message.channel.isThread();
 }

--- a/apps/platform/discord/src/test-helpers.ts
+++ b/apps/platform/discord/src/test-helpers.ts
@@ -254,6 +254,7 @@ export function createGuildChatMessage(options: {
   let lastThreadName: string | null = null;
   let channelFileSendCalls = 0;
   let threadFileSendCalls = 0;
+  const mockInstanceId = `m${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 
   const userId = options.userId ?? "424242424242424242";
   const channelId = options.channelId ?? "guild_channel_1";
@@ -362,7 +363,7 @@ export function createGuildChatMessage(options: {
         throw options.startThreadError;
       }
 
-      createdThreadId = `created_thread_${startThreadCalls}`;
+      createdThreadId = `created_thread_${mockInstanceId}_${startThreadCalls}`;
       const thread = createThreadChannel(createdThreadId, channelId, false);
       existingThreads.set(createdThreadId, {
         id: createdThreadId,

--- a/apps/platform/discord/src/thread-store.test.ts
+++ b/apps/platform/discord/src/thread-store.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { ThreadStore } from "./thread-store";
+import { withTempHome } from "./test-helpers";
+
+describe("ThreadStore ownership", () => {
+  test("tracks multiple owned thread ids independently", async () => {
+    await withTempHome(async (homeDir) => {
+      const store = new ThreadStore(path.join(homeDir, ".nakama", "discord", "chat-threads.json"));
+      await store.load();
+
+      store.add("thread_a");
+      store.add("thread_b");
+      await store.save();
+
+      expect(store.hasThreadId("thread_a")).toBe(true);
+      expect(store.hasThreadId("thread_b")).toBe(true);
+
+      expect(store.deleteByThreadId("thread_a")).toBe(true);
+      await store.save();
+
+      expect(store.hasThreadId("thread_a")).toBe(false);
+      expect(store.hasThreadId("thread_b")).toBe(true);
+    });
+  });
+
+  test("loads legacy lookup-map values as owned thread ids", async () => {
+    await withTempHome(async (homeDir) => {
+      const filePath = path.join(homeDir, ".nakama", "discord", "chat-threads.json");
+      await mkdir(path.dirname(filePath), { recursive: true });
+      await writeFile(
+        filePath,
+        `${JSON.stringify({ "g:guild_channel_1:u:424242424242424242": "thread_old" }, null, 2)}\n`,
+      );
+
+      const store = new ThreadStore(filePath);
+      await store.load();
+
+      expect(store.hasThreadId("thread_old")).toBe(true);
+    });
+  });
+
+  test("loads non-object JSON as empty ownership", async () => {
+    await withTempHome(async (homeDir) => {
+      const filePath = path.join(homeDir, ".nakama", "discord", "chat-threads.json");
+      await mkdir(path.dirname(filePath), { recursive: true });
+      await writeFile(filePath, "[]\n");
+
+      const store = new ThreadStore(filePath);
+      await store.load();
+
+      expect(store.hasThreadId("thread_any")).toBe(false);
+    });
+  });
+});

--- a/apps/platform/discord/src/thread-store.ts
+++ b/apps/platform/discord/src/thread-store.ts
@@ -2,11 +2,10 @@ import { readTextOrNull, writePrivateTextFile } from "@nakama/core/fs";
 import { getDiscordConfigDir } from "@nakama/core/discord-config";
 import { dirname, join } from "node:path";
 
-type ThreadMap = Record<string, string>;
-
+/** Persisted ownership of Discord threads the bot started. */
 export class ThreadStore {
   private readonly path: string;
-  private map: ThreadMap = {};
+  private owned = new Set<string>();
 
   constructor(path = getThreadMapPath()) {
     this.path = path;
@@ -16,64 +15,61 @@ export class ThreadStore {
     const raw = await readTextOrNull(this.path);
 
     if (raw === null) {
-      this.map = {};
+      this.owned = new Set();
       return;
     }
 
-    const parsed = JSON.parse(raw) as unknown;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw) as unknown;
+    } catch {
+      this.owned = new Set();
+      return;
+    }
 
     if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-      this.map = {};
+      this.owned = new Set();
       return;
     }
 
-    const next: ThreadMap = {};
+    const next = new Set<string>();
 
-    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+    // Legacy shape: { "g:channel:u:user": "threadId" } — keep values as owned ids.
+    // Ownership shape: { "threadId": "threadId" } (or any object whose values are thread ids).
+    for (const value of Object.values(parsed as Record<string, unknown>)) {
       if (typeof value === "string" && value.trim()) {
-        next[key] = value;
+        next.add(value.trim());
       }
     }
 
-    this.map = next;
+    this.owned = next;
   }
 
-  get(lookupKey: string): string | undefined {
-    return this.map[lookupKey];
+  /** Record a Discord thread id created/tracked by this bot. */
+  add(threadId: string): void {
+    const id = threadId.trim();
+    if (!id) {
+      return;
+    }
+    this.owned.add(id);
   }
 
   /** True when this thread id was created/tracked by the Discord agent. */
   hasThreadId(threadId: string): boolean {
-    for (const stored of Object.values(this.map)) {
-      if (stored === threadId) {
-        return true;
-      }
-    }
-    return false;
+    return this.owned.has(threadId);
   }
 
-  set(lookupKey: string, threadId: string): void {
-    this.map[lookupKey] = threadId;
-  }
-
-  delete(lookupKey: string): void {
-    delete this.map[lookupKey];
-  }
-
-  /** Drop every mapping that points at this Discord thread id. */
+  /** Drop ownership for this Discord thread id. */
   deleteByThreadId(threadId: string): boolean {
-    let removed = false;
-    for (const [key, value] of Object.entries(this.map)) {
-      if (value === threadId) {
-        delete this.map[key];
-        removed = true;
-      }
-    }
-    return removed;
+    return this.owned.delete(threadId);
   }
 
   async save(): Promise<void> {
-    await writePrivateTextFile(this.path, `${JSON.stringify(this.map, null, 2)}\n`, {
+    const map: Record<string, string> = {};
+    for (const id of this.owned) {
+      map[id] = id;
+    }
+    await writePrivateTextFile(this.path, `${JSON.stringify(map, null, 2)}\n`, {
       ensureDir: dirname(this.path),
     });
   }

--- a/docs/website/content/docs/discord.mdx
+++ b/docs/website/content/docs/discord.mdx
@@ -126,11 +126,15 @@ This keeps server channels usable without making the bot noisy.
 
 In Discord threads, each thread keeps its own Nakama session.
 
+- In a parent server channel, every `@mention` or reply to the bot starts a **new** Discord thread (you do not need `/close` or `/new` first)
+- Continue chatting inside a bot-started thread without mentioning the bot again
+- The same user can have multiple open bot threads in one channel, and agent replies in different threads can run at the same time
 - `/profile` inside a thread changes only that thread
 - new threads use the default Discord profile until you switch them
 - `/profile` in the main channel changes the channel-level profile
 - `/org` stays channel-level, so switch org first if a thread needs a profile from another org
-- `/close` inside a bot-started thread archives it and frees the slot so the next @mention opens a new one
+- `/close` inside a bot-started thread archives that thread only; other open bot threads stay usable
+- `/new` starts a fresh Nakama conversation in the current Discord thread (it does not open a new Discord thread)
 - the bot ignores messages in threads it did not start, including @mentions
 
 Replies in server channels are visible to everyone in that channel. Nakama prefixes those messages so the agent knows the reply is public.
@@ -146,13 +150,13 @@ Session control uses Discord slash commands. Org and profile switching use text 
 | `/stop` | Slash | Stop the current in-progress reply |
 | `/clear` | Slash | Clear chat history |
 | `/compact` | Slash | Compact conversation history |
-| `/new` | Slash | Start a new conversation |
-| `/close` | Slash | Close (archive) the bot conversation thread |
+| `/new` | Slash | Start a new conversation (same Discord thread) |
+| `/close` | Slash | Close (archive) this bot conversation thread |
 | `/status` | Slash | Show server and model status |
 | `/org` | Text | Choose or switch organization |
 | `/profile` | Text | Choose or switch profile |
 
-In servers, `@mention` the bot or reply to it to chat. Complete DM pairing first.
+In servers, `@mention` the bot or reply to it to chat — each mention in a parent channel opens a new thread. Complete DM pairing first.
 
 ## Reply formatting
 


### PR DESCRIPTION
## Summary
- Parent-channel `@mention` / reply-to-bot always creates a **new** Discord thread instead of reusing one mapped slot per user+channel ([#188](https://github.com/ahmadrosid/nakama/issues/188)).
- Thread store tracks **ownership of all** bot-started threads (with legacy `chat-threads.json` value migration); agent chat locks are per conversation/thread so parallel runs can overlap.
- Docs and HELP_TEXT describe always-new mentions, concurrent threads, and that `/new` does not open a Discord thread.

## Test plan
- [x] `bun test apps/platform/discord/src/chat-handler.test.ts apps/platform/discord/src/guild-message.test.ts apps/platform/discord/src/thread-store.test.ts`
- [ ] In a real guild channel: mention twice → two threads; reply in each; `/close` one and confirm the other still answers

Fixes #188

Made with [Cursor](https://cursor.com)