### PR TITLE
test(core): deduplicate telegram/discord channel config test suites

### DIFF
--- a/packages/core/src/discord-config.test.ts
+++ b/packages/core/src/discord-config.test.ts
@@ -1,7 +1,9 @@
-import { afterEach, describe, expect, spyOn, test } from "bun:test";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import * as os from "node:os";
-import path from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  describeSharedChannelConfigTests,
+  withTempHomedir,
+  writeChannelIniConfig,
+} from "./testing/channel-config-fixtures";
 import {
   buildDiscordInviteUrl,
   generateHandshakeCode,
@@ -63,39 +65,30 @@ describe("resolveDiscordApplicationId", () => {
 });
 
 describe("loadDiscordSettingsPublic", () => {
-  let tempHome = "";
-  let homedirSpy: ReturnType<typeof spyOn<typeof os, "homedir">> | null = null;
   const originalFetch = globalThis.fetch;
 
-  afterEach(async () => {
+  afterEach(() => {
     globalThis.fetch = originalFetch;
-    homedirSpy?.mockRestore();
-    homedirSpy = null;
-
-    if (tempHome) {
-      await rm(tempHome, { force: true, recursive: true });
-      tempHome = "";
-    }
   });
 
   test("includes an invite URL when Discord returns the application id", async () => {
-    tempHome = await mkdtemp(
-      path.join(os.tmpdir(), "nakama-core-discord-home-")
-    );
-    homedirSpy = spyOn(os, "homedir").mockReturnValue(tempHome);
-    await writeDiscordConfig(tempHome, { botToken: "discord-bot-token" });
+    await withTempHomedir("nakama-core-discord-home-", async (tempHome) => {
+      await writeChannelIniConfig(tempHome, "discord", {
+        botToken: "discord-bot-token",
+      });
 
-    globalThis.fetch = (async () =>
-      new Response(JSON.stringify({ id: "1525937133096013954" }), {
-        headers: { "Content-Type": "application/json" },
-        status: 200,
-      })) as typeof fetch;
+      globalThis.fetch = (async () =>
+        new Response(JSON.stringify({ id: "1525937133096013954" }), {
+          headers: { "Content-Type": "application/json" },
+          status: 200,
+        })) as typeof fetch;
 
-    const settings = await loadDiscordSettingsPublic();
+      const settings = await loadDiscordSettingsPublic();
 
-    expect(settings.inviteUrl).toBe(
-      "https://discord.com/oauth2/authorize?client_id=1525937133096013954&permissions=101376&scope=bot+applications.commands"
-    );
+      expect(settings.inviteUrl).toBe(
+        "https://discord.com/oauth2/authorize?client_id=1525937133096013954&permissions=101376&scope=bot+applications.commands"
+      );
+    });
   });
 });
 
@@ -112,242 +105,34 @@ describe("parseAllowedUserIds", () => {
   });
 });
 
-describe("maskBotToken", () => {
-  test("masks long tokens", () => {
-    expect(maskBotToken("12345678901234567890")).toBe("••••••••••••7890");
-  });
-
-  test("returns null for empty", () => {
-    expect(maskBotToken("")).toBeNull();
-  });
+describeSharedChannelConfigTests({
+  allowlistInput: "123456789012345678, 987654321098765432",
+  allowlistParsed: ["123456789012345678", "987654321098765432"],
+  authorize: {
+    allowlisted: "1002",
+    paired: "1001",
+    unauthorized: "1003",
+  },
+  botToken: "discord-bot-token",
+  env: {
+    allowlistKey: "DISCORD_ALLOWED_USER_IDS",
+    allowlistParsed: ["123456789012345678", "987654321098765432"],
+    allowlistValue: "123456789012345678, 987654321098765432",
+    botTokenKey: "DISCORD_BOT_TOKEN",
+  },
+  generateHandshakeCode,
+  isUserAuthorized: isDiscordUserAuthorized,
+  label: "Discord",
+  loadConfigFile: loadDiscordConfigFile,
+  mask: maskBotToken,
+  name: "discord",
+  normalize: normalizeHandshakeInput,
+  resolveConfigFromSources: resolveDiscordConfigFromSources,
+  resolveFile: {
+    allowedUserIds: ["999999999999999999"],
+    pairedUserIds: ["111111111111111111"],
+  },
+  sampleId: "900100000000000001",
+  saveConfig: saveDiscordConfig,
+  verifyAndPair: verifyAndPairDiscordUser,
 });
-
-describe("normalizeHandshakeInput", () => {
-  test("strips spaces and uppercases", () => {
-    expect(normalizeHandshakeInput(" ab cd12 ")).toBe("ABCD12");
-  });
-});
-
-describe("isDiscordUserAuthorized", () => {
-  test("accepts paired or allowlisted users", () => {
-    expect(
-      isDiscordUserAuthorized("1001", {
-        allowedUserIds: [],
-        pairedUserIds: ["1001"],
-      })
-    ).toBe(true);
-    expect(
-      isDiscordUserAuthorized("1002", {
-        allowedUserIds: ["1002"],
-        pairedUserIds: [],
-      })
-    ).toBe(true);
-    expect(
-      isDiscordUserAuthorized("1003", { allowedUserIds: [], pairedUserIds: [] })
-    ).toBe(false);
-  });
-});
-
-describe("generateHandshakeCode", () => {
-  test("returns 8 uppercase hex chars", () => {
-    expect(generateHandshakeCode()).toMatch(/^[0-9A-F]{8}$/);
-  });
-});
-
-describe("verifyAndPairDiscordUser", () => {
-  let tempHome = "";
-  let homedirSpy: ReturnType<typeof spyOn<typeof os, "homedir">> | null = null;
-
-  afterEach(async () => {
-    homedirSpy?.mockRestore();
-    homedirSpy = null;
-
-    if (tempHome) {
-      await rm(tempHome, { force: true, recursive: true });
-      tempHome = "";
-    }
-  });
-
-  async function useTempDiscordHome(
-    config: Parameters<typeof writeDiscordConfig>[1],
-    run: () => Promise<void>
-  ): Promise<void> {
-    tempHome = await mkdtemp(
-      path.join(os.tmpdir(), "nakama-core-discord-home-")
-    );
-    homedirSpy = spyOn(os, "homedir").mockReturnValue(tempHome);
-    await writeDiscordConfig(tempHome, config);
-    await run();
-  }
-
-  test("pairs a user and clears the handshake code", async () => {
-    await useTempDiscordHome(
-      {
-        botToken: "discord-bot-token",
-        handshakeCode: "AABBCCDD",
-      },
-      async () => {
-        const result = await verifyAndPairDiscordUser(
-          "aa bb cc dd",
-          "900100000000000001"
-        );
-
-        expect(result).toEqual({
-          message: "Linked successfully. You can chat with Nakama now.",
-          ok: true,
-        });
-
-        const config = await loadDiscordConfigFile();
-        expect(config?.pairedUserIds).toEqual(["900100000000000001"]);
-        expect(config?.handshakeCode).toBeNull();
-      }
-    );
-  });
-
-  test("rejects invalid pairing codes", async () => {
-    await useTempDiscordHome(
-      {
-        botToken: "discord-bot-token",
-        handshakeCode: "AABBCCDD",
-      },
-      async () => {
-        const result = await verifyAndPairDiscordUser(
-          "DEADBEEF",
-          "900100000000000001"
-        );
-
-        expect(result).toEqual({
-          message:
-            "Invalid pairing code. Copy it from Integrations → Discord and try again.",
-          ok: false,
-        });
-
-        const config = await loadDiscordConfigFile();
-        expect(config?.pairedUserIds).toEqual([]);
-        expect(config?.handshakeCode).toBe("AABBCCDD");
-      }
-    );
-  });
-
-  test("rejects pairing when discord is not configured", async () => {
-    tempHome = await mkdtemp(
-      path.join(os.tmpdir(), "nakama-core-discord-home-")
-    );
-    homedirSpy = spyOn(os, "homedir").mockReturnValue(tempHome);
-
-    const result = await verifyAndPairDiscordUser(
-      "AABBCCDD",
-      "900100000000000001"
-    );
-
-    expect(result).toEqual({
-      message: "Discord is not configured on the server yet.",
-      ok: false,
-    });
-  });
-});
-
-describe("saveDiscordConfig", () => {
-  let tempHome = "";
-  let homedirSpy: ReturnType<typeof spyOn<typeof os, "homedir">> | null = null;
-
-  afterEach(async () => {
-    homedirSpy?.mockRestore();
-    homedirSpy = null;
-
-    if (tempHome) {
-      await rm(tempHome, { force: true, recursive: true });
-      tempHome = "";
-    }
-  });
-
-  async function useTempDiscordHome(run: () => Promise<void>): Promise<void> {
-    tempHome = await mkdtemp(
-      path.join(os.tmpdir(), "nakama-core-discord-home-")
-    );
-    homedirSpy = spyOn(os, "homedir").mockReturnValue(tempHome);
-    await run();
-  }
-
-  test("generates a handshake code for a new unrestricted config", async () => {
-    await useTempDiscordHome(async () => {
-      const result = await saveDiscordConfig({ botToken: "discord-bot-token" });
-
-      expect(result.handshakeCode).toMatch(/^[0-9A-F]{8}$/);
-
-      const saved = await loadDiscordConfigFile();
-      expect(saved?.handshakeCode).toBe(result.handshakeCode);
-      expect(saved?.allowedUserIds).toEqual([]);
-    });
-  });
-});
-
-describe("resolveDiscordConfigFromSources", () => {
-  test("returns null when no bot token is available", () => {
-    expect(
-      resolveDiscordConfigFromSources({
-        env: {},
-        file: null,
-      })
-    ).toBeNull();
-  });
-
-  test("prefers env bot token and allowlist over file config", () => {
-    const resolved = resolveDiscordConfigFromSources({
-      env: {
-        DISCORD_ALLOWED_USER_IDS: "123456789012345678, 987654321098765432",
-        DISCORD_BOT_TOKEN: "env-token",
-      },
-      file: {
-        allowedUserIds: ["999999999999999999"],
-        botToken: "file-token",
-        handshakeCode: "ABCD1234",
-        pairedUserIds: ["111111111111111111"],
-        profileId: "profile_from_file",
-      },
-    });
-
-    expect(resolved).toEqual({
-      allowedUserIds: ["123456789012345678", "987654321098765432"],
-      botToken: "env-token",
-      handshakeCode: "ABCD1234",
-      pairedUserIds: ["111111111111111111"],
-      profileId: "profile_from_file",
-    });
-  });
-});
-
-async function writeDiscordConfig(
-  homeDir: string,
-  config: {
-    botToken: string;
-    profileId?: string;
-    handshakeCode?: string | null;
-    pairedUserIds?: string[];
-    allowedUserIds?: string[];
-  }
-): Promise<void> {
-  const dir = path.join(homeDir, ".nakama", "discord");
-  await mkdir(dir, { recursive: true });
-
-  const lines = [
-    "# Nakama Discord bridge",
-    `bot_token=${config.botToken}`,
-    `profile_id=${config.profileId ?? "default"}`,
-  ];
-
-  if (config.handshakeCode) {
-    lines.push(`handshake_code=${config.handshakeCode}`);
-  }
-
-  if (config.pairedUserIds?.length) {
-    lines.push(`paired_user_ids=${config.pairedUserIds.join(",")}`);
-  }
-
-  if (config.allowedUserIds?.length) {
-    lines.push(`allowed_user_ids=${config.allowedUserIds.join(",")}`);
-  }
-
-  lines.push("");
-  await writeFile(path.join(dir, "config.ini"), lines.join("\n"), "utf8");
-}

--- a/packages/core/src/telegram-config.test.ts
+++ b/packages/core/src/telegram-config.test.ts
@@ -1,7 +1,5 @@
-import { afterEach, describe, expect, spyOn, test } from "bun:test";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import * as os from "node:os";
-import path from "node:path";
+import { describe, expect, test } from "bun:test";
+import { describeSharedChannelConfigTests } from "./testing/channel-config-fixtures";
 import {
   generateHandshakeCode,
   isTelegramUserAuthorized,
@@ -28,269 +26,34 @@ describe("parseAllowedUserIds", () => {
   });
 });
 
-describe("maskBotToken", () => {
-  test("masks long tokens", () => {
-    expect(maskBotToken("12345678901234567890")).toBe("••••••••••••7890");
-  });
-
-  test("returns null for empty", () => {
-    expect(maskBotToken("")).toBeNull();
-  });
+describeSharedChannelConfigTests({
+  allowlistInput: "42, 43",
+  allowlistParsed: [42, 43],
+  authorize: {
+    allowlisted: 2,
+    paired: 1,
+    unauthorized: 3,
+  },
+  botToken: "1234567890:TEST",
+  env: {
+    allowlistKey: "TELEGRAM_ALLOWED_USER_IDS",
+    allowlistParsed: [42, 43],
+    allowlistValue: "42, 43",
+    botTokenKey: "TELEGRAM_BOT_TOKEN",
+  },
+  generateHandshakeCode,
+  isUserAuthorized: isTelegramUserAuthorized,
+  label: "Telegram",
+  loadConfigFile: loadTelegramConfigFile,
+  mask: maskBotToken,
+  name: "telegram",
+  normalize: normalizeHandshakeInput,
+  resolveConfigFromSources: resolveTelegramConfigFromSources,
+  resolveFile: {
+    allowedUserIds: [99],
+    pairedUserIds: [1],
+  },
+  sampleId: 9001,
+  saveConfig: saveTelegramConfig,
+  verifyAndPair: verifyAndPairTelegramUser,
 });
-
-describe("normalizeHandshakeInput", () => {
-  test("strips spaces and uppercases", () => {
-    expect(normalizeHandshakeInput(" ab cd12 ")).toBe("ABCD12");
-  });
-});
-
-describe("isTelegramUserAuthorized", () => {
-  test("accepts paired or allowlisted users", () => {
-    expect(
-      isTelegramUserAuthorized(1, { allowedUserIds: [], pairedUserIds: [1] })
-    ).toBe(true);
-    expect(
-      isTelegramUserAuthorized(2, { allowedUserIds: [2], pairedUserIds: [] })
-    ).toBe(true);
-    expect(
-      isTelegramUserAuthorized(3, { allowedUserIds: [], pairedUserIds: [] })
-    ).toBe(false);
-  });
-});
-
-describe("generateHandshakeCode", () => {
-  test("returns 8 uppercase hex chars", () => {
-    expect(generateHandshakeCode()).toMatch(/^[0-9A-F]{8}$/);
-  });
-});
-
-describe("verifyAndPairTelegramUser", () => {
-  let tempHome = "";
-  let homedirSpy: ReturnType<typeof spyOn<typeof os, "homedir">> | null = null;
-
-  afterEach(async () => {
-    homedirSpy?.mockRestore();
-    homedirSpy = null;
-
-    if (tempHome) {
-      await rm(tempHome, { force: true, recursive: true });
-      tempHome = "";
-    }
-  });
-
-  async function useTempTelegramHome(
-    config: Parameters<typeof writeTelegramConfig>[1],
-    run: () => Promise<void>
-  ): Promise<void> {
-    tempHome = await mkdtemp(path.join(os.tmpdir(), "nakama-core-tg-home-"));
-    homedirSpy = spyOn(os, "homedir").mockReturnValue(tempHome);
-    await writeTelegramConfig(tempHome, config);
-    await run();
-  }
-
-  test("pairs a user and clears the handshake code", async () => {
-    await useTempTelegramHome(
-      {
-        botToken: "1234567890:TEST",
-        handshakeCode: "AABBCCDD",
-      },
-      async () => {
-        const result = await verifyAndPairTelegramUser("aa bb cc dd", 9001);
-
-        expect(result).toEqual({
-          message: "Linked successfully. You can chat with Nakama now.",
-          ok: true,
-        });
-
-        const config = await loadTelegramConfigFile();
-        expect(config?.pairedUserIds).toEqual([9001]);
-        expect(config?.handshakeCode).toBeNull();
-      }
-    );
-  });
-
-  test("rejects invalid pairing codes", async () => {
-    await useTempTelegramHome(
-      {
-        botToken: "1234567890:TEST",
-        handshakeCode: "AABBCCDD",
-      },
-      async () => {
-        const result = await verifyAndPairTelegramUser("DEADBEEF", 9001);
-
-        expect(result).toEqual({
-          message:
-            "Invalid pairing code. Copy it from Integrations → Telegram and try again.",
-          ok: false,
-        });
-
-        const config = await loadTelegramConfigFile();
-        expect(config?.pairedUserIds).toEqual([]);
-        expect(config?.handshakeCode).toBe("AABBCCDD");
-      }
-    );
-  });
-
-  test("rejects pairing when telegram is not configured", async () => {
-    tempHome = await mkdtemp(path.join(os.tmpdir(), "nakama-core-tg-home-"));
-    homedirSpy = spyOn(os, "homedir").mockReturnValue(tempHome);
-
-    const result = await verifyAndPairTelegramUser("AABBCCDD", 9001);
-
-    expect(result).toEqual({
-      message: "Telegram is not configured on the server yet.",
-      ok: false,
-    });
-  });
-
-  test("returns already linked for paired users", async () => {
-    await useTempTelegramHome(
-      {
-        botToken: "1234567890:TEST",
-        pairedUserIds: [9001],
-      },
-      async () => {
-        const result = await verifyAndPairTelegramUser("anything", 9001);
-
-        expect(result).toEqual({
-          message: "This chat is already linked.",
-          ok: true,
-        });
-      }
-    );
-  });
-});
-
-describe("saveTelegramConfig", () => {
-  let tempHome = "";
-  let homedirSpy: ReturnType<typeof spyOn<typeof os, "homedir">> | null = null;
-
-  afterEach(async () => {
-    homedirSpy?.mockRestore();
-    homedirSpy = null;
-
-    if (tempHome) {
-      await rm(tempHome, { force: true, recursive: true });
-      tempHome = "";
-    }
-  });
-
-  async function useTempTelegramHome(run: () => Promise<void>): Promise<void> {
-    tempHome = await mkdtemp(path.join(os.tmpdir(), "nakama-core-tg-home-"));
-    homedirSpy = spyOn(os, "homedir").mockReturnValue(tempHome);
-    await run();
-  }
-
-  test("generates a handshake code for a new unrestricted config", async () => {
-    await useTempTelegramHome(async () => {
-      const result = await saveTelegramConfig({ botToken: "1234567890:TEST" });
-
-      expect(result.handshakeCode).toMatch(/^[0-9A-F]{8}$/);
-
-      const saved = await loadTelegramConfigFile();
-      expect(saved?.handshakeCode).toBe(result.handshakeCode);
-      expect(saved?.allowedUserIds).toEqual([]);
-    });
-  });
-
-  test("does not generate a handshake code when allowlist is set", async () => {
-    await useTempTelegramHome(async () => {
-      const result = await saveTelegramConfig({
-        allowedUserIds: "42, 43",
-        botToken: "1234567890:TEST",
-      });
-
-      expect(result.handshakeCode).toBeNull();
-
-      const saved = await loadTelegramConfigFile();
-      expect(saved?.allowedUserIds).toEqual([42, 43]);
-      expect(saved?.handshakeCode).toBeNull();
-    });
-  });
-});
-
-describe("resolveTelegramConfigFromSources", () => {
-  test("returns null when no bot token is available", () => {
-    expect(
-      resolveTelegramConfigFromSources({
-        env: {},
-        file: null,
-      })
-    ).toBeNull();
-  });
-
-  test("prefers env bot token and allowlist over file config", () => {
-    const resolved = resolveTelegramConfigFromSources({
-      env: {
-        TELEGRAM_ALLOWED_USER_IDS: "42, 43",
-        TELEGRAM_BOT_TOKEN: "env-token",
-      },
-      file: {
-        allowedUserIds: [99],
-        botToken: "file-token",
-        handshakeCode: "ABCD1234",
-        pairedUserIds: [1],
-        profileId: "profile_from_file",
-      },
-    });
-
-    expect(resolved).toEqual({
-      allowedUserIds: [42, 43],
-      botToken: "env-token",
-      handshakeCode: "ABCD1234",
-      pairedUserIds: [1],
-      profileId: "profile_from_file",
-    });
-  });
-
-  test("falls back to file config when env token is absent", () => {
-    const resolved = resolveTelegramConfigFromSources({
-      env: {},
-      file: {
-        allowedUserIds: [7],
-        botToken: "file-token",
-        handshakeCode: null,
-        pairedUserIds: [],
-        profileId: "profile_from_file",
-      },
-    });
-
-    expect(resolved?.botToken).toBe("file-token");
-    expect(resolved?.allowedUserIds).toEqual([7]);
-  });
-});
-
-async function writeTelegramConfig(
-  homeDir: string,
-  config: {
-    botToken: string;
-    profileId?: string;
-    handshakeCode?: string | null;
-    pairedUserIds?: number[];
-    allowedUserIds?: number[];
-  }
-): Promise<void> {
-  const dir = path.join(homeDir, ".nakama", "telegram");
-  await mkdir(dir, { recursive: true });
-
-  const lines = [
-    "# Nakama Telegram bridge",
-    `bot_token=${config.botToken}`,
-    `profile_id=${config.profileId ?? "default"}`,
-  ];
-
-  if (config.handshakeCode) {
-    lines.push(`handshake_code=${config.handshakeCode}`);
-  }
-
-  if (config.pairedUserIds?.length) {
-    lines.push(`paired_user_ids=${config.pairedUserIds.join(",")}`);
-  }
-
-  if (config.allowedUserIds?.length) {
-    lines.push(`allowed_user_ids=${config.allowedUserIds.join(",")}`);
-  }
-
-  lines.push("");
-  await writeFile(path.join(dir, "config.ini"), lines.join("\n"), "utf8");
-}

--- a/packages/core/src/testing/channel-config-fixtures.ts
+++ b/packages/core/src/testing/channel-config-fixtures.ts
@@ -1,0 +1,343 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import * as os from "node:os";
+import path from "node:path";
+
+export const HANDSHAKE_CODE_PATTERN = /^[0-9A-F]{8}$/;
+
+export const MASK_BOT_TOKEN_CASES = [
+  {
+    expected: "••••••••••••7890",
+    input: "12345678901234567890",
+    name: "masks long tokens",
+  },
+  {
+    expected: null,
+    input: "",
+    name: "returns null for empty",
+  },
+] as const;
+
+export const NORMALIZE_HANDSHAKE_INPUT_CASES = [
+  {
+    expected: "ABCD12",
+    input: " ab cd12 ",
+    name: "strips spaces and uppercases",
+  },
+] as const;
+
+export async function withTempHomedir(
+  prefix: string,
+  run: (homeDir: string) => Promise<void>
+): Promise<void> {
+  const tempHome = await mkdtemp(path.join(os.tmpdir(), prefix));
+  const homedirSpy = spyOn(os, "homedir").mockReturnValue(tempHome);
+
+  try {
+    await run(tempHome);
+  } finally {
+    homedirSpy.mockRestore();
+    await rm(tempHome, { force: true, recursive: true });
+  }
+}
+
+export type ChannelIniConfig = {
+  botToken: string;
+  profileId?: string;
+  handshakeCode?: string | null;
+  pairedUserIds?: Array<string | number>;
+  allowedUserIds?: Array<string | number>;
+};
+
+export async function writeChannelIniConfig(
+  homeDir: string,
+  channel: "telegram" | "discord",
+  config: ChannelIniConfig
+): Promise<void> {
+  const dir = path.join(homeDir, ".nakama", channel);
+  await mkdir(dir, { recursive: true });
+
+  const label = channel === "telegram" ? "Telegram" : "Discord";
+  const lines = [
+    `# Nakama ${label} bridge`,
+    `bot_token=${config.botToken}`,
+    `profile_id=${config.profileId ?? "default"}`,
+  ];
+
+  if (config.handshakeCode) {
+    lines.push(`handshake_code=${config.handshakeCode}`);
+  }
+
+  if (config.pairedUserIds?.length) {
+    lines.push(`paired_user_ids=${config.pairedUserIds.join(",")}`);
+  }
+
+  if (config.allowedUserIds?.length) {
+    lines.push(`allowed_user_ids=${config.allowedUserIds.join(",")}`);
+  }
+
+  lines.push("");
+  await writeFile(path.join(dir, "config.ini"), lines.join("\n"), "utf8");
+}
+
+export type SharedChannelConfigCase<TId extends string | number> = {
+  name: "telegram" | "discord";
+  label: string;
+  botToken: string;
+  sampleId: TId;
+  authorize: {
+    paired: TId;
+    allowlisted: TId;
+    unauthorized: TId;
+  };
+  allowlistInput: string;
+  allowlistParsed: TId[];
+  env: {
+    botTokenKey: string;
+    allowlistKey: string;
+    allowlistValue: string;
+    allowlistParsed: TId[];
+  };
+  resolveFile: {
+    allowedUserIds: TId[];
+    pairedUserIds: TId[];
+  };
+  mask: (token: string) => string | null;
+  normalize: (input: string) => string;
+  generateHandshakeCode: () => string;
+  isUserAuthorized: (
+    userId: TId,
+    access: { allowedUserIds: TId[]; pairedUserIds: TId[] }
+  ) => boolean;
+  verifyAndPair: (
+    code: string,
+    userId: TId
+  ) => Promise<{ ok: boolean; message: string }>;
+  saveConfig: (input: {
+    botToken: string;
+    allowedUserIds?: string;
+  }) => Promise<{ handshakeCode: string | null }>;
+  loadConfigFile: () => Promise<{
+    handshakeCode: string | null;
+    pairedUserIds: TId[];
+    allowedUserIds: TId[];
+  } | null>;
+  resolveConfigFromSources: (sources: {
+    env: Record<string, string | undefined>;
+    file: {
+      allowedUserIds: TId[];
+      botToken: string;
+      handshakeCode: string | null;
+      pairedUserIds: TId[];
+      profileId: string;
+    } | null;
+  }) => {
+    allowedUserIds: TId[];
+    botToken: string;
+    handshakeCode: string | null;
+    pairedUserIds: TId[];
+    profileId: string;
+  } | null;
+};
+
+export function describeSharedChannelConfigTests<TId extends string | number>(
+  tc: SharedChannelConfigCase<TId>
+): void {
+  const tempPrefix = `nakama-core-${tc.name}-home-`;
+
+  describe(`${tc.name} shared channel config`, () => {
+    describe("maskBotToken", () => {
+      for (const c of MASK_BOT_TOKEN_CASES) {
+        test(c.name, () => {
+          expect(tc.mask(c.input)).toBe(c.expected);
+        });
+      }
+    });
+
+    describe("normalizeHandshakeInput", () => {
+      for (const c of NORMALIZE_HANDSHAKE_INPUT_CASES) {
+        test(c.name, () => {
+          expect(tc.normalize(c.input)).toBe(c.expected);
+        });
+      }
+    });
+
+    describe("isUserAuthorized", () => {
+      test("accepts paired or allowlisted users", () => {
+        expect(
+          tc.isUserAuthorized(tc.authorize.paired, {
+            allowedUserIds: [],
+            pairedUserIds: [tc.authorize.paired],
+          })
+        ).toBe(true);
+        expect(
+          tc.isUserAuthorized(tc.authorize.allowlisted, {
+            allowedUserIds: [tc.authorize.allowlisted],
+            pairedUserIds: [],
+          })
+        ).toBe(true);
+        expect(
+          tc.isUserAuthorized(tc.authorize.unauthorized, {
+            allowedUserIds: [],
+            pairedUserIds: [],
+          })
+        ).toBe(false);
+      });
+    });
+
+    describe("generateHandshakeCode", () => {
+      test("returns 8 uppercase hex chars", () => {
+        expect(tc.generateHandshakeCode()).toMatch(HANDSHAKE_CODE_PATTERN);
+      });
+    });
+
+    describe("verifyAndPair", () => {
+      test("pairs a user and clears the handshake code", async () => {
+        await withTempHomedir(tempPrefix, async (homeDir) => {
+          await writeChannelIniConfig(homeDir, tc.name, {
+            botToken: tc.botToken,
+            handshakeCode: "AABBCCDD",
+          });
+
+          const result = await tc.verifyAndPair("aa bb cc dd", tc.sampleId);
+
+          expect(result).toEqual({
+            message: "Linked successfully. You can chat with Nakama now.",
+            ok: true,
+          });
+
+          const config = await tc.loadConfigFile();
+          expect(config?.pairedUserIds).toEqual([tc.sampleId]);
+          expect(config?.handshakeCode).toBeNull();
+        });
+      });
+
+      test("rejects invalid pairing codes", async () => {
+        await withTempHomedir(tempPrefix, async (homeDir) => {
+          await writeChannelIniConfig(homeDir, tc.name, {
+            botToken: tc.botToken,
+            handshakeCode: "AABBCCDD",
+          });
+
+          const result = await tc.verifyAndPair("DEADBEEF", tc.sampleId);
+
+          expect(result).toEqual({
+            message: `Invalid pairing code. Copy it from Integrations → ${tc.label} and try again.`,
+            ok: false,
+          });
+
+          const config = await tc.loadConfigFile();
+          expect(config?.pairedUserIds).toEqual([]);
+          expect(config?.handshakeCode).toBe("AABBCCDD");
+        });
+      });
+
+      test("rejects pairing when channel is not configured", async () => {
+        await withTempHomedir(tempPrefix, async () => {
+          const result = await tc.verifyAndPair("AABBCCDD", tc.sampleId);
+
+          expect(result).toEqual({
+            message: `${tc.label} is not configured on the server yet.`,
+            ok: false,
+          });
+        });
+      });
+
+      test("returns already linked for paired users", async () => {
+        await withTempHomedir(tempPrefix, async (homeDir) => {
+          await writeChannelIniConfig(homeDir, tc.name, {
+            botToken: tc.botToken,
+            pairedUserIds: [tc.sampleId],
+          });
+
+          const result = await tc.verifyAndPair("anything", tc.sampleId);
+
+          expect(result).toEqual({
+            message: "This chat is already linked.",
+            ok: true,
+          });
+        });
+      });
+    });
+
+    describe("saveConfig", () => {
+      test("generates a handshake code for a new unrestricted config", async () => {
+        await withTempHomedir(tempPrefix, async () => {
+          const result = await tc.saveConfig({ botToken: tc.botToken });
+
+          expect(result.handshakeCode).toMatch(HANDSHAKE_CODE_PATTERN);
+
+          const saved = await tc.loadConfigFile();
+          expect(saved?.handshakeCode).toBe(result.handshakeCode);
+          expect(saved?.allowedUserIds).toEqual([]);
+        });
+      });
+
+      test("does not generate a handshake code when allowlist is set", async () => {
+        await withTempHomedir(tempPrefix, async () => {
+          const result = await tc.saveConfig({
+            allowedUserIds: tc.allowlistInput,
+            botToken: tc.botToken,
+          });
+
+          expect(result.handshakeCode).toBeNull();
+
+          const saved = await tc.loadConfigFile();
+          expect(saved?.allowedUserIds).toEqual(tc.allowlistParsed);
+          expect(saved?.handshakeCode).toBeNull();
+        });
+      });
+    });
+
+    describe("resolveConfigFromSources", () => {
+      test("returns null when no bot token is available", () => {
+        expect(
+          tc.resolveConfigFromSources({
+            env: {},
+            file: null,
+          })
+        ).toBeNull();
+      });
+
+      test("prefers env bot token and allowlist over file config", () => {
+        const resolved = tc.resolveConfigFromSources({
+          env: {
+            [tc.env.allowlistKey]: tc.env.allowlistValue,
+            [tc.env.botTokenKey]: "env-token",
+          },
+          file: {
+            allowedUserIds: tc.resolveFile.allowedUserIds,
+            botToken: "file-token",
+            handshakeCode: "ABCD1234",
+            pairedUserIds: tc.resolveFile.pairedUserIds,
+            profileId: "profile_from_file",
+          },
+        });
+
+        expect(resolved).toEqual({
+          allowedUserIds: tc.env.allowlistParsed,
+          botToken: "env-token",
+          handshakeCode: "ABCD1234",
+          pairedUserIds: tc.resolveFile.pairedUserIds,
+          profileId: "profile_from_file",
+        });
+      });
+
+      test("falls back to file config when env token is absent", () => {
+        const resolved = tc.resolveConfigFromSources({
+          env: {},
+          file: {
+            allowedUserIds: tc.allowlistParsed,
+            botToken: "file-token",
+            handshakeCode: null,
+            pairedUserIds: [],
+            profileId: "profile_from_file",
+          },
+        });
+
+        expect(resolved?.botToken).toBe("file-token");
+        expect(resolved?.allowedUserIds).toEqual(tc.allowlistParsed);
+      });
+    });
+  });
+}

--- a/packages/core/src/whatsapp-config.test.ts
+++ b/packages/core/src/whatsapp-config.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, describe, expect, spyOn, test } from "bun:test";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import * as os from "node:os";
+import { describe, expect, test } from "bun:test";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { withTempHomedir } from "./testing/channel-config-fixtures";
 import {
   generatePairingCode,
   isWhatsAppUserAuthorized,
@@ -99,27 +99,8 @@ describe("generatePairingCode", () => {
 });
 
 describe("saveWhatsAppConfig", () => {
-  let tempHome = "";
-  let homedirSpy: ReturnType<typeof spyOn<typeof os, "homedir">> | null = null;
-
-  afterEach(async () => {
-    homedirSpy?.mockRestore();
-    homedirSpy = null;
-
-    if (tempHome) {
-      await rm(tempHome, { force: true, recursive: true });
-      tempHome = "";
-    }
-  });
-
-  async function useTempWhatsAppHome(run: () => Promise<void>): Promise<void> {
-    tempHome = await mkdtemp(path.join(os.tmpdir(), "nakama-core-wa-home-"));
-    homedirSpy = spyOn(os, "homedir").mockReturnValue(tempHome);
-    await run();
-  }
-
   test("creates config without auto-generating a pairing code", async () => {
-    await useTempWhatsAppHome(async () => {
+    await withTempHomedir("nakama-core-wa-home-", async () => {
       const result = await saveWhatsAppConfig({ profileId: "profile_custom" });
 
       expect(result.pairingCode).toBeNull();
@@ -135,7 +116,7 @@ describe("saveWhatsAppConfig", () => {
   });
 
   test("saves profile without requiring a phone number", async () => {
-    await useTempWhatsAppHome(async () => {
+    await withTempHomedir("nakama-core-wa-home-", async () => {
       const result = await saveWhatsAppConfig({
         profileId: "profile_custom",
       });
@@ -148,7 +129,7 @@ describe("saveWhatsAppConfig", () => {
   });
 
   test("preserves pairedJid when updating other fields", async () => {
-    await useTempWhatsAppHome(async () => {
+    await withTempHomedir("nakama-core-wa-home-", async (tempHome) => {
       await saveWhatsAppConfig({ phoneNumber: "+1234567890" });
       const first = await loadWhatsAppConfigFile();
 
@@ -177,7 +158,7 @@ describe("saveWhatsAppConfig", () => {
   });
 
   test("allows first save with profile only", async () => {
-    await useTempWhatsAppHome(async () => {
+    await withTempHomedir("nakama-core-wa-home-", async () => {
       const result = await saveWhatsAppConfig({ profileId: "default" });
       expect(result.configured).toBe(true);
     });
@@ -185,27 +166,8 @@ describe("saveWhatsAppConfig", () => {
 });
 
 describe("resetWhatsAppSessionForReconnect", () => {
-  let tempHome = "";
-  let homedirSpy: ReturnType<typeof spyOn<typeof os, "homedir">> | null = null;
-
-  afterEach(async () => {
-    homedirSpy?.mockRestore();
-    homedirSpy = null;
-
-    if (tempHome) {
-      await rm(tempHome, { force: true, recursive: true });
-      tempHome = "";
-    }
-  });
-
-  async function useTempWhatsAppHome(run: () => Promise<void>): Promise<void> {
-    tempHome = await mkdtemp(path.join(os.tmpdir(), "nakama-core-wa-reset-"));
-    homedirSpy = spyOn(os, "homedir").mockReturnValue(tempHome);
-    await run();
-  }
-
   test("clears auth dir, pairing fields, and QR while preserving phone and profile", async () => {
-    await useTempWhatsAppHome(async () => {
+    await withTempHomedir("nakama-core-wa-reset-", async (tempHome) => {
       await saveWhatsAppConfig({
         phoneNumber: "+1234567890",
         profileId: "profile_custom",
@@ -259,7 +221,7 @@ describe("resetWhatsAppSessionForReconnect", () => {
   });
 
   test("throws when WhatsApp is not configured", async () => {
-    await useTempWhatsAppHome(async () => {
+    await withTempHomedir("nakama-core-wa-reset-", async () => {
       expect(resetWhatsAppSessionForReconnect()).rejects.toThrow(
         "Enable WhatsApp in Integrations before reconnecting."
       );
@@ -267,7 +229,7 @@ describe("resetWhatsAppSessionForReconnect", () => {
   });
 
   test("succeeds when auth dir and QR file are already absent", async () => {
-    await useTempWhatsAppHome(async () => {
+    await withTempHomedir("nakama-core-wa-reset-", async () => {
       await saveWhatsAppConfig({ phoneNumber: "+1234567890" });
 
       const result = await resetWhatsAppSessionForReconnect();
@@ -330,110 +292,93 @@ describe("resolveWhatsAppConfigFromSources", () => {
 });
 
 describe("syncWhatsAppOwnerPairing", () => {
-  let tempHome = "";
-  let homedirSpy: ReturnType<typeof spyOn<typeof os, "homedir">> | null = null;
-
-  afterEach(async () => {
-    homedirSpy?.mockRestore();
-    homedirSpy = null;
-
-    if (tempHome) {
-      await rm(tempHome, { force: true, recursive: true });
-      tempHome = "";
-    }
-  });
-
   test("auto-pairs owner when WhatsApp JID includes a device suffix", async () => {
-    tempHome = await mkdtemp(path.join(os.tmpdir(), "nakama-core-wa-sync-"));
-    homedirSpy = spyOn(os, "homedir").mockReturnValue(tempHome);
+    await withTempHomedir("nakama-core-wa-sync-", async () => {
+      await saveWhatsAppConfig({ profileId: "default" });
 
-    await saveWhatsAppConfig({ profileId: "default" });
+      await syncWhatsAppOwnerPairing({
+        ownerJid: "6281379292556:12@s.whatsapp.net",
+        ownerLid: "236283431522503@lid",
+      });
 
-    await syncWhatsAppOwnerPairing({
-      ownerJid: "6281379292556:12@s.whatsapp.net",
-      ownerLid: "236283431522503@lid",
+      const saved = await loadWhatsAppConfigFile();
+      expect(saved?.phoneNumber).toBe("6281379292556");
+      expect(saved?.pairedJid).toBe("6281379292556:12@s.whatsapp.net");
+      expect(saved?.pairedLid).toBe("236283431522503@lid");
+      expect(saved?.pairingCode).toBeNull();
     });
-
-    const saved = await loadWhatsAppConfigFile();
-    expect(saved?.phoneNumber).toBe("6281379292556");
-    expect(saved?.pairedJid).toBe("6281379292556:12@s.whatsapp.net");
-    expect(saved?.pairedLid).toBe("236283431522503@lid");
-    expect(saved?.pairingCode).toBeNull();
   });
 
   test("overwrites a stale phone number after QR link", async () => {
-    tempHome = await mkdtemp(path.join(os.tmpdir(), "nakama-core-wa-sync-"));
-    homedirSpy = spyOn(os, "homedir").mockReturnValue(tempHome);
+    await withTempHomedir("nakama-core-wa-sync-", async () => {
+      await saveWhatsAppConfig({ phoneNumber: "+6281227900622" });
 
-    await saveWhatsAppConfig({ phoneNumber: "+6281227900622" });
+      await syncWhatsAppOwnerPairing({
+        ownerJid: "6281379292556:17@s.whatsapp.net",
+        ownerLid: "128415361462410:17@lid",
+      });
 
-    await syncWhatsAppOwnerPairing({
-      ownerJid: "6281379292556:17@s.whatsapp.net",
-      ownerLid: "128415361462410:17@lid",
+      const saved = await loadWhatsAppConfigFile();
+      expect(saved?.phoneNumber).toBe("6281379292556");
+      expect(saved?.pairedJid).toBe("6281379292556:17@s.whatsapp.net");
     });
-
-    const saved = await loadWhatsAppConfigFile();
-    expect(saved?.phoneNumber).toBe("6281379292556");
-    expect(saved?.pairedJid).toBe("6281379292556:17@s.whatsapp.net");
   });
 
   test("clears stale pairing code when owner pairing sync completes", async () => {
-    tempHome = await mkdtemp(path.join(os.tmpdir(), "nakama-core-wa-sync-"));
-    homedirSpy = spyOn(os, "homedir").mockReturnValue(tempHome);
+    await withTempHomedir("nakama-core-wa-sync-", async (tempHome) => {
+      await saveWhatsAppConfig({ phoneNumber: "+6281379292556" });
 
-    await saveWhatsAppConfig({ phoneNumber: "+6281379292556" });
+      const dir = path.join(tempHome, ".nakama", "whatsapp");
+      await writeFile(
+        path.join(dir, "config.ini"),
+        [
+          "# Nakama WhatsApp bridge",
+          "phone_number=+6281379292556",
+          "profile_id=default",
+          "pairing_code=ABCD1234",
+          "paired_jid=6281379292556@s.whatsapp.net",
+          "",
+        ].join("\n"),
+        "utf8"
+      );
 
-    const dir = path.join(tempHome, ".nakama", "whatsapp");
-    await writeFile(
-      path.join(dir, "config.ini"),
-      [
-        "# Nakama WhatsApp bridge",
-        "phone_number=+6281379292556",
-        "profile_id=default",
-        "pairing_code=ABCD1234",
-        "paired_jid=6281379292556@s.whatsapp.net",
-        "",
-      ].join("\n"),
-      "utf8"
-    );
+      await syncWhatsAppOwnerPairing({
+        ownerJid: "6281379292556:12@s.whatsapp.net",
+        ownerLid: "236283431522503@lid",
+      });
 
-    await syncWhatsAppOwnerPairing({
-      ownerJid: "6281379292556:12@s.whatsapp.net",
-      ownerLid: "236283431522503@lid",
+      const saved = await loadWhatsAppConfigFile();
+      expect(saved?.pairedJid).toBe("6281379292556@s.whatsapp.net");
+      expect(saved?.pairedLid).toBe("236283431522503@lid");
+      expect(saved?.pairingCode).toBeNull();
     });
-
-    const saved = await loadWhatsAppConfigFile();
-    expect(saved?.pairedJid).toBe("6281379292556@s.whatsapp.net");
-    expect(saved?.pairedLid).toBe("236283431522503@lid");
-    expect(saved?.pairingCode).toBeNull();
   });
 
   test("preserves an existing paired LID during owner sync", async () => {
-    tempHome = await mkdtemp(path.join(os.tmpdir(), "nakama-core-wa-sync-"));
-    homedirSpy = spyOn(os, "homedir").mockReturnValue(tempHome);
+    await withTempHomedir("nakama-core-wa-sync-", async (tempHome) => {
+      const dir = path.join(tempHome, ".nakama", "whatsapp");
+      await mkdir(dir, { recursive: true });
+      await writeFile(
+        path.join(dir, "config.ini"),
+        [
+          "# Nakama WhatsApp bridge",
+          "phone_number=6281379292556",
+          "profile_id=default",
+          "paired_jid=6281379292556@s.whatsapp.net",
+          "paired_lid=104784384290844@lid",
+          "",
+        ].join("\n"),
+        "utf8"
+      );
 
-    const dir = path.join(tempHome, ".nakama", "whatsapp");
-    await mkdir(dir, { recursive: true });
-    await writeFile(
-      path.join(dir, "config.ini"),
-      [
-        "# Nakama WhatsApp bridge",
-        "phone_number=6281379292556",
-        "profile_id=default",
-        "paired_jid=6281379292556@s.whatsapp.net",
-        "paired_lid=104784384290844@lid",
-        "",
-      ].join("\n"),
-      "utf8"
-    );
+      await syncWhatsAppOwnerPairing({
+        ownerJid: "6281379292556:18@s.whatsapp.net",
+        ownerLid: "128415361462410:18@lid",
+      });
 
-    await syncWhatsAppOwnerPairing({
-      ownerJid: "6281379292556:18@s.whatsapp.net",
-      ownerLid: "128415361462410:18@lid",
+      const saved = await loadWhatsAppConfigFile();
+      expect(saved?.pairedJid).toBe("6281379292556@s.whatsapp.net");
+      expect(saved?.pairedLid).toBe("104784384290844@lid");
     });
-
-    const saved = await loadWhatsAppConfigFile();
-    expect(saved?.pairedJid).toBe("6281379292556@s.whatsapp.net");
-    expect(saved?.pairedLid).toBe("104784384290844@lid");
   });
 });


### PR DESCRIPTION
## Summary
- Fixes #221 by extracting `packages/core/src/testing/channel-config-fixtures.ts` with `withTempHomedir`, shared mask/normalize/handshake cases, `writeChannelIniConfig`, and `describeSharedChannelConfigTests`.
- Refactors Telegram and Discord config tests to drive shared scenarios from a harness parameterized by ID type and token fixture; keeps channel-specific ID parsing / Discord invite-application tests local.
- Reuses `withTempHomedir` in WhatsApp config tests (QR/JID flows stay WhatsApp-only).

## Test plan
- [x] `bun test src/telegram-config.test.ts src/discord-config.test.ts src/whatsapp-config.test.ts` (62 pass)


Made with [Cursor](https://cursor.com)