### PR TITLE
fix(discord): keep bot-owned threads responsive after save or lock failures

### DIFF
--- a/apps/platform/discord/src/chat-handler.test.ts
+++ b/apps/platform/discord/src/chat-handler.test.ts
@@ -1,8 +1,13 @@
 import path from "node:path";
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import type { ChatMessage } from "@nakama/core/contract";
 import { DiscordAuthStore } from "./auth-store";
-import { createChatHandler } from "./chat-handler";
+import {
+  chatLockOptions,
+  createChatHandler,
+  resetChatLocksForTests,
+  withChatLock,
+} from "./chat-handler";
 import { SessionStore } from "./session-store";
 import { ThreadStore } from "./thread-store";
 import {
@@ -15,6 +20,11 @@ import {
   withTempHome,
   writeDiscordConfigIni,
 } from "./test-helpers";
+
+afterEach(() => {
+  resetChatLocksForTests();
+  chatLockOptions.waitMs = 15 * 60 * 1000;
+});
 
 async function createPairedHandler(
   homeDir: string,
@@ -858,5 +868,181 @@ describe("createChatHandler guild thread routing", () => {
       expect(foreignClose.replies).toContain("I can only close threads I started.");
       expect(threadStore.hasThreadId("thread_owned")).toBe(true);
     });
+  });
+
+  test("threadStore save failure still tracks the created Discord thread", async () => {
+    await withTempHome(async (homeDir) => {
+      const streamedInputs: unknown[] = [];
+      const { handleMessage, threadStore } = await createPairedHandler(homeDir, {
+        onSendStream: async (input) => {
+          streamedInputs.push(input);
+          return "Tracked despite save failure";
+        },
+      });
+
+      const originalSave = threadStore.save.bind(threadStore);
+      let saveCalls = 0;
+      threadStore.save = async () => {
+        saveCalls += 1;
+        throw new Error("ENOSPC");
+      };
+
+      const mention = createGuildChatMessage({
+        content: "<@bot_id> start me",
+        mentionsBot: true,
+      });
+      await handleMessage(mention.message);
+
+      const threadId = mention.createdThreadId;
+      expect(threadId).toBeTruthy();
+      expect(saveCalls).toBeGreaterThan(0);
+      expect(threadStore.hasThreadId(threadId!)).toBe(true);
+      expect(mention.threadSentMessages).toContain("Tracked despite save failure");
+      expect(mention.channelSentMessages).not.toContain("Tracked despite save failure");
+
+      threadStore.save = originalSave;
+
+      const followUp = createGuildChatMessage({
+        content: "still here",
+        inThread: true,
+        threadId: threadId!,
+        parentId: "guild_channel_1",
+      });
+      await handleMessage(followUp.message);
+
+      expect(followUp.threadSentMessages).toContain("Tracked despite save failure");
+      expect(streamedInputs).toHaveLength(2);
+    });
+  });
+
+  test("claim-thread save failure still tracks ownership for follow-ups", async () => {
+    await withTempHome(async (homeDir) => {
+      const { handleMessage, threadStore } = await createPairedHandler(homeDir, {
+        onSendStream: async () => "Claimed despite save failure",
+      });
+
+      threadStore.save = async () => {
+        throw new Error("EACCES");
+      };
+
+      const claim = createGuildChatMessage({
+        content: "<@bot_id> join please",
+        mentionsBot: true,
+        inThread: true,
+        threadId: "user_thread_claim",
+        parentId: "guild_channel_1",
+      });
+      await handleMessage(claim.message);
+
+      expect(threadStore.hasThreadId("user_thread_claim")).toBe(true);
+      expect(claim.threadSentMessages).toContain("Claimed despite save failure");
+
+      const followUp = createGuildChatMessage({
+        content: "keep going",
+        inThread: true,
+        threadId: "user_thread_claim",
+        parentId: "guild_channel_1",
+      });
+      await handleMessage(followUp.message);
+
+      expect(followUp.threadSentMessages.length).toBeGreaterThan(0);
+    });
+  });
+
+  test("partial thread hydrates parentId via channel.fetch so org keys stay correct", async () => {
+    await withTempHome(async (homeDir) => {
+      const streamedByKey: string[] = [];
+      const { handleMessage, threadStore, orgStore, sessionStore } = await createPairedHandler(
+        homeDir,
+        {
+          orgs: createMultiTestOrgs(),
+          onSendStream: async (input) => {
+            streamedByKey.push(String((input as { message?: string }).message ?? ""));
+            return "Partial ok";
+          },
+        },
+      );
+
+      orgStore.set("g:guild_channel_1", "org_a");
+      await orgStore.save();
+      threadStore.add("thread_partial");
+      await threadStore.save();
+
+      const followUp = createGuildChatMessage({
+        content: "hello from partial",
+        inThread: true,
+        threadId: "thread_partial",
+        parentId: null,
+        fetchParentId: "guild_channel_1",
+      });
+      await handleMessage(followUp.message);
+
+      expect(followUp.threadSentMessages).toContain("Partial ok");
+      expect(streamedByKey).toEqual(["hello from partial"]);
+      expect(orgStore.get("g:thread_partial")).toBeUndefined();
+      expect(sessionStore.get("g:guild_channel_1:t:thread_partial")).toBeTruthy();
+      expect(sessionStore.get("g:thread_partial:t:thread_partial")).toBeUndefined();
+    });
+  });
+
+  test("slash commands in partial threads hydrate parentId via channel.fetch", async () => {
+    await withTempHome(async (homeDir) => {
+      const { handleSlashCommand, orgStore, sessionStore } = await createPairedHandler(homeDir, {
+        orgs: createMultiTestOrgs(),
+      });
+
+      orgStore.set("g:guild_channel_1", "org_b");
+      await orgStore.save();
+      sessionStore.set("g:guild_channel_1:t:thread_partial_slash", {
+        sessionId: "session_test",
+        profileId: "default",
+        updatedAt: new Date().toISOString(),
+      });
+      await sessionStore.save();
+
+      const clearCmd = createSlashInteraction({
+        commandName: "clear",
+        inThread: true,
+        threadId: "thread_partial_slash",
+        parentId: null,
+        fetchParentId: "guild_channel_1",
+      });
+      await handleSlashCommand(clearCmd.interaction);
+
+      expect(clearCmd.replies.some((text) => text.includes("Choose an organization"))).toBe(false);
+      expect(clearCmd.replies).toContain("History cleared.");
+      expect(orgStore.get("g:thread_partial_slash")).toBeUndefined();
+    });
+  });
+
+  test("wedged chat lock recovers so follow-ups are not silenced forever", async () => {
+    chatLockOptions.waitMs = 40;
+
+    let releaseHang!: () => void;
+    const hang = new Promise<void>((resolve) => {
+      releaseHang = resolve;
+    });
+
+    const order: string[] = [];
+    const first = withChatLock("g:channel:t:thread_wedge", async () => {
+      order.push("first-start");
+      await hang;
+      order.push("first-end");
+    });
+
+    await Bun.sleep(5);
+    const secondStarted = Date.now();
+    const second = withChatLock("g:channel:t:thread_wedge", async () => {
+      order.push("second");
+    });
+
+    await second;
+    const waitedMs = Date.now() - secondStarted;
+    expect(waitedMs).toBeGreaterThanOrEqual(35);
+    expect(order).toEqual(["first-start", "second"]);
+
+    releaseHang();
+    await first;
+    expect(order).toEqual(["first-start", "second", "first-end"]);
   });
 });

