### PR TITLE
fix(discord): usable artifact share publish (#220)

### DIFF
--- a/apps/platform/discord/src/channel-artifact-flow.ts
+++ b/apps/platform/discord/src/channel-artifact-flow.ts
@@ -212,22 +212,17 @@ export async function deliverDiscordTurnArtifactShares(input: {
   });
   await input.sessionStore.save();
 
-  const fallbackArtifacts: DeliverableChannelArtifact[] = [];
-
   for (const artifact of delivered) {
-    const uploaded = await tryUploadDiscordArtifact({
+    await tryUploadDiscordArtifact({
       artifact,
       channel: input.channel,
       client: input.client,
       profileId: input.profileId,
     });
-
-    if (!uploaded) {
-      fallbackArtifacts.push(artifact);
-    }
   }
 
-  const footer = formatArtifactShareFooter(fallbackArtifacts, {
+  // Always post share links (like Telegram); attachment upload is additive.
+  const footer = formatArtifactShareFooter(delivered, {
     webPublicUrlConfigured,
   });
 

--- a/apps/platform/discord/src/chat-handler.test.ts
+++ b/apps/platform/discord/src/chat-handler.test.ts
@@ -163,7 +163,7 @@ describe("createChatHandler artifact delivery", () => {
         dm.sentMessages.some((reply) =>
           reply.includes("https://app.example/s/tok_test")
         )
-      ).toBe(false);
+      ).toBe(true);
     });
   });
 

--- a/apps/server/src/http/routes/artifact-shares.test.ts
+++ b/apps/server/src/http/routes/artifact-shares.test.ts
@@ -200,4 +200,116 @@ describe("artifact share routes", () => {
       "inline"
     );
   });
+
+  test("publish prefers clientOrigin over loopback request URL", async () => {
+    const { app, databaseAdapter } = createApp();
+    const session = await setupFreshInstallSession(app, databaseAdapter);
+    const orgId = session.orgId!;
+    const profileId = "profile_share_origin";
+    const now = new Date().toISOString();
+
+    await databaseAdapter.upsertProfile({
+      createdAt: now,
+      id: profileId,
+      isSuper: false,
+      model: "openrouter/auto",
+      name: "Share Origin",
+      orgId,
+      systemPrompt: "test",
+      updatedAt: now,
+    });
+
+    const artifactsDir = getProfileArtifactsDir(orgId, profileId);
+    await mkdir(artifactsDir, { recursive: true });
+    await writeFile(join(artifactsDir, "note.md"), "hello", "utf8");
+
+    const publishResponse = await app.fetch(
+      new Request(
+        `http://127.0.0.1:4310/v1/profiles/${profileId}/artifacts/shares`,
+        {
+          body: JSON.stringify({
+            clientOrigin: "https://nakama.example.com/",
+            path: "note.md",
+          }),
+          headers: session.headers(
+            {
+              "Content-Type": "application/json",
+              "X-CSRF-Token": session.csrfToken,
+            },
+            orgId
+          ),
+          method: "POST",
+        }
+      )
+    );
+
+    expect(publishResponse.status).toBe(201);
+    const published = (await publishResponse.json()) as {
+      shareUrl: string | null;
+      webPublicUrlConfigured: boolean;
+    };
+    expect(published.shareUrl).toMatch(/^https:\/\/nakama\.example\.com\/s\//);
+    expect(published.webPublicUrlConfigured).toBe(true);
+  });
+
+  test("publish prefers configured web public URL over loopback request URL", async () => {
+    const previous = process.env.NAKAMA_WEB_PUBLIC_URL;
+    process.env.NAKAMA_WEB_PUBLIC_URL = "https://deployed.example.com/";
+
+    try {
+      const { app, databaseAdapter } = createApp();
+      const session = await setupFreshInstallSession(app, databaseAdapter);
+      const orgId = session.orgId!;
+      const profileId = "profile_share_env";
+      const now = new Date().toISOString();
+
+      await databaseAdapter.upsertProfile({
+        createdAt: now,
+        id: profileId,
+        isSuper: false,
+        model: "openrouter/auto",
+        name: "Share Env",
+        orgId,
+        systemPrompt: "test",
+        updatedAt: now,
+      });
+
+      const artifactsDir = getProfileArtifactsDir(orgId, profileId);
+      await mkdir(artifactsDir, { recursive: true });
+      await writeFile(join(artifactsDir, "note.md"), "hello", "utf8");
+
+      const publishResponse = await app.fetch(
+        new Request(
+          `http://127.0.0.1:4310/v1/profiles/${profileId}/artifacts/shares`,
+          {
+            body: JSON.stringify({ path: "note.md" }),
+            headers: session.headers(
+              {
+                "Content-Type": "application/json",
+                "X-CSRF-Token": session.csrfToken,
+              },
+              orgId
+            ),
+            method: "POST",
+          }
+        )
+      );
+
+      expect(publishResponse.status).toBe(201);
+      const published = (await publishResponse.json()) as {
+        shareUrl: string | null;
+        webPublicUrlConfigured: boolean;
+      };
+      expect(published.shareUrl).toMatch(
+        /^https:\/\/deployed\.example\.com\/s\//
+      );
+      expect(published.webPublicUrlConfigured).toBe(true);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.NAKAMA_WEB_PUBLIC_URL;
+      } else {
+        process.env.NAKAMA_WEB_PUBLIC_URL = previous;
+      }
+    }
+  });
 });

