### PR TITLE
feat(discord): polish interactive artifact attachments

### DIFF
--- a/apps/platform/discord/src/channel-artifact-flow.ts
+++ b/apps/platform/discord/src/channel-artifact-flow.ts
@@ -38,6 +38,7 @@ export async function maybeSendRequestedDiscordArtifactAttachment(input: {
   const { data } = await input.client.readProfileArtifactContent(input.profileId, artifact.path);
   const result = await sendDiscordArtifactAttachment(input.channel, {
     filename: artifact.filename,
+    mimeType: artifact.mimeType,
     bytes: new Uint8Array(data),
   });
 
@@ -131,6 +132,7 @@ async function tryUploadDiscordArtifact(input: {
 
     const result = await sendDiscordArtifactAttachment(input.channel, {
       filename: input.artifact.filename,
+      mimeType: input.artifact.mimeType,
       bytes,
     });
 

--- a/apps/platform/discord/src/chat-handler.test.ts
+++ b/apps/platform/discord/src/chat-handler.test.ts
@@ -138,6 +138,144 @@ describe("createChatHandler artifact delivery", () => {
     });
   });
 
+  test("auto-uploads a PDF artifact after a paired save-artifact turn", async () => {
+    await withTempHome(async (homeDir) => {
+      const pdfMeta = JSON.stringify({
+        mimeType: "application/pdf",
+        savedAt: "2026-07-13T10:00:00.000Z",
+        sizeBytes: 270_000,
+      });
+      const pdfMessages: ChatMessage[] = [
+        { role: "user", content: "save pitch deck" },
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [
+            {
+              id: "tool_1",
+              name: "write_file",
+              arguments: { path: "artifacts/nakama-pitch-deck.pdf", content: "%PDF-1.4" },
+            },
+            {
+              id: "tool_2",
+              name: "write_file",
+              arguments: { path: "artifacts/nakama-pitch-deck.pdf.nakama-meta.json", content: pdfMeta },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          toolCallId: "tool_1",
+          name: "write_file",
+          content: JSON.stringify({
+            path: "/home/.nakama/orgs/org/profiles/default/artifacts/nakama-pitch-deck.pdf",
+            bytesWritten: 270_000,
+          }),
+        },
+        {
+          role: "tool",
+          toolCallId: "tool_2",
+          name: "write_file",
+          content: JSON.stringify({
+            path: "/home/.nakama/orgs/org/profiles/default/artifacts/nakama-pitch-deck.pdf.nakama-meta.json",
+            bytesWritten: pdfMeta.length,
+          }),
+        },
+        { role: "assistant", content: "Saved the pitch deck." },
+      ];
+
+      const { handleMessage, calls, sessionStore } = await createPairedHandler(homeDir, {
+        messages: pdfMessages,
+        artifactContentBytes: new TextEncoder().encode("%PDF-1.4"),
+      });
+      sessionStore.set("dm_channel_1", {
+        sessionId: "session_test",
+        profileId: "default",
+        updatedAt: new Date().toISOString(),
+      });
+      await sessionStore.save();
+
+      const dm = createDmMessage({
+        userId: "424242424242424242",
+        content: "thanks",
+      });
+      await handleMessage(dm.message);
+
+      expect(calls.publishProfileArtifactShare).toBe(1);
+      expect(calls.readProfileArtifactContent).toBe(1);
+      expect(dm.fileSendCalls).toBe(1);
+    });
+  });
+
+  test("auto-uploads a CSV artifact after a paired save-artifact turn", async () => {
+    await withTempHome(async (homeDir) => {
+      const csvMeta = JSON.stringify({
+        mimeType: "text/csv",
+        savedAt: "2026-07-13T10:00:00.000Z",
+        sizeBytes: 24,
+      });
+      const csvMessages: ChatMessage[] = [
+        { role: "user", content: "export csv" },
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [
+            {
+              id: "tool_1",
+              name: "write_file",
+              arguments: { path: "artifacts/export.csv", content: "a,b\n1,2\n" },
+            },
+            {
+              id: "tool_2",
+              name: "write_file",
+              arguments: { path: "artifacts/export.csv.nakama-meta.json", content: csvMeta },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          toolCallId: "tool_1",
+          name: "write_file",
+          content: JSON.stringify({
+            path: "/home/.nakama/orgs/org/profiles/default/artifacts/export.csv",
+            bytesWritten: 8,
+          }),
+        },
+        {
+          role: "tool",
+          toolCallId: "tool_2",
+          name: "write_file",
+          content: JSON.stringify({
+            path: "/home/.nakama/orgs/org/profiles/default/artifacts/export.csv.nakama-meta.json",
+            bytesWritten: csvMeta.length,
+          }),
+        },
+        { role: "assistant", content: "Saved the CSV." },
+      ];
+
+      const { handleMessage, calls, sessionStore } = await createPairedHandler(homeDir, {
+        messages: csvMessages,
+        artifactContentBytes: new TextEncoder().encode("a,b\n1,2\n"),
+      });
+      sessionStore.set("dm_channel_1", {
+        sessionId: "session_test",
+        profileId: "default",
+        updatedAt: new Date().toISOString(),
+      });
+      await sessionStore.save();
+
+      const dm = createDmMessage({
+        userId: "424242424242424242",
+        content: "thanks",
+      });
+      await handleMessage(dm.message);
+
+      expect(calls.publishProfileArtifactShare).toBe(1);
+      expect(calls.readProfileArtifactContent).toBe(1);
+      expect(dm.fileSendCalls).toBe(1);
+    });
+  });
+
   test("falls back to a share link when the artifact exceeds the Discord attachment cap", async () => {
     await withTempHome(async (homeDir) => {
       const oversizedMeta = JSON.stringify({
@@ -256,7 +394,7 @@ describe("createChatHandler artifact delivery", () => {
 
   test("sends a document when the user asks to attach a saved artifact", async () => {
     await withTempHome(async (homeDir) => {
-      const { handleMessage, calls, sessionStore } = await createPairedHandler(homeDir);
+      const { handleMessage, sessionStore } = await createPairedHandler(homeDir);
       sessionStore.set("dm_channel_1", {
         sessionId: "session_test",
         profileId: "default",
@@ -282,6 +420,73 @@ describe("createChatHandler artifact delivery", () => {
       await handleMessage(dm.message);
 
       expect(dm.fileSendCalls).toBe(1);
+    });
+  });
+
+  test("sends a PDF when the user asks to send the pdf", async () => {
+    await withTempHome(async (homeDir) => {
+      const { handleMessage, sessionStore } = await createPairedHandler(homeDir, {
+        artifactContentBytes: new TextEncoder().encode("%PDF-1.4"),
+      });
+      sessionStore.set("dm_channel_1", {
+        sessionId: "session_test",
+        profileId: "default",
+        updatedAt: new Date().toISOString(),
+        deliverableArtifacts: [
+          {
+            filename: "nakama-pitch-deck.pdf",
+            path: "nakama-pitch-deck.pdf",
+            mimeType: "application/pdf",
+            sizeBytes: 270_000,
+            savedAt: "2026-07-13T10:00:00.000Z",
+            shareUrl: "https://app.example/s/tok_pdf",
+            sharePath: "/s/tok_pdf",
+          },
+        ],
+      });
+      await sessionStore.save();
+
+      const dm = createDmMessage({
+        userId: "424242424242424242",
+        content: "send the pdf",
+      });
+      await handleMessage(dm.message);
+
+      expect(dm.fileSendCalls).toBe(1);
+    });
+  });
+
+  test("returns a clear error when attach is requested for an unsupported type", async () => {
+    await withTempHome(async (homeDir) => {
+      const { handleMessage, sessionStore } = await createPairedHandler(homeDir, {
+        artifactContentBytes: new Uint8Array([0x4d, 0x5a]),
+      });
+      sessionStore.set("dm_channel_1", {
+        sessionId: "session_test",
+        profileId: "default",
+        updatedAt: new Date().toISOString(),
+        deliverableArtifacts: [
+          {
+            filename: "payload.exe",
+            path: "payload.exe",
+            mimeType: "application/octet-stream",
+            sizeBytes: 2,
+            savedAt: "2026-07-13T10:00:00.000Z",
+            shareUrl: "https://app.example/s/tok_exe",
+            sharePath: "/s/tok_exe",
+          },
+        ],
+      });
+      await sessionStore.save();
+
+      const dm = createDmMessage({
+        userId: "424242424242424242",
+        content: "send me the file",
+      });
+      await handleMessage(dm.message);
+
+      expect(dm.fileSendCalls).toBe(0);
+      expect(dm.sentMessages.some((reply) => /unsupported file type/i.test(reply))).toBe(true);
     });
   });
 });

--- a/apps/platform/discord/src/send-artifact-attachment.test.ts
+++ b/apps/platform/discord/src/send-artifact-attachment.test.ts
@@ -1,8 +1,65 @@
 import { describe, expect, test } from "bun:test";
-import { DISCORD_ARTIFACT_ATTACHMENT_MAX_BYTES } from "./send-artifact-attachment";
+import {
+  DISCORD_ARTIFACT_ATTACHMENT_MAX_BYTES,
+  isDiscordAttachableArtifact,
+  sendDiscordArtifactAttachment,
+} from "./send-artifact-attachment";
 
 describe("sendDiscordArtifactAttachment limits", () => {
   test("exports an 8 MB discord cap", () => {
     expect(DISCORD_ARTIFACT_ATTACHMENT_MAX_BYTES).toBe(8 * 1024 * 1024);
+  });
+
+  test("accepts common Discord attachment types", () => {
+    expect(isDiscordAttachableArtifact({ filename: "deck.pdf", mimeType: "application/pdf" })).toBe(
+      true,
+    );
+    expect(isDiscordAttachableArtifact({ filename: "export.csv", mimeType: "text/csv" })).toBe(true);
+    expect(isDiscordAttachableArtifact({ filename: "shot.png", mimeType: "image/png" })).toBe(true);
+    expect(isDiscordAttachableArtifact({ filename: "bundle.zip", mimeType: "application/zip" })).toBe(
+      true,
+    );
+  });
+
+  test("rejects unsupported attachment types with a clear reason", () => {
+    expect(isDiscordAttachableArtifact({ filename: "payload.exe", mimeType: "application/octet-stream" })).toBe(
+      false,
+    );
+  });
+
+  test("returns a clear error when the file exceeds the Discord size cap", async () => {
+    const channel = {
+      send: async () => {
+        throw new Error("should not send");
+      },
+    };
+
+    const result = await sendDiscordArtifactAttachment(channel as never, {
+      filename: "deck.pdf",
+      mimeType: "application/pdf",
+      bytes: new Uint8Array(DISCORD_ARTIFACT_ATTACHMENT_MAX_BYTES + 1),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/too large for Discord/i);
+    expect(result.error).toMatch(/8\.0 MB/i);
+  });
+
+  test("returns a clear error for unsupported file types", async () => {
+    const channel = {
+      send: async () => {
+        throw new Error("should not send");
+      },
+    };
+
+    const result = await sendDiscordArtifactAttachment(channel as never, {
+      filename: "payload.exe",
+      mimeType: "application/octet-stream",
+      bytes: new Uint8Array([1, 2, 3]),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/unsupported file type/i);
+    expect(result.error).toMatch(/\.exe/i);
   });
 });

--- a/apps/platform/discord/src/send-artifact-attachment.ts
+++ b/apps/platform/discord/src/send-artifact-attachment.ts
@@ -1,15 +1,67 @@
 import { AttachmentBuilder, type TextBasedChannel } from "discord.js";
+import { inferArtifactMimeType, normalizeMimeType } from "@nakama/core/artifact-mime";
 
 export const DISCORD_ARTIFACT_ATTACHMENT_MAX_BYTES = 8 * 1024 * 1024;
+
+/** Common Discord-friendly attachment types (issue #200 + existing channel artifacts). */
+const DISCORD_ATTACHABLE_EXTENSIONS = new Set([
+  "pdf",
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "txt",
+  "csv",
+  "tsv",
+  "md",
+  "markdown",
+  "json",
+  "zip",
+  "docx",
+  "html",
+  "htm",
+]);
+
+const DISCORD_ATTACHABLE_MIME_TYPES = new Set([
+  "application/pdf",
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "text/plain",
+  "text/csv",
+  "text/tab-separated-values",
+  "text/markdown",
+  "application/json",
+  "application/zip",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "text/html",
+  "application/xhtml+xml",
+]);
 
 export interface SendArtifactAttachmentInput {
   filename: string;
   bytes: Uint8Array;
+  mimeType?: string;
 }
 
 export interface SendArtifactAttachmentResult {
   ok: boolean;
   error?: string;
+}
+
+export function isDiscordAttachableArtifact(input: {
+  filename: string;
+  mimeType?: string;
+}): boolean {
+  const extension = fileExtension(input.filename);
+  if (extension && DISCORD_ATTACHABLE_EXTENSIONS.has(extension)) {
+    return true;
+  }
+
+  const mimeType = normalizeMimeType(input.mimeType ?? "") || inferArtifactMimeType(input.filename);
+  return DISCORD_ATTACHABLE_MIME_TYPES.has(mimeType);
 }
 
 export async function sendDiscordArtifactAttachment(
@@ -23,6 +75,15 @@ export async function sendDiscordArtifactAttachment(
     };
   }
 
+  if (!isDiscordAttachableArtifact(input)) {
+    const extension = fileExtension(input.filename);
+    const typeLabel = extension ? `.${extension}` : input.mimeType?.trim() || "unknown";
+    return {
+      ok: false,
+      error: `Unsupported file type for Discord attachment (${typeLabel}). Supported: PDF, images (PNG/JPEG/GIF/WebP), text, CSV, ZIP, and common document types.`,
+    };
+  }
+
   try {
     const attachment = new AttachmentBuilder(Buffer.from(input.bytes)).setName(input.filename);
     await channel.send({ files: [attachment] });
@@ -33,6 +94,15 @@ export async function sendDiscordArtifactAttachment(
       error: error instanceof Error ? error.message : "Failed to send attachment.",
     };
   }
+}
+
+function fileExtension(filename: string): string {
+  const basename = filename.split(/[\\/]/).pop() ?? filename;
+  const dotIndex = basename.lastIndexOf(".");
+  if (dotIndex <= 0 || dotIndex === basename.length - 1) {
+    return "";
+  }
+  return basename.slice(dotIndex + 1).toLowerCase();
 }
 
 function formatMegabytes(bytes: number): string {

--- a/packages/core/src/channel-artifact-delivery.test.ts
+++ b/packages/core/src/channel-artifact-delivery.test.ts
@@ -12,6 +12,10 @@ describe("isAttachIntent", () => {
     expect(isAttachIntent("send me the file")).toBe(true);
     expect(isAttachIntent("attach it")).toBe(true);
     expect(isAttachIntent("/attach")).toBe(true);
+    expect(isAttachIntent("send the pdf")).toBe(true);
+    expect(isAttachIntent("send me the csv")).toBe(true);
+    expect(isAttachIntent("attach the image")).toBe(true);
+    expect(isAttachIntent("send nakama-pitch-deck.pdf")).toBe(true);
   });
 
   test("does not match unrelated text", () => {

--- a/packages/core/src/channel-artifact-delivery.ts
+++ b/packages/core/src/channel-artifact-delivery.ts
@@ -12,9 +12,13 @@ export interface PublishArtifactShareResult {
   refreshed: boolean;
 }
 
+const ATTACH_NOUN =
+  "file|document|attachment|artifact|pdf|csv|zip|image|photo|screenshot|report|deck";
+
 const ATTACH_INTENT_PATTERNS = [
-  /\b(?:send|attach|share)\s+(?:me\s+)?(?:the\s+)?(?:file|document|attachment|artifact)\b/i,
-  /\b(?:download|get)\s+(?:me\s+)?(?:the\s+)?(?:file|document|attachment|artifact)\b/i,
+  new RegExp(String.raw`\b(?:send|attach|share)\s+(?:me\s+)?(?:the\s+)?(?:${ATTACH_NOUN})\b`, "i"),
+  new RegExp(String.raw`\b(?:download|get)\s+(?:me\s+)?(?:the\s+)?(?:${ATTACH_NOUN})\b`, "i"),
+  /\bsend\s+(?:me\s+)?(?:the\s+)?\S+\.(?:pdf|csv|png|jpe?g|gif|webp|zip|txt|md)\b/i,
   /\battach\s+it\b/i,
   /^\/attach(?:@\w+)?(?:\s|$)/i,
 ];


### PR DESCRIPTION
## Summary
- Broaden Discord/Telegram attach-intent phrases so requests like `send the pdf`, `send me the csv`, and `send deck.pdf` trigger native file send.
- Reject unsupported Discord attachment types with a clear error; keep the 8 MB size cap message.
- Cover PDF + CSV auto-upload and unsupported-type attach errors in Discord tests (interactive polish for #200).

## Test plan
- [ ] `bun test packages/core/src/channel-artifact-delivery.test.ts apps/platform/discord/src/send-artifact-attachment.test.ts apps/platform/discord/src/chat-handler.test.ts`
- [ ] In Discord DM: save a PDF under `artifacts/` with sidecar → confirm auto-upload
- [ ] Reply `send the pdf` after a saved artifact → confirm attachment
- [ ] Try attaching an unsupported type (e.g. `.exe` in registry) → confirm clear error text
- [ ] Oversized file (>8 MB) still falls back to share link on auto-upload

## Post-Deploy Monitoring & Validation
- Watch Discord worker logs for attachment send failures / `Unsupported file type` / `too large for Discord`
- Healthy: PDF/CSV/image saves under 8 MB appear as Discord attachments; attach phrases succeed
- Failure signals: spike in share-link-only fallbacks for common types, or user reports that `send the pdf` is ignored
- Rollback: revert this PR; prior auto-upload (#184) remains for paired saves with older attach phrases

Closes #200


Made with [Cursor](https://cursor.com)