### PR TITLE
feat(discord): claim foreign threads on mention or reply

### DIFF
--- a/apps/platform/discord/src/bot.ts
+++ b/apps/platform/discord/src/bot.ts
@@ -45,6 +45,12 @@ export async function createBot(
   });
 
   client.on(Events.MessageCreate, async (message: Message) => {
+    console.log(
+      "[discord] message",
+      message.author.id,
+      message.channelId,
+      message.content?.slice(0, 80),
+    );
     try {
       await handler.handleMessage(message);
     } catch (error) {
@@ -56,6 +62,8 @@ export async function createBot(
     if (!interaction.isChatInputCommand()) {
       return;
     }
+
+    console.log("[discord] slash", interaction.commandName, interaction.user.id);
 
     // Acknowledge immediately — Discord expires interactions after ~3s.
     // Any work (locks, API calls) must happen after this.

--- a/apps/platform/discord/src/chat-handler.test.ts
+++ b/apps/platform/discord/src/chat-handler.test.ts
@@ -622,7 +622,7 @@ describe("createChatHandler guild thread routing", () => {
     });
   });
 
-  test("ignores messages in threads the agent did not start", async () => {
+  test("ignores unmentioned messages in threads the agent did not start", async () => {
     await withTempHome(async (homeDir) => {
       const streamedInputs: unknown[] = [];
       const { handleMessage } = await createPairedHandler(homeDir, {
@@ -631,6 +631,29 @@ describe("createChatHandler guild thread routing", () => {
           return "Should not reply";
         },
       });
+
+      const guild = createGuildChatMessage({
+        content: "please join this thread",
+        inThread: true,
+        threadId: "user_thread_9",
+        parentId: "guild_channel_1",
+      });
+      await handleMessage(guild.message);
+
+      expect(guild.startThreadCalls).toBe(0);
+      expect(guild.threadSentMessages).toHaveLength(0);
+      expect(guild.channelSentMessages).toHaveLength(0);
+      expect(streamedInputs).toHaveLength(0);
+    });
+  });
+
+  test("claims a foreign thread on @mention and replies inside it", async () => {
+    await withTempHome(async (homeDir) => {
+      const { handleMessage, threadStore } = await createPairedHandler(homeDir, {
+        onSendStream: async () => "Joined the thread",
+      });
+
+      expect(threadStore.hasThreadId("user_thread_9")).toBe(false);
 
       const guild = createGuildChatMessage({
         content: "<@bot_id> please join this thread",
@@ -642,9 +665,19 @@ describe("createChatHandler guild thread routing", () => {
       await handleMessage(guild.message);
 
       expect(guild.startThreadCalls).toBe(0);
-      expect(guild.threadSentMessages).toHaveLength(0);
+      expect(threadStore.hasThreadId("user_thread_9")).toBe(true);
+      expect(guild.threadSentMessages).toContain("Joined the thread");
       expect(guild.channelSentMessages).toHaveLength(0);
-      expect(streamedInputs).toHaveLength(0);
+
+      const followUp = createGuildChatMessage({
+        content: "keep going",
+        inThread: true,
+        threadId: "user_thread_9",
+        parentId: "guild_channel_1",
+      });
+      await handleMessage(followUp.message);
+
+      expect(followUp.threadSentMessages.length).toBeGreaterThan(0);
     });
   });
 

--- a/apps/platform/discord/src/chat-handler.ts
+++ b/apps/platform/discord/src/chat-handler.ts
@@ -131,9 +131,25 @@ export function createChatHandler(deps: ChatHandlerDeps) {
       ? explainGuildMessageHandling(message, botInfo, { botOwnsThread })
       : null;
 
+    console.log(
+      "[discord] handle",
+      groupDecision?.reason ?? (isGuild ? "none" : "dm"),
+      { channelId, isThread, botOwnsThread, botId: botInfo?.id },
+    );
+
     if (groupDecision && !groupDecision.shouldHandle) {
+      console.log("[discord] skip", groupDecision.reason);
       return;
     }
+
+    if (isThread && groupDecision?.reason === "claim-thread") {
+      await withChatLock(THREAD_OWNERSHIP_LOCK_KEY, async () => {
+        threadStore.add(channelId);
+        await threadStore.save();
+      });
+      console.log("[discord] claimed thread", channelId);
+    }
+
     const parentChannelId = resolveOrgChannelId(message, channelId, isGuild);
     // Threads share the parent channel's org selection — do not key by thread id.
     const channelOrgKey = resolveChannelOrgKey(parentChannelId, userId, isGuild);
@@ -145,6 +161,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     const isAuthorized = authStore.isAuthorized(userId);
 
     if (!isAuthorized) {
+      console.log("[discord] unauthorized", userId);
       if (isGuild) {
         await messenger.send(LINK_IN_PRIVATE_REPLY);
         return;
@@ -174,6 +191,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
         isGuild && text && botInfo ? stripBotMention(text, botInfo) : text;
       const orgReady = await ensureOrgReady(messenger, channelOrgKey, orgGateText);
       if (!orgReady) {
+        console.log("[discord] skip org-gate", channelOrgKey);
         return;
       }
     }
@@ -219,8 +237,13 @@ export function createChatHandler(deps: ChatHandlerDeps) {
         replyConversationKey = `g:${channelId}:t:${thread.id}`;
         replyMessenger = createDiscordMessenger(thread);
         replyIsThread = true;
+        console.log("[discord] thread created", thread.id);
+      } else {
+        console.log("[discord] thread create failed, falling back to channel");
       }
     }
+
+    console.log("[discord] chat start", replyConversationKey, messageText.slice(0, 80));
 
     await withChatLock(replyConversationKey, async () => {
       await handleChatMessage(
@@ -232,6 +255,8 @@ export function createChatHandler(deps: ChatHandlerDeps) {
         replyIsThread,
       );
     });
+
+    console.log("[discord] chat done", replyConversationKey);
   }
 
   async function createGuildThread(

--- a/apps/platform/discord/src/format.ts
+++ b/apps/platform/discord/src/format.ts
@@ -126,4 +126,4 @@ export const HELP_TEXT = `Nakama Discord commands:
 /profile — choose or switch bot profile (send as text)
 /status — server and model status
 
-In servers, @mention the bot or reply to it to chat — each mention in a parent channel opens a new thread. Pair in a DM first.`;
+In servers, @mention the bot or reply to it to chat — each mention in a parent channel opens a new thread. @mention inside another thread claims it. Pair in a DM first.`;

--- a/apps/platform/discord/src/guild-message.test.ts
+++ b/apps/platform/discord/src/guild-message.test.ts
@@ -110,7 +110,7 @@ describe("explainGuildMessageHandling", () => {
     expect(decision.reason).toBe("foreign-thread");
   });
 
-  test("ignores mentions inside threads the agent did not start", () => {
+  test("claims a foreign thread when the bot is @mentioned", () => {
     const decision = explainGuildMessageHandling(
       createGuildMessage({
         content: "<@999000111222333444> please join",
@@ -121,8 +121,23 @@ describe("explainGuildMessageHandling", () => {
       { botOwnsThread: false },
     );
 
-    expect(decision.shouldHandle).toBe(false);
-    expect(decision.reason).toBe("foreign-thread");
+    expect(decision.shouldHandle).toBe(true);
+    expect(decision.reason).toBe("claim-thread");
+  });
+
+  test("claims a foreign thread when the user replies to the bot", () => {
+    const decision = explainGuildMessageHandling(
+      createGuildMessage({
+        content: "please join",
+        replyToBot: true,
+        thread: true,
+      }),
+      BOT_INFO,
+      { botOwnsThread: false },
+    );
+
+    expect(decision.shouldHandle).toBe(true);
+    expect(decision.reason).toBe("claim-thread");
   });
 
   test("still requires a trigger in plain channels", () => {

--- a/apps/platform/discord/src/guild-message.ts
+++ b/apps/platform/discord/src/guild-message.ts
@@ -12,6 +12,7 @@ export interface GuildMessageHandlingDecision {
     | "missing-bot-info"
     | "in-thread"
     | "foreign-thread"
+    | "claim-thread"
     | "reply-to-bot"
     | "bot-mention"
     | "no-text"
@@ -102,12 +103,18 @@ export function explainGuildMessageHandling(
     return { shouldHandle: false, reason: "missing-bot-info" };
   }
 
-  // Only continue conversations in threads the agent started — ignore user-created threads.
+  // Bot-owned threads continue without a mention. Foreign threads stay quiet
+  // unless the user @mentions the bot or replies to it — then we claim the thread.
   if (message.channel.isThread()) {
-    if (!options?.botOwnsThread) {
-      return { shouldHandle: false, reason: "foreign-thread" };
+    if (options?.botOwnsThread) {
+      return { shouldHandle: true, reason: "in-thread" };
     }
-    return { shouldHandle: true, reason: "in-thread" };
+
+    if (isReplyToBot(message, botInfo.id) || hasBotMention(message, botInfo)) {
+      return { shouldHandle: true, reason: "claim-thread" };
+    }
+
+    return { shouldHandle: false, reason: "foreign-thread" };
   }
 
   if (isReplyToBot(message, botInfo.id)) {

--- a/docs/website/content/docs/discord.mdx
+++ b/docs/website/content/docs/discord.mdx
@@ -135,7 +135,7 @@ In Discord threads, each thread keeps its own Nakama session.
 - `/org` stays channel-level, so switch org first if a thread needs a profile from another org
 - `/close` inside a bot-started thread archives that thread only; other open bot threads stay usable
 - `/new` starts a fresh Nakama conversation in the current Discord thread (it does not open a new Discord thread)
-- the bot ignores messages in threads it did not start, including @mentions
+- threads the bot did not start stay quiet until you `@mention` the bot (or reply to it); that claims the thread so follow-ups work without another mention
 
 Replies in server channels are visible to everyone in that channel. Nakama prefixes those messages so the agent knows the reply is public.
 


### PR DESCRIPTION
## Summary
Guild threads the bot did not start stayed silent even on @mention, so users could not pull the bot into an existing conversation.

@mention or reply-to-bot in a foreign thread now claims it (persisted ownership), replies in-thread, and later messages continue without another mention. Unmentioned messages in foreign threads still stay quiet. Docs and help text match that behavior; handler logging is included for bridge debugging.

## Test plan
- [ ] In a user-created Discord thread, message without mentioning the bot — no reply
- [ ] @mention the bot in that thread — bot claims it and replies in-thread (no new thread)
- [ ] Send a follow-up without mention — bot continues in the same thread
- [ ] Reply to a bot message in a foreign thread — same claim behavior
- [ ] `bun test apps/platform/discord/src/guild-message.test.ts apps/platform/discord/src/chat-handler.test.ts`
