### PR TITLE
polish(web): tighten settings, tools, chats, and integration UI

### DIFF
--- a/apps/web/src/components/integration-settings.shared.tsx
+++ b/apps/web/src/components/integration-settings.shared.tsx
@@ -61,7 +61,7 @@ export function PairingStepTile({
         </span>
         <div className="min-w-0 space-y-0.5">
           <p className="text-sm font-medium text-foreground">{title}</p>
-          <p className="text-xs text-muted-foreground">{description}</p>
+          <p className="text-pretty text-xs text-muted-foreground">{description}</p>
         </div>
       </div>
     </div>
@@ -84,7 +84,7 @@ export function SettingsRow({
       <div className="min-w-0 space-y-0.5">
         <p className="text-sm font-medium text-foreground">{label}</p>
         {description ? (
-          <p className="text-xs text-muted-foreground [text-wrap:pretty]">{description}</p>
+          <p className="text-pretty text-xs text-muted-foreground">{description}</p>
         ) : null}
       </div>
       {children}
@@ -108,23 +108,25 @@ export function IntegrationStatusHeader({
   className?: string;
 }) {
   return (
-    <div className={cn("flex flex-wrap items-center justify-between gap-3 px-4 py-3", className)}>
+    <div className={cn("flex flex-wrap items-start justify-between gap-3 px-4 py-3", className)}>
       <div className="min-w-0 space-y-0.5">
-        <p className="text-sm font-medium text-foreground">{title}</p>
-        <p className="text-xs text-muted-foreground [text-wrap:pretty]">{subtitle}</p>
+        <div className="flex flex-wrap items-center gap-2">
+          <p className="text-balance text-sm font-medium text-foreground">{title}</p>
+          <span
+            className={cn(
+              "inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[11px] font-medium",
+              connected
+                ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+                : configured
+                  ? "bg-amber-500/10 text-amber-800 dark:text-amber-200"
+                  : "bg-muted text-muted-foreground",
+            )}
+          >
+            {statusBadge}
+          </span>
+        </div>
+        <p className="text-pretty text-xs text-muted-foreground">{subtitle}</p>
       </div>
-      <span
-        className={cn(
-          "shrink-0 rounded-full border px-2.5 py-0.5 text-xs font-medium",
-          connected
-            ? "border-emerald-200 bg-emerald-50 text-emerald-800 dark:border-emerald-800/60 dark:bg-emerald-950/40 dark:text-emerald-200"
-            : configured
-              ? "border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-800/50 dark:bg-amber-950/30 dark:text-amber-100"
-              : "border-border bg-muted text-muted-foreground",
-        )}
-      >
-        {statusBadge}
-      </span>
     </div>
   );
 }
@@ -156,7 +158,7 @@ export function IntegrationSettingsFooter({
             "min-w-0 text-xs",
             formError || loadError
               ? "text-destructive"
-              : "text-emerald-800 dark:text-emerald-200",
+              : "text-emerald-700 dark:text-emerald-300",
           )}
           role={formError || loadError ? "alert" : "status"}
         >

--- a/apps/web/src/components/settings/TranscriptionSettingsCard.tsx
+++ b/apps/web/src/components/settings/TranscriptionSettingsCard.tsx
@@ -88,7 +88,7 @@ export function TranscriptionSettingsCard() {
         savedHint || formError ? (
           <>
             {savedHint ? (
-              <p className="text-xs text-emerald-200" role="status">
+              <p className="text-xs text-emerald-700 dark:text-emerald-300" role="status">
                 {savedHint}
               </p>
             ) : null}

--- a/apps/web/src/components/settings/VisionSettingsCard.tsx
+++ b/apps/web/src/components/settings/VisionSettingsCard.tsx
@@ -83,7 +83,7 @@ export function VisionSettingsCard() {
         savedHint || formError ? (
           <>
             {savedHint ? (
-              <p className="text-xs text-emerald-200" role="status">
+              <p className="text-xs text-emerald-700 dark:text-emerald-300" role="status">
                 {savedHint}
               </p>
             ) : null}

--- a/apps/web/src/components/settings/WebPublicUrlSettingsRow.tsx
+++ b/apps/web/src/components/settings/WebPublicUrlSettingsRow.tsx
@@ -72,27 +72,25 @@ export function WebPublicUrlSettingsRow() {
 
   return (
     <div className="space-y-2 px-4 py-3">
-      <div className="space-y-0.5">
-        <label htmlFor="web-public-url" className="text-sm font-medium text-foreground">
-          Public web URL
-        </label>
-        {savedHint ? (
-          <p className="text-xs text-emerald-200" role="status">
-            {savedHint}
-          </p>
-        ) : formError ? (
-          <p className="text-xs text-destructive" role="alert">
-            {formError}
-          </p>
-        ) : (
+      <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+        <div className="min-w-0 space-y-0.5">
+          <label htmlFor="web-public-url" className="text-balance text-sm font-medium text-foreground">
+            Public web URL
+          </label>
           <p className="text-pretty text-xs text-muted-foreground">For OAuth callbacks</p>
-        )}
-        {data?.envOverride ? (
-          <p className="text-pretty text-xs text-amber-800 dark:text-amber-200">
-            Server env overrides this with {data.envOverride}.
+        </div>
+        {savedHint ? (
+          <p className="text-xs text-emerald-700 dark:text-emerald-300" role="status">
+            {savedHint}
           </p>
         ) : null}
       </div>
+
+      {data?.envOverride ? (
+        <p className="text-pretty text-xs text-amber-800 dark:text-amber-200">
+          Server env overrides this with {data.envOverride}.
+        </p>
+      ) : null}
 
       <div className="flex flex-wrap items-center gap-2">
         <Input
@@ -111,9 +109,10 @@ export function WebPublicUrlSettingsRow() {
             }
           }}
           placeholder="https://nakama.example.com"
-          className="min-w-0 flex-1"
+          className="min-w-[12rem] flex-1"
           disabled={saveMutation.isPending}
           aria-invalid={formError ? true : undefined}
+          aria-describedby={formError ? "web-public-url-error" : undefined}
         />
         <Button
           type="button"
@@ -140,6 +139,12 @@ export function WebPublicUrlSettingsRow() {
           )}
         </Button>
       </div>
+
+      {formError ? (
+        <p id="web-public-url-error" className="text-pretty text-xs text-destructive" role="alert">
+          {formError}
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/soul-tools/ToolsTab.tsx
+++ b/apps/web/src/components/soul-tools/ToolsTab.tsx
@@ -94,8 +94,8 @@ export function ToolsTab({ embedded = false }: { embedded?: boolean } = {}) {
     <div className="min-w-0 p-4 sm:p-5">
       <div className="mb-5 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
-          <h2 className="type-section-title">All tools</h2>
-          <p className="type-body mt-1 text-xs">
+          <h2 className="type-section-title text-balance">All tools</h2>
+          <p className="type-body mt-1 text-xs tabular-nums">
             {tools.length === 0
               ? "No tools registered yet"
               : `${tools.length} registered · ${customTools.length} custom · ${builtinTools.length} built-in`}
@@ -119,11 +119,6 @@ export function ToolsTab({ embedded = false }: { embedded?: boolean } = {}) {
         <div className="space-y-6">
           <ToolListSection
             title="Custom tools"
-            description={
-              customTools.length === 0
-                ? "No custom tools yet. Ask Super Bot to create one."
-                : `${customTools.length} registered`
-            }
             tools={customTools}
             busy={busy}
             canUsePlayground={canUsePlayground}
@@ -135,7 +130,6 @@ export function ToolsTab({ embedded = false }: { embedded?: boolean } = {}) {
 
           <ToolListSection
             title="Built-in tools"
-            description={`${builtinTools.length} registered`}
             tools={builtinTools}
             busy={busy}
             canUsePlayground={canUsePlayground}
@@ -207,7 +201,6 @@ export function ToolsTab({ embedded = false }: { embedded?: boolean } = {}) {
 
 function ToolListSection({
   title,
-  description,
   tools,
   busy,
   canUsePlayground,
@@ -217,7 +210,6 @@ function ToolListSection({
   onConfigureEmail,
 }: {
   title: string;
-  description: string;
   tools: ToolDetail[];
   busy: boolean;
   canUsePlayground: boolean;
@@ -228,14 +220,16 @@ function ToolListSection({
 }) {
   return (
     <section>
-      <div className="mb-3">
-        <h3 className="text-sm font-medium text-foreground">{title}</h3>
-        <p className="mt-1 text-xs text-muted-foreground">{description}</p>
+      <div className="mb-3 flex items-baseline gap-2">
+        <h3 className="type-section-title text-balance">{title}</h3>
+        {tools.length > 0 ? (
+          <span className="tabular-nums text-xs text-muted-foreground">{tools.length}</span>
+        ) : null}
       </div>
 
       {tools.length === 0 ? (
         <div className="flex flex-col items-center justify-center gap-3 rounded-md border border-dashed border-border px-4 py-6 text-center">
-          <p className="text-xs text-muted-foreground">None registered.</p>
+          <p className="text-xs text-pretty text-muted-foreground">None registered.</p>
           {onCreateTool ? (
             <Button type="button" size="sm" disabled={busy} onClick={onCreateTool}>
               <PlusIcon className="size-4" aria-hidden />
@@ -310,7 +304,7 @@ function ToolListItem({
 
       <div className="flex shrink-0 flex-col items-end gap-2 sm:flex-row sm:items-center">
         {deletable ? (
-          <span className="scope-badge scope-badge-custom">custom tool</span>
+          <span className="scope-badge scope-badge-custom">custom</span>
         ) : (
           <span className="scope-badge scope-badge-active">built-in</span>
         )}

--- a/apps/web/src/components/ui/button-variants.ts
+++ b/apps/web/src/components/ui/button-variants.ts
@@ -1,7 +1,7 @@
 import { cva } from "class-variance-authority";
 
 export const buttonVariants = cva(
-  "group/button inline-flex shrink-0 cursor-pointer items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 cursor-pointer items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-[color,background-color,border-color,box-shadow,transform,opacity] outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:scale-[0.96] disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -652,15 +652,15 @@
   }
 
   .scope-badge {
-    @apply shrink-0 rounded-full px-2 py-0.5 text-xs font-semibold normal-case tracking-normal;
+    @apply inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[11px] font-medium normal-case tracking-normal;
   }
 
   .scope-badge-active {
-    @apply bg-emerald-100 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300;
+    @apply bg-emerald-500/10 text-emerald-700 dark:text-emerald-300;
   }
 
   .scope-badge-custom {
-    @apply bg-amber-100 text-amber-900 dark:bg-amber-950/50 dark:text-amber-200;
+    @apply bg-amber-500/10 text-amber-800 dark:text-amber-200;
   }
 
   .chat-markdown {

--- a/apps/web/src/pages/HistoryPage.tsx
+++ b/apps/web/src/pages/HistoryPage.tsx
@@ -113,11 +113,11 @@ export function HistoryPage() {
     }
 
     if (sessions.length === 0) {
-      return "No saved chats";
+      return "No chats";
     }
 
     if (isSearching && filteredSessions.length !== sessions.length) {
-      return `${filteredSessions.length} of ${sessions.length}`;
+      return `${filteredSessions.length} of ${sessions.length} chats`;
     }
 
     return `${sessions.length} chat${sessions.length === 1 ? "" : "s"}`;

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -55,7 +55,7 @@ export function SettingsPage() {
           <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
             <div className="space-y-0.5">
               <p className="text-sm font-medium text-foreground">Appearance</p>
-              <p className="text-xs text-muted-foreground">Color theme</p>
+              <p className="text-pretty text-xs text-muted-foreground">Color theme</p>
             </div>
             <ThemeToggle />
           </div>
@@ -66,11 +66,11 @@ export function SettingsPage() {
                 <div className="min-w-0 space-y-0.5">
                   <p className="text-sm font-medium text-foreground">Timezone</p>
                   {timezoneHint ? (
-                    <p className="text-xs text-emerald-200" role="status">
+                    <p className="text-xs text-emerald-700 dark:text-emerald-300" role="status">
                       {timezoneHint}
                     </p>
                   ) : (
-                    <p className="text-xs text-muted-foreground">For scheduled automations</p>
+                    <p className="text-pretty text-xs text-muted-foreground">For scheduled automations</p>
                   )}
                 </div>
                 <div className="flex items-center gap-2">

--- a/apps/web/src/pages/history-delete-dialog.tsx
+++ b/apps/web/src/pages/history-delete-dialog.tsx
@@ -26,13 +26,14 @@ export function HistoryDeleteDialog({
     <Dialog open={deleteTarget !== null} onOpenChange={onOpenChange}>
       <DialogContent className="gap-6 p-6 sm:max-w-md">
         <DialogHeader className="gap-3">
-          <DialogTitle>Delete conversation?</DialogTitle>
-          <DialogDescription>
-            This removes {deleteTarget?.messageCount ?? 0} message
-            {(deleteTarget?.messageCount ?? 0) === 1 ? "" : "s"}. This cannot be undone.
+          <DialogTitle className="text-balance">Delete chat?</DialogTitle>
+          <DialogDescription className="text-pretty">
+            Deletes this chat and its{" "}
+            <span className="tabular-nums">{deleteTarget?.messageCount ?? 0}</span> message
+            {(deleteTarget?.messageCount ?? 0) === 1 ? "" : "s"} permanently.
           </DialogDescription>
           {deleteTarget ? (
-            <p className="text-sm font-medium text-foreground line-clamp-2">
+            <p className="line-clamp-2 text-sm font-medium text-foreground">
               {formatSessionTitle(deleteTarget)}
             </p>
           ) : null}

--- a/apps/web/src/pages/history-page.shared.ts
+++ b/apps/web/src/pages/history-page.shared.ts
@@ -1,7 +1,7 @@
 import type { SessionSummary } from "@nakama/core/contract";
 
 export function formatSessionTitle(session: SessionSummary): string {
-  return session.title?.trim() || "Untitled";
+  return session.title?.trim() || "Untitled chat";
 }
 
 export function groupSessionsByDate(sessions: SessionSummary[]): Array<{

--- a/apps/web/src/pages/history-sessions-panel.tsx
+++ b/apps/web/src/pages/history-sessions-panel.tsx
@@ -61,10 +61,10 @@ export function HistorySessionsPanel({
           <Input
             value={searchQuery}
             onChange={(event) => onSearchChange(event.target.value)}
-            placeholder="Search…"
+            placeholder="Search chats…"
             disabled={!profileId || initialLoading}
             className={cn("pl-9", isSearching && "pr-9")}
-            aria-label="Search conversations"
+            aria-label="Search chats"
           />
           {isSearching ? (
             <button
@@ -79,13 +79,13 @@ export function HistorySessionsPanel({
         </div>
 
         <div className="flex items-center gap-2">
-          <span className="text-xs text-muted-foreground tabular-nums">{countLabel}</span>
+          <span className="tabular-nums text-xs text-muted-foreground">{countLabel}</span>
           <Button
             type="button"
             variant="ghost"
             size="icon-sm"
             disabled={refreshing || busy || !profileId}
-            aria-label="Refresh"
+            aria-label="Refresh chats"
             onClick={onRefresh}
           >
             {refreshing ? <Spinner className="size-4" /> : <RefreshCwIcon className="size-4" />}
@@ -95,7 +95,7 @@ export function HistorySessionsPanel({
 
       {profiles.length === 0 ? (
         <HistoryEmptyMessage
-          message="Create a profile first."
+          message="Create a profile to start chatting."
           actionLabel="Go to Profiles"
           onAction={onGoToProfiles}
         />
@@ -104,18 +104,16 @@ export function HistorySessionsPanel({
       ) : filteredSessions.length === 0 ? (
         <HistoryEmptyMessage
           message={
-            sessions.length > 0
-              ? "No conversations match your search."
-              : "No saved chats for this profile."
+            sessions.length > 0 ? "No chats match your search." : "No chats yet."
           }
-          actionLabel={sessions.length > 0 ? "Clear search" : "Go to Chat"}
+          actionLabel={sessions.length > 0 ? "Clear search" : "New chat"}
           onAction={() => (sessions.length > 0 ? onClearSearch() : onGoToChat())}
         />
       ) : (
         <div className="divide-y divide-border">
           {groupedSessions.map((group) => (
             <section key={group.label}>
-              <p className="px-4 py-2 text-xs text-muted-foreground">{group.label}</p>
+              <p className="px-4 py-2 text-xs font-medium text-muted-foreground">{group.label}</p>
               <ul>
                 {group.sessions.map((session) => (
                   <li key={session.id}>
@@ -136,6 +134,10 @@ export function HistorySessionsPanel({
   );
 }
 
+function formatMessageCount(count: number): string {
+  return count === 1 ? "1 message" : `${count} messages`;
+}
+
 function HistorySessionRow({
   session,
   disabled,
@@ -150,15 +152,15 @@ function HistorySessionRow({
   const title = formatSessionTitle(session);
 
   return (
-    <div className="group flex items-center gap-2 px-4 py-3 hover:bg-muted/40">
+    <div className="group flex items-center gap-2 px-4 py-3 transition-colors duration-150 ease-out hover:bg-muted/40">
       <button
         type="button"
         disabled={disabled}
         className="min-w-0 flex-1 text-left disabled:opacity-50"
         onClick={onOpen}
       >
-        <p className="truncate text-sm text-foreground">{title}</p>
-        <p className="mt-0.5 text-xs text-muted-foreground">
+        <p className="truncate text-sm font-medium text-foreground">{title}</p>
+        <p className="mt-0.5 text-pretty text-xs text-muted-foreground">
           {session.channel !== "web" ? (
             <>
               <span>{formatSessionChannelLabel(session.channel)}</span>
@@ -169,7 +171,7 @@ function HistorySessionRow({
             {formatSessionRelativeTime(session.updatedAt)}
           </time>
           {" · "}
-          {session.messageCount} messages
+          <span className="tabular-nums">{formatMessageCount(session.messageCount)}</span>
         </p>
       </button>
 
@@ -202,7 +204,7 @@ function HistoryEmptyMessage({
 }) {
   return (
     <div className="px-4 py-12 text-center">
-      <p className="text-sm text-muted-foreground">{message}</p>
+      <p className="text-pretty text-sm text-muted-foreground">{message}</p>
       {actionLabel && onAction ? (
         <Button type="button" variant="link" className="mt-2 h-auto p-0" onClick={onAction}>
           {actionLabel}
@@ -214,7 +216,7 @@ function HistoryEmptyMessage({
 
 function HistoryListSkeleton() {
   return (
-    <div className="divide-y divide-border" aria-busy="true">
+    <div className="divide-y divide-border" aria-busy="true" aria-label="Loading chats">
       {Array.from({ length: 4 }).map((_, index) => (
         <div key={index} className="space-y-2 px-4 py-3">
           <div className="h-4 w-2/3 animate-pulse rounded bg-muted/50" />


### PR DESCRIPTION
## Summary
Dense admin surfaces were louder and less consistent than they needed to be: solid status pills, hard-to-read saved hints in light mode, stacked tool section subtitles, and mixed “chat” vs “conversation” copy on History.

This pass softens SoftPill-style badges across tools and integrations, keeps settings hints readable on light backgrounds, collapses tool section headers to a single line, and unifies Chats vocabulary end-to-end (search, empty states, delete dialog). Shared buttons also get interruptible press feedback at `scale(0.96)` instead of `transition-all`.

## Test plan
- [ ] System → Tools: custom/built-in badges and one-line section headers look quiet and aligned
- [ ] Settings: save Public web URL / timezone in light mode — “Saved” is readable; errors stay under the URL field
- [ ] Integrations → Telegram/Discord/WhatsApp: status pill sits beside the title with soft fills
- [ ] Chats: search placeholder, empty states, and delete dialog all say “chat”; counts use tabular numerals
- [ ] Spot-check a primary button press for subtle scale feedback without exaggerated motion
