### PR TITLE
refactor(web): unify automation and task pages

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,6 +27,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "hashvatar": "^0.1.2",
+    "hugeicons-react": "^0.4.0",
     "lucide-react": "^1.16.0",
     "nanoid": "^5.1.11",
     "qrcode.react": "^4.2.0",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -22,7 +22,6 @@ import { SettingsPage } from "@/pages/SettingsPage";
 import { SetupWizardPage } from "@/pages/SetupWizardPage";
 import { SkillDetailPage } from "@/pages/SkillDetailPage";
 import { SystemPage } from "@/pages/SystemPage";
-import { TasksPage } from "@/pages/TasksPage";
 import { ToolPlaygroundPage } from "@/pages/ToolPlaygroundPage";
 
 function QueryCacheListener() {
@@ -71,7 +70,10 @@ function AppShell() {
                     />
                   </Route>
                   <Route element={<AutomationsPage />} path="/automations" />
-                  <Route element={<TasksPage />} path="/tasks" />
+                  <Route
+                    element={<Navigate replace to="/automations?tab=tasks" />}
+                    path="/tasks"
+                  />
                   <Route element={<IntegrationsPage />} path="/integrations" />
                   <Route
                     element={<NotificationsPage />}

--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -23,7 +23,6 @@ import {
   canAccessSystemPage,
   findNavItem,
   NAV_GROUPS,
-  NAV_ITEM_ICONS,
   type NavItem,
   navHrefForPage,
   PAGE_PATHS,
@@ -115,7 +114,7 @@ export function Layout() {
                             : undefined
                         }
                         collapsed={collapsed}
-                        icon={NAV_ITEM_ICONS[item.id]}
+                        icon={item.icon}
                         item={item}
                         key={item.id}
                         onPrefetch={

--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -1,5 +1,5 @@
-import type { LucideIcon } from "lucide-react";
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+import type { ElementType } from "react";
 import { useMemo } from "react";
 import { Link, Outlet, useLocation } from "react-router-dom";
 import { OrgSwitcher } from "@/components/OrgSwitcher";
@@ -234,7 +234,7 @@ function SidebarNavButton({
   className,
 }: {
   item: NavItem;
-  icon: LucideIcon;
+  icon: ElementType;
   active: boolean;
   collapsed: boolean;
   to: string;

--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -139,14 +139,13 @@ export function Layout() {
           <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
             {page === "chat" ? null : (
               <header className="app-shell-header gap-4 bg-card px-6">
-                <h1 className="type-brand min-w-0 truncate">
-                  {activeNav?.label}
-                </h1>
                 {page === "automations" ? (
-                  <div className="ml-auto shrink-0">
-                    <AgentWorkTabs />
-                  </div>
-                ) : null}
+                  <AgentWorkTabs />
+                ) : (
+                  <h1 className="type-brand min-w-0 truncate">
+                    {activeNav?.label}
+                  </h1>
+                )}
               </header>
             )}
 

--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -31,6 +31,7 @@ import {
   pageIdFromPath,
 } from "@/lib/navigation";
 import { cn } from "@/lib/utils";
+import { AgentWorkTabs } from "@/pages/automations/agent-work-tabs";
 
 export function Layout() {
   const location = useLocation();
@@ -141,6 +142,11 @@ export function Layout() {
                 <h1 className="type-brand min-w-0 truncate">
                   {activeNav?.label}
                 </h1>
+                {page === "automations" ? (
+                  <div className="ml-auto shrink-0">
+                    <AgentWorkTabs />
+                  </div>
+                ) : null}
               </header>
             )}
 

--- a/apps/web/src/components/ProfileAdminPlusButton.tsx
+++ b/apps/web/src/components/ProfileAdminPlusButton.tsx
@@ -1,4 +1,4 @@
-import { HugeiconsIcon, PlusIcon } from "hugeicons-react";
+import { Add01Icon } from "hugeicons-react";
 import { Button } from "@/components/ui/button";
 import {
   Tooltip,
@@ -31,7 +31,7 @@ export function ProfileAdminPlusButton({
             type="button"
             variant="ghost"
           >
-            <HugeiconsIcon aria-hidden className="size-4" icon={PlusIcon} />
+            <Add01Icon aria-hidden className="size-4" />
           </Button>
         }
       />

--- a/apps/web/src/components/ProfileAdminPlusButton.tsx
+++ b/apps/web/src/components/ProfileAdminPlusButton.tsx
@@ -1,4 +1,4 @@
-import { PlusIcon } from "lucide-react";
+import { HugeiconsIcon, PlusIcon } from "hugeicons-react";
 import { Button } from "@/components/ui/button";
 import {
   Tooltip,
@@ -31,7 +31,7 @@ export function ProfileAdminPlusButton({
             type="button"
             variant="ghost"
           >
-            <PlusIcon aria-hidden className="size-4" strokeWidth={1.75} />
+            <HugeiconsIcon aria-hidden className="size-4" icon={PlusIcon} />
           </Button>
         }
       />

--- a/apps/web/src/components/ProviderSetupForm.tsx
+++ b/apps/web/src/components/ProviderSetupForm.tsx
@@ -1,6 +1,6 @@
 import type { CreateProviderResponse } from "@nakama/core/contract";
 import { ollamaRequiresApiKey } from "@nakama/core/ollama-provider-config";
-import { EyeIcon, EyeOffIcon } from "lucide-react";
+import { ViewIcon, ViewOffIcon } from "hugeicons-react";
 import { useState } from "react";
 import { BrowsableModelFields } from "@/components/BrowsableModelFields";
 import { CustomProviderFields } from "@/components/CustomProviderFields";
@@ -156,7 +156,7 @@ export function ProviderSetupForm({
                   onClick={() => form.setShowApiKey((current) => !current)}
                   size="icon-sm"
                 >
-                  {form.showApiKey ? <EyeOffIcon /> : <EyeIcon />}
+                  {form.showApiKey ? <ViewOffIcon /> : <ViewIcon />}
                 </InputGroupButton>
               </InputGroupAddon>
             </InputGroup>

--- a/apps/web/src/components/SidebarNotifications.tsx
+++ b/apps/web/src/components/SidebarNotifications.tsx
@@ -1,4 +1,4 @@
-import { BellIcon } from "lucide-react";
+import { HugeiconsIcon, Notification01Icon } from "hugeicons-react";
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { NotificationList } from "@/components/notifications/notification-list";
@@ -31,7 +31,11 @@ export function SidebarNotifications() {
       type="button"
     >
       <span className="relative shrink-0">
-        <BellIcon aria-hidden className="size-4" strokeWidth={1.75} />
+        <HugeiconsIcon
+          aria-hidden
+          className="size-4"
+          icon={Notification01Icon}
+        />
         {showBadge ? (
           <span
             aria-hidden

--- a/apps/web/src/components/SidebarNotifications.tsx
+++ b/apps/web/src/components/SidebarNotifications.tsx
@@ -1,4 +1,4 @@
-import { HugeiconsIcon, Notification01Icon } from "hugeicons-react";
+import { Notification01Icon } from "hugeicons-react";
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { NotificationList } from "@/components/notifications/notification-list";
@@ -31,11 +31,7 @@ export function SidebarNotifications() {
       type="button"
     >
       <span className="relative shrink-0">
-        <HugeiconsIcon
-          aria-hidden
-          className="size-4"
-          icon={Notification01Icon}
-        />
+        <Notification01Icon aria-hidden className="size-4" />
         {showBadge ? (
           <span
             aria-hidden

--- a/apps/web/src/components/TimezoneSelect.tsx
+++ b/apps/web/src/components/TimezoneSelect.tsx
@@ -1,4 +1,4 @@
-import { ChevronDownIcon } from "lucide-react";
+import { ArrowDown01Icon } from "hugeicons-react";
 import { useMemo, useState } from "react";
 import {
   Command,
@@ -96,7 +96,7 @@ export function TimezoneSelect({
           {loading ? (
             <Spinner className="size-4 shrink-0" />
           ) : (
-            <ChevronDownIcon
+            <ArrowDown01Icon
               aria-hidden
               className="size-4 shrink-0 text-muted-foreground"
             />

--- a/apps/web/src/components/settings/DataPortabilityPanel.tsx
+++ b/apps/web/src/components/settings/DataPortabilityPanel.tsx
@@ -1,5 +1,6 @@
 import type { DataImportPreviewResponse } from "@nakama/core/contract";
-import { AlertTriangleIcon, DownloadIcon, UploadIcon } from "lucide-react";
+import { Alert02Icon, Download04Icon, Upload04Icon } from "hugeicons-react";
+import type { SVGProps } from "react";
 import { useRef, useState } from "react";
 import {
   DataImportPreview,
@@ -15,6 +16,13 @@ import {
 import { formatError } from "@/lib/client";
 import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
+
+const DownloadIcon = ({ className }: SVGProps<SVGSVGElement>) => (
+  <Download04Icon className={className} />
+);
+const UploadIcon = ({ className }: SVGProps<SVGSVGElement>) => (
+  <Upload04Icon className={className} />
+);
 
 export function DataPortabilityPanel() {
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -151,7 +159,7 @@ export function DataPortabilityPanel() {
               "border-destructive/30 bg-destructive/10 text-destructive"
             )}
           >
-            <AlertTriangleIcon aria-hidden className="mt-0.5 size-4 shrink-0" />
+            <Alert02Icon aria-hidden className="mt-0.5 size-4 shrink-0" />
             <span className="text-pretty">{error}</span>
           </div>
         </div>

--- a/apps/web/src/components/settings/ProviderSettingsCard.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsCard.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangleIcon, PlusIcon } from "lucide-react";
+import { Add01Icon, Alert02Icon } from "hugeicons-react";
 import { useState } from "react";
 import { ProviderSetupForm } from "@/components/ProviderSetupForm";
 import { Button } from "@/components/ui/button";
@@ -79,7 +79,7 @@ export function ProviderSettingsCard({
                 type="button"
                 variant="outline"
               >
-                <PlusIcon className="mr-1.5 size-4" />
+                <Add01Icon className="mr-1.5 size-4" />
                 Add provider
               </Button>
             ) : null}
@@ -127,7 +127,7 @@ export function ProviderSettingsCard({
           ) : (
             <>
               <div className="flex items-start gap-3 border-border border-b px-4 py-3">
-                <AlertTriangleIcon
+                <Alert02Icon
                   aria-hidden="true"
                   className="mt-0.5 size-5 shrink-0 text-amber-200"
                 />

--- a/apps/web/src/components/settings/provider-instance-card.tsx
+++ b/apps/web/src/components/settings/provider-instance-card.tsx
@@ -3,7 +3,12 @@ import type {
   ProviderModelOption,
   UpdateProviderRequest,
 } from "@nakama/core/contract";
-import { KeyRoundIcon, ListIcon, PencilIcon, Trash2Icon } from "lucide-react";
+import {
+  Delete02Icon,
+  Key01Icon,
+  ListViewIcon,
+  PencilIcon,
+} from "hugeicons-react";
 import type { ReactNode } from "react";
 import { CatalogProviderModelFields } from "@/components/CatalogProviderModelFields";
 import { CustomProviderFields } from "@/components/CustomProviderFields";
@@ -132,14 +137,14 @@ export function ProviderInstanceCard({
                 label="Manage models"
                 onClick={card.openManage}
               >
-                <ListIcon className="size-3.5" />
+                <ListViewIcon className="size-3.5" />
               </ProviderActionButton>
             ) : null}
             <ProviderActionButton
               label={instance.hasApiKey ? "Update key" : "Add key"}
               onClick={() => card.setReplaceKeyOpen(true)}
             >
-              <KeyRoundIcon className="size-3.5" />
+              <Key01Icon className="size-3.5" />
             </ProviderActionButton>
             <ProviderActionButton
               destructive
@@ -147,7 +152,7 @@ export function ProviderInstanceCard({
               label="Remove"
               onClick={() => void card.handleDelete()}
             >
-              <Trash2Icon className="size-3.5" />
+              <Delete02Icon className="size-3.5" />
             </ProviderActionButton>
           </div>
         </td>

--- a/apps/web/src/components/settings/provider-instance-dialogs.tsx
+++ b/apps/web/src/components/settings/provider-instance-dialogs.tsx
@@ -1,5 +1,5 @@
 import type { ProviderInstanceSummary } from "@nakama/core/contract";
-import { EyeIcon, EyeOffIcon } from "lucide-react";
+import { ViewIcon, ViewOffIcon } from "hugeicons-react";
 import type { ReactNode } from "react";
 import { CustomProviderFields } from "@/components/CustomProviderFields";
 import type { ModelListRow } from "@/components/ModelListEditor";
@@ -70,7 +70,7 @@ export function ProviderReplaceKeyDialog({
               onClick={onToggleShowApiKey}
               size="icon-sm"
             >
-              {showApiKey ? <EyeOffIcon /> : <EyeIcon />}
+              {showApiKey ? <ViewOffIcon /> : <ViewIcon />}
             </InputGroupButton>
           </InputGroupAddon>
         </InputGroup>

--- a/apps/web/src/components/theme-options.ts
+++ b/apps/web/src/components/theme-options.ts
@@ -1,12 +1,12 @@
-import { MonitorIcon, MoonIcon, SunIcon } from "lucide-react";
+import { ComputerIcon, MoonIcon, Sun01Icon } from "hugeicons-react";
 import type { Theme } from "@/lib/theme";
 
 export const THEME_OPTIONS: {
   id: Theme;
   label: string;
-  icon: typeof SunIcon;
+  icon: typeof Sun01Icon;
 }[] = [
-  { icon: SunIcon, id: "light", label: "Light" },
+  { icon: Sun01Icon, id: "light", label: "Light" },
   { icon: MoonIcon, id: "dark", label: "Dark" },
-  { icon: MonitorIcon, id: "system", label: "System" },
+  { icon: ComputerIcon, id: "system", label: "System" },
 ];

--- a/apps/web/src/lib/navigation.test.ts
+++ b/apps/web/src/lib/navigation.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import {
+  agentWorkTabFromSearchParams,
+  agentWorkTabPath,
+  pageIdFromPath,
+} from "./navigation";
+
+describe("agent work navigation", () => {
+  test("defaults the unified page to automations", () => {
+    expect(agentWorkTabFromSearchParams(new URLSearchParams())).toBe(
+      "automations"
+    );
+    expect(
+      agentWorkTabFromSearchParams(new URLSearchParams("tab=unknown"))
+    ).toBe("automations");
+  });
+
+  test("reads the tasks tab from the URL", () => {
+    expect(agentWorkTabFromSearchParams(new URLSearchParams("tab=tasks"))).toBe(
+      "tasks"
+    );
+  });
+
+  test("builds canonical tab URLs", () => {
+    expect(agentWorkTabPath("automations")).toBe(
+      "/automations?tab=automations"
+    );
+    expect(agentWorkTabPath("tasks")).toBe("/automations?tab=tasks");
+  });
+
+  test("maps the legacy tasks path to the unified page", () => {
+    expect(pageIdFromPath("/tasks")).toBe("automations");
+    expect(pageIdFromPath("/automations")).toBe("automations");
+  });
+});

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -1,16 +1,16 @@
 import {
-  AiBrain02Icon,
-  AiNetworkIcon,
-  AiScanIcon,
-  ChatDelayIcon,
+  Brain03Icon,
+  Chat01Icon,
   KanbanIcon,
   Notification01Icon,
   PlusSignSquareIcon,
   Settings01Icon,
+  SharedWifiIcon,
+  UserSquareIcon,
   WebhookIcon,
 } from "hugeicons-react";
 
-type NavIcon = typeof AiNetworkIcon;
+type NavIcon = typeof SharedWifiIcon;
 
 export type PageId =
   | "chat"
@@ -88,14 +88,14 @@ export const STANDALONE_PAGES: Partial<Record<PageId, NavItem>> = {
 };
 
 export const NAV_ITEM_ICONS: Record<PageId, NavIcon> = {
-  automations: AiNetworkIcon,
+  automations: SharedWifiIcon,
   chat: PlusSignSquareIcon,
-  history: ChatDelayIcon,
+  history: Chat01Icon,
   integrations: WebhookIcon,
   notifications: Notification01Icon,
-  profiles: AiScanIcon,
+  profiles: UserSquareIcon,
   settings: Settings01Icon,
-  soul: AiBrain02Icon,
+  soul: Brain03Icon,
   tasks: KanbanIcon,
 };
 

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -60,14 +60,9 @@ export const NAV_GROUPS: NavGroup[] = [
         label: "Profiles",
       },
       {
-        description: "Draft workflows from natural language",
+        description: "Manage automations and agent tasks",
         id: "automations",
-        label: "Automations",
-      },
-      {
-        description: "Agent swarm kanban board",
-        id: "tasks",
-        label: "Tasks",
+        label: "Agent work",
       },
     ],
     label: "Agent",
@@ -236,6 +231,18 @@ export const PAGE_PATHS: Record<PageId, string> = {
   tasks: "/tasks",
 };
 
+export type AgentWorkTab = "automations" | "tasks";
+
+export function agentWorkTabFromSearchParams(
+  searchParams: URLSearchParams
+): AgentWorkTab {
+  return searchParams.get("tab") === "tasks" ? "tasks" : "automations";
+}
+
+export function agentWorkTabPath(tab: AgentWorkTab): string {
+  return `${PAGE_PATHS.automations}?tab=${tab}`;
+}
+
 export function pathForPage(pageId: PageId): string {
   return PAGE_PATHS[pageId];
 }
@@ -264,6 +271,10 @@ export function findNavItem(pageId: PageId): NavItem | undefined {
 export function pageIdFromPath(pathname: string): PageId | null {
   if (pathname === "/chat" || pathname.startsWith("/chat/")) {
     return "chat";
+  }
+
+  if (pathname === PAGE_PATHS.tasks) {
+    return "automations";
   }
 
   if (

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -1,15 +1,16 @@
-import type { LucideIcon } from "lucide-react";
 import {
-  BellIcon,
-  BrainIcon,
-  CableIcon,
-  CircleFadingPlusIcon,
-  CircleUserRoundIcon,
-  ClockIcon,
-  CogIcon,
+  AiBrain02Icon,
+  AiNetworkIcon,
+  AiScanIcon,
+  ChatDelayIcon,
   KanbanIcon,
-  WorkflowIcon,
-} from "lucide-react";
+  Notification01Icon,
+  PlusSignSquareIcon,
+  Settings01Icon,
+  WebhookIcon,
+} from "hugeicons-react";
+
+type NavIcon = typeof AiNetworkIcon;
 
 export type PageId =
   | "chat"
@@ -34,57 +35,43 @@ export interface NavGroup {
   label: string;
 }
 
+const navItem = (id: PageId, label: string, description: string): NavItem => ({
+  description,
+  id,
+  label,
+});
+
 export const NAV_GROUPS: NavGroup[] = [
   {
     id: "chat",
     items: [
-      {
-        description: "New chat",
-        id: "chat",
-        label: "New chat",
-      },
-      {
-        description: "Browse and reopen saved chats",
-        id: "history",
-        label: "Chats",
-      },
+      navItem("chat", "New chat", "New chat"),
+      navItem("history", "Chats", "Browse and reopen saved chats"),
     ],
     label: "Chat",
   },
   {
     id: "agent",
     items: [
-      {
-        description: "Manage bot configs and tool allowlists",
-        id: "profiles",
-        label: "Profiles",
-      },
-      {
-        description: "Manage automations and agent tasks",
-        id: "automations",
-        label: "Agent work",
-      },
+      navItem("profiles", "Profiles", "Manage bot configs and tool allowlists"),
+      navItem(
+        "automations",
+        "Agent work",
+        "Manage automations and agent tasks"
+      ),
     ],
     label: "Agent",
   },
   {
     id: "system",
     items: [
-      {
-        description: "Bridges and Composio",
-        id: "integrations",
-        label: "Integrations",
-      },
-      {
-        description: "Identity stack files and registered agent tools",
-        id: "soul",
-        label: "System",
-      },
-      {
-        description: "Provider API key and model",
-        id: "settings",
-        label: "Settings",
-      },
+      navItem("integrations", "Integrations", "Bridges and Composio"),
+      navItem(
+        "soul",
+        "System",
+        "Identity stack files and registered agent tools"
+      ),
+      navItem("settings", "Settings", "Provider API key and model"),
     ],
     label: "System",
   },
@@ -93,22 +80,22 @@ export const NAV_GROUPS: NavGroup[] = [
 export const NAV_ITEMS: NavItem[] = NAV_GROUPS.flatMap((group) => group.items);
 
 export const STANDALONE_PAGES: Partial<Record<PageId, NavItem>> = {
-  notifications: {
-    description: "Automation runs and org memory proposals",
-    id: "notifications",
-    label: "Notifications",
-  },
+  notifications: navItem(
+    "notifications",
+    "Notifications",
+    "Automation runs and org memory proposals"
+  ),
 };
 
-export const NAV_ITEM_ICONS: Record<PageId, LucideIcon> = {
-  automations: WorkflowIcon,
-  chat: CircleFadingPlusIcon,
-  history: ClockIcon,
-  integrations: CableIcon,
-  notifications: BellIcon,
-  profiles: CircleUserRoundIcon,
-  settings: CogIcon,
-  soul: BrainIcon,
+export const NAV_ITEM_ICONS: Record<PageId, NavIcon> = {
+  automations: AiNetworkIcon,
+  chat: PlusSignSquareIcon,
+  history: ChatDelayIcon,
+  integrations: WebhookIcon,
+  notifications: Notification01Icon,
+  profiles: AiScanIcon,
+  settings: Settings01Icon,
+  soul: AiBrain02Icon,
   tasks: KanbanIcon,
 };
 
@@ -132,81 +119,71 @@ export function canAccessIntegrationsPage(
   return orgRole === "admin" || orgRole === "member";
 }
 
-export function canUseToolPlayground(
-  isPlatformAdmin: boolean,
-  orgRole: string | undefined
-): boolean {
-  return isPlatformAdmin || orgRole === "admin";
-}
+export const canUseToolPlayground = canAccessSystemPage;
 
-export function toolsTabPath(): string {
-  return `${PAGE_PATHS.soul}?tab=tools`;
-}
+const queryPath = (path: string, params: Record<string, string>): string =>
+  `${path}?${new URLSearchParams(params)}`;
 
-export function statusTabPath(): string {
-  return `${PAGE_PATHS.soul}?tab=status`;
-}
+export const toolsTabPath = (): string =>
+  queryPath(PAGE_PATHS.soul, { tab: "tools" });
 
-export function profilePath(profileId: string): string {
-  return `${PAGE_PATHS.profiles}?profile=${encodeURIComponent(profileId)}`;
-}
+export const statusTabPath = (): string =>
+  queryPath(PAGE_PATHS.soul, { tab: "status" });
+
+export const profilePath = (profileId: string): string =>
+  queryPath(PAGE_PATHS.profiles, { profile: profileId });
 
 export function skillDetailPath(
   skillId: string,
   options?: { profileId?: string }
 ): string {
   const path = `${PAGE_PATHS.profiles}/skills/${encodeURIComponent(skillId)}`;
-  if (!options?.profileId) {
-    return path;
-  }
-
-  const params = new URLSearchParams({ profile: options.profileId });
-  return `${path}?${params.toString()}`;
+  return options?.profileId
+    ? queryPath(path, { profile: options.profileId })
+    : path;
 }
+
+const backTarget = (
+  profileId: string | null,
+  fallback: { href: string; label: string }
+): { href: string; label: string } =>
+  profileId ? { href: profilePath(profileId), label: "Profile" } : fallback;
 
 /** Resolve skill detail back-navigation from search params set by skillDetailPath. */
-export function skillDetailBackTarget(searchParams: URLSearchParams): {
+export const skillDetailBackTarget = (
+  searchParams: URLSearchParams
+): {
   href: string;
   label: string;
-} {
-  const profileId = searchParams.get("profile");
-  if (profileId) {
-    return { href: profilePath(profileId), label: "Profile" };
-  }
-
-  return { href: PAGE_PATHS.profiles, label: "Profiles" };
-}
+} =>
+  backTarget(searchParams.get("profile"), {
+    href: PAGE_PATHS.profiles,
+    label: "Profiles",
+  });
 
 export function toolPlaygroundPath(
   toolId: string,
   options?: { fromProfileId?: string }
 ): string {
   const path = `${PAGE_PATHS.soul}/playground/${encodeURIComponent(toolId)}`;
-  if (!options?.fromProfileId) {
-    return path;
-  }
-
-  const params = new URLSearchParams({
-    from: "profiles",
-    profile: options.fromProfileId,
-  });
-  return `${path}?${params.toString()}`;
+  return options?.fromProfileId
+    ? queryPath(path, { from: "profiles", profile: options.fromProfileId })
+    : path;
 }
 
 /** Resolve playground back-navigation from search params set by toolPlaygroundPath. */
-export function toolPlaygroundBackTarget(searchParams: URLSearchParams): {
+export const toolPlaygroundBackTarget = (
+  searchParams: URLSearchParams
+): {
   href: string;
   label: string;
-} {
-  const fromProfileId =
+} =>
+  backTarget(
     searchParams.get("from") === "profiles"
       ? searchParams.get("profile")
-      : null;
-  if (fromProfileId) {
-    return { href: profilePath(fromProfileId), label: "Profile" };
-  }
-  return { href: toolsTabPath(), label: "Tools" };
-}
+      : null,
+    { href: toolsTabPath(), label: "Tools" }
+  );
 
 export function orgSkillProposalsPath(profileId?: string): string {
   const params = new URLSearchParams({
@@ -230,6 +207,12 @@ export const PAGE_PATHS: Record<PageId, string> = {
   soul: "/system",
   tasks: "/tasks",
 };
+
+const PREFIX_PAGE_IDS: readonly [string, PageId][] = [
+  [PAGE_PATHS.chat, "chat"],
+  [PAGE_PATHS.soul, "soul"],
+  [PAGE_PATHS.profiles, "profiles"],
+];
 
 export type AgentWorkTab = "automations" | "tasks";
 
@@ -269,40 +252,20 @@ export function findNavItem(pageId: PageId): NavItem | undefined {
 }
 
 export function pageIdFromPath(pathname: string): PageId | null {
-  if (pathname === "/chat" || pathname.startsWith("/chat/")) {
-    return "chat";
-  }
-
   if (pathname === PAGE_PATHS.tasks) {
     return "automations";
   }
 
-  if (
-    pathname === PAGE_PATHS.soul ||
-    pathname.startsWith(`${PAGE_PATHS.soul}/`)
-  ) {
-    return "soul";
+  const prefixPage = PREFIX_PAGE_IDS.find(
+    ([prefix]) => pathname === prefix || pathname.startsWith(`${prefix}/`)
+  );
+  if (prefixPage) {
+    return prefixPage[1];
   }
 
-  if (
-    pathname === PAGE_PATHS.profiles ||
-    pathname.startsWith(`${PAGE_PATHS.profiles}/`)
-  ) {
-    return "profiles";
-  }
-
-  for (const [pageId, path] of Object.entries(PAGE_PATHS) as [
-    PageId,
-    string,
-  ][]) {
-    if (pageId === "chat" || pageId === "profiles") {
-      continue;
-    }
-
-    if (pathname === path) {
-      return pageId;
-    }
-  }
-
-  return null;
+  return (
+    (Object.entries(PAGE_PATHS) as [PageId, string][]).find(
+      ([, path]) => pathname === path
+    )?.[0] ?? null
+  );
 }

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -1,7 +1,6 @@
 import {
   Brain03Icon,
   Chat01Icon,
-  KanbanIcon,
   Notification01Icon,
   PlusSignSquareIcon,
   Settings01Icon,
@@ -25,6 +24,7 @@ export type PageId =
 
 export interface NavItem {
   description: string;
+  icon: NavIcon;
   id: PageId;
   label: string;
 }
@@ -35,8 +35,14 @@ export interface NavGroup {
   label: string;
 }
 
-const navItem = (id: PageId, label: string, description: string): NavItem => ({
+const navItem = (
+  id: PageId,
+  label: string,
+  description: string,
+  icon: NavIcon
+): NavItem => ({
   description,
+  icon,
   id,
   label,
 });
@@ -45,19 +51,30 @@ export const NAV_GROUPS: NavGroup[] = [
   {
     id: "chat",
     items: [
-      navItem("chat", "New chat", "New chat"),
-      navItem("history", "Chats", "Browse and reopen saved chats"),
+      navItem(
+        "chat",
+        "New chat",
+        "Start a new conversation",
+        PlusSignSquareIcon
+      ),
+      navItem("history", "Chats", "Browse and reopen saved chats", Chat01Icon),
     ],
     label: "Chat",
   },
   {
     id: "agent",
     items: [
-      navItem("profiles", "Profiles", "Manage bot configs and tool allowlists"),
+      navItem(
+        "profiles",
+        "Profiles",
+        "Manage bot configs and tool allowlists",
+        UserSquareIcon
+      ),
       navItem(
         "automations",
         "Agent work",
-        "Manage automations and agent tasks"
+        "Manage automations and agent tasks",
+        SharedWifiIcon
       ),
     ],
     label: "Agent",
@@ -65,13 +82,24 @@ export const NAV_GROUPS: NavGroup[] = [
   {
     id: "system",
     items: [
-      navItem("integrations", "Integrations", "Bridges and Composio"),
+      navItem(
+        "integrations",
+        "Integrations",
+        "Bridges and Composio",
+        WebhookIcon
+      ),
       navItem(
         "soul",
         "System",
-        "Identity stack files and registered agent tools"
+        "Identity stack files and registered agent tools",
+        Brain03Icon
       ),
-      navItem("settings", "Settings", "Provider API key and model"),
+      navItem(
+        "settings",
+        "Settings",
+        "Provider API key and model",
+        Settings01Icon
+      ),
     ],
     label: "System",
   },
@@ -83,20 +111,25 @@ export const STANDALONE_PAGES: Partial<Record<PageId, NavItem>> = {
   notifications: navItem(
     "notifications",
     "Notifications",
-    "Automation runs and org memory proposals"
+    "Automation runs and org memory proposals",
+    Notification01Icon
   ),
 };
 
+const navItemsWithIcons = [
+  ...NAV_ITEMS,
+  ...Object.values(STANDALONE_PAGES).filter(
+    (item): item is NavItem => item !== undefined
+  ),
+];
+
+/** Compatibility lookup for consumers that only need an icon by page id. */
 export const NAV_ITEM_ICONS: Record<PageId, NavIcon> = {
-  automations: SharedWifiIcon,
-  chat: PlusSignSquareIcon,
-  history: Chat01Icon,
-  integrations: WebhookIcon,
-  notifications: Notification01Icon,
-  profiles: UserSquareIcon,
-  settings: Settings01Icon,
-  soul: Brain03Icon,
-  tasks: KanbanIcon,
+  ...(Object.fromEntries(
+    navItemsWithIcons.map((item) => [item.id, item.icon])
+  ) as Record<PageId, NavIcon>),
+  tasks:
+    NAV_ITEMS.find((item) => item.id === "automations")?.icon ?? SharedWifiIcon,
 };
 
 export const SETUP_PATH = "/setup";

--- a/apps/web/src/pages/AutomationsPage.tsx
+++ b/apps/web/src/pages/AutomationsPage.tsx
@@ -1,14 +1,115 @@
+import type { KeyboardEvent, ReactNode } from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  type AgentWorkTab,
+  agentWorkTabFromSearchParams,
+} from "@/lib/navigation";
 import { AutomationsDialogs } from "@/pages/automations/automations-dialogs";
 import { AutomationsPageLayout } from "@/pages/automations/automations-page-layout";
 import { useAutomationsPage } from "@/pages/automations/use-automations-page";
+import { TasksPage } from "@/pages/TasksPage";
 
 export function AutomationsPage() {
   const state = useAutomationsPage();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab = agentWorkTabFromSearchParams(searchParams);
+
+  function selectTab(tab: AgentWorkTab) {
+    const nextSearchParams = new URLSearchParams(searchParams);
+    if (tab === "automations") {
+      nextSearchParams.delete("tab");
+    } else {
+      nextSearchParams.set("tab", tab);
+    }
+    setSearchParams(nextSearchParams);
+  }
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <AutomationsPageLayout {...state} />
+      <div className="flex shrink-0 items-center gap-1 border-border border-b bg-card px-6 py-2">
+        <div aria-label="Agent work views" role="tablist">
+          <TabButton
+            active={activeTab === "automations"}
+            onClick={() => selectTab("automations")}
+            onKeyDown={(event) => {
+              if (event.key === "ArrowRight") {
+                event.preventDefault();
+                selectTab("tasks");
+                document.getElementById("agent-work-tab-tasks")?.focus();
+              }
+            }}
+            tab="automations"
+          >
+            Automations
+          </TabButton>
+          <TabButton
+            active={activeTab === "tasks"}
+            onClick={() => selectTab("tasks")}
+            onKeyDown={(event) => {
+              if (event.key === "ArrowLeft") {
+                event.preventDefault();
+                selectTab("automations");
+                document.getElementById("agent-work-tab-automations")?.focus();
+              }
+            }}
+            tab="tasks"
+          >
+            Tasks
+          </TabButton>
+        </div>
+      </div>
+      {activeTab === "automations" ? (
+        <div
+          aria-labelledby="agent-work-tab-automations"
+          className="min-h-0 flex-1"
+          id="agent-work-panel-automations"
+          role="tabpanel"
+        >
+          <AutomationsPageLayout {...state} />
+        </div>
+      ) : (
+        <div
+          aria-labelledby="agent-work-tab-tasks"
+          className="min-h-0 flex-1"
+          id="agent-work-panel-tasks"
+          role="tabpanel"
+        >
+          <TasksPage />
+        </div>
+      )}
       <AutomationsDialogs {...state} />
     </div>
+  );
+}
+
+function TabButton({
+  active,
+  children,
+  onClick,
+  onKeyDown,
+  tab,
+}: {
+  active: boolean;
+  children: ReactNode;
+  onClick: () => void;
+  onKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => void;
+  tab: AgentWorkTab;
+}) {
+  return (
+    <button
+      aria-controls={`agent-work-panel-${tab}`}
+      aria-selected={active}
+      className={`rounded-md px-3 py-1.5 font-medium text-sm transition-colors hover:bg-muted ${
+        active ? "bg-muted text-foreground" : "text-muted-foreground"
+      }`}
+      id={`agent-work-tab-${tab}`}
+      onClick={onClick}
+      onKeyDown={onKeyDown}
+      role="tab"
+      tabIndex={active ? 0 : -1}
+      type="button"
+    >
+      {children}
+    </button>
   );
 }

--- a/apps/web/src/pages/AutomationsPage.tsx
+++ b/apps/web/src/pages/AutomationsPage.tsx
@@ -1,9 +1,5 @@
-import type { KeyboardEvent, ReactNode } from "react";
 import { useSearchParams } from "react-router-dom";
-import {
-  type AgentWorkTab,
-  agentWorkTabFromSearchParams,
-} from "@/lib/navigation";
+import { agentWorkTabFromSearchParams } from "@/lib/navigation";
 import { AutomationsDialogs } from "@/pages/automations/automations-dialogs";
 import { AutomationsPageLayout } from "@/pages/automations/automations-page-layout";
 import { useAutomationsPage } from "@/pages/automations/use-automations-page";
@@ -11,53 +7,11 @@ import { TasksPage } from "@/pages/TasksPage";
 
 export function AutomationsPage() {
   const state = useAutomationsPage();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const activeTab = agentWorkTabFromSearchParams(searchParams);
-
-  function selectTab(tab: AgentWorkTab) {
-    const nextSearchParams = new URLSearchParams(searchParams);
-    if (tab === "automations") {
-      nextSearchParams.delete("tab");
-    } else {
-      nextSearchParams.set("tab", tab);
-    }
-    setSearchParams(nextSearchParams);
-  }
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <div className="flex shrink-0 items-center gap-1 border-border border-b bg-card px-6 py-2">
-        <div aria-label="Agent work views" role="tablist">
-          <TabButton
-            active={activeTab === "automations"}
-            onClick={() => selectTab("automations")}
-            onKeyDown={(event) => {
-              if (event.key === "ArrowRight") {
-                event.preventDefault();
-                selectTab("tasks");
-                document.getElementById("agent-work-tab-tasks")?.focus();
-              }
-            }}
-            tab="automations"
-          >
-            Automations
-          </TabButton>
-          <TabButton
-            active={activeTab === "tasks"}
-            onClick={() => selectTab("tasks")}
-            onKeyDown={(event) => {
-              if (event.key === "ArrowLeft") {
-                event.preventDefault();
-                selectTab("automations");
-                document.getElementById("agent-work-tab-automations")?.focus();
-              }
-            }}
-            tab="tasks"
-          >
-            Tasks
-          </TabButton>
-        </div>
-      </div>
       {activeTab === "automations" ? (
         <div
           aria-labelledby="agent-work-tab-automations"
@@ -79,37 +33,5 @@ export function AutomationsPage() {
       )}
       <AutomationsDialogs {...state} />
     </div>
-  );
-}
-
-function TabButton({
-  active,
-  children,
-  onClick,
-  onKeyDown,
-  tab,
-}: {
-  active: boolean;
-  children: ReactNode;
-  onClick: () => void;
-  onKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => void;
-  tab: AgentWorkTab;
-}) {
-  return (
-    <button
-      aria-controls={`agent-work-panel-${tab}`}
-      aria-selected={active}
-      className={`rounded-md px-3 py-1.5 font-medium text-sm transition-colors hover:bg-muted ${
-        active ? "bg-muted text-foreground" : "text-muted-foreground"
-      }`}
-      id={`agent-work-tab-${tab}`}
-      onClick={onClick}
-      onKeyDown={onKeyDown}
-      role="tab"
-      tabIndex={active ? 0 : -1}
-      type="button"
-    >
-      {children}
-    </button>
   );
 }

--- a/apps/web/src/pages/automations/agent-work-tabs.tsx
+++ b/apps/web/src/pages/automations/agent-work-tabs.tsx
@@ -1,0 +1,86 @@
+import type { KeyboardEvent, ReactNode } from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  type AgentWorkTab,
+  agentWorkTabFromSearchParams,
+} from "@/lib/navigation";
+
+export function AgentWorkTabs() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab = agentWorkTabFromSearchParams(searchParams);
+
+  function selectTab(tab: AgentWorkTab) {
+    const nextSearchParams = new URLSearchParams(searchParams);
+    if (tab === "automations") {
+      nextSearchParams.delete("tab");
+    } else {
+      nextSearchParams.set("tab", tab);
+    }
+    setSearchParams(nextSearchParams);
+  }
+
+  return (
+    <div aria-label="Agent work views" role="tablist">
+      <TabButton
+        active={activeTab === "automations"}
+        onClick={() => selectTab("automations")}
+        onKeyDown={(event) => {
+          if (event.key === "ArrowRight") {
+            event.preventDefault();
+            selectTab("tasks");
+            document.getElementById("agent-work-tab-tasks")?.focus();
+          }
+        }}
+        tab="automations"
+      >
+        Automations
+      </TabButton>
+      <TabButton
+        active={activeTab === "tasks"}
+        onClick={() => selectTab("tasks")}
+        onKeyDown={(event) => {
+          if (event.key === "ArrowLeft") {
+            event.preventDefault();
+            selectTab("automations");
+            document.getElementById("agent-work-tab-automations")?.focus();
+          }
+        }}
+        tab="tasks"
+      >
+        Tasks
+      </TabButton>
+    </div>
+  );
+}
+
+function TabButton({
+  active,
+  children,
+  onClick,
+  onKeyDown,
+  tab,
+}: {
+  active: boolean;
+  children: ReactNode;
+  onClick: () => void;
+  onKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => void;
+  tab: AgentWorkTab;
+}) {
+  return (
+    <button
+      aria-controls={`agent-work-panel-${tab}`}
+      aria-selected={active}
+      className={`rounded-md px-3 py-1.5 font-medium text-sm transition-colors hover:bg-muted ${
+        active ? "bg-muted text-foreground" : "text-muted-foreground"
+      }`}
+      id={`agent-work-tab-${tab}`}
+      onClick={onClick}
+      onKeyDown={onKeyDown}
+      role="tab"
+      tabIndex={active ? 0 : -1}
+      type="button"
+    >
+      {children}
+    </button>
+  );
+}

--- a/apps/web/src/pages/automations/agent-work-tabs.tsx
+++ b/apps/web/src/pages/automations/agent-work-tabs.tsx
@@ -20,7 +20,11 @@ export function AgentWorkTabs() {
   }
 
   return (
-    <div aria-label="Agent work views" role="tablist">
+    <div
+      aria-label="Agent work views"
+      className="flex items-center gap-1"
+      role="tablist"
+    >
       <TabButton
         active={activeTab === "automations"}
         onClick={() => selectTab("automations")}

--- a/bun.lock
+++ b/bun.lock
@@ -102,6 +102,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "hashvatar": "^0.1.2",
+        "hugeicons-react": "^0.4.0",
         "lucide-react": "^1.16.0",
         "nanoid": "^5.1.11",
         "qrcode.react": "^4.2.0",
@@ -422,6 +423,10 @@
     "@hono/zod-openapi": ["@hono/zod-openapi@1.4.0", "", { "dependencies": { "@asteasolutions/zod-to-openapi": "^8.5.0", "@hono/zod-validator": "^0.8.0", "openapi3-ts": "^4.5.0" }, "peerDependencies": { "hono": ">=4.10.0", "zod": "^4.0.0" } }, "sha512-AFchqR1N/NxfI4hUOSGI2/g8zLROxA1OE7Oh5JJFlTaGxhrdRyH+93gd0tIBpb0z8s9r8hUoNnaOBfHbdb4NMw=="],
 
     "@hono/zod-validator": ["@hono/zod-validator@0.8.0", "", { "peerDependencies": { "hono": ">=4.10.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-5uS4S1/LKtZQYvD4BtpPUFkOv8d1wNxHHrChm26buMiEYc1FrHWvDUaKVBwkiVtvSExHSpLGDvcnpI2Copyj9w=="],
+
+    "@hugeicons/core-free-icons": ["@hugeicons/core-free-icons@3.3.0", "", {}, "sha512-qYyr4JQ2eQIHTSTbITvnJvs6ERNK64D9gpwZnf2IyuG0exzqfyABLO/oTB71FB3RZPfu1GbwycdiGSo46apjMQ=="],
+
+    "@hugeicons/react": ["@hugeicons/react@1.1.9", "", { "peerDependencies": { "react": ">=16.0.0" } }, "sha512-O+lWSWjbijoAvMCxn4K2bQWCGN5+mP1y5j+X99j23mXMj+s0X25fs71T6t9YJLaBodwmZdaewD27dzS/PiboQw=="],
 
     "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
 
@@ -1450,6 +1455,8 @@
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "hugeicons-react": ["hugeicons-react@0.4.0", "", { "dependencies": { "@hugeicons/core-free-icons": "^3.1.1", "@hugeicons/react": "^1.1.4" }, "peerDependencies": { "react": ">=16.0.0" } }, "sha512-HA2UI3VkDd1dNi9P4JGjaMODdGEs4QVMwQcc34W0aoGHptdsIex/756Jik4GFYN/023jGFKNVvQKhx2IpZtV+g=="],
 
     "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
 


### PR DESCRIPTION
## Summary

Agent work is now one destination instead of separate Automations and Tasks pages. Users can switch between the two workflows with URL-backed tabs, while existing `/tasks` links continue to open the Tasks tab.

The existing automation controls, unread badge, task board, dialogs, polling, and task run chat remain behind their respective tab panels; no server, database, API, or authorization behavior changes.

## Validation

- `bun test apps/web/src/lib/navigation.test.ts`
- `bun run --filter @nakama/web build`
- `bun x ultracite check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
