### PR TITLE
feat(discord): admin /allow slash command for allowed users

### DIFF
--- a/apps/platform/discord/src/auth-store.ts
+++ b/apps/platform/discord/src/auth-store.ts
@@ -25,6 +25,11 @@ export class DiscordAuthStore {
     return isDiscordUserAuthorized(userId, this.config);
   }
 
+  /** Paired bridge owners — admin for Discord bot management commands. */
+  isPaired(userId: string): boolean {
+    return this.config?.pairedUserIds.includes(userId) ?? false;
+  }
+
   async tryPair(
     handshakeInput: string,
     userId: string

--- a/apps/platform/discord/src/chat-handler.test.ts
+++ b/apps/platform/discord/src/chat-handler.test.ts
@@ -1,10 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import path from "node:path";
 import type { ChatMessage } from "@nakama/core/contract";
-import {
-  isDiscordUserAuthorized,
-  loadDiscordConfigFile,
-} from "@nakama/core/discord-config";
+import { loadDiscordConfigFile } from "@nakama/core/discord-config";
 import { DiscordAuthStore } from "./auth-store";
 import {
   chatLockOptions,
@@ -43,11 +40,14 @@ async function createPairedHandler(
       typeof createMockClient
     >[0]["artifactContentBytes"];
     configProfileId?: string;
+    pairedUserIds?: string[];
+    allowedUserIds?: string[];
   } = {}
 ) {
   await writeDiscordConfigIni(homeDir, {
+    allowedUserIds: options.allowedUserIds ?? [],
     botToken: "discord-bot-token",
-    pairedUserIds: ["424242424242424242"],
+    pairedUserIds: options.pairedUserIds ?? ["424242424242424242"],
   });
 
   const authStore = new DiscordAuthStore();
@@ -1352,36 +1352,11 @@ describe("createChatHandler guild thread routing", () => {
     });
   });
 