--- a/apps/server/src/http/routes/artifact-shares.test.ts
+++ b/apps/server/src/http/routes/artifact-shares.test.ts
@@ -2,13 +2,19 @@ import { describe, expect, test } from "bun:test";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { getProfileArtifactsDir } from "@nakama/core";
-import { createInMemoryDatabaseAdapter } from "@nakama/db";
+import {
+  createInMemoryDatabaseAdapter,
+  type DatabaseAdapter,
+} from "@nakama/db";
 import { AuthService } from "../../services/auth-service";
 import { OrgService } from "../../services/org-service";
 import { setupTestConfigDir } from "../../test-config-dir";
 import { createHonoApp } from "../app";
 import { isPublicRouteRequest } from "../public-routes";
-import { setupFreshInstallSession } from "../test-session-helpers";
+import {
+  setupFreshInstallSession,
+  type TestBrowserSession,
+} from "../test-session-helpers";
 
 setupTestConfigDir("nakama-artifact-shares-test-");
 
@@ -32,6 +38,89 @@ function createApp(databaseAdapter = createInMemoryDatabaseAdapter()) {
   };
 }
 
+async function withEnv<T>(
+  vars: Record<string, string | undefined>,
+  run: () => Promise<T>
+): Promise<T> {
+  const previous = new Map(
+    Object.keys(vars).map((key) => [key, process.env[key]] as const)
+  );
+  for (const [key, value] of Object.entries(vars)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  try {
+    return await run();
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+async function seedProfileArtifact(params: {
+  content: string;
+  databaseAdapter: DatabaseAdapter;
+  filename: string;
+  meta?: string;
+  name: string;
+  orgId: string;
+  profileId: string;
+}): Promise<string> {
+  const now = new Date().toISOString();
+  await params.databaseAdapter.upsertProfile({
+    createdAt: now,
+    id: params.profileId,
+    isSuper: false,
+    model: "openrouter/auto",
+    name: params.name,
+    orgId: params.orgId,
+    systemPrompt: "test",
+    updatedAt: now,
+  });
+
+  const artifactsDir = getProfileArtifactsDir(params.orgId, params.profileId);
+  await mkdir(artifactsDir, { recursive: true });
+  await writeFile(join(artifactsDir, params.filename), params.content);
+  if (params.meta !== undefined) {
+    await writeFile(
+      join(artifactsDir, `${params.filename}.nakama-meta.json`),
+      params.meta
+    );
+  }
+  return now;
+}
+
+function publishArtifactShareRequest(params: {
+  body: Record<string, unknown>;
+  host?: string;
+  orgId: string;
+  profileId: string;
+  session: TestBrowserSession;
+}): Request {
+  return new Request(
+    `http://${params.host ?? "localhost"}:4310/v1/profiles/${params.profileId}/artifacts/shares`,
+    {
+      body: JSON.stringify(params.body),
+      headers: params.session.headers(
+        {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": params.session.csrfToken,
+        },
+        params.orgId
+      ),
+      method: "POST",
+    }
+  );
+}
+
 describe("artifact share routes", () => {
   test("public artifact share GET is allowlisted", () => {
     expect(
@@ -47,38 +136,23 @@ describe("artifact share routes", () => {
     const session = await setupFreshInstallSession(app, databaseAdapter);
     const orgId = session.orgId!;
     const profileId = "profile_share_test";
-    const now = new Date().toISOString();
 
-    await databaseAdapter.upsertProfile({
-      createdAt: now,
-      id: profileId,
-      isSuper: false,
-      model: "openrouter/auto",
+    await seedProfileArtifact({
+      content: "# Shared report",
+      databaseAdapter,
+      filename: "report.md",
       name: "Share Test",
       orgId,
-      systemPrompt: "test",
-      updatedAt: now,
+      profileId,
     });
 
-    const artifactsDir = getProfileArtifactsDir(orgId, profileId);
-    await mkdir(artifactsDir, { recursive: true });
-    await writeFile(join(artifactsDir, "report.md"), "# Shared report", "utf8");
-
     const publishResponse = await app.fetch(
-      new Request(
-        `http://localhost:4310/v1/profiles/${profileId}/artifacts/shares`,
-        {
-          body: JSON.stringify({ path: "report.md" }),
-          headers: session.headers(
-            {
-              "Content-Type": "application/json",
-              "X-CSRF-Token": session.csrfToken,
-            },
-            orgId
-          ),
-          method: "POST",
-        }
-      )
+      publishArtifactShareRequest({
+        body: { path: "report.md" },
+        orgId,
+        profileId,
+        session,
+      })
     );
 
     expect(publishResponse.status).toBe(201);
@@ -130,45 +204,28 @@ describe("artifact share routes", () => {
     const profileId = "profile_share_video";
     const now = new Date().toISOString();
 
-    await databaseAdapter.upsertProfile({
-      createdAt: now,
-      id: profileId,
-      isSuper: false,
-      model: "openrouter/auto",
-      name: "Share Video",
-      orgId,
-      systemPrompt: "test",
-      updatedAt: now,
-    });
-
-    const artifactsDir = getProfileArtifactsDir(orgId, profileId);
-    await mkdir(artifactsDir, { recursive: true });
     // Minimal bytes; MIME comes from filename when sidecar is missing/generic.
-    await writeFile(join(artifactsDir, "clip.mp4"), "fake-mp4-bytes");
-    await writeFile(
-      join(artifactsDir, "clip.mp4.nakama-meta.json"),
-      JSON.stringify({
+    await seedProfileArtifact({
+      content: "fake-mp4-bytes",
+      databaseAdapter,
+      filename: "clip.mp4",
+      meta: JSON.stringify({
         mimeType: "application/octet-stream",
         savedAt: now,
         sizeBytes: 13,
-      })
-    );
+      }),
+      name: "Share Video",
+      orgId,
+      profileId,
+    });
 
     const publishResponse = await app.fetch(
-      new Request(
-        `http://localhost:4310/v1/profiles/${profileId}/artifacts/shares`,
-        {
-          body: JSON.stringify({ path: "clip.mp4" }),
-          headers: session.headers(
-            {
-              "Content-Type": "application/json",
-              "X-CSRF-Token": session.csrfToken,
-            },
-            orgId
-          ),
-          method: "POST",
-        }
-      )
+      publishArtifactShareRequest({
+        body: { path: "clip.mp4" },
+        orgId,
+        profileId,
+        session,
+      })
     );
 
     expect(publishResponse.status).toBe(201);
@@ -206,41 +263,27 @@ describe("artifact share routes", () => {
     const session = await setupFreshInstallSession(app, databaseAdapter);
     const orgId = session.orgId!;
     const profileId = "profile_share_origin";
-    const now = new Date().toISOString();
 
-    await databaseAdapter.upsertProfile({
-      createdAt: now,
-      id: profileId,
-      isSuper: false,
-      model: "openrouter/auto",
+    await seedProfileArtifact({
+      content: "hello",
+      databaseAdapter,
+      filename: "note.md",
       name: "Share Origin",
       orgId,
-      systemPrompt: "test",
-      updatedAt: now,
+      profileId,
     });
 
-    const artifactsDir = getProfileArtifactsDir(orgId, profileId);
-    await mkdir(artifactsDir, { recursive: true });
-    await writeFile(join(artifactsDir, "note.md"), "hello", "utf8");
-
     const publishResponse = await app.fetch(
-      new Request(
-        `http://127.0.0.1:4310/v1/profiles/${profileId}/artifacts/shares`,
-        {
-          body: JSON.stringify({
-            clientOrigin: "https://nakama.example.com/",
-            path: "note.md",
-          }),
-          headers: session.headers(
-            {
-              "Content-Type": "application/json",
-              "X-CSRF-Token": session.csrfToken,
-            },
-            orgId
-          ),
-          method: "POST",
-        }
-      )
+      publishArtifactShareRequest({
+        body: {
+          clientOrigin: "https://nakama.example.com/",
+          path: "note.md",
+        },
+        host: "127.0.0.1",
+        orgId,
+        profileId,
+        session,
+      })
     );
 
     expect(publishResponse.status).toBe(201);
@@ -253,63 +296,43 @@ describe("artifact share routes", () => {
   });
 
   test("publish prefers configured web public URL over loopback request URL", async () => {
-    const previous = process.env.NAKAMA_WEB_PUBLIC_URL;
-    process.env.NAKAMA_WEB_PUBLIC_URL = "https://deployed.example.com/";
+    await withEnv(
+      { NAKAMA_WEB_PUBLIC_URL: "https://deployed.example.com/" },
+      async () => {
+        const { app, databaseAdapter } = createApp();
+        const session = await setupFreshInstallSession(app, databaseAdapter);
+        const orgId = session.orgId!;
+        const profileId = "profile_share_env";
 
-    try {
-      const { app, databaseAdapter } = createApp();
-      const session = await setupFreshInstallSession(app, databaseAdapter);
-      const orgId = session.orgId!;
-      const profileId = "profile_share_env";
-      const now = new Date().toISOString();
+        await seedProfileArtifact({
+          content: "hello",
+          databaseAdapter,
+          filename: "note.md",
+          name: "Share Env",
+          orgId,
+          profileId,
+        });
 
-      await databaseAdapter.upsertProfile({
-        createdAt: now,
-        id: profileId,
-        isSuper: false,
-        model: "openrouter/auto",
-        name: "Share Env",
-        orgId,
-        systemPrompt: "test",
-        updatedAt: now,
-      });
+        const publishResponse = await app.fetch(
+          publishArtifactShareRequest({
+            body: { path: "note.md" },
+            host: "127.0.0.1",
+            orgId,
+            profileId,
+            session,
+          })
+        );
 
-      const artifactsDir = getProfileArtifactsDir(orgId, profileId);
-      await mkdir(artifactsDir, { recursive: true });
-      await writeFile(join(artifactsDir, "note.md"), "hello", "utf8");
-
-      const publishResponse = await app.fetch(
-        new Request(
-          `http://127.0.0.1:4310/v1/profiles/${profileId}/artifacts/shares`,
-          {
-            body: JSON.stringify({ path: "note.md" }),
-            headers: session.headers(
-              {
-                "Content-Type": "application/json",
-                "X-CSRF-Token": session.csrfToken,
-              },
-              orgId
-            ),
-            method: "POST",
-          }
-        )
-      );
-
-      expect(publishResponse.status).toBe(201);
-      const published = (await publishResponse.json()) as {
-        shareUrl: string | null;
-        webPublicUrlConfigured: boolean;
-      };
-      expect(published.shareUrl).toMatch(
-        /^https:\/\/deployed\.example\.com\/s\//
-      );
-      expect(published.webPublicUrlConfigured).toBe(true);
-    } finally {
-      if (previous === undefined) {
-        delete process.env.NAKAMA_WEB_PUBLIC_URL;
-      } else {
-        process.env.NAKAMA_WEB_PUBLIC_URL = previous;
+        expect(publishResponse.status).toBe(201);
+        const published = (await publishResponse.json()) as {
+          shareUrl: string | null;
+          webPublicUrlConfigured: boolean;
+        };
+        expect(published.shareUrl).toMatch(
+          /^https:\/\/deployed\.example\.com\/s\//
+        );
+        expect(published.webPublicUrlConfigured).toBe(true);
       }
-    }
+    );
   });
 });

--- a/apps/server/src/http/routes/artifact-shares.ts
+++ b/apps/server/src/http/routes/artifact-shares.ts
@@ -6,6 +6,7 @@ import type {
   RevokeArtifactShareResponse,
 } from "@nakama/core/contract";
 import { ArtifactShareService } from "../../services/artifact-share-service";
+import { resolveRequestClientOrigin } from "../../services/composio-callback-url";
 import type { ServerOptions } from "../context";
 import {
   requireActiveOrgIdFromContext,
@@ -37,6 +38,11 @@ export function registerArtifactShareRoutes(
       return json({ error: "path is required" }, 400);
     }
 
+    const clientOrigin = resolveRequestClientOrigin(
+      c.req.raw,
+      body.clientOrigin
+    );
+
     return json<PublishArtifactShareResponse>(
       await service.publishArtifactShare({
         orgId,
@@ -44,6 +50,7 @@ export function registerArtifactShareRoutes(
         request: c.req.raw,
         sourcePath: body.path.trim(),
         userId: auth.user.id,
+        ...(clientOrigin ? { clientOrigin } : {}),
       }),
       201
     );

--- a/apps/server/src/services/artifact-share-service.test.ts
+++ b/apps/server/src/services/artifact-share-service.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveArtifactShareBaseUrl } from "./artifact-share-service";
+
+describe("resolveArtifactShareBaseUrl", () => {
+  test("prefers explicit clientOrigin over loopback request URL", () => {
+    const request = new Request(
+      "http://127.0.0.1:4310/v1/profiles/p1/artifacts/shares",
+      { method: "POST" }
+    );
+
+    expect(
+      resolveArtifactShareBaseUrl({
+        clientOrigin: "https://nakama.example.com/",
+        request,
+      })
+    ).toBe("https://nakama.example.com");
+  });
+
+  test("prefers configured web public URL when request host is loopback", () => {
+    const previous = process.env.NAKAMA_WEB_PUBLIC_URL;
+    process.env.NAKAMA_WEB_PUBLIC_URL = "https://deployed.example.com/";
+
+    try {
+      const request = new Request(
+        "http://127.0.0.1:4310/v1/profiles/p1/artifacts/shares",
+        { method: "POST" }
+      );
+
+      expect(resolveArtifactShareBaseUrl({ request })).toBe(
+        "https://deployed.example.com"
+      );
+    } finally {
+      if (previous === undefined) {
+        delete process.env.NAKAMA_WEB_PUBLIC_URL;
+      } else {
+        process.env.NAKAMA_WEB_PUBLIC_URL = previous;
+      }
+    }
+  });
+
+  test("keeps loopback when no configured web public URL exists", () => {
+    const configDir = join(
+      tmpdir(),
+      `nakama-artifact-share-base-${Date.now()}`
+    );
+    mkdirSync(configDir, { recursive: true });
+
+    const previousConfigDir = process.env.NAKAMA_CONFIG_DIR;
+    const previousWeb = process.env.NAKAMA_WEB_PUBLIC_URL;
+    const previousPublic = process.env.NAKAMA_PUBLIC_URL;
+    process.env.NAKAMA_CONFIG_DIR = configDir;
+    delete process.env.NAKAMA_WEB_PUBLIC_URL;
+    delete process.env.NAKAMA_PUBLIC_URL;
+
+    try {
+      const request = new Request(
+        "http://127.0.0.1:4310/v1/profiles/p1/artifacts/shares",
+        { method: "POST" }
+      );
+
+      expect(resolveArtifactShareBaseUrl({ request })).toBe(
+        "http://127.0.0.1:4310"
+      );
+    } finally {
+      if (previousConfigDir === undefined) {
+        delete process.env.NAKAMA_CONFIG_DIR;
+      } else {
+        process.env.NAKAMA_CONFIG_DIR = previousConfigDir;
+      }
+      if (previousWeb === undefined) {
+        delete process.env.NAKAMA_WEB_PUBLIC_URL;
+      } else {
+        process.env.NAKAMA_WEB_PUBLIC_URL = previousWeb;
+      }
+      if (previousPublic === undefined) {
+        delete process.env.NAKAMA_PUBLIC_URL;
+      } else {
+        process.env.NAKAMA_PUBLIC_URL = previousPublic;
+      }
+      rmSync(configDir, { force: true, recursive: true });
+    }
+  });
+
+  test("reads Origin header from request when clientOrigin is absent", () => {
+    const request = new Request(
+      "http://127.0.0.1:4310/v1/profiles/p1/artifacts/shares",
+      {
+        headers: { Origin: "https://app.example.com" },
+        method: "POST",
+      }
+    );
+
+    expect(resolveArtifactShareBaseUrl({ request })).toBe(
+      "https://app.example.com"
+    );
+  });
+});

--- a/apps/server/src/services/artifact-share-service.test.ts
+++ b/apps/server/src/services/artifact-share-service.test.ts
@@ -4,97 +4,93 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { resolveArtifactShareBaseUrl } from "./artifact-share-service";
 
+const SHARE_PUBLISH_URL =
+  "http://127.0.0.1:4310/v1/profiles/p1/artifacts/shares";
+
+function sharePublishRequest(init?: RequestInit): Request {
+  return new Request(SHARE_PUBLISH_URL, { method: "POST", ...init });
+}
+
+async function withEnv<T>(
+  vars: Record<string, string | undefined>,
+  run: () => T | Promise<T>
+): Promise<T> {
+  const previous = new Map(
+    Object.keys(vars).map((key) => [key, process.env[key]] as const)
+  );
+  for (const [key, value] of Object.entries(vars)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  try {
+    return await run();
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+async function withFreshConfigDir<T>(run: () => T | Promise<T>): Promise<T> {
+  const configDir = join(tmpdir(), `nakama-artifact-share-base-${Date.now()}`);
+  mkdirSync(configDir, { recursive: true });
+  try {
+    return await withEnv(
+      {
+        NAKAMA_CONFIG_DIR: configDir,
+        NAKAMA_PUBLIC_URL: undefined,
+        NAKAMA_WEB_PUBLIC_URL: undefined,
+      },
+      run
+    );
+  } finally {
+    rmSync(configDir, { force: true, recursive: true });
+  }
+}
+
 describe("resolveArtifactShareBaseUrl", () => {
   test("prefers explicit clientOrigin over loopback request URL", () => {
-    const request = new Request(
-      "http://127.0.0.1:4310/v1/profiles/p1/artifacts/shares",
-      { method: "POST" }
-    );
-
     expect(
       resolveArtifactShareBaseUrl({
         clientOrigin: "https://nakama.example.com/",
-        request,
+        request: sharePublishRequest(),
       })
     ).toBe("https://nakama.example.com");
   });
 
-  test("prefers configured web public URL when request host is loopback", () => {
-    const previous = process.env.NAKAMA_WEB_PUBLIC_URL;
-    process.env.NAKAMA_WEB_PUBLIC_URL = "https://deployed.example.com/";
-
-    try {
-      const request = new Request(
-        "http://127.0.0.1:4310/v1/profiles/p1/artifacts/shares",
-        { method: "POST" }
-      );
-
-      expect(resolveArtifactShareBaseUrl({ request })).toBe(
-        "https://deployed.example.com"
-      );
-    } finally {
-      if (previous === undefined) {
-        delete process.env.NAKAMA_WEB_PUBLIC_URL;
-      } else {
-        process.env.NAKAMA_WEB_PUBLIC_URL = previous;
+  test("prefers configured web public URL when request host is loopback", async () => {
+    await withEnv(
+      { NAKAMA_WEB_PUBLIC_URL: "https://deployed.example.com/" },
+      () => {
+        expect(
+          resolveArtifactShareBaseUrl({ request: sharePublishRequest() })
+        ).toBe("https://deployed.example.com");
       }
-    }
+    );
   });
 
-  test("keeps loopback when no configured web public URL exists", () => {
-    const configDir = join(
-      tmpdir(),
-      `nakama-artifact-share-base-${Date.now()}`
-    );
-    mkdirSync(configDir, { recursive: true });
-
-    const previousConfigDir = process.env.NAKAMA_CONFIG_DIR;
-    const previousWeb = process.env.NAKAMA_WEB_PUBLIC_URL;
-    const previousPublic = process.env.NAKAMA_PUBLIC_URL;
-    process.env.NAKAMA_CONFIG_DIR = configDir;
-    delete process.env.NAKAMA_WEB_PUBLIC_URL;
-    delete process.env.NAKAMA_PUBLIC_URL;
-
-    try {
-      const request = new Request(
-        "http://127.0.0.1:4310/v1/profiles/p1/artifacts/shares",
-        { method: "POST" }
-      );
-
-      expect(resolveArtifactShareBaseUrl({ request })).toBe(
-        "http://127.0.0.1:4310"
-      );
-    } finally {
-      if (previousConfigDir === undefined) {
-        delete process.env.NAKAMA_CONFIG_DIR;
-      } else {
-        process.env.NAKAMA_CONFIG_DIR = previousConfigDir;
-      }
-      if (previousWeb === undefined) {
-        delete process.env.NAKAMA_WEB_PUBLIC_URL;
-      } else {
-        process.env.NAKAMA_WEB_PUBLIC_URL = previousWeb;
-      }
-      if (previousPublic === undefined) {
-        delete process.env.NAKAMA_PUBLIC_URL;
-      } else {
-        process.env.NAKAMA_PUBLIC_URL = previousPublic;
-      }
-      rmSync(configDir, { force: true, recursive: true });
-    }
+  test("keeps loopback when no configured web public URL exists", async () => {
+    await withFreshConfigDir(() => {
+      expect(
+        resolveArtifactShareBaseUrl({ request: sharePublishRequest() })
+      ).toBe("http://127.0.0.1:4310");
+    });
   });
 
   test("reads Origin header from request when clientOrigin is absent", () => {
-    const request = new Request(
-      "http://127.0.0.1:4310/v1/profiles/p1/artifacts/shares",
-      {
-        headers: { Origin: "https://app.example.com" },
-        method: "POST",
-      }
-    );
-
-    expect(resolveArtifactShareBaseUrl({ request })).toBe(
-      "https://app.example.com"
-    );
+    expect(
+      resolveArtifactShareBaseUrl({
+        request: sharePublishRequest({
+          headers: { Origin: "https://app.example.com" },
+        }),
+      })
+    ).toBe("https://app.example.com");
   });
 });

--- a/apps/server/src/services/artifact-share-service.ts
+++ b/apps/server/src/services/artifact-share-service.ts
@@ -8,6 +8,7 @@ import {
   readArtifactFile,
   readArtifactShareSnapshot,
   resolveArtifactMimeType,
+  resolveWebPublicUrl,
   writeArtifactShareSnapshot,
 } from "@nakama/core";
 import type {
@@ -18,8 +19,33 @@ import type {
 } from "@nakama/core/contract";
 import type { DatabaseAdapter, StoredArtifactShareRecord } from "@nakama/db";
 import type { AuthService } from "./auth-service";
-import { resolveComposioCallbackBaseUrl } from "./composio-callback-url";
+import {
+  isLoopbackComposioCallbackBaseUrl,
+  resolveComposioCallbackBaseUrl,
+} from "./composio-callback-url";
 import { ProfileService } from "./profile-service";
+
+/** Share links must be reachable outside the API host (Discord/Telegram). */
+export function resolveArtifactShareBaseUrl(options: {
+  clientOrigin?: string;
+  request?: Request;
+}): string {
+  const resolved = resolveComposioCallbackBaseUrl({
+    clientOrigin: options.clientOrigin,
+    request: options.request,
+  });
+
+  if (!isLoopbackComposioCallbackBaseUrl(resolved)) {
+    return resolved;
+  }
+
+  const configured = resolveWebPublicUrl();
+  if (configured && !isLoopbackComposioCallbackBaseUrl(configured)) {
+    return configured;
+  }
+
+  return resolved;
+}
 
 export class ArtifactShareService {
   private readonly profileService: ProfileService;
@@ -36,6 +62,7 @@ export class ArtifactShareService {
     profileId: string;
     sourcePath: string;
     userId: string;
+    clientOrigin?: string;
     request?: Request;
   }): Promise<PublishArtifactShareResponse> {
     await this.requireProfile(input.orgId, input.profileId);
@@ -117,9 +144,12 @@ export class ArtifactShareService {
       await this.db.createArtifactShare(record);
     }
 
-    const baseUrl = resolveComposioCallbackBaseUrl({ request: input.request });
+    const baseUrl = resolveArtifactShareBaseUrl({
+      clientOrigin: input.clientOrigin,
+      request: input.request,
+    });
     const webPublicUrlConfigured = Boolean(
-      baseUrl && !baseUrl.includes("127.0.0.1")
+      baseUrl && !isLoopbackComposioCallbackBaseUrl(baseUrl)
     );
     const shareUrl = token
       ? `${baseUrl}${buildArtifactSharePath(token)}`
@@ -139,6 +169,7 @@ export class ArtifactShareService {
     orgId: string;
     profileId: string;
     sourcePath: string;
+    clientOrigin?: string;
     request?: Request;
   }): Promise<ArtifactShareStatusResponse | null> {
     await this.requireProfile(input.orgId, input.profileId);
@@ -153,9 +184,12 @@ export class ArtifactShareService {
       return null;
     }
 
-    const baseUrl = resolveComposioCallbackBaseUrl({ request: input.request });
+    const baseUrl = resolveArtifactShareBaseUrl({
+      clientOrigin: input.clientOrigin,
+      request: input.request,
+    });
     const webPublicUrlConfigured = Boolean(
-      baseUrl && !baseUrl.includes("127.0.0.1")
+      baseUrl && !isLoopbackComposioCallbackBaseUrl(baseUrl)
     );
 
     return {

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -313,3 +313,63 @@ test("notification destination client methods hit the expected routes", async ()
     "http://localhost:4310/v1/notification-destinations/dest_1"
   );
 });
+
+test("publishProfileArtifactShare includes clientOrigin when configured", async () => {
+  const fetchCalls: Array<{ input: RequestInfo | URL; init?: RequestInit }> =
+    [];
+  const client = createClient({
+    authToken: "local-auth-token",
+    baseUrl: "http://127.0.0.1:4310",
+    clientOrigin: "https://nakama.example.com/",
+    fetch: async (input, init) => {
+      fetchCalls.push({ init, input });
+      return Response.json({
+        id: "share_1",
+        refreshed: false,
+        sharePath: "/s/tok",
+        shareUrl: "https://nakama.example.com/s/tok",
+        token: "tok",
+        webPublicUrlConfigured: true,
+      });
+    },
+    orgId: "org_test",
+  });
+
+  await client.publishProfileArtifactShare("profile_1", "report.md");
+
+  expect(fetchCalls).toHaveLength(1);
+  expect(fetchCalls[0]!.input.toString()).toBe(
+    "http://127.0.0.1:4310/v1/profiles/profile_1/artifacts/shares"
+  );
+  expect(JSON.parse(fetchCalls[0]!.init?.body as string)).toEqual({
+    clientOrigin: "https://nakama.example.com",
+    path: "report.md",
+  });
+});
+
+test("publishProfileArtifactShare omits clientOrigin when unset", async () => {
+  const fetchCalls: Array<{ input: RequestInfo | URL; init?: RequestInit }> =
+    [];
+  const client = createClient({
+    authToken: "local-auth-token",
+    baseUrl: "http://127.0.0.1:4310",
+    fetch: async (input, init) => {
+      fetchCalls.push({ init, input });
+      return Response.json({
+        id: "share_1",
+        refreshed: false,
+        sharePath: "/s/tok",
+        shareUrl: null,
+        token: "tok",
+        webPublicUrlConfigured: false,
+      });
+    },
+    orgId: "org_test",
+  });
+
+  await client.publishProfileArtifactShare("profile_1", "report.md");
+
+  expect(JSON.parse(fetchCalls[0]!.init?.body as string)).toEqual({
+    path: "report.md",
+  });
+});

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -314,25 +314,38 @@ test("notification destination client methods hit the expected routes", async ()
   );
 });
 
-test("publishProfileArtifactShare includes clientOrigin when configured", async () => {
+function createPublishShareClient(options: {
+  clientOrigin?: string;
+  response: Record<string, unknown>;
+}) {
   const fetchCalls: Array<{ input: RequestInfo | URL; init?: RequestInit }> =
     [];
   const client = createClient({
     authToken: "local-auth-token",
     baseUrl: "http://127.0.0.1:4310",
-    clientOrigin: "https://nakama.example.com/",
+    ...(options.clientOrigin === undefined
+      ? {}
+      : { clientOrigin: options.clientOrigin }),
     fetch: async (input, init) => {
       fetchCalls.push({ init, input });
-      return Response.json({
-        id: "share_1",
-        refreshed: false,
-        sharePath: "/s/tok",
-        shareUrl: "https://nakama.example.com/s/tok",
-        token: "tok",
-        webPublicUrlConfigured: true,
-      });
+      return Response.json(options.response);
     },
     orgId: "org_test",
+  });
+  return { client, fetchCalls };
+}
+
+test("publishProfileArtifactShare includes clientOrigin when configured", async () => {
+  const { client, fetchCalls } = createPublishShareClient({
+    clientOrigin: "https://nakama.example.com/",
+    response: {
+      id: "share_1",
+      refreshed: false,
+      sharePath: "/s/tok",
+      shareUrl: "https://nakama.example.com/s/tok",
+      token: "tok",
+      webPublicUrlConfigured: true,
+    },
   });
 
   await client.publishProfileArtifactShare("profile_1", "report.md");
@@ -348,23 +361,15 @@ test("publishProfileArtifactShare includes clientOrigin when configured", async 
 });
 
 test("publishProfileArtifactShare omits clientOrigin when unset", async () => {
-  const fetchCalls: Array<{ input: RequestInfo | URL; init?: RequestInit }> =
-    [];
-  const client = createClient({
-    authToken: "local-auth-token",
-    baseUrl: "http://127.0.0.1:4310",
-    fetch: async (input, init) => {
-      fetchCalls.push({ init, input });
-      return Response.json({
-        id: "share_1",
-        refreshed: false,
-        sharePath: "/s/tok",
-        shareUrl: null,
-        token: "tok",
-        webPublicUrlConfigured: false,
-      });
+  const { client, fetchCalls } = createPublishShareClient({
+    response: {
+      id: "share_1",
+      refreshed: false,
+      sharePath: "/s/tok",
+      shareUrl: null,
+      token: "tok",
+      webPublicUrlConfigured: false,
     },
-    orgId: "org_test",
   });
 
   await client.publishProfileArtifactShare("profile_1", "report.md");

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -897,10 +897,15 @@ export class NakamaClient {
     profileId: string,
     path: string
   ): Promise<PublishArtifactShareResponse> {
+    const body: PublishArtifactShareRequest = { path };
+    if (this.clientOrigin) {
+      body.clientOrigin = this.clientOrigin;
+    }
+
     return this.request<PublishArtifactShareResponse>(
       `/v1/profiles/${encodeURIComponent(profileId)}/artifacts/shares`,
       {
-        body: JSON.stringify({ path } satisfies PublishArtifactShareRequest),
+        body: JSON.stringify(body),
         method: "POST",
       }
     );

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -1649,6 +1649,8 @@ export interface DeleteArtifactResponse {
 }
 
 export interface PublishArtifactShareRequest {
+  /** Public web origin for minting share URLs (workers; browsers send Origin). */
+  clientOrigin?: string;
   path: string;
 }
 


### PR DESCRIPTION
## Summary
- **Client:** `publishProfileArtifactShare` now sends `clientOrigin` in the request body when the client was constructed with one (Discord/Telegram workers set this from `resolveWebPublicUrl()`).
- **Server:** Artifact share minting threads `clientOrigin` through the route into `resolveArtifactShareBaseUrl`, which prefers an explicit/browser origin and, when the resolved base is loopback, falls back to `NAKAMA_WEB_PUBLIC_URL` / saved Web Public URL instead of minting `http://127.0.0.1:4310/s/…`. OAuth `resolveComposioCallbackBaseUrl` behavior is unchanged.
- **Discord:** `deliverDiscordArtifacts` posts share-link footers for all delivered artifacts (same as Telegram), not only attachment upload failures.

Closes #220

## Test plan
- [x] `bun test` packages/client — 16 pass
- [x] `bun test` packages/core (artifact shares + channel delivery) — 14 pass
- [x] `bun test` apps/server artifact-share + composio-callback suites — 14 pass
- [x] `bun test` apps/platform/discord — 76 pass
- [ ] Manual: Discord paired save-artifact turn with Web Public URL set → usable `https://…/s/{token}` footer (and attachment when Attach Files is allowed)


Made with [Cursor](https://cursor.com)