--- a/apps/platform/discord/src/chat-handler.ts
+++ b/apps/platform/discord/src/chat-handler.ts
@@ -68,6 +68,15 @@ const chatLocks = new Map<string, Promise<void>>();
 const pendingQuestionnaires = new Map<string, AgentQuestionnaire>();
 const THREAD_OWNERSHIP_LOCK_KEY = "__discord_thread_ownership__";
 
+/**
+ * Max time a queued message waits for the previous agent run on the same key.
+ * Long enough for legitimate multi-minute tool/LLM turns; short enough that a
+ * wedged run cannot silence a thread forever. Slash commands bypass this lock.
+ */
+export const chatLockOptions = {
+  waitMs: 15 * 60 * 1000,
+};
+
 const GROUP_MESSAGE_PREFIX =
   "[Discord channel — your reply is visible to everyone in this channel.]\n";
 
@@ -126,6 +135,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     const isGuild = isDiscordGuildMessage(message);
     const isThread = isDiscordThreadMessage(message);
     const botInfo = resolveBotInfo(message, getBotInfo());
+    // Ownership is by thread id alone — partial parentId cannot flip this to foreign.
     const botOwnsThread = isThread ? threadStore.hasThreadId(channelId) : false;
     const groupDecision = isGuild
       ? explainGuildMessageHandling(message, botInfo, { botOwnsThread })
