### PR TITLE
docs: add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,115 @@
+# Contributing to Nakama
+
+Nakama is a multi-tenant Bun + TypeScript platform for running AI agent teams (orgs, profiles, tools, channels). This guide is for people changing the codebase.
+
+- [README.md](./README.md) — product overview and quick start
+- [ARCHITECTURE.md](./ARCHITECTURE.md) — system design
+- [AGENTS.md](./AGENTS.md) — authoritative agent/dev notes (layout, tests, docs conventions)
+- Discord: https://discord.gg/qhKbMFEUc
+
+## Prerequisites
+
+- [Bun](https://bun.sh) 1.3+
+- git
+- [GitHub CLI](https://cli.github.com/) (`gh`) for opening PRs
+
+## Setup
+
+```bash
+git clone https://github.com/ahmadrosid/nakama.git
+cd nakama
+bun install
+```
+
+Run the pieces you need:
+
+```bash
+bun run dev:server   # API
+bun run dev:web      # web dashboard (starts the server if needed)
+bun run dev:cli      # terminal client
+```
+
+- Local Bun web dashboard: http://localhost:3000
+- Docker single-container dashboard (API + web + workers): http://localhost:4310
+
+See [AGENTS.md](./AGENTS.md) for Docker run/build scripts and deeper layout notes.
+
+## Repo layout
+
+| Path | Purpose |
+|---|---|
+| `apps/server` | Hono HTTP API, agent service, tool playground, workers control |
+| `apps/web` | React dashboard |
+| `apps/cli` | Terminal chat client |
+| `apps/platform/telegram` | Telegram channel worker |
+| `apps/platform/whatsapp` | WhatsApp channel worker |
+| `apps/platform/discord` | Discord channel worker |
+| `apps/platform/automation` | Automation worker |
+| `packages/core` | Soul, tools, skills, contracts |
+| `packages/agent` | Chat loop, prompts, compaction |
+| `packages/db` | SQLite schema and adapters |
+| `packages/client` | HTTP + SSE client (`X-Org-Id`, auth) |
+| `docs/website` | User-facing docs site (MDX) |
+
+Workspaces: `apps/*`, `apps/platform/*`, `packages/*`.
+
+## Code style and checks
+
+Lint and format with Biome via [Ultracite](https://www.ultracite.ai/). Config: `biome.jsonc`.
+
+```bash
+bun run check   # ultracite check
+bun run fix     # ultracite fix
+```
+
+Husky runs `bun x ultracite fix` on staged files in `.husky/pre-commit` and re-stages them. Fix issues locally before pushing; CI expects a clean check.
+
+## Testing
+
+```bash
+bun test
+```
+
+Assert behavior (outputs, status codes, side effects), not prompt text, description strings, or exact error copy.
+
+### LLM cassette tests (MSW)
+
+Live provider tests record one real HTTP exchange, commit the cassette, then replay offline. Helper: `apps/server/src/testing/llm-msw-cassette.ts` (`withMswCassette`).
+
+- Name live tests `*.llm.test.ts`
+- Cassettes: `apps/server/src/testing/cassettes/`
+- Default: replay when a cassette exists (`LLM_VCR_MODE` unset → `auto` locally, `replay` in CI)
+- Re-record (needs a provider API key):
+
+```bash
+bun test path/to/foo.llm.test.ts
+LLM_VCR_MODE=record bun test path/to/foo.llm.test.ts
+```
+
+## Docs contributions
+
+User docs live in `docs/website/content/docs/` (MDX). Audience is operators and chat users — prefer why / value / how to use; keep contributor internals in this file or `AGENTS.md` unless the page is explicitly for integrators.
+
+When adding or changing a page:
+
+1. Edit or add MDX under `docs/website/content/docs/`
+2. Register the page in `docs/website/content/docs/meta.json`
+3. Cross-link from the hub `docs/website/content/docs/docs.mdx`
+4. Screenshots go in `docs/website/public/screenshots/` (`![alt](/screenshots/foo.png)`); capture scripts in `docs/website/scripts/`
+5. Verify: `bun run build:docs`
+
+## Workflow
+
+1. Branch from `main` (or fork, then branch)
+2. One concern per PR
+3. Push and open a PR:
+
+```bash
+git push -u origin HEAD
+gh pr create
+```
+
+4. PR body should state what changed, what you verified, and remaining risks
+5. CI must pass before merge
+
+Do not rewrite `AGENTS.md`, `README.md`, or `ARCHITECTURE.md` unless the change is specifically about those files.

--- a/docs/website/content/docs/contributing.mdx
+++ b/docs/website/content/docs/contributing.mdx
@@ -1,0 +1,66 @@
+---
+title: "Contributing"
+description: "Run Nakama from source, find your way around the monorepo, test changes, and open a pull request."
+---
+
+Want to change Nakama itself? This page is the short path. For the full checklist (style, cassette tests, docs conventions), see [CONTRIBUTING.md](https://github.com/ahmadrosid/nakama/blob/main/CONTRIBUTING.md) on GitHub.
+
+## Run locally
+
+You need [Bun](https://bun.sh) 1.3+, git, and optionally the [GitHub CLI](https://cli.github.com/) for PRs.
+
+```bash
+git clone https://github.com/ahmadrosid/nakama.git
+cd nakama
+bun install
+bun run dev:web
+```
+
+Open the web dashboard at http://localhost:3000. `dev:web` starts the API if needed.
+
+Other entry points:
+
+```bash
+bun run dev:server   # API only
+bun run dev:cli      # terminal client
+```
+
+If you run the Docker single-container image instead, the dashboard is at http://localhost:4310 (API, web, and platform workers together).
+
+## Where to look
+
+| Area | Path |
+|---|---|
+| API and agent runtime | `apps/server` |
+| Dashboard | `apps/web` |
+| CLI | `apps/cli` |
+| Channel workers | `apps/platform/{telegram,whatsapp,discord,automation}` |
+| Shared libraries | `packages/{core,agent,db,client}` |
+| User docs (this site) | `docs/website` |
+
+Deeper layout and conventions: [AGENTS.md](https://github.com/ahmadrosid/nakama/blob/main/AGENTS.md), system design: [ARCHITECTURE.md](https://github.com/ahmadrosid/nakama/blob/main/ARCHITECTURE.md).
+
+## How to test
+
+```bash
+bun test
+bun run check    # Biome via Ultracite
+```
+
+Assert behavior, not exact prompt or error copy. Live LLM tests use MSW cassettes (`*.llm.test.ts`); see [CONTRIBUTING.md](https://github.com/ahmadrosid/nakama/blob/main/CONTRIBUTING.md#testing) for replay and `LLM_VCR_MODE=record`.
+
+Docs-only changes: register new MDX pages in `meta.json`, link them from the [Documentation](/docs) hub, then run `bun run build:docs`.
+
+## Open a pull request
+
+1. Branch from `main` (or fork first)
+2. Keep the PR to one concern
+3. Push and create the PR with `gh pr create`
+4. In the body: what changed, what you verified, remaining risks
+5. Wait for CI to pass
+
+## Links
+
+- [GitHub repository](https://github.com/ahmadrosid/nakama)
+- [CONTRIBUTING.md](https://github.com/ahmadrosid/nakama/blob/main/CONTRIBUTING.md)
+- [Discord](https://discord.gg/qhKbMFEUc)

--- a/docs/website/content/docs/docs.mdx
+++ b/docs/website/content/docs/docs.mdx
@@ -70,6 +70,11 @@ Then open the dashboard, complete the setup wizard, and send your first message.
 - [MCP servers](/mcp) — connect external tool providers
 - [Composio](/composio) — SaaS OAuth and toolkit assignment
 
+## Community
+
+- [Contributing](/contributing) — run from source, test, and open a pull request
+- [GitHub repository](https://github.com/ahmadrosid/nakama) — source code and issues
+
 ## Reference
 
 - [llms.txt](/llms.txt) — documentation index for AI agents and tooling

--- a/docs/website/content/docs/meta.json
+++ b/docs/website/content/docs/meta.json
@@ -27,6 +27,8 @@
     "coding-agent",
     "agent-browser",
     "mcp",
-    "composio"
+    "composio",
+    "---Community---",
+    "contributing"
   ]
 }


### PR DESCRIPTION
## Summary
- Add root `CONTRIBUTING.md` covering setup, repo layout, Ultracite/Biome checks, LLM cassette tests, docs workflow, and PR expectations
- Add docs-site page `contributing.mdx`, register it under a new Community nav section in `meta.json`, and link it from the docs hub

## Test plan
- [x] `bun run build:docs` passes (with `NODE_ENV` unset; ambient `NODE_ENV=development` breaks Next production build)
- [x] `bun run check` on changed MDX/JSON — clean
- [ ] Spot-check `/contributing` on docs preview if desired

## Remaining risks
- Docs build requires a clean `NODE_ENV` (not `development`); contributors hitting that locally may think the page itself is broken
- `CONTRIBUTING.md` links to `main` blob URLs that only resolve after merge


Made with [Cursor](https://cursor.com)