### PR TITLE
feat(web): image generation tool UI using AICSS Image Generation component

### DIFF
--- a/apps/web/src/components/chat/ImageGeneration.module.css
+++ b/apps/web/src/components/chat/ImageGeneration.module.css
@@ -1,0 +1,284 @@
+/* Adapted from AIcss Image Generation (https://www.aicss.dev/components/image-generation) — licensed component. */
+
+.igWrap {
+  --c-text: var(--foreground);
+  --c-muted: var(--muted-foreground);
+  --c-surface: var(--muted);
+  --c-border: var(--border);
+  --c-res-bg: color-mix(in oklch, var(--background) 82%, transparent);
+  --c-dot: color-mix(in oklch, var(--muted-foreground) 55%, transparent);
+  --c-dot-active: color-mix(in oklch, var(--foreground) 72%, transparent);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  align-items: flex-start;
+  width: 100%;
+  max-width: 208px;
+  font-family: var(--font-sans);
+  color: var(--c-text);
+}
+
+.igCanvas {
+  position: relative;
+  width: 100%;
+  max-width: 208px;
+  aspect-ratio: 1 / 1;
+  overflow: hidden;
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  border-radius: 12px;
+}
+
+.igCanvasPortrait {
+  aspect-ratio: 2 / 3;
+}
+
+.igCanvasLandscape {
+  max-width: 260px;
+  aspect-ratio: 3 / 2;
+}
+
+.igDots {
+  position: absolute;
+  inset: 2px;
+  background-image: radial-gradient(
+    circle,
+    var(--c-dot) 0.7px,
+    transparent 1.3px
+  );
+  background-repeat: space;
+  background-size: 11px 11px;
+  opacity: 0.28;
+}
+
+.igGlow {
+  position: absolute;
+  inset: 2px;
+  background-image: radial-gradient(
+    circle,
+    var(--c-dot-active) 1.1px,
+    transparent 1.6px
+  );
+  background-repeat: space;
+  background-size: 11px 11px;
+  -webkit-mask-image:
+    radial-gradient(ellipse at center, #000 0%, transparent 60%),
+    radial-gradient(ellipse at center, #000 0%, transparent 62%);
+  mask-image:
+    radial-gradient(ellipse at center, #000 0%, transparent 60%),
+    radial-gradient(ellipse at center, #000 0%, transparent 62%);
+  -webkit-mask-repeat: no-repeat, no-repeat;
+  mask-repeat: no-repeat, no-repeat;
+  -webkit-mask-position:
+    16% 20%,
+    30% 32%;
+  mask-position:
+    16% 20%,
+    30% 32%;
+  -webkit-mask-size:
+    72% 62%,
+    52% 52%;
+  mask-size:
+    72% 62%,
+    52% 52%;
+  animation:
+    ig-morph 4.2s cubic-bezier(0.35, 1.55, 0.65, 1) infinite,
+    ig-breathe 1.9s cubic-bezier(0.66, 0, 0.34, 1) infinite;
+}
+
+@keyframes ig-morph {
+  0% {
+    -webkit-mask-position:
+      16% 20%,
+      30% 32%;
+    mask-position:
+      16% 20%,
+      30% 32%;
+    -webkit-mask-size:
+      52% 46%,
+      40% 40%;
+    mask-size:
+      52% 46%,
+      40% 40%;
+  }
+
+  25% {
+    -webkit-mask-position:
+      84% 16%,
+      66% 30%;
+    mask-position:
+      84% 16%,
+      66% 30%;
+    -webkit-mask-size:
+      46% 58%,
+      44% 38%;
+    mask-size:
+      46% 58%,
+      44% 38%;
+  }
+
+  50% {
+    -webkit-mask-position:
+      82% 84%,
+      62% 68%;
+    mask-position:
+      82% 84%,
+      62% 68%;
+    -webkit-mask-size:
+      60% 44%,
+      38% 46%;
+    mask-size:
+      60% 44%,
+      38% 46%;
+  }
+
+  75% {
+    -webkit-mask-position:
+      14% 82%,
+      34% 66%;
+    mask-position:
+      14% 82%,
+      34% 66%;
+    -webkit-mask-size:
+      48% 54%,
+      46% 40%;
+    mask-size:
+      48% 54%,
+      46% 40%;
+  }
+
+  100% {
+    -webkit-mask-position:
+      16% 20%,
+      30% 32%;
+    mask-position:
+      16% 20%,
+      30% 32%;
+    -webkit-mask-size:
+      52% 46%,
+      40% 40%;
+    mask-size:
+      52% 46%,
+      40% 40%;
+  }
+}
+
+@keyframes ig-breathe {
+  0%,
+  100% {
+    opacity: 0.45;
+  }
+
+  50% {
+    opacity: 0.85;
+  }
+}
+
+.igRes {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  padding: 2px 7px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.3;
+  color: var(--c-muted);
+  background: var(--c-res-bg);
+  border: 1px solid var(--c-border);
+  border-radius: 4px;
+}
+
+.igMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  align-items: flex-start;
+  width: 100%;
+  text-align: left;
+}
+
+.igLabel {
+  font-size: 14px;
+  font-weight: 550;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  background: linear-gradient(
+    90deg,
+    var(--c-text) 0%,
+    var(--c-text) 30%,
+    color-mix(in oklch, var(--c-text) 45%, transparent) 45%,
+    color-mix(in oklch, var(--c-text) 45%, transparent) 55%,
+    var(--c-text) 70%,
+    var(--c-text) 100%
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  background-size: 300% 100%;
+  animation: ig-shine 2.25s cubic-bezier(0.25, 0.1, 0.25, 1) infinite;
+}
+
+@keyframes ig-shine {
+  0%,
+  18% {
+    background-position: 100% 0;
+  }
+
+  82%,
+  100% {
+    background-position: 0% 0;
+  }
+}
+
+.igPrompt {
+  font-size: 13px;
+  line-height: 1.35;
+  color: var(--c-muted);
+  overflow-wrap: anywhere;
+}
+
+.igImage {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.igFailed {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-start;
+  justify-content: center;
+  width: 100%;
+  min-height: 100%;
+  padding: 16px;
+  background: color-mix(in oklch, var(--destructive) 8%, var(--c-surface));
+}
+
+.igFailedLabel {
+  font-size: 13px;
+  font-weight: 550;
+  color: var(--destructive);
+}
+
+.igFailedDetail {
+  font-size: 12px;
+  line-height: 1.4;
+  color: color-mix(in oklch, var(--destructive) 80%, var(--c-muted));
+  overflow-wrap: anywhere;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .igGlow {
+    opacity: 0.7;
+    animation: none;
+  }
+
+  .igLabel {
+    color: var(--c-text);
+    -webkit-text-fill-color: var(--c-text);
+    background: none;
+    animation: none;
+  }
+}

--- a/apps/web/src/components/chat/ImageGeneration.tsx
+++ b/apps/web/src/components/chat/ImageGeneration.tsx
@@ -1,0 +1,81 @@
+/**
+ * Adapted from AIcss Image Generation (https://www.aicss.dev/components/image-generation).
+ * Production use requires a valid AIcss license per https://www.aicss.dev/pricing
+ */
+import { cn } from "@/lib/utils";
+import styles from "./ImageGeneration.module.css";
+
+export type ImageGenerationAspect = "square" | "portrait" | "landscape";
+
+export interface ImageGenerationProps {
+  aspect?: ImageGenerationAspect;
+  className?: string;
+  /** When set (and no imageUrl), shows a failure canvas. */
+  error?: string | null;
+  /** When set, replaces the shimmer canvas with the generated image. */
+  imageUrl?: string | null;
+  prompt?: string;
+  resolution?: string;
+}
+
+export function ImageGeneration({
+  prompt = "a calm mountain lake at dawn",
+  resolution = "1024 × 1024",
+  aspect = "square",
+  imageUrl = null,
+  error = null,
+  className,
+}: ImageGenerationProps) {
+  const canvasClass = cn(
+    styles.igCanvas,
+    aspect === "portrait" && styles.igCanvasPortrait,
+    aspect === "landscape" && styles.igCanvasLandscape
+  );
+
+  const isFailed = !imageUrl && Boolean(error);
+  const isComplete = Boolean(imageUrl);
+
+  return (
+    <div className={cn(styles.igWrap, className)}>
+      <div
+        aria-label={
+          isFailed
+            ? "Image generation failed"
+            : isComplete
+              ? "Generated image"
+              : "Generating image"
+        }
+        className={canvasClass}
+        role="img"
+      >
+        {imageUrl ? (
+          <img alt={prompt} className={styles.igImage} src={imageUrl} />
+        ) : isFailed ? (
+          <div className={styles.igFailed}>
+            {error ? (
+              <span className={styles.igFailedDetail}>{error}</span>
+            ) : (
+              <span className={styles.igFailedLabel}>Generation failed</span>
+            )}
+          </div>
+        ) : (
+          <>
+            <span aria-hidden className={styles.igDots} />
+            <span aria-hidden className={styles.igGlow} />
+            <span className={styles.igRes}>{resolution}</span>
+          </>
+        )}
+      </div>
+      <div className={styles.igMeta}>
+        {isFailed ? (
+          <span className={styles.igFailedLabel}>Generation failed</span>
+        ) : isComplete ? (
+          <span className={styles.igPrompt}>Generated image</span>
+        ) : (
+          <span className={styles.igLabel}>Generating image</span>
+        )}
+        <span className={styles.igPrompt}>“{prompt}”</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/ImageGenerationToolRow.tsx
+++ b/apps/web/src/components/chat/ImageGenerationToolRow.tsx
@@ -1,0 +1,32 @@
+import { ImageGeneration } from "@/components/chat/ImageGeneration";
+import type { ChatListItem } from "@/lib/chat-history";
+import {
+  buildGenerateImageToolState,
+  shouldRenderGenerateImageToolRow,
+} from "@/lib/chat-stream-image-generation";
+
+export function ImageGenerationToolRow({
+  message,
+  profileId,
+}: {
+  message: ChatListItem;
+  profileId?: string | null;
+}) {
+  if (!shouldRenderGenerateImageToolRow(message)) {
+    return null;
+  }
+
+  const state = buildGenerateImageToolState(message, profileId);
+
+  return (
+    <div className="w-full max-w-full">
+      <ImageGeneration
+        aspect={state.aspect}
+        error={state.error}
+        imageUrl={state.imageUrl}
+        prompt={state.prompt}
+        resolution={state.resolution}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/assistant-tool-group.tsx
+++ b/apps/web/src/components/chat/assistant-tool-group.tsx
@@ -7,6 +7,7 @@ import {
   MessageResponse,
 } from "@/components/ai-elements/message";
 import type { AssistantTurnSegment } from "@/components/chat/assistant-tool-group.shared";
+import { ImageGenerationToolRow } from "@/components/chat/ImageGenerationToolRow";
 import { ThinkingReasoning } from "@/components/chat/ThinkingReasoning";
 import thinkingStyles from "@/components/chat/ThinkingReasoning.module.css";
 import { WebFetchToolRow } from "@/components/chat/WebFetchToolRow";
@@ -26,6 +27,10 @@ import {
   parseSubAgentResult,
 } from "@/lib/chat-stream";
 import {
+  isGenerateImageTool,
+  shouldRenderGenerateImageToolRow,
+} from "@/lib/chat-stream-image-generation";
+import {
   isWebFetchTool,
   shouldRenderWebFetchToolRow,
 } from "@/lib/chat-stream-web-fetch";
@@ -40,15 +45,18 @@ export function AssistantTurnSegmentView({
   segment,
   showThinking = true,
   modelLabel,
+  profileId,
 }: {
   segment: AssistantTurnSegment;
   showThinking?: boolean;
   modelLabel?: string | null;
+  profileId?: string | null;
 }) {
   if (segment.kind === "work") {
     return (
       <AssistantWorkGroup
         modelLabel={modelLabel}
+        profileId={profileId}
         thinking={showThinking ? segment.thinking : undefined}
         tools={segment.tools}
       />
@@ -109,10 +117,12 @@ function AssistantWorkGroup({
   thinking,
   tools,
   modelLabel,
+  profileId,
 }: {
   thinking?: ChatListItem;
   tools: ChatListItem[];
   modelLabel?: string | null;
+  profileId?: string | null;
 }) {
   const visibleTools = tools.filter((tool) => !isArtifactMetaSidecarTool(tool));
   const isThinkingStreaming = Boolean(thinking?.thinkingStreaming);
@@ -126,7 +136,13 @@ function AssistantWorkGroup({
   }
 
   if (!thinking) {
-    return <ToolOnlyWorkGroup modelLabel={modelLabel} tools={visibleTools} />;
+    return (
+      <ToolOnlyWorkGroup
+        modelLabel={modelLabel}
+        profileId={profileId}
+        tools={visibleTools}
+      />
+    );
   }
 
   return (
@@ -140,7 +156,11 @@ function AssistantWorkGroup({
       {visibleTools.map((tool, index) => (
         <TimelineStep isLast={index === visibleTools.length - 1} key={tool.id}>
           {isDedicatedTool(tool) ? (
-            <DedicatedToolRow message={tool} modelLabel={modelLabel} />
+            <DedicatedToolRow
+              message={tool}
+              modelLabel={modelLabel}
+              profileId={profileId}
+            />
           ) : (
             <ToolTimelineItem
               defaultDetailsOpen={visibleTools.length === 1}
@@ -156,9 +176,11 @@ function AssistantWorkGroup({
 function ToolOnlyWorkGroup({
   tools,
   modelLabel,
+  profileId,
 }: {
   tools: ChatListItem[];
   modelLabel?: string | null;
+  profileId?: string | null;
 }) {
   const hasRunningTools = tools.some((tool) => tool.toolStatus === "running");
   const isWorkActive = hasRunningTools;
@@ -242,7 +264,11 @@ function ToolOnlyWorkGroup({
               {tools.map((tool, index) => (
                 <TimelineStep isLast={index === tools.length - 1} key={tool.id}>
                   {isDedicatedTool(tool) ? (
-                    <DedicatedToolRow message={tool} modelLabel={modelLabel} />
+                    <DedicatedToolRow
+                      message={tool}
+                      modelLabel={modelLabel}
+                      profileId={profileId}
+                    />
                   ) : (
                     <ToolTimelineItem
                       defaultDetailsOpen={tools.length === 1}
@@ -316,17 +342,28 @@ function isDedicatedTool(tool: ChatListItem): boolean {
   return (
     isSubAgentTool(tool.tool) ||
     shouldRenderWebSearchToolRow(tool) ||
-    shouldRenderWebFetchToolRow(tool)
+    shouldRenderWebFetchToolRow(tool) ||
+    shouldRenderGenerateImageToolRow(tool)
   );
 }
 
 function DedicatedToolRow({
   message,
   modelLabel,
+  profileId,
 }: {
   message: ChatListItem;
   modelLabel?: string | null;
+  profileId?: string | null;
 }) {
+  if (isGenerateImageTool(message.tool)) {
+    if (shouldRenderGenerateImageToolRow(message)) {
+      return <ImageGenerationToolRow message={message} profileId={profileId} />;
+    }
+
+    return <ToolTimelineItem message={message} />;
+  }
+
   if (isWebFetchTool(message.tool)) {
     if (shouldRenderWebFetchToolRow(message)) {
       return <WebFetchToolRow message={message} />;

--- a/apps/web/src/components/chat/chat-message-list.tsx
+++ b/apps/web/src/components/chat/chat-message-list.tsx
@@ -367,6 +367,7 @@ function AssistantTurn({
               : `text:${segment.message.id}`
           }
           modelLabel={modelLabel}
+          profileId={profileId}
           segment={segment}
           showThinking={showThinking}
         />

--- a/apps/web/src/lib/chat-stream-image-generation.test.ts
+++ b/apps/web/src/lib/chat-stream-image-generation.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import type { ChatListItem } from "./chat-history";
+import {
+  buildGenerateImageToolState,
+  formatImageGenerationResolution,
+  imageGenerationAspectFromSize,
+  isGenerateImageTool,
+  parseGenerateImagePrompt,
+  parseGenerateImageSize,
+  shouldRenderGenerateImageToolRow,
+} from "./chat-stream-image-generation";
+
+function toolMessage(
+  partial: Partial<ChatListItem> & Pick<ChatListItem, "toolStatus">
+): ChatListItem {
+  return {
+    content: "",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    id: "tool_1",
+    role: "tool",
+    tool: "generate_image",
+    toolCallId: "call_1",
+    toolInput: { prompt: "a red kite" },
+    ...partial,
+  };
+}
+
+describe("chat-stream-image-generation", () => {
+  test("isGenerateImageTool matches name", () => {
+    expect(isGenerateImageTool("generate_image")).toBe(true);
+    expect(isGenerateImageTool("web_search")).toBe(false);
+    expect(isGenerateImageTool(undefined)).toBe(false);
+  });
+
+  test("parseGenerateImagePrompt and size", () => {
+    expect(parseGenerateImagePrompt({ prompt: "  lake  " })).toBe("lake");
+    expect(parseGenerateImagePrompt({})).toBeNull();
+    expect(parseGenerateImageSize({ size: "1024x1536" })).toBe("1024x1536");
+    expect(parseGenerateImageSize({ prompt: "x" })).toBeNull();
+  });
+
+  test("formatImageGenerationResolution uses multiplication sign", () => {
+    expect(formatImageGenerationResolution("1024x1024")).toBe("1024 × 1024");
+    expect(formatImageGenerationResolution("1536x1024")).toBe("1536 × 1024");
+    expect(formatImageGenerationResolution("auto")).toBe("auto");
+    expect(formatImageGenerationResolution(null)).toBe("1024 × 1024");
+  });
+
+  test("imageGenerationAspectFromSize maps ratios", () => {
+    expect(imageGenerationAspectFromSize("1024x1024")).toBe("square");
+    expect(imageGenerationAspectFromSize("1024x1536")).toBe("portrait");
+    expect(imageGenerationAspectFromSize("1536x1024")).toBe("landscape");
+    expect(imageGenerationAspectFromSize("auto")).toBe("square");
+  });
+
+  test("buildGenerateImageToolState running uses prompt and resolution", () => {
+    const state = buildGenerateImageToolState(
+      toolMessage({
+        toolInput: {
+          prompt: "a calm mountain lake at dawn",
+          size: "1024x1536",
+        },
+        toolStatus: "running",
+      }),
+      "profile_1"
+    );
+
+    expect(state).toEqual({
+      aspect: "portrait",
+      error: null,
+      imageUrl: null,
+      prompt: "a calm mountain lake at dawn",
+      resolution: "1024 × 1536",
+      status: "running",
+    });
+  });
+
+  test("buildGenerateImageToolState done builds artifact image URL", () => {
+    const state = buildGenerateImageToolState(
+      toolMessage({
+        toolInput: { prompt: "logo", size: "1024x1024" },
+        toolResult: {
+          attachmentId: "att_1",
+          mimeType: "image/png",
+          model: "gpt-image-2",
+          path: "artifacts/logo.png",
+          sizeBytes: 1200,
+        },
+        toolStatus: "done",
+      }),
+      "profile_1"
+    );
+
+    expect(state.status).toBe("done");
+    expect(state.imageUrl).toContain(
+      "/v1/profiles/profile_1/artifacts/content?path=logo.png"
+    );
+    expect(state.imageUrl).toContain("inline=1");
+    expect(state.error).toBeNull();
+  });
+
+  test("buildGenerateImageToolState surfaces tool errors", () => {
+    const state = buildGenerateImageToolState(
+      toolMessage({
+        toolResult: { error: "Configure an image generation model" },
+        toolStatus: "done",
+      }),
+      "profile_1"
+    );
+
+    expect(state).toMatchObject({
+      error: "Configure an image generation model",
+      imageUrl: null,
+      status: "error",
+    });
+  });
+
+  test("shouldRenderGenerateImageToolRow is true for generate_image", () => {
+    expect(
+      shouldRenderGenerateImageToolRow(toolMessage({ toolStatus: "running" }))
+    ).toBe(true);
+    expect(
+      shouldRenderGenerateImageToolRow({
+        ...toolMessage({ toolStatus: "done" }),
+        tool: "web_search",
+      })
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/lib/chat-stream-image-generation.ts
+++ b/apps/web/src/lib/chat-stream-image-generation.ts
@@ -1,0 +1,183 @@
+import type { ImageGenerationAspect } from "@/components/chat/ImageGeneration";
+import {
+  buildArtifactContentUrl,
+  toArtifactsRelativePath,
+} from "@/lib/chat-artifacts";
+import type { ChatListItem } from "@/lib/chat-history";
+
+export const GENERATE_IMAGE_TOOL_NAME = "generate_image";
+
+export type ImageGenerationToolStatus = "running" | "done" | "error";
+
+export interface ImageGenerationToolState {
+  aspect: ImageGenerationAspect;
+  error: string | null;
+  imageUrl: string | null;
+  prompt: string;
+  resolution: string;
+  status: ImageGenerationToolStatus;
+}
+
+const DEFAULT_PROMPT = "a calm mountain lake at dawn";
+const DEFAULT_SIZE = "1024x1024";
+
+function readRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+export function isGenerateImageTool(tool: string | undefined): boolean {
+  return tool === GENERATE_IMAGE_TOOL_NAME;
+}
+
+export function parseGenerateImagePrompt(input: unknown): string | null {
+  const record = readRecord(input);
+  if (!record) {
+    return null;
+  }
+
+  return readString(record.prompt);
+}
+
+export function parseGenerateImageSize(input: unknown): string | null {
+  const record = readRecord(input);
+  if (!record) {
+    return null;
+  }
+
+  return readString(record.size);
+}
+
+/** Format tool size (`1024x1024`) as display resolution (`1024 × 1024`). */
+export function formatImageGenerationResolution(size: string | null): string {
+  const normalized = (size ?? DEFAULT_SIZE).trim().toLowerCase();
+  if (!normalized || normalized === "auto") {
+    return normalized === "auto" ? "auto" : "1024 × 1024";
+  }
+
+  const match = normalized.match(/^(\d+)\s*[x×]\s*(\d+)$/i);
+  if (!match) {
+    return size?.trim() || "1024 × 1024";
+  }
+
+  return `${match[1]} × ${match[2]}`;
+}
+
+export function imageGenerationAspectFromSize(
+  size: string | null
+): ImageGenerationAspect {
+  const normalized = (size ?? DEFAULT_SIZE).trim().toLowerCase();
+  const match = normalized.match(/^(\d+)\s*[x×]\s*(\d+)$/i);
+  if (!match) {
+    return "square";
+  }
+
+  const width = Number(match[1]);
+  const height = Number(match[2]);
+  if (!(width > 0 && height > 0)) {
+    return "square";
+  }
+
+  if (width === height) {
+    return "square";
+  }
+
+  return width > height ? "landscape" : "portrait";
+}
+
+function parseGenerateImageError(result: unknown): string | null {
+  const record = readRecord(result);
+  if (!record) {
+    return null;
+  }
+
+  return readString(record.error);
+}
+
+function parseGenerateImagePath(result: unknown): string | null {
+  const record = readRecord(result);
+  if (!record) {
+    return null;
+  }
+
+  const path = readString(record.path);
+  if (!path) {
+    return null;
+  }
+
+  return toArtifactsRelativePath(path) ?? path.replace(/^\.\//, "");
+}
+
+export function buildGenerateImageToolState(
+  item: ChatListItem,
+  profileId?: string | null
+): ImageGenerationToolState {
+  const prompt = parseGenerateImagePrompt(item.toolInput) ?? DEFAULT_PROMPT;
+  const size = parseGenerateImageSize(item.toolInput);
+  const resolution = formatImageGenerationResolution(size);
+  const aspect = imageGenerationAspectFromSize(size);
+
+  if (item.toolStatus === "running") {
+    return {
+      aspect,
+      error: null,
+      imageUrl: null,
+      prompt,
+      resolution,
+      status: "running",
+    };
+  }
+
+  const error = parseGenerateImageError(item.toolResult);
+  if (error) {
+    return {
+      aspect,
+      error,
+      imageUrl: null,
+      prompt,
+      resolution,
+      status: "error",
+    };
+  }
+
+  const relativePath = parseGenerateImagePath(item.toolResult);
+  const imageUrl =
+    relativePath && profileId
+      ? buildArtifactContentUrl(profileId, relativePath, true)
+      : null;
+
+  if (!imageUrl) {
+    return {
+      aspect,
+      error: relativePath
+        ? "Image ready, but preview is unavailable."
+        : "Image generation returned no path.",
+      imageUrl: null,
+      prompt,
+      resolution,
+      status: "error",
+    };
+  }
+
+  return {
+    aspect,
+    error: null,
+    imageUrl,
+    prompt,
+    resolution,
+    status: "done",
+  };
+}
+
+export function shouldRenderGenerateImageToolRow(
+  message: ChatListItem
+): boolean {
+  return isGenerateImageTool(message.tool);
+}


### PR DESCRIPTION
## Summary
- Port the AICSS Image Generation placeholder into the chat tool UI (design-token adapted: flat surfaces, hairline borders, light/dark).
- While `generate_image` is running, show shimmer + prompt + resolution; on success swap to the artifact image; on failure show a consistent error canvas.
- Wire as a dedicated tool row alongside web search/fetch; add parser/state helpers + unit tests.

Closes #219

## Test plan
- [ ] Trigger `generate_image` in chat and confirm the shimmer placeholder shows the real prompt and resolution while running
- [ ] Confirm the placeholder swaps to the generated image when the tool completes
- [ ] Confirm a failed generation (e.g. image model unset) shows the failure state
- [ ] Spot-check light and dark theme
- [ ] `bun test apps/web/src/lib/chat-stream-image-generation.test.ts`
- [ ] `bun x ultracite check` on touched files / `bun run --filter @nakama/web build`


Made with [Cursor](https://cursor.com)