### PR TITLE
fix(discord): respond when a held role is @mentioned

### DIFF
--- a/apps/platform/discord/src/chat-handler.test.ts
+++ b/apps/platform/discord/src/chat-handler.test.ts
@@ -777,6 +777,37 @@ describe("createChatHandler guild thread routing", () => {
     });
   });
 
+  test("role mention of a role the bot holds creates a thread", async () => {
+    await withTempHome(async (homeDir) => {
+      const streamedInputs: unknown[] = [];
+      const { handleMessage, threadStore } = await createPairedHandler(
+        homeDir,
+        {
+          onSendStream: async (input) => {
+            streamedInputs.push(input);
+            return "Role mention reply";
+          },
+        }
+      );
+
+      const roleId = "1525964112708894884";
+      const guild = createGuildChatMessage({
+        botHeldRoleIds: [roleId],
+        content: `<@&${roleId}> pull the latest main branch`,
+        mentionedRoleIds: [roleId],
+      });
+      await handleMessage(guild.message);
+
+      expect(guild.startThreadCalls).toBe(1);
+      expect(guild.lastThreadName).toBe("pull the latest main branch");
+      expect(guild.threadSentMessages).toContain("Role mention reply");
+      expect(threadStore.hasThreadId(guild.createdThreadId!)).toBe(true);
+      expect(streamedInputs[0]).toEqual({
+        message: "pull the latest main branch",
+      });
+    });
+  });
+
   test("second mention in the same channel creates a new thread", async () => {
     await withTempHome(async (homeDir) => {
       const { handleMessage, threadStore } = await createPairedHandler(

--- a/apps/platform/discord/src/chat-handler.ts
+++ b/apps/platform/discord/src/chat-handler.ts
@@ -50,6 +50,7 @@ import {
   resolveBotInfo,
   resolveChannelOrgKey,
   resolveConversationKey,
+  resolveMentionedBotRoleIds,
   resolveOrgChannelId,
   stripBotMention,
 } from "./guild-message";
@@ -219,9 +220,15 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     const bypassOrgGate =
       command === "/help" || command === "/start" || command === "/org";
 
+    const mentionedBotRoleIds = isGuild
+      ? resolveMentionedBotRoleIds(message)
+      : [];
+
     if (!bypassOrgGate) {
       const orgGateText =
-        isGuild && text && botInfo ? stripBotMention(text, botInfo) : text;
+        isGuild && text && botInfo
+          ? stripBotMention(text, botInfo, mentionedBotRoleIds)
+          : text;
       const orgReady = await ensureOrgReady(
         messenger,
         channelOrgKey,
@@ -260,7 +267,9 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     }
 
     const messageText =
-      isGuild && botInfo ? stripBotMention(text, botInfo) : text;
+      isGuild && botInfo
+        ? stripBotMention(text, botInfo, mentionedBotRoleIds)
+        : text;
 
     if (!messageText) {
       return;

--- a/apps/platform/discord/src/format.ts
+++ b/apps/platform/discord/src/format.ts
@@ -129,4 +129,4 @@ export const HELP_TEXT = `Nakama Discord commands:
 /profile — choose or switch bot profile (send as text)
 /status — server and model status
 
-In servers, @mention the bot or reply to it to chat — each mention in a parent channel opens a new thread. @mention inside another thread claims it. Pair in a DM first.`;
+In servers, @mention the bot (or a role it holds) or reply to it to chat — each mention in a parent channel opens a new thread. @mention inside another thread claims it. Pair in a DM first.`;

--- a/apps/platform/discord/src/guild-message.test.ts
+++ b/apps/platform/discord/src/guild-message.test.ts
@@ -8,15 +8,23 @@ import {
 
 const BOT_INFO = { id: "999000111222333444", username: "nakamabot" };
 
+const GUILD_ID = "guild_1";
+const BOT_ROLE_ID = "1525964112708894884";
+const OTHER_ROLE_ID = "role_other";
+
 function createGuildMessage(options: {
   content?: string;
   mentionsBot?: boolean;
+  mentionedRoleIds?: string[];
+  botHeldRoleIds?: string[];
   replyToBot?: boolean;
   thread?: boolean;
   parentId?: string | null;
 }) {
   const channelId = "channel_1";
   const messages = new Map<string, { author: { id: string } }>();
+  const mentionedRoleIds = options.mentionedRoleIds ?? [];
+  const botHeldRoleIds = new Set(options.botHeldRoleIds ?? []);
 
   if (options.replyToBot) {
     messages.set("reply_1", { author: { id: BOT_INFO.id } });
@@ -34,7 +42,22 @@ function createGuildMessage(options: {
     },
     client: { user: { id: BOT_INFO.id, username: BOT_INFO.username } },
     content: options.content ?? "",
+    guild: {
+      id: GUILD_ID,
+      members: {
+        me: {
+          roles: {
+            cache: {
+              has: (id: string) => botHeldRoleIds.has(id),
+            },
+          },
+        },
+      },
+    },
     mentions: {
+      roles: {
+        keys: () => mentionedRoleIds.values(),
+      },
       users: {
         has: (id: string) => (options.mentionsBot ? id === BOT_INFO.id : false),
       },
@@ -65,6 +88,64 @@ describe("explainGuildMessageHandling", () => {
 
     expect(decision.shouldHandle).toBe(true);
     expect(decision.reason).toBe("bot-mention");
+  });
+
+  test("handles @mention of a role the bot holds", () => {
+    const decision = explainGuildMessageHandling(
+      createGuildMessage({
+        botHeldRoleIds: [BOT_ROLE_ID],
+        content: `<@&${BOT_ROLE_ID}> can you pull the latest main branch`,
+        mentionedRoleIds: [BOT_ROLE_ID],
+      }),
+      BOT_INFO
+    );
+
+    expect(decision.shouldHandle).toBe(true);
+    expect(decision.reason).toBe("bot-mention");
+  });
+
+  test("ignores @mention of a role the bot does not hold", () => {
+    const decision = explainGuildMessageHandling(
+      createGuildMessage({
+        botHeldRoleIds: [BOT_ROLE_ID],
+        content: `<@&${OTHER_ROLE_ID}> hello`,
+        mentionedRoleIds: [OTHER_ROLE_ID],
+      }),
+      BOT_INFO
+    );
+
+    expect(decision.shouldHandle).toBe(false);
+    expect(decision.reason).toBe("no-trigger");
+  });
+
+  test("ignores @everyone role mention", () => {
+    const decision = explainGuildMessageHandling(
+      createGuildMessage({
+        botHeldRoleIds: [GUILD_ID],
+        content: `<@&${GUILD_ID}> hello`,
+        mentionedRoleIds: [GUILD_ID],
+      }),
+      BOT_INFO
+    );
+
+    expect(decision.shouldHandle).toBe(false);
+    expect(decision.reason).toBe("no-trigger");
+  });
+
+  test("claims a foreign thread when a held role is @mentioned", () => {
+    const decision = explainGuildMessageHandling(
+      createGuildMessage({
+        botHeldRoleIds: [BOT_ROLE_ID],
+        content: `<@&${BOT_ROLE_ID}> please join`,
+        mentionedRoleIds: [BOT_ROLE_ID],
+        thread: true,
+      }),
+      BOT_INFO,
+      { botOwnsThread: false }
+    );
+
+    expect(decision.shouldHandle).toBe(true);
+    expect(decision.reason).toBe("claim-thread");
   });
 
   test("handles reply to bot", () => {
@@ -205,5 +286,15 @@ describe("stripBotMention", () => {
     expect(stripBotMention(`<@!${BOT_INFO.id}> question`, BOT_INFO)).toBe(
       "question"
     );
+  });
+
+  test("removes held role mention markup", () => {
+    expect(
+      stripBotMention(
+        `<@&${BOT_ROLE_ID}> can you pull the latest main branch`,
+        BOT_INFO,
+        [BOT_ROLE_ID]
+      )
+    ).toBe("can you pull the latest main branch");
   });
 });

--- a/apps/platform/discord/src/guild-message.ts
+++ b/apps/platform/discord/src/guild-message.ts
@@ -155,21 +155,30 @@ export function explainGuildMessageHandling(
 
 export function stripBotMention(
   text: string,
-  botInfo: DiscordBotInfo | undefined
+  botInfo: DiscordBotInfo | undefined,
+  roleIds: readonly string[] = []
 ): string {
-  if (!botInfo) {
-    return text.trim();
-  }
+  const patterns: RegExp[] = [];
 
-  const patterns = [
-    new RegExp(`<@!?${botInfo.id}>`, "g"),
-    botInfo.username
-      ? new RegExp(
+  if (botInfo) {
+    patterns.push(new RegExp(`<@!?${botInfo.id}>`, "g"));
+    if (botInfo.username) {
+      patterns.push(
+        new RegExp(
           `@${botInfo.username.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`,
           "gi"
         )
-      : null,
-  ].filter(Boolean) as RegExp[];
+      );
+    }
+  }
+
+  for (const roleId of roleIds) {
+    patterns.push(new RegExp(`<@&${roleId}>`, "g"));
+  }
+
+  if (patterns.length === 0) {
+    return text.trim();
+  }
 
   let result = text;
 
@@ -178,6 +187,31 @@ export function stripBotMention(
   }
 
   return result.replace(/\s+/g, " ").trim();
+}
+
+/** Role IDs mentioned in the message that the bot currently holds (excludes @everyone). */
+export function resolveMentionedBotRoleIds(message: Message): string[] {
+  const guild = message.guild;
+  const botMember = guild?.members.me;
+
+  if (!(guild && botMember)) {
+    return [];
+  }
+
+  const everyoneRoleId = guild.id;
+  const roleIds: string[] = [];
+
+  for (const roleId of message.mentions.roles.keys()) {
+    if (roleId === everyoneRoleId) {
+      continue;
+    }
+
+    if (botMember.roles.cache.has(roleId)) {
+      roleIds.push(roleId);
+    }
+  }
+
+  return roleIds;
 }
 
 function isReplyToBot(message: Message, botId: string): boolean {
@@ -194,6 +228,12 @@ function isReplyToBot(message: Message, botId: string): boolean {
 
 function hasBotMention(message: Message, botInfo: DiscordBotInfo): boolean {
   if (message.mentions.users.has(botInfo.id)) {
+    return true;
+  }
+
+  // Users often pick a role with the bot's name from autocomplete (`<@&role>`),
+  // which does not populate mentions.users — treat held role pings as triggers.
+  if (resolveMentionedBotRoleIds(message).length > 0) {
     return true;
   }
 

--- a/apps/platform/discord/src/test-helpers.ts
+++ b/apps/platform/discord/src/test-helpers.ts
@@ -252,6 +252,8 @@ export function createGuildChatMessage(options: {
   fetchParentId?: string;
   content?: string;
   mentionsBot?: boolean;
+  mentionedRoleIds?: string[];
+  botHeldRoleIds?: string[];
   replyToBot?: boolean;
   inThread?: boolean;
   startThreadError?: Error;
@@ -280,6 +282,9 @@ export function createGuildChatMessage(options: {
     options.parentId === null ? null : (options.parentId ?? channelId);
   const fetchParentId = options.fetchParentId ?? channelId;
   const botId = "bot_id";
+  const guildId = "guild_1";
+  const mentionedRoleIds = options.mentionedRoleIds ?? [];
+  const botHeldRoleIds = new Set(options.botHeldRoleIds ?? []);
   const existingThreads = options.existingThreads ?? new Map();
 
   const messages = new Map<string, { author: { id: string } }>();
@@ -380,7 +385,22 @@ export function createGuildChatMessage(options: {
       user: { id: botId, username: "nakamabot" },
     },
     content: options.content ?? "",
+    guild: {
+      id: guildId,
+      members: {
+        me: {
+          roles: {
+            cache: {
+              has: (id: string) => botHeldRoleIds.has(id),
+            },
+          },
+        },
+      },
+    },
     mentions: {
+      roles: {
+        keys: () => mentionedRoleIds.values(),
+      },
       users: {
         has: (id: string) => (options.mentionsBot ? id === botId : false),
       },

--- a/apps/web/src/components/ai-elements/prompt-input-media.ts
+++ b/apps/web/src/components/ai-elements/prompt-input-media.ts
@@ -7,13 +7,10 @@ export const convertBlobUrlToDataUrl = async (
       return null;
     }
     const blob = await response.blob();
-    // FileReader uses callback-based API, wrapping in Promise is necessary
-    // oxlint-disable-next-line eslint-plugin-promise(avoid-new)
+    // FileReader uses a callback API, so wrapping in a Promise is required.
     return new Promise((resolve) => {
       const reader = new FileReader();
-      // oxlint-disable-next-line eslint-plugin-unicorn(prefer-add-event-listener)
       reader.onloadend = () => resolve(reader.result as string);
-      // oxlint-disable-next-line eslint-plugin-unicorn(prefer-add-event-listener)
       reader.onerror = () => resolve(null);
       reader.readAsDataURL(blob);
     });

--- a/apps/web/src/components/ai-elements/prompt-input.tsx
+++ b/apps/web/src/components/ai-elements/prompt-input.tsx
@@ -81,7 +81,6 @@ export const PromptInputProvider = ({
     (FileUIPart & { id: string })[]
   >([]);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  // oxlint-disable-next-line eslint(no-empty-function)
   const openRef = useRef<() => void>(() => {});
 
   const add = useCallback((files: File[] | FileList) => {

--- a/apps/web/src/components/tasks/TaskRunHistoryPanel.tsx
+++ b/apps/web/src/components/tasks/TaskRunHistoryPanel.tsx
@@ -2,6 +2,7 @@ import type { ProfileSummary, StoredTask } from "@nakama/core/contract";
 import { useQueryClient } from "@tanstack/react-query";
 import { XIcon } from "lucide-react";
 import { useCallback, useMemo, useRef, useState } from "react";
+import { PromptInputProvider } from "@/components/ai-elements/prompt-input";
 import { ChatComposer } from "@/components/chat/chat-composer";
 import { ChatMessageList } from "@/components/chat/chat-message-list";
 import { Button } from "@/components/ui/button";
@@ -213,18 +214,20 @@ export function TaskRunHistoryPanel({
           </p>
         </div>
       ) : (
-        <ChatComposer
-          busy={busy}
-          canStop={canStop}
-          chatStatus={chatStatus}
-          className="border-border/50 border-t px-4 py-4 sm:px-5"
-          disabled={!sessionId || waitingForMessages}
-          error={displayError}
-          onStop={stopStreaming}
-          onSubmit={(text) => void sendMessage(text)}
-          placeholder="Follow up on this task…"
-          variant="minimal"
-        />
+        <PromptInputProvider>
+          <ChatComposer
+            busy={busy}
+            canStop={canStop}
+            chatStatus={chatStatus}
+            className="border-border/50 border-t px-4 py-4 sm:px-5"
+            disabled={!sessionId || waitingForMessages}
+            error={displayError}
+            onStop={stopStreaming}
+            onSubmit={(text) => void sendMessage(text)}
+            placeholder="Follow up on this task…"
+            variant="minimal"
+          />
+        </PromptInputProvider>
       )}
     </aside>
   );

--- a/apps/web/src/components/tasks/TaskRunHistoryPanel.tsx
+++ b/apps/web/src/components/tasks/TaskRunHistoryPanel.tsx
@@ -43,8 +43,14 @@ export function TaskRunHistoryPanel({
     error: loadError,
   } = useTaskMessagesQuery(task.id);
 
-  const [messages, setMessages] = useState<ChatListItem[]>([]);
-  const [sessionId, setSessionId] = useState<string | null>(task.sessionId);
+  // Prefetch can resolve before mount; seed from cached query data so the
+  // data!==syncedData sync is not skipped when both start as the same reference.
+  const [messages, setMessages] = useState<ChatListItem[]>(() =>
+    data ? chatMessagesToListItems(data.messages) : []
+  );
+  const [sessionId, setSessionId] = useState<string | null>(
+    () => data?.sessionId || task.sessionId
+  );
   const [busy, setBusy] = useState(false);
   const [canStop, setCanStop] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/apps/web/src/components/tasks/TaskRunHistoryPanel.tsx
+++ b/apps/web/src/components/tasks/TaskRunHistoryPanel.tsx
@@ -1,14 +1,33 @@
-import type { ProfileSummary, StoredTask } from "@nakama/core/contract";
+import type {
+  ProfileSummary,
+  StoredTask,
+  ThinkingEffort,
+} from "@nakama/core/contract";
 import { useQueryClient } from "@tanstack/react-query";
+import type { FileUIPart } from "ai";
 import { XIcon } from "lucide-react";
 import { useCallback, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { PromptInputProvider } from "@/components/ai-elements/prompt-input";
 import { ChatComposer } from "@/components/chat/chat-composer";
 import { ChatMessageList } from "@/components/chat/chat-message-list";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
+import { useAppContext } from "@/context/use-app-context";
+import { useProfileQuery } from "@/hooks/use-app-queries";
+import { useUpdateProfileMutation } from "@/hooks/use-resource-mutations";
 import { useTaskMessagesQuery } from "@/hooks/use-tasks";
+import {
+  buildThinkingSettingsPayload,
+  useSaveThinkingSettings,
+  useThinkingSettings,
+} from "@/hooks/use-thinking-settings";
 import { type ChatListItem, chatMessagesToListItems } from "@/lib/chat-history";
+import {
+  filePartsToDisplayDocuments,
+  filePartsToDocumentAttachments,
+  filePartsToImageAttachments,
+} from "@/lib/chat-images";
 import {
   appendOutgoingMessages,
   buildStreamHandlers,
@@ -17,9 +36,22 @@ import {
   isAbortError,
 } from "@/lib/chat-stream";
 import { client, formatError } from "@/lib/client";
-import { NAV_ITEM_ICONS } from "@/lib/navigation";
+import {
+  decodeModelSelection,
+  effectiveProfileModelSelection,
+  extractModelId,
+  groupModelsByProvider,
+  resolveModelThinkingSupport,
+  resolveModelVisionSupport,
+} from "@/lib/models";
+import { NAV_ITEM_ICONS, SETUP_PATH } from "@/lib/navigation";
 import { queryKeys } from "@/lib/query-keys";
 import { TASK_STATUS_BADGE } from "@/lib/task-board";
+import {
+  DEFAULT_THINKING_EFFORT,
+  shouldBlockThinkingEffortChange,
+  shouldShowThinkingEffort,
+} from "@/lib/thinking-settings";
 import { cn } from "@/lib/utils";
 
 const ChatNavIcon = NAV_ITEM_ICONS.chat;
@@ -35,7 +67,15 @@ export function TaskRunHistoryPanel({
   profile,
   onClose,
 }: TaskRunHistoryPanelProps) {
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const { health, models } = useAppContext();
+  const profileId = profile?.id ?? task.profileId;
+  const profileDetailQuery = useProfileQuery(profileId || null);
+  const updateProfileMutation = useUpdateProfileMutation();
+  const { data: thinkingSettings, isLoading: thinkingSettingsLoading } =
+    useThinkingSettings();
+  const saveThinkingSettingsMutation = useSaveThinkingSettings();
   const {
     data,
     isLoading,
@@ -58,6 +98,58 @@ export function TaskRunHistoryPanel({
   const streamAbortRef = useRef<AbortController | null>(null);
   const statusBadge = TASK_STATUS_BADGE[task.status];
   const profileLabel = profile?.name ?? task.profileId;
+  const availableSkills = profileDetailQuery.data?.skills ?? [];
+
+  const providerModelGroups = useMemo(
+    () => groupModelsByProvider(models?.models ?? []),
+    [models?.models]
+  );
+
+  const currentModelSelection = useMemo(
+    () => effectiveProfileModelSelection(profile?.model, providerModelGroups),
+    [profile?.model, providerModelGroups]
+  );
+
+  const renderModelLabel = useCallback(
+    (selection: string | null) => {
+      if (!selection) {
+        return "Select model";
+      }
+      const decoded = decodeModelSelection(selection);
+      if (!decoded) {
+        return selection;
+      }
+      if (decoded.providerId === "__unknown__") {
+        return decoded.modelId;
+      }
+      const group = providerModelGroups.find(
+        (entry) => entry.providerId === decoded.providerId
+      );
+      return (
+        group?.models.find((model) => model.id === decoded.modelId)?.name ??
+        decoded.modelId
+      );
+    },
+    [providerModelGroups]
+  );
+
+  const activeModelSupportsThinking = useMemo(
+    () =>
+      resolveModelThinkingSupport(currentModelSelection, providerModelGroups),
+    [currentModelSelection, providerModelGroups]
+  );
+
+  const activeModelSupportsVision = useMemo(
+    () => resolveModelVisionSupport(currentModelSelection, providerModelGroups),
+    [currentModelSelection, providerModelGroups]
+  );
+
+  const thinkingEffortVisible = shouldShowThinkingEffort(
+    activeModelSupportsThinking
+  );
+  const thinkingEffort = thinkingSettings?.effort ?? DEFAULT_THINKING_EFFORT;
+  const thinkingEffortDisabled =
+    busy || thinkingSettingsLoading || saveThinkingSettingsMutation.isPending;
 
   const waitingForMessages = isLoading || (isFetching && messages.length === 0);
   const [syncedData, setSyncedData] = useState(data);
@@ -84,17 +176,81 @@ export function TaskRunHistoryPanel({
     streamAbortRef.current?.abort();
   }, []);
 
+  const handleModelChange = useCallback(
+    (selection: string) => {
+      if (!(profileId && selection)) {
+        return;
+      }
+      const decoded = decodeModelSelection(selection);
+      if (!decoded) {
+        return;
+      }
+      void updateProfileMutation
+        .mutateAsync({ input: { model: selection }, profileId })
+        .catch((err) => {
+          setError(formatError(err));
+        });
+    },
+    [profileId, updateProfileMutation]
+  );
+
+  const handleThinkingEffortChange = useCallback(
+    (effort: ThinkingEffort) => {
+      if (!profileId || effort === thinkingEffort) {
+        return;
+      }
+
+      if (
+        shouldBlockThinkingEffortChange(busy) ||
+        saveThinkingSettingsMutation.isPending
+      ) {
+        if (busy) {
+          setError("Wait for the current response to finish.");
+        }
+        return;
+      }
+
+      void saveThinkingSettingsMutation
+        .mutateAsync(buildThinkingSettingsPayload(effort))
+        .catch((err) => {
+          setError(formatError(err));
+        });
+    },
+    [profileId, thinkingEffort, busy, saveThinkingSettingsMutation]
+  );
+
   const sendMessage = useCallback(
-    async (text: string) => {
-      if (!text.trim() || busy || !sessionId) {
+    async (text: string, files: FileUIPart[] = []) => {
+      if ((!text.trim() && files.length === 0) || busy || !sessionId) {
         return;
       }
 
       setBusy(true);
       setError(null);
 
+      const images = filePartsToImageAttachments(files);
+      const documents = filePartsToDocumentAttachments(files);
+      const displayDocuments = filePartsToDisplayDocuments(files);
+      const displayImages = images.map((image) => ({
+        mediaType: image.mediaType,
+        url: `data:${image.mediaType};base64,${image.data}`,
+      }));
+      const useImageAttachments = activeModelSupportsVision === false;
+
       const chatSession = client.createChatSession(sessionId, "task");
-      appendOutgoingMessages(setMessages, text);
+      appendOutgoingMessages(
+        setMessages,
+        text,
+        useImageAttachments ? [] : displayImages,
+        displayDocuments.length > 0 ? displayDocuments : undefined,
+        {
+          imageAttachments:
+            useImageAttachments && displayImages.length > 0
+              ? displayImages
+              : undefined,
+          thinkingEnabled: thinkingEffortVisible,
+        }
+      );
 
       const abortController = new AbortController();
       streamAbortRef.current = abortController;
@@ -102,7 +258,11 @@ export function TaskRunHistoryPanel({
 
       try {
         await chatSession.sendStream(
-          { message: text },
+          {
+            documents: documents.length > 0 ? documents : undefined,
+            images: images.length > 0 ? images : undefined,
+            message: text,
+          },
           buildStreamHandlers(setMessages),
           { signal: abortController.signal }
         );
@@ -127,7 +287,14 @@ export function TaskRunHistoryPanel({
         setBusy(false);
       }
     },
-    [busy, queryClient, sessionId, task.id]
+    [
+      activeModelSupportsVision,
+      busy,
+      queryClient,
+      sessionId,
+      task.id,
+      thinkingEffortVisible,
+    ]
   );
 
   const displayError = error ?? (loadError ? formatError(loadError) : null);
@@ -135,6 +302,7 @@ export function TaskRunHistoryPanel({
     !(sessionId || waitingForMessages) && messages.length > 0;
   const emptyHistory =
     !(waitingForMessages || displayError) && messages.length === 0;
+  const showOfflineHint = health?.providerConfigured === false;
 
   return (
     <aside
@@ -146,20 +314,18 @@ export function TaskRunHistoryPanel({
         "xl:w-[26rem]"
       )}
     >
-      <header className="flex items-start justify-between gap-3 border-border/50 border-b bg-muted/20 px-4 py-4 sm:px-5">
-        <div className="min-w-0 space-y-2">
+      <header className="flex items-start justify-between gap-3 border-border/50 border-b bg-muted/20 px-4 py-3 sm:px-5">
+        <div className="min-w-0 space-y-1.5">
           <div className="flex items-center gap-2">
             <ChatNavIcon
               aria-hidden
               className="sidebar-nav-icon text-muted-foreground"
-              strokeWidth={1.75}
+              strokeWidth={2}
             />
             <p className="type-label">Run chat</p>
           </div>
-          <h2 className="truncate font-semibold text-foreground text-sm">
-            {task.title}
-          </h2>
-          <div className="flex flex-wrap items-center gap-2">
+          <h2 className="type-section-title truncate">{task.title}</h2>
+          <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
             <span
               className={cn(
                 "rounded-full px-2 py-0.5 font-medium text-[11px]",
@@ -175,13 +341,13 @@ export function TaskRunHistoryPanel({
         </div>
         <Button
           aria-label="Close task chat"
-          className="shrink-0"
+          className="relative shrink-0 after:absolute after:top-1/2 after:left-1/2 after:size-10 after:-translate-x-1/2 after:-translate-y-1/2"
           onClick={onClose}
           size="icon-sm"
           type="button"
           variant="ghost"
         >
-          <XIcon aria-hidden className="size-4" />
+          <XIcon aria-hidden className="size-4" strokeWidth={2} />
         </Button>
       </header>
 
@@ -206,15 +372,15 @@ export function TaskRunHistoryPanel({
 
       {displayError ? (
         <div className="shrink-0 border-border/50 border-t px-4 py-3 sm:px-5">
-          <p className="text-red-700 text-sm dark:text-red-300">
+          <p className="text-pretty text-red-700 text-sm dark:text-red-300">
             {displayError}
           </p>
         </div>
       ) : null}
 
       {chatUnavailable ? (
-        <div className="shrink-0 space-y-2 border-border/50 border-t px-4 py-4 sm:px-5">
-          <p className="text-muted-foreground text-sm">
+        <div className="shrink-0 border-border/50 border-t px-4 py-3 sm:px-5">
+          <p className="text-pretty text-muted-foreground text-sm">
             Run history is shown above. Restart the Nakama server to enable
             follow-up chat.
           </p>
@@ -222,16 +388,29 @@ export function TaskRunHistoryPanel({
       ) : (
         <PromptInputProvider>
           <ChatComposer
+            availableSkills={availableSkills}
             busy={busy}
             canStop={canStop}
             chatStatus={chatStatus}
             className="border-border/50 border-t px-4 py-4 sm:px-5"
+            currentModelSelection={currentModelSelection}
             disabled={!sessionId || waitingForMessages}
             error={displayError}
+            onModelChange={handleModelChange}
+            onNavigateSetup={() => navigate(SETUP_PATH)}
             onStop={stopStreaming}
-            onSubmit={(text) => void sendMessage(text)}
+            onSubmit={(text, files) => void sendMessage(text, files)}
+            onThinkingEffortChange={handleThinkingEffortChange}
             placeholder="Follow up on this task…"
-            variant="minimal"
+            primarySupportsVision={activeModelSupportsVision}
+            profileModelId={extractModelId(profile?.model)}
+            providerConfigured={health?.providerConfigured}
+            providerModelGroups={providerModelGroups}
+            renderModelLabel={renderModelLabel}
+            showOfflineHint={showOfflineHint}
+            thinkingEffort={thinkingEffort}
+            thinkingEffortDisabled={thinkingEffortDisabled}
+            thinkingEffortVisible={thinkingEffortVisible}
           />
         </PromptInputProvider>
       )}

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -39,7 +39,10 @@ function SelectTrigger({
       {children}
       <SelectPrimitive.Icon
         render={
-          <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+          <ChevronDownIcon
+            className="pointer-events-none size-4 text-muted-foreground"
+            strokeWidth={1.5}
+          />
         }
       />
     </SelectPrimitive.Trigger>
@@ -74,7 +77,7 @@ function SelectContent({
       >
         <SelectPrimitive.Popup
           className={cn(
-            "data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:fade-in-0 data-open:zoom-in-95 data-closed:fade-out-0 data-closed:zoom-out-95 relative isolate z-50 w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-hidden rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-closed:animate-out data-open:animate-in",
+            "data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:fade-in-0 data-open:zoom-in-95 data-closed:fade-out-0 data-closed:zoom-out-95 relative isolate z-50 w-max min-w-[max(9rem,var(--anchor-width))] max-w-[min(24rem,var(--available-width,92vw))] origin-(--transform-origin) overflow-hidden rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-closed:animate-out data-open:animate-in",
             className
           )}
           data-align-trigger={alignItemWithTrigger}
@@ -100,13 +103,13 @@ function SelectItem({
   return (
     <SelectPrimitive.Item
       className={cn(
-        "relative flex w-full cursor-default select-none items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "relative flex w-full cursor-default select-none items-center gap-1.5 rounded-sm py-1.5 pr-8 pl-1.5 text-sm outline-hidden transition-colors duration-100 ease-out focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0 *:[span]:last:flex *:[span]:last:min-w-0 *:[span]:last:items-center *:[span]:last:gap-2",
         className
       )}
       data-slot="select-item"
       {...props}
     >
-      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+      <SelectPrimitive.ItemText className="flex min-w-0 flex-1 gap-2 truncate">
         {children}
       </SelectPrimitive.ItemText>
       <SelectPrimitive.ItemIndicator
@@ -114,7 +117,7 @@ function SelectItem({
           <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
         }
       >
-        <CheckIcon className="pointer-events-none" />
+        <CheckIcon className="pointer-events-none" strokeWidth={1.5} />
       </SelectPrimitive.ItemIndicator>
     </SelectPrimitive.Item>
   );
@@ -133,7 +136,7 @@ function SelectScrollUpButton({
       data-slot="select-scroll-up-button"
       {...props}
     >
-      <ChevronUpIcon />
+      <ChevronUpIcon strokeWidth={1.5} />
     </SelectPrimitive.ScrollUpArrow>
   );
 }
@@ -151,7 +154,7 @@ function SelectScrollDownButton({
       data-slot="select-scroll-down-button"
       {...props}
     >
-      <ChevronDownIcon />
+      <ChevronDownIcon strokeWidth={1.5} />
     </SelectPrimitive.ScrollDownArrow>
   );
 }

--- a/docs/website/content/docs/discord.mdx
+++ b/docs/website/content/docs/discord.mdx
@@ -118,7 +118,7 @@ In a server channel, the bot responds only when the message is:
 
 - a slash command from Discord's command menu
 - a reply to one of the bot's messages
-- a direct `@mention` of the bot
+- a direct `@mention` of the bot, or of a Discord role the bot holds
 
 This keeps server channels usable without making the bot noisy.
 
@@ -156,7 +156,7 @@ Session control uses Discord slash commands. Org and profile switching use text 
 | `/org` | Text | Choose or switch organization |
 | `/profile` | Text | Choose or switch profile |
 
-In servers, `@mention` the bot or reply to it to chat — each mention in a parent channel opens a new thread. Complete DM pairing first.
+In servers, `@mention` the bot (or a role it holds) or reply to it to chat — each mention in a parent channel opens a new thread. Complete DM pairing first.
 
 ## Reply formatting
 
@@ -234,14 +234,16 @@ Usually one of these is true:
 
 - **Message Content Intent** is off — turn the toggle on under **Bot → Privileged Gateway Intents** (see Step 1a)
 - the bot was invited before Message Content Intent was enabled — re-invite with a fresh URL (Step 1b)
-- the message was not a slash command, reply, or direct `@mention`
+- the message was not a slash command, reply, bot `@mention`, or `@mention` of a role the bot holds
 - the user has not completed DM pairing yet
 
 ### Mentions do not work in servers
 
 1. Turn **Message Content Intent** on (Step 1a), then re-invite the bot (Step 1b)
 2. Make sure only one Discord bridge worker is running
-3. `@mention` the bot or reply to one of its messages
+3. `@mention` the bot user (or a role assigned to the bot) or reply to one of its messages
+
+If Discord autocomplete offers both a **role** and the **bot user** with similar names, either works when the bot holds that role. Mentioning an unrelated role does not trigger a reply.
 
 ### Discord says to link in a private DM
 


### PR DESCRIPTION
## Summary

In Discord servers, pinging a **role** the bot holds (often the same-named role from autocomplete) used to be silently ignored as `no-trigger`. Those pings now start a thread and get an agent reply the same way a direct bot `@mention` does.

Unrelated roles and `@everyone` still do not trigger. Held role tags are stripped from the text sent to the agent.

## Test plan

- [x] Unit: held-role mention → `bot-mention`; foreign role / `@everyone` stay `no-trigger`
- [x] Unit: role markup stripped from agent input
- [x] Integration: held-role ping in a guild channel creates a thread and streams the stripped message
- [ ] Restart Discord bridge and verify a same-named role ping responds in a live server

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Cursor](https://img.shields.io/badge/Grok_4.5-000000)
