### PR TITLE
fix(providers): round-trip DeepSeek reasoning_content on tool turns

### DIFF
--- a/apps/server/src/providers/openai/index.ts
+++ b/apps/server/src/providers/openai/index.ts
@@ -6,6 +6,7 @@ import type {
   GenerateTextInput,
   GenerateTextResult,
   LlmToolDefinition,
+  ProviderChatOptions,
   ProviderClient,
   ProviderName,
   StreamChatHandlers,
@@ -19,9 +20,11 @@ import {
 import {
   buildChatCompletionResult,
   extractOpenAITokenUsage,
+  normalizeThinkingEffort,
   notifyToolInputDelta,
   parseJsonRecord,
   readSseEvents,
+  sanitizeToolCallHistory,
 } from "../shared";
 import { generateOpenAIResponsesChat } from "./responses";
 import {
@@ -81,6 +84,7 @@ export function createOpenAIProvider(
         messages: input.messages,
         model,
         system: input.system,
+        thinking: input.providerOptions?.thinking,
         tools: input.tools,
       });
     },
@@ -117,6 +121,7 @@ export function createOpenAIProvider(
         messages: input.messages,
         model,
         system: input.system,
+        thinking: input.providerOptions?.thinking,
         tools: input.tools,
       });
     },
@@ -198,6 +203,7 @@ type OpenAIMessage =
   | {
       role: "assistant";
       content: string | null;
+      reasoning_content?: string;
       tool_calls?: Array<{
         id: string;
         type: "function";
@@ -213,7 +219,7 @@ export async function toOpenAIMessages(
 ): Promise<OpenAIMessage[]> {
   const result: OpenAIMessage[] = [{ content: system, role: "system" }];
 
-  for (const message of messages) {
+  for (const message of sanitizeToolCallHistory(messages)) {
     result.push(await toOpenAIMessage(message, provider));
   }
 
@@ -323,8 +329,10 @@ async function buildChatCompletionRequestBody(options: {
   stream?: boolean;
   streamOptions?: { includeUsage: boolean };
   provider?: ProviderName;
+  thinking?: ProviderChatOptions["thinking"];
 }) {
   const hasTools = Boolean(options.tools?.length);
+  const provider = options.provider ?? "openai";
 
   return {
     model: options.model,
@@ -337,8 +345,11 @@ async function buildChatCompletionRequestBody(options: {
     messages: await toOpenAIMessages(
       options.system,
       options.messages,
-      options.provider ?? "openai"
+      provider
     ),
+    ...(provider === "deepseek"
+      ? buildDeepSeekThinkingBody(options.thinking)
+      : {}),
     ...(hasTools
       ? {
           tool_choice: "auto",
@@ -352,6 +363,53 @@ async function buildChatCompletionRequestBody(options: {
   };
 }
 
+function buildDeepSeekThinkingBody(
+  thinking: ProviderChatOptions["thinking"] | undefined
+) {
+  if (thinking?.enabled === false) {
+    return { thinking: { type: "disabled" as const } };
+  }
+
+  if (!thinking?.enabled) {
+    return {};
+  }
+
+  const effort = normalizeThinkingEffort(thinking.effort);
+  // DeepSeek accepts low/high/max; map medium → high for compatibility.
+  const reasoningEffort = effort === "medium" ? "high" : effort;
+
+  return {
+    reasoning_effort: reasoningEffort,
+    thinking: { type: "enabled" as const },
+  };
+}
+
+function readReasoningContent(
+  value: unknown,
+  options?: { preserveWhitespace?: boolean }
+): string | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return;
+  }
+
+  const record = value as Record<string, unknown>;
+  const direct =
+    typeof record.reasoning_content === "string"
+      ? record.reasoning_content
+      : undefined;
+
+  if (direct === undefined) {
+    return;
+  }
+
+  if (options?.preserveWhitespace) {
+    return direct.length > 0 ? direct : undefined;
+  }
+
+  const trimmed = direct.trim();
+  return trimmed ? trimmed : undefined;
+}
+
 async function requestChatCompletion(
   client: OpenAIClientConfig,
   options: {
@@ -359,6 +417,7 @@ async function requestChatCompletion(
     system: string;
     messages: ChatMessage[];
     tools?: LlmToolDefinition[];
+    thinking?: ProviderChatOptions["thinking"];
   }
 ): Promise<ChatCompletionResult> {
   const response = await fetch(chatCompletionsUrl(client), {
@@ -383,6 +442,7 @@ async function requestChatCompletion(
     choices?: Array<{
       message?: {
         content?: string | null;
+        reasoning_content?: string | null;
         tool_calls?: Array<{
           id?: string;
           function?: { name?: string; arguments?: string };
@@ -394,13 +454,15 @@ async function requestChatCompletion(
   const message = payload.choices?.[0]?.message;
   const toolCalls = parseOpenAIToolCalls(message?.tool_calls);
   const content = message?.content ?? "";
+  const thinking = readReasoningContent(message);
 
-  if (!content.trim() && toolCalls.length === 0) {
+  if (!content.trim() && toolCalls.length === 0 && !thinking) {
     throw new Error(`${client.label} returned an empty response.`);
   }
 
   return buildChatCompletionResult({
     content,
+    thinking,
     toolCalls,
     usage: extractOpenAITokenUsage(payload.usage),
   });
@@ -415,6 +477,7 @@ async function streamChatCompletion(
     system: string;
     messages: ChatMessage[];
     tools?: LlmToolDefinition[];
+    thinking?: ProviderChatOptions["thinking"];
     handlers: StreamChatHandlers;
   }
 ): Promise<ChatCompletionResult> {
@@ -427,6 +490,7 @@ async function streamChatCompletion(
         stream: true,
         streamOptions: { includeUsage: true },
         system: options.system,
+        thinking: options.thinking,
         tools: options.tools,
       })
     ),
@@ -555,6 +619,7 @@ async function readOpenAIStream(
   label = "OpenAI"
 ): Promise<ChatCompletionResult> {
   let content = "";
+  let thinking = "";
   let usage: ChatCompletionResult["usage"];
   const pending = new Map<number, PendingToolCall>();
 
@@ -564,6 +629,7 @@ async function readOpenAIStream(
       choices?: Array<{
         delta?: {
           content?: string | null;
+          reasoning_content?: string | null;
           tool_calls?: Array<{
             index?: number;
             id?: string;
@@ -580,6 +646,15 @@ async function readOpenAIStream(
     if (delta?.content) {
       content += delta.content;
       handlers.onChunk(delta.content);
+    }
+
+    const reasoningDelta = readReasoningContent(delta, {
+      preserveWhitespace: true,
+    });
+
+    if (reasoningDelta) {
+      thinking += reasoningDelta;
+      handlers.onThinking?.(reasoningDelta);
     }
 
     if (delta?.tool_calls) {
@@ -599,10 +674,16 @@ async function readOpenAIStream(
   });
 
   const toolCalls = finalizePendingToolCalls(pending);
+  const thinkingText = thinking.trim() || undefined;
 
-  if (!content.trim() && toolCalls.length === 0) {
+  if (!content.trim() && toolCalls.length === 0 && !thinkingText) {
     throw new Error(`${label} returned an empty response.`);
   }
 
-  return buildChatCompletionResult({ content, toolCalls, usage });
+  return buildChatCompletionResult({
+    content,
+    thinking: thinkingText,
+    toolCalls,
+    usage,
+  });
 }

--- a/apps/server/src/providers/openai/stream.test.ts
+++ b/apps/server/src/providers/openai/stream.test.ts
@@ -182,4 +182,187 @@ describe("OpenAI provider streaming", () => {
     expect(result.content).toBe("Hi");
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  test("deepseek stream tool turn re-sends reasoning_content on follow-up", async () => {
+    const bodies: Array<Record<string, unknown>> = [];
+    let callCount = 0;
+
+    const fetchMock = mock(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        callCount += 1;
+        bodies.push(
+          JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>
+        );
+
+        if (callCount === 1) {
+          return new Response(
+            streamFromChunks([
+              'data:{"choices":[{"delta":{"reasoning_content":"Need lookup"}}]}\r\n\r\n',
+              'data:{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{\\"q\\":\\"x\\"}"}}]}}]}\r\n\r\n',
+              "data:[DONE]\r\n\r\n",
+            ]),
+            { headers: { "Content-Type": "text/event-stream" }, status: 200 }
+          );
+        }
+
+        return new Response(
+          streamFromChunks([
+            'data:{"choices":[{"delta":{"content":"Done"}}]}\r\n\r\n',
+            "data:[DONE]\r\n\r\n",
+          ]),
+          { headers: { "Content-Type": "text/event-stream" }, status: 200 }
+        );
+      }
+    );
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = createOpenAIProvider({
+      apiKey: "sk-test",
+      baseUrl: "https://api.deepseek.com",
+      model: "deepseek-chat",
+      providerName: "deepseek",
+    });
+
+    const tools = [
+      {
+        description: "Lookup",
+        name: "lookup",
+        parameters: {
+          properties: { q: { type: "string" } },
+          required: ["q"],
+          type: "object",
+        },
+      },
+    ];
+
+    const first = await provider.streamChat(
+      {
+        messages: [{ content: "Look it up", role: "user" }],
+        providerOptions: { thinking: { effort: "high", enabled: true } },
+        system: "You are helpful.",
+        tools,
+      },
+      { onChunk: () => {} }
+    );
+
+    expect(first.assistantMessage.thinking).toBe("Need lookup");
+    expect(first.toolCalls).toEqual([
+      { arguments: { q: "x" }, id: "call_1", name: "lookup" },
+    ]);
+    expect(bodies[0]?.thinking).toEqual({ type: "enabled" });
+    expect(bodies[0]?.reasoning_effort).toBe("high");
+
+    const second = await provider.streamChat(
+      {
+        messages: [
+          { content: "Look it up", role: "user" },
+          first.assistantMessage,
+          {
+            content: "value",
+            name: "lookup",
+            role: "tool",
+            toolCallId: "call_1",
+          },
+        ],
+        providerOptions: { thinking: { effort: "high", enabled: true } },
+        system: "You are helpful.",
+        tools,
+      },
+      { onChunk: () => {} }
+    );
+
+    expect(second.content).toBe("Done");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const followUpMessages = bodies[1]?.messages as Array<
+      Record<string, unknown>
+    >;
+    const assistantWithTools = followUpMessages.find(
+      (message) => message.role === "assistant" && message.tool_calls
+    );
+
+    expect(assistantWithTools?.reasoning_content).toBe("Need lookup");
+    expect(assistantWithTools?.tool_calls).toEqual([
+      {
+        function: { arguments: '{"q":"x"}', name: "lookup" },
+        id: "call_1",
+        type: "function",
+      },
+    ]);
+  });
+
+  test("deepseek omits thinking body when thinking is disabled", async () => {
+    const fetchMock = mock(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body ?? "{}")) as {
+          thinking?: unknown;
+          reasoning_effort?: unknown;
+        };
+        expect(body.thinking).toEqual({ type: "disabled" });
+        expect(body.reasoning_effort).toBeUndefined();
+
+        return new Response(
+          streamFromChunks([
+            'data:{"choices":[{"delta":{"content":"Hi"}}]}\r\n\r\n',
+            "data:[DONE]\r\n\r\n",
+          ]),
+          { headers: { "Content-Type": "text/event-stream" }, status: 200 }
+        );
+      }
+    );
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = createOpenAIProvider({
+      apiKey: "sk-test",
+      baseUrl: "https://api.deepseek.com",
+      model: "deepseek-chat",
+      providerName: "deepseek",
+    });
+
+    const result = await provider.streamChat(
+      {
+        messages: [{ content: "Say hi", role: "user" }],
+        providerOptions: { thinking: { enabled: false } },
+        system: "You are helpful.",
+      },
+      { onChunk: () => {} }
+    );
+
+    expect(result.content).toBe("Hi");
+  });
+
+  test("captures reasoning_content from non-streaming deepseek responses", async () => {
+    const fetchMock = mock(async () =>
+      Response.json({
+        choices: [
+          {
+            message: {
+              content: "Answer",
+              reasoning_content: "Plan",
+            },
+          },
+        ],
+      })
+    );
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = createOpenAIProvider({
+      apiKey: "sk-test",
+      baseUrl: "https://api.deepseek.com",
+      model: "deepseek-chat",
+      providerName: "deepseek",
+    });
+
+    const result = await provider.generateChat({
+      messages: [{ content: "Think", role: "user" }],
+      providerOptions: { thinking: { effort: "medium", enabled: true } },
+      system: "You are helpful.",
+    });
+
+    expect(result.content).toBe("Answer");
+    expect(result.assistantMessage.thinking).toBe("Plan");
+  });
 });

--- a/apps/server/src/providers/openai/stream.test.ts
+++ b/apps/server/src/providers/openai/stream.test.ts
@@ -183,66 +183,83 @@ describe("OpenAI provider streaming", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  test("deepseek stream tool turn re-sends reasoning_content on follow-up", async () => {
-    const bodies: Array<Record<string, unknown>> = [];
-    let callCount = 0;
-
-    const fetchMock = mock(
-      async (_input: RequestInfo | URL, init?: RequestInit) => {
-        callCount += 1;
-        bodies.push(
-          JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>
-        );
-
-        if (callCount === 1) {
-          return new Response(
-            streamFromChunks([
-              'data:{"choices":[{"delta":{"reasoning_content":"Need lookup"}}]}\r\n\r\n',
-              'data:{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{\\"q\\":\\"x\\"}"}}]}}]}\r\n\r\n',
-              "data:[DONE]\r\n\r\n",
-            ]),
-            { headers: { "Content-Type": "text/event-stream" }, status: 200 }
-          );
-        }
-
-        return new Response(
-          streamFromChunks([
-            'data:{"choices":[{"delta":{"content":"Done"}}]}\r\n\r\n',
-            "data:[DONE]\r\n\r\n",
-          ]),
-          { headers: { "Content-Type": "text/event-stream" }, status: 200 }
-        );
-      }
-    );
-
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
-
-    const provider = createOpenAIProvider({
+  const deepseekProvider = () =>
+    createOpenAIProvider({
       apiKey: "sk-test",
       baseUrl: "https://api.deepseek.com",
       model: "deepseek-chat",
       providerName: "deepseek",
     });
 
-    const tools = [
-      {
-        description: "Lookup",
-        name: "lookup",
-        parameters: {
-          properties: { q: { type: "string" } },
-          required: ["q"],
-          type: "object",
+  const sseResponse = (...deltas: Record<string, unknown>[]) =>
+    new Response(
+      streamFromChunks([
+        ...deltas.map(
+          (delta) => `data:${JSON.stringify({ choices: [{ delta }] })}\r\n\r\n`
+        ),
+        "data:[DONE]\r\n\r\n",
+      ]),
+      { headers: { "Content-Type": "text/event-stream" }, status: 200 }
+    );
+
+  const mockFetchBodies = (
+    handler: (call: number, body: Record<string, unknown>) => Response
+  ) => {
+    const bodies: Array<Record<string, unknown>> = [];
+    let callCount = 0;
+    const fetchMock = mock(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        callCount += 1;
+        const body = JSON.parse(String(init?.body ?? "{}")) as Record<
+          string,
+          unknown
+        >;
+        bodies.push(body);
+        return handler(callCount, body);
+      }
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    return { bodies, fetchMock };
+  };
+
+  test("deepseek stream tool turn re-sends reasoning_content on follow-up", async () => {
+    const { bodies, fetchMock } = mockFetchBodies((call) =>
+      call === 1
+        ? sseResponse(
+            { reasoning_content: "Need lookup" },
+            {
+              tool_calls: [
+                {
+                  function: { arguments: '{"q":"x"}', name: "lookup" },
+                  id: "call_1",
+                  index: 0,
+                  type: "function",
+                },
+              ],
+            }
+          )
+        : sseResponse({ content: "Done" })
+    );
+
+    const provider = deepseekProvider();
+    const request = {
+      providerOptions: { thinking: { effort: "high" as const, enabled: true } },
+      system: "You are helpful.",
+      tools: [
+        {
+          description: "Lookup",
+          name: "lookup",
+          parameters: {
+            properties: { q: { type: "string" } },
+            required: ["q"],
+            type: "object",
+          },
         },
-      },
-    ];
+      ],
+    };
 
     const first = await provider.streamChat(
-      {
-        messages: [{ content: "Look it up", role: "user" }],
-        providerOptions: { thinking: { effort: "high", enabled: true } },
-        system: "You are helpful.",
-        tools,
-      },
+      { messages: [{ content: "Look it up", role: "user" }], ...request },
       { onChunk: () => {} }
     );
 
@@ -265,9 +282,7 @@ describe("OpenAI provider streaming", () => {
             toolCallId: "call_1",
           },
         ],
-        providerOptions: { thinking: { effort: "high", enabled: true } },
-        system: "You are helpful.",
-        tools,
+        ...request,
       },
       { onChunk: () => {} }
     );
@@ -275,53 +290,24 @@ describe("OpenAI provider streaming", () => {
     expect(second.content).toBe("Done");
     expect(fetchMock).toHaveBeenCalledTimes(2);
 
-    const followUpMessages = bodies[1]?.messages as Array<
+    const followUpMessages = (bodies[1]?.messages ?? []) as Array<
       Record<string, unknown>
     >;
     const assistantWithTools = followUpMessages.find(
       (message) => message.role === "assistant" && message.tool_calls
     );
-
     expect(assistantWithTools?.reasoning_content).toBe("Need lookup");
-    expect(assistantWithTools?.tool_calls).toEqual([
-      {
-        function: { arguments: '{"q":"x"}', name: "lookup" },
-        id: "call_1",
-        type: "function",
-      },
-    ]);
+    expect(assistantWithTools?.tool_calls).toBeDefined();
   });
 
   test("deepseek omits thinking body when thinking is disabled", async () => {
-    const fetchMock = mock(
-      async (_input: RequestInfo | URL, init?: RequestInit) => {
-        const body = JSON.parse(String(init?.body ?? "{}")) as {
-          thinking?: unknown;
-          reasoning_effort?: unknown;
-        };
-        expect(body.thinking).toEqual({ type: "disabled" });
-        expect(body.reasoning_effort).toBeUndefined();
-
-        return new Response(
-          streamFromChunks([
-            'data:{"choices":[{"delta":{"content":"Hi"}}]}\r\n\r\n',
-            "data:[DONE]\r\n\r\n",
-          ]),
-          { headers: { "Content-Type": "text/event-stream" }, status: 200 }
-        );
-      }
-    );
-
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
-
-    const provider = createOpenAIProvider({
-      apiKey: "sk-test",
-      baseUrl: "https://api.deepseek.com",
-      model: "deepseek-chat",
-      providerName: "deepseek",
+    mockFetchBodies((_call, body) => {
+      expect(body.thinking).toEqual({ type: "disabled" });
+      expect(body.reasoning_effort).toBeUndefined();
+      return sseResponse({ content: "Hi" });
     });
 
-    const result = await provider.streamChat(
+    const result = await deepseekProvider().streamChat(
       {
         messages: [{ content: "Say hi", role: "user" }],
         providerOptions: { thinking: { enabled: false } },
@@ -337,26 +323,13 @@ describe("OpenAI provider streaming", () => {
     const fetchMock = mock(async () =>
       Response.json({
         choices: [
-          {
-            message: {
-              content: "Answer",
-              reasoning_content: "Plan",
-            },
-          },
+          { message: { content: "Answer", reasoning_content: "Plan" } },
         ],
       })
     );
-
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-    const provider = createOpenAIProvider({
-      apiKey: "sk-test",
-      baseUrl: "https://api.deepseek.com",
-      model: "deepseek-chat",
-      providerName: "deepseek",
-    });
-
-    const result = await provider.generateChat({
+    const result = await deepseekProvider().generateChat({
       messages: [{ content: "Think", role: "user" }],
       providerOptions: { thinking: { effort: "medium", enabled: true } },
       system: "You are helpful.",

--- a/apps/server/src/providers/shared.test.ts
+++ b/apps/server/src/providers/shared.test.ts
@@ -101,57 +101,47 @@ describe("provider shared helpers", () => {
     );
   });
 
-  test("sanitizeToolCallHistory drops orphaned tool_calls assistants", () => {
-    const messages: ChatMessage[] = [
-      { content: "Use the tool", role: "user" },
-      {
-        content: "",
-        role: "assistant",
-        toolCalls: [{ arguments: {}, id: "call_missing", name: "lookup" }],
-      },
-      { content: "Thanks", role: "user" },
-    ];
+  const user = (content: string): ChatMessage => ({ content, role: "user" });
+  const toolResult = (toolCallId: string, content = "ok"): ChatMessage => ({
+    content,
+    name: "lookup",
+    role: "tool",
+    toolCallId,
+  });
+  const assistantTools = (
+    id: string,
+    args: Record<string, unknown> = {},
+    thinking?: string
+  ): ChatMessage => ({
+    content: "",
+    role: "assistant",
+    ...(thinking ? { thinking } : {}),
+    toolCalls: [{ arguments: args, id, name: "lookup" }],
+  });
 
-    expect(sanitizeToolCallHistory(messages)).toEqual([
-      { content: "Use the tool", role: "user" },
-      { content: "Thanks", role: "user" },
-    ]);
+  test("sanitizeToolCallHistory drops orphaned tool_calls assistants", () => {
+    expect(
+      sanitizeToolCallHistory([
+        user("Use the tool"),
+        assistantTools("call_missing"),
+        user("Thanks"),
+      ])
+    ).toEqual([user("Use the tool"), user("Thanks")]);
   });
 
   test("sanitizeToolCallHistory drops orphaned tool messages", () => {
-    const messages: ChatMessage[] = [
-      { content: "Hi", role: "user" },
-      {
-        content: "result",
-        name: "lookup",
-        role: "tool",
-        toolCallId: "call_orphan",
-      },
-    ];
-
-    expect(sanitizeToolCallHistory(messages)).toEqual([
-      { content: "Hi", role: "user" },
-    ]);
+    expect(
+      sanitizeToolCallHistory([user("Hi"), toolResult("call_orphan", "result")])
+    ).toEqual([user("Hi")]);
   });
 
   test("sanitizeToolCallHistory leaves intact tool pairs untouched", () => {
     const messages: ChatMessage[] = [
-      { content: "Use the tool", role: "user" },
-      {
-        content: "",
-        role: "assistant",
-        thinking: "plan",
-        toolCalls: [{ arguments: { q: "x" }, id: "call_1", name: "lookup" }],
-      },
-      {
-        content: "ok",
-        name: "lookup",
-        role: "tool",
-        toolCallId: "call_1",
-      },
+      user("Use the tool"),
+      assistantTools("call_1", { q: "x" }, "plan"),
+      toolResult("call_1"),
       { content: "Done", role: "assistant" },
     ];
-
     expect(sanitizeToolCallHistory(messages)).toEqual(messages);
   });
 });

--- a/apps/server/src/providers/shared.test.ts
+++ b/apps/server/src/providers/shared.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test";
+import type { ChatMessage } from "@nakama/core";
 import {
   formatHttpErrorBody,
   normalizeThinkingEffort,
   parseJsonRecord,
   readRecord,
   readSseEvents,
+  sanitizeToolCallHistory,
 } from "./shared";
 
 function streamFromChunks(chunks: string[]): ReadableStream<Uint8Array> {
@@ -97,5 +99,59 @@ describe("provider shared helpers", () => {
     ).toBe(
       "OpenCode Zen request failed (429 FreeUsageLimitError): Rate limit exceeded. Please try again later."
     );
+  });
+
+  test("sanitizeToolCallHistory drops orphaned tool_calls assistants", () => {
+    const messages: ChatMessage[] = [
+      { content: "Use the tool", role: "user" },
+      {
+        content: "",
+        role: "assistant",
+        toolCalls: [{ arguments: {}, id: "call_missing", name: "lookup" }],
+      },
+      { content: "Thanks", role: "user" },
+    ];
+
+    expect(sanitizeToolCallHistory(messages)).toEqual([
+      { content: "Use the tool", role: "user" },
+      { content: "Thanks", role: "user" },
+    ]);
+  });
+
+  test("sanitizeToolCallHistory drops orphaned tool messages", () => {
+    const messages: ChatMessage[] = [
+      { content: "Hi", role: "user" },
+      {
+        content: "result",
+        name: "lookup",
+        role: "tool",
+        toolCallId: "call_orphan",
+      },
+    ];
+
+    expect(sanitizeToolCallHistory(messages)).toEqual([
+      { content: "Hi", role: "user" },
+    ]);
+  });
+
+  test("sanitizeToolCallHistory leaves intact tool pairs untouched", () => {
+    const messages: ChatMessage[] = [
+      { content: "Use the tool", role: "user" },
+      {
+        content: "",
+        role: "assistant",
+        thinking: "plan",
+        toolCalls: [{ arguments: { q: "x" }, id: "call_1", name: "lookup" }],
+      },
+      {
+        content: "ok",
+        name: "lookup",
+        role: "tool",
+        toolCallId: "call_1",
+      },
+      { content: "Done", role: "assistant" },
+    ];
+
+    expect(sanitizeToolCallHistory(messages)).toEqual(messages);
   });
 });

--- a/apps/server/src/providers/shared.ts
+++ b/apps/server/src/providers/shared.ts
@@ -124,6 +124,51 @@ export function buildChatCompletionResult(options: {
   };
 }
 
+/**
+ * Drop orphaned assistant tool_calls / tool results so partial histories cannot
+ * produce provider 400s ("insufficient tool messages following tool_calls").
+ * Intact tool_call ↔ tool pairs are left untouched.
+ */
+export function sanitizeToolCallHistory(
+  messages: ChatMessage[]
+): ChatMessage[] {
+  const toolResultIds = new Set(
+    messages
+      .filter(
+        (message): message is Extract<ChatMessage, { role: "tool" }> =>
+          message.role === "tool"
+      )
+      .map((message) => message.toolCallId)
+  );
+
+  const validToolCallIds = new Set<string>();
+
+  for (const message of messages) {
+    if (message.role !== "assistant" || !message.toolCalls?.length) {
+      continue;
+    }
+
+    const ids = message.toolCalls.map((call) => call.id);
+    if (ids.every((id) => toolResultIds.has(id))) {
+      for (const id of ids) {
+        validToolCallIds.add(id);
+      }
+    }
+  }
+
+  return messages.filter((message) => {
+    if (message.role === "assistant" && message.toolCalls?.length) {
+      return message.toolCalls.every((call) => validToolCallIds.has(call.id));
+    }
+
+    if (message.role === "tool") {
+      return validToolCallIds.has(message.toolCallId);
+    }
+
+    return true;
+  });
+}
+
 export interface SseEvent {
   data: string;
   event: string;


### PR DESCRIPTION
## Problem

DeepSeek (Discord integration path) rejects follow-up requests with HTTP 400:

> An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. (insufficient tool messages following tool_calls message)

DeepSeek routes through `createOpenAIProvider` (not openai-compatible). DeepSeek V4 has thinking on by default — after an assistant `tool_calls` message, the API requires `reasoning_content` to be echoed back on later requests. Nakama never stored it: both `requestChatCompletion` and `readOpenAIStream` parsed only `content` + `tool_calls`, so `thinking` was never populated and `toOpenAIAssistantMessage` had nothing to re-send.

## Fix

- **openai/index.ts**: capture `reasoning_content` on both stream and non-stream paths → store as `thinking` → re-emit via `reasoning_content` on the next request. DeepSeek-only `thinking`/`reasoning_effort` request body options, honoring `providerOptions.thinking.enabled` (disable supported).
- **shared.ts**: `sanitizeToolCallHistory()` — drops orphaned assistant `tool_calls` / tool messages before wire mapping so partial or live histories can never produce this 400.

## Verification

- `bun test apps/server/src/providers` — 131 pass (incl. new DeepSeek stream follow-up, disable, non-stream capture, sanitizer tests)
- `bun test apps/platform/discord/src/chat-handler.test.ts` — 38 pass
- `bun x ultracite check` — clean
- `tsc --noEmit` — no new errors

## Risks

- Sanitizer wired into the OpenAI message path only (covers DeepSeek/Discord); Anthropic/Gemini mapping doesn't call it yet.
- DeepSeek `reasoning_effort` maps `medium` → `high` (DeepSeek accepts low/high/max only).
- If `providerOptions.thinking` is omitted, no toggle is sent (API default applies); reasoning is still captured and replayed.