### PR TITLE
test(db): run the @nakama/db suite in CI

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -6,7 +6,8 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "build": "bun build ./src/index.ts --outdir dist --target bun"
+    "build": "bun build ./src/index.ts --outdir dist --target bun",
+    "test": "bun test"
   },
   "dependencies": {
     "@nakama/core": "workspace:*",

--- a/packages/db/src/reopen.test.ts
+++ b/packages/db/src/reopen.test.ts
@@ -14,6 +14,9 @@ describe("database reopen after restore", () => {
     }
   });
 
+  // Runs migrations twice against a real sqlite file. That is under a second locally but
+  // went past bun's 5s default on a CI runner building nine workspaces at once, and the
+  // ENOENT that followed was afterEach cleaning up underneath the timed-out body.
   test("reopen reads the replacement sqlite file at the same path", async () => {
     rootDir = await mkdtemp(join(tmpdir(), "nakama-db-reopen-"));
     const databaseUrl = `file:${join(rootDir, "sqlite", "nakama.sqlite")}`;
@@ -69,5 +72,5 @@ describe("database reopen after restore", () => {
     ).toBeNull();
 
     database.close();
-  });
+  }, 30_000);
 });


### PR DESCRIPTION
`bun run test` fans out to every workspace with a test script. `@nakama/db` did not have one, so its 55 tests have never run in CI.

Turning it on surfaced one failure, fixed here. The reopen test runs migrations twice against a real sqlite file. Under a second locally, past bun's 5s default on a runner building nine workspaces at once, and the ENOENT that followed was `afterEach` removing the temp dir underneath the timed-out body rather than a second fault. It gets 30s. It is the only test in the workspace over 100ms.

```
$ bun run test
@nakama/db test:  55 pass
@nakama/db test:  0 fail
```

Split out of #195 so that PR is only about crash reporting.
