### PR TITLE
fix(web): scrollable full-width markdown on public artifact share page

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -672,6 +672,10 @@
     letter-spacing: 0.01em;
   }
 
+  .artifact-share-page .chat-markdown {
+    max-width: none;
+  }
+
   /* Streamdown code fences in chat — single compact block, no 200px placeholder */
   .chat-markdown [data-streamdown="code-block"] {
     display: flex !important;

--- a/apps/web/src/pages/PublicArtifactSharePage.tsx
+++ b/apps/web/src/pages/PublicArtifactSharePage.tsx
@@ -83,8 +83,8 @@ export function PublicArtifactSharePage() {
   return (
     <div
       className={cn(
-        "bg-background text-foreground",
-        isHtml ? "flex h-svh flex-col overflow-hidden" : "min-h-svh"
+        "artifact-share-page bg-background text-foreground",
+        isHtml ? "flex h-svh flex-col overflow-hidden" : "h-svh overflow-y-auto"
       )}
     >
       <header className="border-border border-b px-3 py-1.5">


### PR DESCRIPTION
## Summary
- Make the public artifact share page (`/s/:token`) its own scroll container for non-HTML kinds (`h-svh overflow-y-auto`) so tall markdown/image/video/text content is not clipped by the app-shell `html, body, #root { overflow: hidden }` rule. HTML artifacts keep the existing flex + iframe scroll behavior.
- Scope a `.artifact-share-page .chat-markdown { max-width: none; }` override so shared markdown fills the `max-w-5xl` container instead of the chat `68ch` readability cap (chat messages unchanged).

## Test plan
- [x] `bun install`
- [x] `bun run --filter @nakama/web build` (tsc + vite) passes
- [x] `bun x ultracite check` on changed files passes
- [ ] Open a shared markdown artifact taller than the viewport — page scrolls; header scrolls with content
- [ ] Confirm markdown uses full container width (not 68ch)
- [ ] Confirm HTML artifact share still uses iframe scroll, no page scrollbar
- [ ] Confirm chat markdown still capped at 68ch


Made with [Cursor](https://cursor.com)