### PR TITLE
fix(web): confirm before clearing worker logs

### DIFF
--- a/apps/web/src/components/WorkerLogDialog.tsx
+++ b/apps/web/src/components/WorkerLogDialog.tsx
@@ -22,6 +22,7 @@ export function WorkerLogDialog({ workerName, open, onOpenChange }: WorkerLogDia
   const clearLogs = useClearWorkerLogs(workerName);
   const [activeTab, setActiveTab] = useState<"stdout" | "stderr">("stdout");
   const [copied, setCopied] = useState(false);
+  const [confirmClear, setConfirmClear] = useState(false);
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const errorMessage = error ? formatError(error) : null;
   const clearErrorMessage = clearLogs.error ? formatError(clearLogs.error) : null;
@@ -32,6 +33,7 @@ export function WorkerLogDialog({ workerName, open, onOpenChange }: WorkerLogDia
   function selectTab(tab: "stdout" | "stderr") {
     setActiveTab(tab);
     setCopied(false);
+    setConfirmClear(false);
   }
 
   async function copyLogs() {
@@ -54,9 +56,26 @@ export function WorkerLogDialog({ workerName, open, onOpenChange }: WorkerLogDia
     }
   }
 
+  async function handleClearLogs() {
+    if (!confirmClear) {
+      setConfirmClear(true);
+      return;
+    }
+
+    try {
+      await clearLogs.mutateAsync();
+      setCopied(false);
+      setConfirmClear(false);
+      await refetch();
+    } catch {
+      // Error surface via clearLogs.error
+    }
+  }
+
   function handleOpenChange(nextOpen: boolean) {
     if (nextOpen) {
       setCopied(false);
+      setConfirmClear(false);
       void refetch();
     }
     onOpenChange(nextOpen);
@@ -126,7 +145,10 @@ export function WorkerLogDialog({ workerName, open, onOpenChange }: WorkerLogDia
             size="sm"
             className="text-xs"
             disabled={isLoading || clearLogs.isPending}
-            onClick={() => void refetch().then(() => setCopied(false))}
+            onClick={() => {
+              setConfirmClear(false);
+              void refetch().then(() => setCopied(false));
+            }}
           >
             Refresh
           </Button>
@@ -136,17 +158,10 @@ export function WorkerLogDialog({ workerName, open, onOpenChange }: WorkerLogDia
             size="sm"
             className="text-xs text-destructive hover:bg-destructive/10 hover:text-destructive"
             disabled={isLoading || clearLogs.isPending}
-            onClick={() => {
-              if (confirm("Are you sure you want to clear the logs?")) {
-                void clearLogs.mutateAsync().then(() => {
-                  setCopied(false);
-                  return refetch();
-                });
-              }
-            }}
+            onClick={() => void handleClearLogs()}
           >
             <Trash2Icon className="mr-1 size-3" aria-hidden />
-            Clear
+            {confirmClear ? "Confirm?" : "Clear"}
           </Button>
         </div>
 

--- a/apps/web/src/hooks/use-worker-logs.ts
+++ b/apps/web/src/hooks/use-worker-logs.ts
@@ -16,7 +16,11 @@ export function useClearWorkerLogs(workerName: string) {
   return useMutation({
     mutationFn: () => client.clearWorkerLogs(workerName),
     onSuccess: () => {
-      queryClient.invalidateQueries({
+      queryClient.setQueriesData({ queryKey: [...queryKeys.workerLogs, workerName] }, {
+        stdout: "",
+        stderr: "",
+      });
+      void queryClient.invalidateQueries({
         queryKey: [...queryKeys.workerLogs, workerName],
       });
     },


### PR DESCRIPTION
## Summary
Clearing worker logs used a browser `confirm()` dialog and left stale cache content until refetch finished.

Clear now uses a two-click in-button confirm (`Clear` → `Confirm?`), and the log query cache is zeroed immediately on success so the dialog goes empty right away.

## Test plan
- [ ] Open Status → worker logs dialog
- [ ] Click Clear once — button becomes Confirm?; logs remain
- [ ] Click Confirm? — logs clear; button resets
- [ ] Refresh / reopen dialog — still empty after clear
- [ ] Cancel path: click Clear then Refresh — confirm state resets without clearing