-  test("allow denies non-paired users", async () => {
+  test("denies non-paired users", async () => {
     await withTempHome(async (homeDir) => {
-      await writeDiscordConfigIni(homeDir, {
-        allowedUserIds: ["555555555555555555"],
-        botToken: "discord-bot-token",
-        pairedUserIds: ["424242424242424242"],
+      const { handleSlashCommand } = await createPairedHandler(homeDir, {
+        pairedUserIds: [],
       });
-
-      const authStore = new DiscordAuthStore();
-      await authStore.reload();
-      const { client } = createMockClient();
-      const sessionStore = new SessionStore(
-        path.join(homeDir, ".nakama", "discord", "chat-sessions.json")
-      );
-      await sessionStore.load();
-      const threadStore = new ThreadStore(
-        path.join(homeDir, ".nakama", "discord", "chat-threads.json")
-      );
-      await threadStore.load();
-      const orgStore = createTestOrgStore(homeDir);
-      await orgStore.load();
-      const { handleSlashCommand } = createChatHandler({
-        authStore,
-        client,
-        config: { botToken: "discord-bot-token", profileId: "default" },
-        orgStore,
-        sessionStore,
-        threadStore,
-      });
-
       const allowCmd = createSlashInteraction({
         commandName: "allow",
         userId: "555555555555555555",
@@ -1392,17 +1367,14 @@ describe("createChatHandler guild thread routing", () => {
       expect(
         allowCmd.replies.some((reply) => /not authorized/i.test(reply))
       ).toBe(true);
-
-      const config = await loadDiscordConfigFile();
-      expect(config?.allowedUserIds).toEqual(["555555555555555555"]);
+      expect((await loadDiscordConfigFile())?.allowedUserIds ?? []).toEqual([]);
     });
   });
 
-  test("allow adds a mentioned user and persists to config", async () => {
+  test("adds a mentioned user", async () => {
     await withTempHome(async (homeDir) => {
       const { handleSlashCommand } = await createPairedHandler(homeDir);
       const targetUserId = "777777777777777777";
-
       const allowCmd = createSlashInteraction({
         commandName: "allow",
         userOption: { id: targetUserId, username: "alice" },
@@ -1412,52 +1384,18 @@ describe("createChatHandler guild thread routing", () => {
       expect(
         allowCmd.replies.some((reply) => reply.includes(`<@${targetUserId}>`))
       ).toBe(true);
-      expect(allowCmd.replies.some((reply) => /already/i.test(reply))).toBe(
-        false
+      expect((await loadDiscordConfigFile())?.allowedUserIds).toContain(
+        targetUserId
       );
-
-      const config = await loadDiscordConfigFile();
-      expect(config?.allowedUserIds).toContain(targetUserId);
-      expect(
-        isDiscordUserAuthorized(targetUserId, {
-          allowedUserIds: config?.allowedUserIds ?? [],
-          pairedUserIds: config?.pairedUserIds ?? [],
-        })
-      ).toBe(true);
     });
   });
 
-  test("allow reports when the user is already on the allowed list", async () => {
+  test("reports already-allowed users", async () => {
     await withTempHome(async (homeDir) => {
       const targetUserId = "888888888888888888";
-      await writeDiscordConfigIni(homeDir, {
+      const { handleSlashCommand } = await createPairedHandler(homeDir, {
         allowedUserIds: [targetUserId],
-        botToken: "discord-bot-token",
-        pairedUserIds: ["424242424242424242"],
       });
-
-      const authStore = new DiscordAuthStore();
-      await authStore.reload();
-      const { client } = createMockClient();
-      const sessionStore = new SessionStore(
-        path.join(homeDir, ".nakama", "discord", "chat-sessions.json")
-      );
-      await sessionStore.load();
-      const threadStore = new ThreadStore(
-        path.join(homeDir, ".nakama", "discord", "chat-threads.json")
-      );
-      await threadStore.load();
-      const orgStore = createTestOrgStore(homeDir);
-      await orgStore.load();
-      const { handleSlashCommand } = createChatHandler({
-        authStore,
-        client,
-        config: { botToken: "discord-bot-token", profileId: "default" },
-        orgStore,
-        sessionStore,
-        threadStore,
-      });
-
       const allowCmd = createSlashInteraction({
         commandName: "allow",
         userOption: { id: targetUserId },
@@ -1467,9 +1405,6 @@ describe("createChatHandler guild thread routing", () => {
       expect(allowCmd.replies.some((reply) => /already/i.test(reply))).toBe(
         true
       );
-
-      const config = await loadDiscordConfigFile();
-      expect(config?.allowedUserIds).toEqual([targetUserId]);
     });
   });
 

--- a/apps/platform/discord/src/chat-handler.test.ts
+++ b/apps/platform/discord/src/chat-handler.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import path from "node:path";
 import type { ChatMessage } from "@nakama/core/contract";
+import {
+  isDiscordUserAuthorized,
+  loadDiscordConfigFile,
+} from "@nakama/core/discord-config";
 import { DiscordAuthStore } from "./auth-store";
 import {
   chatLockOptions,
@@ -1345,6 +1349,127 @@ describe("createChatHandler guild thread routing", () => {
         "I can only close threads I started."
       );
       expect(threadStore.hasThreadId("thread_owned")).toBe(true);
+    });
+  });
+
+  test("allow denies non-paired users", async () => {
+    await withTempHome(async (homeDir) => {
+      await writeDiscordConfigIni(homeDir, {
+        allowedUserIds: ["555555555555555555"],
+        botToken: "discord-bot-token",
+        pairedUserIds: ["424242424242424242"],
+      });
+
+      const authStore = new DiscordAuthStore();
+      await authStore.reload();
+      const { client } = createMockClient();
+      const sessionStore = new SessionStore(
+        path.join(homeDir, ".nakama", "discord", "chat-sessions.json")
+      );
+      await sessionStore.load();
+      const threadStore = new ThreadStore(
+        path.join(homeDir, ".nakama", "discord", "chat-threads.json")
+      );
+      await threadStore.load();
+      const orgStore = createTestOrgStore(homeDir);
+      await orgStore.load();
+      const { handleSlashCommand } = createChatHandler({
+        authStore,
+        client,
+        config: { botToken: "discord-bot-token", profileId: "default" },
+        orgStore,
+        sessionStore,
+        threadStore,
+      });
+
+      const allowCmd = createSlashInteraction({
+        commandName: "allow",
+        userId: "555555555555555555",
+        userOption: { id: "999999999999999999" },
+      });
+      await handleSlashCommand(allowCmd.interaction);
+
+      expect(
+        allowCmd.replies.some((reply) => /not authorized/i.test(reply))
+      ).toBe(true);
+
+      const config = await loadDiscordConfigFile();
+      expect(config?.allowedUserIds).toEqual(["555555555555555555"]);
+    });
+  });
+
+  test("allow adds a mentioned user and persists to config", async () => {
+    await withTempHome(async (homeDir) => {
+      const { handleSlashCommand } = await createPairedHandler(homeDir);
+      const targetUserId = "777777777777777777";
+
+      const allowCmd = createSlashInteraction({
+        commandName: "allow",
+        userOption: { id: targetUserId, username: "alice" },
+      });
+      await handleSlashCommand(allowCmd.interaction);
+
+      expect(
+        allowCmd.replies.some((reply) => reply.includes(`<@${targetUserId}>`))
+      ).toBe(true);
+      expect(allowCmd.replies.some((reply) => /already/i.test(reply))).toBe(
+        false
+      );
+
+      const config = await loadDiscordConfigFile();
+      expect(config?.allowedUserIds).toContain(targetUserId);
+      expect(
+        isDiscordUserAuthorized(targetUserId, {
+          allowedUserIds: config?.allowedUserIds ?? [],
+          pairedUserIds: config?.pairedUserIds ?? [],
+        })
+      ).toBe(true);
+    });
+  });
+
+  test("allow reports when the user is already on the allowed list", async () => {
+    await withTempHome(async (homeDir) => {
+      const targetUserId = "888888888888888888";
+      await writeDiscordConfigIni(homeDir, {
+        allowedUserIds: [targetUserId],
+        botToken: "discord-bot-token",
+        pairedUserIds: ["424242424242424242"],
+      });
+
+      const authStore = new DiscordAuthStore();
+      await authStore.reload();
+      const { client } = createMockClient();
+      const sessionStore = new SessionStore(
+        path.join(homeDir, ".nakama", "discord", "chat-sessions.json")
+      );
+      await sessionStore.load();
+      const threadStore = new ThreadStore(
+        path.join(homeDir, ".nakama", "discord", "chat-threads.json")
+      );
+      await threadStore.load();
+      const orgStore = createTestOrgStore(homeDir);
+      await orgStore.load();
+      const { handleSlashCommand } = createChatHandler({
+        authStore,
+        client,
+        config: { botToken: "discord-bot-token", profileId: "default" },
+        orgStore,
+        sessionStore,
+        threadStore,
+      });
+
+      const allowCmd = createSlashInteraction({
+        commandName: "allow",
+        userOption: { id: targetUserId },
+      });
+      await handleSlashCommand(allowCmd.interaction);
+
+      expect(allowCmd.replies.some((reply) => /already/i.test(reply))).toBe(
+        true
+      );
+
+      const config = await loadDiscordConfigFile();
+      expect(config?.allowedUserIds).toEqual([targetUserId]);
     });
   });
 

--- a/apps/platform/discord/src/chat-handler.ts
+++ b/apps/platform/discord/src/chat-handler.ts
@@ -12,6 +12,7 @@ import type {
   AgentQuestionnaire,
   SendMessageInput,
 } from "@nakama/core/contract";
+import { addDiscordAllowedUserId } from "@nakama/core/discord-config";
 import {
   filterProfilesForChatAccess,
   formatProfileSelectionPrompt,
@@ -101,6 +102,8 @@ const NO_CODE_PROMPT =
   "This bot is not linked yet.\n\n" +
   "Open Nakama Integrations → Discord, save your bot token, and copy the pairing code. " +
   "Then send that code here in a DM.";
+
+const ALLOW_NOT_AUTHORIZED = "You are not authorized to use this command.";
 
 export interface ChatHandlerDeps {
   authStore: DiscordAuthStore;
@@ -403,6 +406,41 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     }
   }
 
+  async function handleAllowCommand(
+    interaction: ChatInputCommandInteraction,
+    messenger: DiscordMessenger,
+    requesterId: string
+  ): Promise<void> {
+    if (!authStore.isPaired(requesterId)) {
+      await messenger.send(ALLOW_NOT_AUTHORIZED);
+      return;
+    }
+
+    const targetUser = interaction.options.getUser("user");
+
+    if (!targetUser) {
+      await messenger.send("Choose a Discord user to allow.");
+      return;
+    }
+
+    const result = await addDiscordAllowedUserId(targetUser.id);
+    await authStore.reload();
+
+    if (!result.ok) {
+      await messenger.send(result.message);
+      return;
+    }
+
+    if (result.alreadyAllowed) {
+      await messenger.send(
+        `<@${result.userId}> is already on the allowed list.`
+      );
+      return;
+    }
+
+    await messenger.send(`Added <@${result.userId}> to the allowed list.`);
+  }
+
   async function handleSlashCommand(
     interaction: ChatInputCommandInteraction
   ): Promise<void> {
@@ -441,6 +479,11 @@ export function createChatHandler(deps: ChatHandlerDeps) {
 
     try {
       await authStore.reload();
+
+      if (interaction.commandName === "allow") {
+        await handleAllowCommand(interaction, messenger, userId);
+        return;
+      }
 
       if (!authStore.isAuthorized(userId)) {
         if (

--- a/apps/platform/discord/src/format.ts
+++ b/apps/platform/discord/src/format.ts
@@ -125,6 +125,7 @@ export const HELP_TEXT = `Nakama Discord commands:
 /compact — compact conversation history
 /new — start a new conversation
 /close — close this bot conversation thread
+/allow — add a Discord user to the allowed list (admin)
 /org — choose or switch organization (send as text)
 /profile — choose or switch bot profile (send as text)
 /status — server and model status

--- a/apps/platform/discord/src/slash-commands.test.ts
+++ b/apps/platform/discord/src/slash-commands.test.ts
@@ -2,30 +2,16 @@ import { describe, expect, test } from "bun:test";
 import { buildSlashCommands } from "./slash-commands";
 
 describe("buildSlashCommands", () => {
-  test("includes allow with a required user option alongside existing commands", () => {
+  test("registers allow with a required user option", () => {
     const commands = buildSlashCommands();
-    const names = commands.map((command) => command.name);
-
-    expect(names).toEqual([
-      "start",
-      "help",
-      "stop",
-      "clear",
-      "compact",
-      "new",
-      "close",
-      "status",
-      "allow",
-    ]);
+    expect(commands.map((command) => command.name)).toContain("allow");
 
     const allow = commands.find((command) => command.name === "allow");
     expect(allow).toBeDefined();
 
-    const json = allow!.toJSON();
-    const userOption = json.options?.find(
-      (option: { name?: string }) => option.name === "user"
-    );
-
+    const userOption = allow!
+      .toJSON()
+      .options?.find((option: { name?: string }) => option.name === "user");
     expect(userOption).toMatchObject({
       name: "user",
       required: true,

--- a/apps/platform/discord/src/slash-commands.test.ts
+++ b/apps/platform/discord/src/slash-commands.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { buildSlashCommands } from "./slash-commands";
+
+describe("buildSlashCommands", () => {
+  test("includes allow with a required user option alongside existing commands", () => {
+    const commands = buildSlashCommands();
+    const names = commands.map((command) => command.name);
+
+    expect(names).toEqual([
+      "start",
+      "help",
+      "stop",
+      "clear",
+      "compact",
+      "new",
+      "close",
+      "status",
+      "allow",
+    ]);
+
+    const allow = commands.find((command) => command.name === "allow");
+    expect(allow).toBeDefined();
+
+    const json = allow!.toJSON();
+    const userOption = json.options?.find(
+      (option: { name?: string }) => option.name === "user"
+    );
+
+    expect(userOption).toMatchObject({
+      name: "user",
+      required: true,
+      type: 6,
+    });
+  });
+});

--- a/apps/platform/discord/src/slash-commands.ts
+++ b/apps/platform/discord/src/slash-commands.ts
@@ -15,10 +15,12 @@ const COMMAND_NAMES = [
   "new",
   "close",
   "status",
+  "allow",
 ] as const;
 
 export function buildSlashCommands(): SlashCommandBuilder[] {
   const descriptions: Record<(typeof COMMAND_NAMES)[number], string> = {
+    allow: "Add a Discord user to the bot allowed list",
     clear: "Clear chat history",
     close: "Close this bot conversation thread",
     compact: "Compact conversation history",
@@ -29,12 +31,23 @@ export function buildSlashCommands(): SlashCommandBuilder[] {
     stop: "Stop the current agent reply",
   };
 
-  return COMMAND_NAMES.map((name) =>
-    new SlashCommandBuilder()
+  return COMMAND_NAMES.map((name) => {
+    const builder = new SlashCommandBuilder()
       .setName(name)
       .setDescription(descriptions[name])
-      .setContexts(InteractionContextType.Guild, InteractionContextType.BotDM)
-  );
+      .setContexts(InteractionContextType.Guild, InteractionContextType.BotDM);
+
+    if (name === "allow") {
+      builder.addUserOption((option) =>
+        option
+          .setName("user")
+          .setDescription("Discord user to allow")
+          .setRequired(true)
+      );
+    }
+
+    return builder;
+  });
 }
 
 export async function registerSlashCommands(

--- a/apps/platform/discord/src/test-helpers.ts
+++ b/apps/platform/discord/src/test-helpers.ts
@@ -472,6 +472,8 @@ export function createSlashInteraction(options: {
   /** Parent id returned by channel.fetch() when initial parentId is null. */
   fetchParentId?: string;
   threadId?: string;
+  /** Resolved USER option for commands like /allow. Pass `null` for missing. */
+  userOption?: { id: string; username?: string } | null;
 }): {
   interaction: import("discord.js").ChatInputCommandInteraction;
   replies: string[];
@@ -483,6 +485,7 @@ export function createSlashInteraction(options: {
   const parentId =
     options.parentId === null ? null : (options.parentId ?? channelId);
   const fetchParentId = options.fetchParentId ?? channelId;
+  const hasUserOption = options.userOption !== undefined;
 
   const channel = options.inThread
     ? {
@@ -521,6 +524,15 @@ export function createSlashInteraction(options: {
     followUp: async ({ content }: { content: string }) => {
       replies.push(content);
     },
+    options: {
+      getUser: (name: string) => {
+        if (name !== "user" || !hasUserOption) {
+          return null;
+        }
+
+        return options.userOption;
+      },
+    },
     reply: async ({ content }: { content: string }) => {
       replies.push(content);
     },
@@ -536,6 +548,7 @@ export async function writeDiscordConfigIni(
     botToken: string;
     profileId?: string;
     pairedUserIds?: string[];
+    allowedUserIds?: string[];
   }
 ): Promise<void> {
   const dir = path.join(homeDir, ".nakama", "discord");
@@ -549,6 +562,10 @@ export async function writeDiscordConfigIni(
 
   if (config.pairedUserIds?.length) {
     lines.push(`paired_user_ids=${config.pairedUserIds.join(",")}`);
+  }
+
+  if (config.allowedUserIds?.length) {
+    lines.push(`allowed_user_ids=${config.allowedUserIds.join(",")}`);
   }
 
   lines.push("");

--- a/packages/core/src/discord-config.test.ts
+++ b/packages/core/src/discord-config.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import * as os from "node:os";
 import path from "node:path";
 import {
+  addDiscordAllowedUserId,
   buildDiscordInviteUrl,
   generateHandshakeCode,
   isDiscordUserAuthorized,
@@ -278,6 +279,71 @@ describe("saveDiscordConfig", () => {
       const saved = await loadDiscordConfigFile();
       expect(saved?.handshakeCode).toBe(result.handshakeCode);
       expect(saved?.allowedUserIds).toEqual([]);
+    });
+  });
+});
+
+describe("addDiscordAllowedUserId", () => {
+  let tempHome = "";
+  let homedirSpy: ReturnType<typeof spyOn<typeof os, "homedir">> | null = null;
+
+  afterEach(async () => {
+    homedirSpy?.mockRestore();
+    homedirSpy = null;
+
+    if (tempHome) {
+      await rm(tempHome, { force: true, recursive: true });
+      tempHome = "";
+    }
+  });
+
+  async function useTempDiscordHome(run: () => Promise<void>): Promise<void> {
+    tempHome = await mkdtemp(
+      path.join(os.tmpdir(), "nakama-core-discord-allow-")
+    );
+    homedirSpy = spyOn(os, "homedir").mockReturnValue(tempHome);
+    await run();
+  }
+
+  test("adds a snowflake id to the allowlist and dedupes", async () => {
+    await useTempDiscordHome(async () => {
+      await writeDiscordConfig(tempHome, {
+        botToken: "discord-bot-token",
+        pairedUserIds: ["111111111111111111"],
+      });
+
+      const userId = "222222222222222222";
+      const added = await addDiscordAllowedUserId(userId);
+      expect(added).toEqual({
+        alreadyAllowed: false,
+        ok: true,
+        userId,
+      });
+
+      const saved = await loadDiscordConfigFile();
+      expect(saved?.allowedUserIds).toEqual([userId]);
+
+      const duplicate = await addDiscordAllowedUserId(userId);
+      expect(duplicate).toEqual({
+        alreadyAllowed: true,
+        ok: true,
+        userId,
+      });
+      expect((await loadDiscordConfigFile())?.allowedUserIds).toEqual([userId]);
+    });
+  });
+
+  test("rejects invalid ids and missing config", async () => {
+    await useTempDiscordHome(async () => {
+      expect(await addDiscordAllowedUserId("not-a-snowflake")).toEqual({
+        message: "Invalid Discord user ID.",
+        ok: false,
+      });
+
+      expect(await addDiscordAllowedUserId("222222222222222222")).toEqual({
+        message: "Discord is not configured on the server yet.",
+        ok: false,
+      });
     });
   });
 });

--- a/packages/core/src/discord-config.test.ts
+++ b/packages/core/src/discord-config.test.ts
@@ -305,7 +305,7 @@ describe("addDiscordAllowedUserId", () => {
     await run();
   }
 
-  test("adds a snowflake id to the allowlist and dedupes", async () => {
+  test("adds a snowflake id and dedupes", async () => {
     await useTempDiscordHome(async () => {
       await writeDiscordConfig(tempHome, {
         botToken: "discord-bot-token",

--- a/packages/core/src/discord-config.ts
+++ b/packages/core/src/discord-config.ts
@@ -334,6 +334,46 @@ export async function saveDiscordConfig(
   return withDiscordInviteUrl(toDiscordSettingsPublic(next), next.botToken);
 }
 
+export async function addDiscordAllowedUserId(
+  userId: string
+): Promise<
+  | { alreadyAllowed: boolean; ok: true; userId: string }
+  | { message: string; ok: false }
+> {
+  const trimmed = userId.trim();
+
+  if (!SNOWFLAKE_PATTERN.test(trimmed)) {
+    return { message: "Invalid Discord user ID.", ok: false };
+  }
+
+  const config = await loadDiscordConfigFile();
+
+  if (!config) {
+    return {
+      message: "Discord is not configured on the server yet.",
+      ok: false,
+    };
+  }
+
+  if (config.allowedUserIds.includes(trimmed)) {
+    return { alreadyAllowed: true, ok: true, userId: trimmed };
+  }
+
+  try {
+    await writeDiscordConfigFile({
+      ...config,
+      allowedUserIds: [...config.allowedUserIds, trimmed],
+    });
+  } catch {
+    return {
+      message: "Could not update the Discord allowed list.",
+      ok: false,
+    };
+  }
+
+  return { alreadyAllowed: false, ok: true, userId: trimmed };
+}
+
 export async function regenerateDiscordHandshake(): Promise<DiscordSettingsPublic> {
   const existing = await loadDiscordConfigFile();
 


### PR DESCRIPTION
## Summary
- Adds Discord `/allow @user` slash command (paired admins only) to append a user snowflake to `allowed_user_ids`
- Persists via `addDiscordAllowedUserId` in discord-config; clear replies for denied, duplicate, and config errors
- Updates help text / command registration and covers auth, success, dedupe, and persistence in tests

Closes #209

## Test plan
- [x] `bun test apps/platform/discord packages/core/src/discord-config.test.ts`
- [x] `bunx biome check` on changed files
- [ ] In a live Discord bot: paired admin runs `/allow @someone` and confirm config.ini updates
- [ ] Non-paired / allowlisted-only user gets not-authorized reply
- [ ] Re-running `/allow` on an already-allowed user reports already allowed


Made with [Cursor](https://cursor.com)