@@ -143,17 +153,18 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     }
 
     if (isThread && groupDecision?.reason === "claim-thread") {
-      await withChatLock(THREAD_OWNERSHIP_LOCK_KEY, async () => {
-        threadStore.add(channelId);
-        await threadStore.save();
-      });
+      await trackOwnedThread(channelId);
       console.log("[discord] claimed thread", channelId);
     }
 
-    const parentChannelId = resolveOrgChannelId(message, channelId, isGuild);
+    const resolvedParentId = isThread
+      ? await resolveThreadParentChannelId(message)
+      : undefined;
+    const parentResolution = resolvedParentId ? { parentChannelId: resolvedParentId } : undefined;
+    const parentChannelId = resolveOrgChannelId(message, channelId, isGuild, parentResolution);
     // Threads share the parent channel's org selection — do not key by thread id.
     const channelOrgKey = resolveChannelOrgKey(parentChannelId, userId, isGuild);
-    const conversationKey = resolveConversationKey(message, channelId, isGuild);
+    const conversationKey = resolveConversationKey(message, channelId, isGuild, parentResolution);
 
     // Auth/org/thread-create run without the agent-stream lock so parallel parent mentions
     // can each open a thread. Agent work locks per conversation/thread key below.
@@ -263,21 +274,38 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     message: Message,
     messageText: string,
   ): Promise<ThreadChannel | null> {
+    let thread: ThreadChannel;
     try {
-      const thread = await message.startThread({
+      thread = await message.startThread({
         name: deriveThreadName(messageText),
         autoArchiveDuration: 1440,
       });
-      // Brief lock so concurrent ownership saves do not drop a newly created id.
-      await withChatLock(THREAD_OWNERSHIP_LOCK_KEY, async () => {
-        threadStore.add(thread.id);
-        await threadStore.save();
-      });
-      return thread;
     } catch (error) {
       console.error("Failed to create Discord thread; falling back to channel reply:", error);
       return null;
     }
+
+    await trackOwnedThread(thread.id);
+    return thread;
+  }
+
+  /**
+   * Register ownership in memory first, then persist. Save failures must not
+   * leave a live Discord thread untracked (that yields permanent foreign-thread drops).
+   */
+  async function trackOwnedThread(threadId: string): Promise<void> {
+    // Brief lock so concurrent ownership saves do not drop a newly created id.
+    await withChatLock(THREAD_OWNERSHIP_LOCK_KEY, async () => {
+      threadStore.add(threadId);
+      try {
+        await threadStore.save();
+      } catch (error) {
+        console.error(
+          `Failed to persist Discord thread ownership for ${threadId}; keeping in-memory tracking:`,
+          error,
+        );
+      }
+    });
   }
 
   async function handleCloseThread(
@@ -325,14 +353,19 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     const userId = interaction.user.id;
     const channelId = interaction.channelId;
     const isGuild = !interaction.channel?.isDMBased();
-    const orgChannelId =
-      isGuild && interaction.channel?.isThread()
-        ? (interaction.channel.parentId ?? channelId)
-        : channelId;
+    const isThread = Boolean(interaction.channel?.isThread());
+    let threadParentId =
+      isGuild && isThread && interaction.channel && "parentId" in interaction.channel
+        ? (interaction.channel.parentId ?? undefined)
+        : undefined;
+    if (isGuild && isThread && !threadParentId && interaction.channel) {
+      threadParentId = await hydrateThreadParentId(interaction.channel);
+    }
+    const orgChannelId = isGuild && isThread ? (threadParentId ?? channelId) : channelId;
     const channelOrgKey = resolveChannelOrgKey(orgChannelId, userId, isGuild);
     const conversationKey = isGuild
-      ? interaction.channel?.isThread()
-        ? `g:${interaction.channel.parentId ?? channelId}:t:${interaction.channel.id}`
+      ? isThread
+        ? `g:${threadParentId ?? channelId}:t:${interaction.channel!.id}`
         : channelId
       : channelId;
 
@@ -964,7 +997,52 @@ async function replyChunks(messenger: DiscordMessenger, text: string): Promise<v
   }
 }
 
-async function withChatLock(chatId: string, fn: () => Promise<void>): Promise<void> {
+/**
+ * Hydrate parent guild channel id for thread messages when Discord delivers a
+ * partial channel (`Partials.Channel`) without `parentId`. Ownership checks use
+ * the thread id alone; this only protects org + conversation keys.
+ */
+async function resolveThreadParentChannelId(message: Message): Promise<string | undefined> {
+  if (!message.channel.isThread()) {
+    return undefined;
+  }
+
+  if (message.channel.parentId) {
+    return message.channel.parentId;
+  }
+
+  return hydrateThreadParentId(message.channel);
+}
+
+async function hydrateThreadParentId(
+  channel: TextBasedChannel | { fetch?: () => Promise<unknown>; id?: string },
+): Promise<string | undefined> {
+  if (typeof channel.fetch !== "function") {
+    return undefined;
+  }
+
+  try {
+    const fetched = await channel.fetch();
+    if (fetched && typeof fetched === "object" && "isThread" in fetched) {
+      const thread = fetched as ThreadChannel;
+      if (typeof thread.isThread === "function" && thread.isThread() && thread.parentId) {
+        return thread.parentId;
+      }
+    }
+  } catch (error) {
+    const id = "id" in channel ? String(channel.id) : "unknown";
+    console.warn(`Failed to hydrate Discord thread parentId for ${id}:`, error);
+  }
+
+  return undefined;
+}
+
+/**
+ * Serialize work per conversation key. Waiting for a prior run is bounded so a
+ * hung agent turn cannot queue follow-ups forever; after the wait budget the
+ * next message proceeds (concurrent with the wedged run).
+ */
+export async function withChatLock(chatId: string, fn: () => Promise<void>): Promise<void> {
   const previous = chatLocks.get(chatId) ?? Promise.resolve();
   let release!: () => void;
   const gate = new Promise<void>((resolve) => {
@@ -972,11 +1050,39 @@ async function withChatLock(chatId: string, fn: () => Promise<void>): Promise<vo
   });
   chatLocks.set(chatId, gate);
 
-  await previous.catch(() => undefined);
+  const waitMs = chatLockOptions.waitMs;
+  let timedOut = false;
+  if (waitMs > 0) {
+    timedOut = await new Promise<boolean>((resolve) => {
+      const timer = setTimeout(() => resolve(true), waitMs);
+      previous
+        .then(() => {
+          clearTimeout(timer);
+          resolve(false);
+        })
+        .catch(() => {
+          clearTimeout(timer);
+          resolve(false);
+        });
+    });
+  } else {
+    await previous.catch(() => undefined);
+  }
+
+  if (timedOut) {
+    console.warn(
+      `Chat lock for ${chatId} exceeded ${waitMs}ms wait; proceeding to recover from a wedged run.`,
+    );
+  }
 
   try {
     await fn();
   } finally {
     release();
   }
+}
+
+/** @internal Test helper — clears the in-process chat lock map. */
+export function resetChatLocksForTests(): void {
+  chatLocks.clear();
 }

--- a/apps/platform/discord/src/guild-message.test.ts
+++ b/apps/platform/discord/src/guild-message.test.ts
@@ -13,7 +13,7 @@ function createGuildMessage(options: {
   mentionsBot?: boolean;
   replyToBot?: boolean;
   thread?: boolean;
-  parentId?: string;
+  parentId?: string | null;
 }) {
   const channelId = "channel_1";
   const messages = new Map<string, { author: { id: string } }>();
@@ -36,7 +36,10 @@ function createGuildMessage(options: {
       id: options.thread ? "thread_1" : channelId,
       isDMBased: () => false,
       isThread: () => options.thread === true,
-      parentId: options.parentId ?? channelId,
+      parentId:
+        options.parentId === null
+          ? null
+          : (options.parentId ?? channelId),
       messages: { cache: messages },
     },
   } as never;
@@ -161,6 +164,17 @@ describe("resolveConversationKey", () => {
 
     expect(key).toBe("g:parent_1:t:thread_1");
   });
+
+  test("uses hydrated parent when partial thread lacks parentId", () => {
+    const key = resolveConversationKey(
+      createGuildMessage({ thread: true, parentId: null }),
+      "thread_1",
+      true,
+      { parentChannelId: "parent_hydrated" },
+    );
+
+    expect(key).toBe("g:parent_hydrated:t:thread_1");
+  });
 });
 
 describe("resolveOrgChannelId", () => {
@@ -172,6 +186,14 @@ describe("resolveOrgChannelId", () => {
   test("uses channel id for plain guild channels", () => {
     const message = createGuildMessage({ content: "hi" });
     expect(resolveOrgChannelId(message, "channel_1", true)).toBe("channel_1");
+  });
+
+  test("prefers resolved parent over thread id when parentId is missing", () => {
+    const message = createGuildMessage({ thread: true, parentId: null });
+    expect(resolveOrgChannelId(message, "thread_1", true)).toBe("thread_1");
+    expect(
+      resolveOrgChannelId(message, "thread_1", true, { parentChannelId: "parent_1" }),
+    ).toBe("parent_1");
   });
 });
 

--- a/apps/platform/discord/src/guild-message.ts
+++ b/apps/platform/discord/src/guild-message.ts
@@ -36,26 +36,46 @@ export function resolveChannelOrgKey(
   return isGuild ? `g:${channelId}` : `u:${userId}`;
 }
 
+/**
+ * Optional overrides when Discord delivers a partial thread (`parentId` missing).
+ * Callers should hydrate via `channel.fetch()` first.
+ */
+export interface ThreadParentResolution {
+  /** Known parent guild channel id when `message.channel.parentId` is unset. */
+  parentChannelId?: string;
+}
+
 /** Parent guild channel for org selection — threads inherit the parent's org. */
-export function resolveOrgChannelId(message: Message, channelId: string, isGuild: boolean): string {
+export function resolveOrgChannelId(
+  message: Message,
+  channelId: string,
+  isGuild: boolean,
+  options?: ThreadParentResolution,
+): string {
   if (!isGuild) {
     return channelId;
   }
 
   if (message.channel.isThread()) {
-    return message.channel.parentId ?? channelId;
+    return message.channel.parentId ?? options?.parentChannelId ?? channelId;
   }
 
   return channelId;
 }
 
-export function resolveConversationKey(message: Message, channelId: string, isGuild: boolean): string {
+export function resolveConversationKey(
+  message: Message,
+  channelId: string,
+  isGuild: boolean,
+  options?: ThreadParentResolution,
+): string {
   if (!isGuild) {
     return channelId;
   }
 
   if (message.channel.isThread()) {
-    return `g:${message.channel.parentId ?? channelId}:t:${message.channel.id}`;
+    const parentId = message.channel.parentId ?? options?.parentChannelId ?? channelId;
+    return `g:${parentId}:t:${message.channel.id}`;
   }
 
   return channelId;

--- a/apps/platform/discord/src/test-helpers.ts
+++ b/apps/platform/discord/src/test-helpers.ts
@@ -232,7 +232,10 @@ export function createGuildChatMessage(options: {
   userId?: string;
   channelId?: string;
   threadId?: string;
-  parentId?: string;
+  /** Pass `null` to simulate a partial thread channel with missing parentId. */
+  parentId?: string | null;
+  /** Parent id returned by channel.fetch() when initial parentId is null. */
+  fetchParentId?: string;
   content?: string;
   mentionsBot?: boolean;
   replyToBot?: boolean;
@@ -259,7 +262,8 @@ export function createGuildChatMessage(options: {
   const userId = options.userId ?? "424242424242424242";
   const channelId = options.channelId ?? "guild_channel_1";
   const threadId = options.threadId ?? "thread_1";
-  const parentId = options.parentId ?? channelId;
+  const parentId = options.parentId === null ? null : (options.parentId ?? channelId);
+  const fetchParentId = options.fetchParentId ?? channelId;
   const botId = "bot_id";
   const existingThreads = options.existingThreads ?? new Map();
 
@@ -268,11 +272,12 @@ export function createGuildChatMessage(options: {
     messages.set("reply_1", { author: { id: botId } });
   }
 
-  function createThreadChannel(id: string, parent: string, archived = false) {
-    return {
+  function createThreadChannel(id: string, parent: string | null, archived = false) {
+    const channel = {
       id,
       parentId: parent,
       archived,
+      partial: parent === null,
       isDMBased: () => false,
       isTextBased: () => true,
       isThread: () => true,
@@ -280,6 +285,7 @@ export function createGuildChatMessage(options: {
         archived = value;
         return createThreadChannel(id, parent, archived);
       },
+      fetch: async () => createThreadChannel(id, fetchParentId, archived),
       send: async (payload: string | { files: unknown[] }) => {
         if (typeof payload === "string") {
           threadSentMessages.push(payload);
@@ -297,6 +303,7 @@ export function createGuildChatMessage(options: {
         }),
       },
     };
+    return channel;
   }
 
   const parentChannel = {
@@ -401,7 +408,10 @@ export function createSlashInteraction(options: {
   channelId?: string;
   commandName: string;
   inThread?: boolean;
-  parentId?: string;
+  /** Pass `null` to simulate a partial thread channel with missing parentId. */
+  parentId?: string | null;
+  /** Parent id returned by channel.fetch() when initial parentId is null. */
+  fetchParentId?: string;
   threadId?: string;
 }): {
   interaction: import("discord.js").ChatInputCommandInteraction;
@@ -411,15 +421,24 @@ export function createSlashInteraction(options: {
   const userId = options.userId ?? "424242424242424242";
   const channelId = options.channelId ?? "guild_channel_1";
   const threadId = options.threadId ?? "thread_1";
-  const parentId = options.parentId ?? channelId;
+  const parentId = options.parentId === null ? null : (options.parentId ?? channelId);
+  const fetchParentId = options.fetchParentId ?? channelId;
 
   const channel = options.inThread
     ? {
         id: threadId,
         parentId,
         archived: false,
+        partial: parentId === null,
         isDMBased: () => false,
         isThread: () => true,
+        fetch: async () => ({
+          id: threadId,
+          parentId: fetchParentId,
+          archived: false,
+          isDMBased: () => false,
+          isThread: () => true,
+        }),
         setArchived: async (value: boolean) => {
           channel.archived = value;
           return channel;


### PR DESCRIPTION
## Summary

Reliability fixes for Discord guild threads, ported onto the current always-new-thread / claim-foreign-thread architecture (PRs #191 and #194). Bot-owned threads could silently stop responding.

## Root cause

createGuildThread wrapped the Discord thread creation and the ThreadStore add + save in a single try/catch. When the store save threw (disk, permissions), the thread existed on Discord but was never registered as bot-owned — every follow-up inside it was then classified as a foreign thread and dropped without a reply. That produced threads the bot would not respond in.

## Fixes

- Track thread ownership in memory before persisting; a save failure logs but no longer leaves a live thread untracked (trackOwnedThread, used by thread creation and foreign-thread claiming)
- Bound withChatLock waits (15 min default): a hung agent run can no longer queue a thread's follow-ups forever; slash commands still bypass the lock
- Hydrate thread parentId via channel.fetch() when Discord delivers a partial channel, so org and conversation keys stay correct (flat owned-id ThreadStore unchanged)

## Tests

7 new regression tests covering save-failure tracking, claim-path tracking, partial-thread hydration, and lock recovery. Discord suite: 48 -> 55 passing. Telegram suite unaffected (89 passing).

## Recovery for existing unresponsive threads

After deploy: re-@mention the bot to claim/start a thread, or add the thread id to chat-threads.json under the owned-ids shape and restart the Discord worker.