### PR TITLE
feat: capture crashes with correlated request context

### DIFF
--- a/apps/platform/automation/src/index.ts
+++ b/apps/platform/automation/src/index.ts
@@ -3,13 +3,17 @@ import {
   clearAutomationWorkerHeartbeat,
   writeAutomationWorkerHeartbeat,
 } from "@nakama/core/automation-worker";
+import { installCrashHandlers } from "@nakama/core/crash-report";
 import {
   ensureServerRunning,
   stopSpawnedServer,
 } from "@nakama/core/ensure-server";
 import { loadLocalAuthToken } from "@nakama/core/local-auth";
+
 import { loadConfig } from "./config";
 import { AutomationWorkerScheduler } from "./scheduler";
+
+installCrashHandlers("worker:automation");
 
 let spawnedChild: Bun.Subprocess | null = null;
 let heartbeatTimer: ReturnType<typeof setInterval> | null = null;

--- a/apps/platform/discord/src/index.ts
+++ b/apps/platform/discord/src/index.ts
@@ -3,6 +3,7 @@ import {
   ChannelOrgStore,
   getChannelOrgSelectionPath,
 } from "@nakama/core/channel-org";
+import { installCrashHandlers } from "@nakama/core/crash-report";
 import {
   clearDiscordWorkerHeartbeat,
   isHeartbeatAlive,
@@ -15,11 +16,14 @@ import {
 } from "@nakama/core/ensure-server";
 import { loadLocalAuthToken } from "@nakama/core/local-auth";
 import { resolveWebPublicUrl } from "@nakama/core/runtime";
+
 import { DiscordAuthStore } from "./auth-store";
 import { createBot } from "./bot";
 import { loadConfig } from "./config";
 import { SessionStore } from "./session-store";
 import { ThreadStore } from "./thread-store";
+
+installCrashHandlers("worker:discord");
 
 let spawnedChild: Bun.Subprocess | null = null;
 let clientStop: (() => void) | null = null;

--- a/apps/platform/telegram/src/index.ts
+++ b/apps/platform/telegram/src/index.ts
@@ -3,6 +3,7 @@ import {
   ChannelOrgStore,
   getChannelOrgSelectionPath,
 } from "@nakama/core/channel-org";
+import { installCrashHandlers } from "@nakama/core/crash-report";
 import {
   ensureServerRunning,
   stopSpawnedServer,
@@ -19,6 +20,8 @@ import { TelegramAuthStore } from "./auth-store";
 import { createBot } from "./bot";
 import { loadConfig } from "./config";
 import { SessionStore } from "./session-store";
+
+installCrashHandlers("worker:telegram");
 
 let spawnedChild: Bun.Subprocess | null = null;
 let botStop: (() => void) | null = null;

--- a/apps/platform/whatsapp/src/index.ts
+++ b/apps/platform/whatsapp/src/index.ts
@@ -3,6 +3,7 @@ import {
   ChannelOrgStore,
   getChannelOrgSelectionPath,
 } from "@nakama/core/channel-org";
+import { reportError } from "@nakama/core/crash-report";
 import {
   ensureServerRunning,
   stopSpawnedServer,
@@ -17,6 +18,7 @@ import {
   writeWhatsAppWorkerHeartbeat,
 } from "@nakama/core/whatsapp-worker";
 import { WhatsAppAuthStore } from "./auth-store";
+
 import { createChatHandler } from "./chat-handler";
 import { loadConfig } from "./config";
 import { startWhatsAppOutboundServer } from "./outbound-server";
@@ -172,11 +174,15 @@ function registerProcessLifecycleLogging(): void {
     console.log(`WhatsApp worker exiting with code ${code}.`);
   });
 
+  // This worker keeps running after both, unlike the others, because listening at all
+  // suppresses Bun's exit(1). That predates crash reporting and is left alone here: a
+  // worker that survives in a broken state is caught by the heartbeat check, not by
+  // changing crash semantics underneath baileys.
   process.on("uncaughtException", (error) => {
-    console.error("WhatsApp worker uncaught exception.", error);
+    void reportError(error, { source: "worker:whatsapp" });
   });
 
   process.on("unhandledRejection", (reason) => {
-    console.error("WhatsApp worker unhandled rejection.", reason);
+    void reportError(reason, { source: "worker:whatsapp" });
   });
 }

--- a/apps/server/src/http/app.ts
+++ b/apps/server/src/http/app.ts
@@ -1,10 +1,17 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
 import { formatServerError, NakamaApiError } from "@nakama/core";
+import {
+  createCrashContext,
+  currentCrashContext,
+  reportError,
+  runWithCrashContext,
+} from "@nakama/core/crash-report";
 import { tryServeStaticWeb } from "../static-web";
 import { createAuthMiddleware } from "./auth-middleware";
 import type { ServerOptions } from "./context";
 import { serializeHttpOpenApiSpec } from "./openapi";
 import { createOrgContextMiddleware } from "./org-middleware";
+
 import { registerArtifactShareRoutes } from "./routes/artifact-shares";
 import { registerAuthRoutes } from "./routes/auth";
 import { registerAutomationRoutes } from "./routes/automations";
@@ -35,10 +42,35 @@ import { registerWorkerRoutes } from "./routes/workers";
 import { errorResponse } from "./shared";
 import type { HonoApp } from "./types";
 
+/**
+ * A rejected request is not a defect. Reporting 4xx would bury the real crashes under
+ * every bad password and malformed body a public endpoint attracts.
+ */
+function isExpectedClientError(error: unknown): boolean {
+  if (error instanceof NakamaApiError) {
+    return error.status < 500;
+  }
+
+  return error instanceof SyntaxError;
+}
+
 export function createHonoApp(options: ServerOptions) {
   const app: HonoApp = new OpenAPIHono();
 
-  app.onError((err) => {
+  app.onError((err, c) => {
+    // Hono calls onError from inside compose, so a middleware try/catch around next()
+    // never sees the error. This still runs inside the AsyncLocalStorage scope opened
+    // below, which is what keeps the request id and breadcrumbs attached.
+    if (!isExpectedClientError(err)) {
+      const context = currentCrashContext();
+
+      if (context) {
+        context.route = `${c.req.method} ${c.req.routePath}`;
+      }
+
+      void reportError(err, { source: "server" });
+    }
+
     if (err instanceof NakamaApiError) {
       return errorResponse(
         err.message,
@@ -94,6 +126,17 @@ export function createHonoApp(options: ServerOptions) {
     // Apply security headers to the final response
     const finalResponse = c.res;
     c.res = applySecurityHeaders(finalResponse);
+  });
+
+  app.use("*", async (c, next) => {
+    const context = createCrashContext({
+      requestId: c.req.header("x-request-id"),
+      source: "server",
+    });
+
+    c.header("x-request-id", context.requestId);
+
+    return runWithCrashContext(context, () => next());
   });
 
   app.use("*", createAuthMiddleware(options));

--- a/apps/server/src/http/crash-context.test.ts
+++ b/apps/server/src/http/crash-context.test.ts
@@ -1,0 +1,111 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  expect,
+  test,
+} from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type CrashReport, setCrashLogger } from "@nakama/core/crash-report";
+import { AuthService } from "../services/auth-service";
+import { createHonoApp } from "./app";
+
+const originalConfigDir = process.env.NAKAMA_CONFIG_DIR;
+let testConfigDir = "";
+let reports: CrashReport[] = [];
+
+beforeAll(() => {
+  testConfigDir = mkdtempSync(join(tmpdir(), "nakama-crash-http-"));
+  process.env.NAKAMA_CONFIG_DIR = testConfigDir;
+});
+
+afterAll(() => {
+  if (originalConfigDir === undefined) {
+    delete process.env.NAKAMA_CONFIG_DIR;
+  } else {
+    process.env.NAKAMA_CONFIG_DIR = originalConfigDir;
+  }
+
+  rmSync(testConfigDir, { force: true, recursive: true });
+});
+
+beforeEach(() => {
+  reports = [];
+  setCrashLogger((report) => {
+    reports.push(report);
+  });
+});
+
+afterEach(() => {
+  setCrashLogger(null);
+});
+
+function createApp(countHumanUsers: () => Promise<number>) {
+  return createHonoApp({
+    agent: { providerConfigured: true } as any,
+    authService: new AuthService(),
+    automationService: {} as any,
+    databaseAdapter: {
+      countHumanUsers,
+      countUsers: async () => 1,
+      getUserByEmail: async () => null,
+    } as any,
+    mcpService: {} as any,
+    orgService: {} as any,
+    systemStatus: { getStatus: async () => ({ ok: true }) } as any,
+    taskService: {} as any,
+    webDistDir: null,
+    workerManager: {} as any,
+  });
+}
+
+test("every response carries a request id", async () => {
+  const app = createApp(async () => 1);
+  const response = await app.fetch(new Request("http://localhost:4310/health"));
+
+  expect(response.status).toBe(200);
+  expect(response.headers.get("x-request-id")).toBeTruthy();
+});
+
+test("an inbound request id is kept so a client and server log line join up", async () => {
+  const app = createApp(async () => 1);
+  const response = await app.fetch(
+    new Request("http://localhost:4310/health", {
+      headers: { "x-request-id": "req-from-client" },
+    })
+  );
+
+  expect(response.headers.get("x-request-id")).toBe("req-from-client");
+});
+
+test("a server-side failure is reported with its route and request id", async () => {
+  const app = createApp(async () => {
+    throw new Error("database is gone");
+  });
+
+  const response = await app.fetch(
+    new Request("http://localhost:4310/health", {
+      headers: { "x-request-id": "req-crash" },
+    })
+  );
+
+  expect(response.status).toBe(500);
+  expect(reports).toHaveLength(1);
+  expect(reports[0]?.source).toBe("server");
+  expect(reports[0]?.requestId).toBe("req-crash");
+  expect(reports[0]?.route).toContain("/health");
+  expect(reports[0]?.fingerprint).toHaveLength(16);
+});
+
+test("a rejected request is not reported as a crash", async () => {
+  const app = createApp(async () => 1);
+  const response = await app.fetch(
+    new Request("http://localhost:4310/v1/system/status")
+  );
+
+  expect(response.status).toBe(401);
+  expect(reports).toHaveLength(0);
+});

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,8 +1,10 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { installCrashHandlers } from "@nakama/core/crash-report";
 import { ensureProcessPath } from "./lib/ensure-process-path";
 
 ensureProcessPath();
+installCrashHandlers("server");
 
 import { mergeOrgMemoryWithApprovedBullet } from "@nakama/agent";
 import {
@@ -22,6 +24,7 @@ import {
   ensureBundledSkillsAssigned,
   seedDatabase,
 } from "@nakama/db";
+
 import { createHonoApp } from "./http/app";
 import { AgentService } from "./services/agent-service";
 import { AuthService } from "./services/auth-service";

--- a/apps/server/src/services/worker-manager-service.test.ts
+++ b/apps/server/src/services/worker-manager-service.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, rm, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readWorkerDesiredState, setWorkerDesiredRunning } from "@nakama/core";
+import { type CrashReport, setCrashLogger } from "@nakama/core/crash-report";
 import { WorkerManagerService } from "./worker-manager-service";
 
 function createMockPm2() {
@@ -523,6 +524,36 @@ describe("WorkerManagerService", () => {
       await service.recoverDesiredWorkers();
 
       expect(mockPm2.start).not.toHaveBeenCalled();
+    });
+
+    test("a worker that stays down is reported, not just logged", async () => {
+      const reports: CrashReport[] = [];
+      setCrashLogger((report) => {
+        reports.push(report);
+      });
+
+      const mockPm2 = createMockPm2();
+      mockPm2.list = mock((cb: (err: Error | null, list: unknown[]) => void) =>
+        cb(null, [])
+      );
+      mockPm2.start = mock((_opts: unknown, cb: (err: Error | null) => void) =>
+        cb(new Error("PM2 start failed"))
+      );
+      const service = new WorkerManagerService(projectRoot, mockPm2);
+
+      try {
+        await setWorkerDesiredRunning("automation", false);
+        await setWorkerDesiredRunning("telegram", true);
+        await service.recoverDesiredWorkers();
+
+        // Nothing throws past the catch in recoverDesiredWorkers, so without a report the
+        // channel simply looks idle to the operator who enabled it.
+        expect(reports).toHaveLength(1);
+        expect(reports[0]?.kind).toBe("invariant");
+        expect(reports[0]?.message).toContain("telegram");
+      } finally {
+        setCrashLogger(null);
+      }
     });
   });
 

--- a/apps/server/src/services/worker-manager-service.ts
+++ b/apps/server/src/services/worker-manager-service.ts
@@ -8,6 +8,7 @@ import {
   readWorkerDesiredState,
   setWorkerDesiredRunning,
 } from "@nakama/core";
+import { reportInvariant } from "@nakama/core/crash-report";
 
 const WORKER_SCRIPTS: Record<string, string> = {
   automation: "apps/platform/automation/src/index.ts",
@@ -162,6 +163,14 @@ export class WorkerManagerService {
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         console.warn(`Could not recover ${name} worker: ${message}`);
+        // The operator asked for this worker and it is not running. Nothing throws past
+        // here, so without this the channel just stays quiet and looks idle.
+        void reportInvariant(
+          `${name} worker was enabled but could not be started`,
+          {
+            source: "server",
+          }
+        );
       }
     }
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,7 @@
     "./bridge-api": "./src/bridge-api.ts",
     "./channel-org": "./src/channel-org.ts",
     "./contract": "./src/contract.ts",
+    "./crash-report": "./src/crash-report.ts",
     "./chat-stream-timeout": "./src/chat-stream-timeout.ts",
     "./config": "./src/config.ts",
     "./fs": "./src/fs.ts",

--- a/packages/core/src/crash-report-handlers.test.ts
+++ b/packages/core/src/crash-report-handlers.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test";
+import { join } from "node:path";
+
+const MODULE = join(import.meta.dir, "crash-report.ts");
+
+/**
+ * The handlers call process.exit, so they cannot be exercised in-process: a passing
+ * assertion would take the test runner down with it. Each case runs in a real bun
+ * process and is judged on what an operator would actually see, the stderr line and
+ * the exit code.
+ */
+async function runCrashingProcess(body: string): Promise<{
+  exitCode: number;
+  stderr: string;
+}> {
+  const child = Bun.spawn(
+    [
+      "bun",
+      "-e",
+      `import { installCrashHandlers } from ${JSON.stringify(MODULE)};
+installCrashHandlers("worker:demo");
+${body}
+setTimeout(() => {}, 5000);`,
+    ],
+    { stderr: "pipe", stdout: "pipe" }
+  );
+
+  const stderr = await new Response(child.stderr).text();
+
+  return { exitCode: await child.exited, stderr };
+}
+
+test("an uncaught exception is logged with a fingerprint and exits non-zero", async () => {
+  const { exitCode, stderr } = await runCrashingProcess(
+    `setTimeout(() => {
+      throw new Error("worker lost its connection");
+    }, 0);`
+  );
+
+  expect(exitCode).toBe(1);
+  expect(stderr).toContain("[nakama:crash] worker:demo");
+  expect(stderr).toContain("worker lost its connection");
+});
+
+test("an unhandled rejection is reported the same way", async () => {
+  const { exitCode, stderr } = await runCrashingProcess(
+    `Promise.reject(new Error("nobody awaited this"));`
+  );
+
+  expect(exitCode).toBe(1);
+  expect(stderr).toContain("[nakama:crash] worker:demo");
+  expect(stderr).toContain("nobody awaited this");
+});
+
+test("the same bug in two runs reports the same fingerprint", async () => {
+  const crash = `setTimeout(() => {
+    throw new Error("worker lost its connection");
+  }, 0);`;
+  const first = await runCrashingProcess(crash);
+  const second = await runCrashingProcess(crash);
+
+  const fingerprint = (stderr: string) =>
+    stderr.match(/\[nakama:crash\] worker:demo (\w{16})/)?.[1];
+
+  expect(fingerprint(first.stderr)).toBeDefined();
+  expect(fingerprint(first.stderr)).toBe(fingerprint(second.stderr));
+});

--- a/packages/core/src/crash-report-scrub.test.ts
+++ b/packages/core/src/crash-report-scrub.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "bun:test";
+import { homedir } from "node:os";
+import { hashId, scrubText } from "./crash-report";
+
+/**
+ * These assert the negative side: given a payload that carries real secrets, none of
+ * them may survive. A crash report leaves the user's machine and carries their org's
+ * data, so a regression here is a third-party data incident, not a telemetry bug.
+ */
+describe("scrubText removes credentials", () => {
+  const cases: Array<[string, string]> = [
+    [
+      "anthropic key",
+      "failed with sk-ant-api03-abcdefghijklmnopqrstuvwxyz012345",
+    ],
+    ["openai key", "Authorization header sk-proj-AAAABBBBCCCCDDDDEEEEFFFF"],
+    ["github token", "clone failed ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"],
+    ["slack token", "post failed xoxb-1234567890-ABCDEFGHIJKL"],
+    ["aws key id", "denied for AKIAIOSFODNN7EXAMPLE"],
+    [
+      "bearer header",
+      "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+    ],
+    ["assignment", 'connect({ apiKey: "hunter2secretvalue" })'],
+    ["env style", "ANTHROPIC_TOKEN=abcd1234efgh5678"],
+  ];
+
+  for (const [name, input] of cases) {
+    test(name, () => {
+      const scrubbed = scrubText(input);
+
+      expect(scrubbed).not.toContain(
+        "sk-ant-api03-abcdefghijklmnopqrstuvwxyz012345"
+      );
+      expect(scrubbed).not.toContain("sk-proj-AAAABBBBCCCCDDDDEEEEFFFF");
+      expect(scrubbed).not.toContain(
+        "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+      );
+      expect(scrubbed).not.toContain("xoxb-1234567890-ABCDEFGHIJKL");
+      expect(scrubbed).not.toContain("AKIAIOSFODNN7EXAMPLE");
+      expect(scrubbed).not.toContain("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9");
+      expect(scrubbed).not.toContain("hunter2secretvalue");
+      expect(scrubbed).not.toContain("abcd1234efgh5678");
+    });
+  }
+});
+
+test("scrubText removes URI passwords", () => {
+  const scrubbed = scrubText(
+    "connect failed postgres://alice:s3cret-pass@db.internal:5432/app"
+  );
+
+  expect(scrubbed).not.toContain("s3cret-pass");
+  expect(scrubbed).not.toContain("alice");
+  expect(scrubbed).toContain("postgres://<redacted>:<redacted>@");
+});
+
+test("scrubText removes HTTP Basic credentials", () => {
+  const scrubbed = scrubText(
+    "upstream said Authorization: Basic YWxpY2U6c2VjcmV0"
+  );
+
+  expect(scrubbed).not.toContain("YWxpY2U6c2VjcmV0");
+  expect(scrubbed.toLowerCase()).toContain("authorization");
+});
+
+test("scrubText removes Slack webhook URLs", () => {
+  const scrubbed = scrubText(
+    "post failed https://hooks.slack.com/services/T00/B00/XXXX"
+  );
+
+  expect(scrubbed).not.toContain("T00/B00/XXXX");
+  expect(scrubbed).toContain("hooks.slack.com/services/<redacted>");
+});
+
+test("scrubText removes email addresses", () => {
+  const scrubbed = scrubText("owner alice@example.com could not be notified");
+
+  expect(scrubbed).not.toContain("alice@example.com");
+  expect(scrubbed).toContain("<email>");
+});
+
+test("scrubText replaces the home directory with a tilde", () => {
+  const scrubbed = scrubText(`ENOENT at ${homedir()}/.nakama/config.ini`);
+
+  expect(scrubbed).not.toContain(homedir());
+  expect(scrubbed).toContain("~/.nakama/config.ini");
+});
+
+test("scrubText replaces home paths belonging to another user", () => {
+  const scrubbed = scrubText(
+    "read failed: /Users/someoneelse/.nakama/orgs/a.db"
+  );
+
+  expect(scrubbed).not.toContain("someoneelse");
+  expect(scrubbed).toContain("~/.nakama/orgs/a.db");
+});
+
+test("scrubText keeps the diagnostic parts of a stack frame", () => {
+  const scrubbed = scrubText(
+    "TypeError: cannot read tools at resolveTools (~/src/a.ts:12:3)"
+  );
+
+  expect(scrubbed).toContain("TypeError");
+  expect(scrubbed).toContain("resolveTools");
+  expect(scrubbed).toContain("a.ts:12:3");
+});
+
+describe("scrubText removes the data an error message quotes back", () => {
+  test("a printed JSON payload does not survive", () => {
+    const scrubbed = scrubText(
+      'Unexpected token in {"name":"Budi","email":"budi@klinik.example","age":34}'
+    );
+
+    expect(scrubbed).not.toContain("Budi");
+    expect(scrubbed).not.toContain("klinik");
+    expect(scrubbed).toContain("Unexpected token in");
+  });
+
+  test("a nested payload does not survive either", () => {
+    const scrubbed = scrubText(
+      'failed on {"patient":{"name":"Budi","room":"A1"}}'
+    );
+
+    expect(scrubbed).not.toContain("Budi");
+    expect(scrubbed).not.toContain("A1");
+  });
+
+  test("a rejected value in double quotes does not survive", () => {
+    const scrubbed = scrubText('Invalid value "Budi" for field name');
+
+    expect(scrubbed).not.toContain("Budi");
+    expect(scrubbed).toContain("for field name");
+  });
+
+  test("a printed row does not survive", () => {
+    const scrubbed = scrubText("constraint failed for ['Budi', 34, 'jakarta']");
+
+    expect(scrubbed).not.toContain("Budi");
+    expect(scrubbed).not.toContain("jakarta");
+  });
+
+  test("single-quoted identifiers stay readable, which is the whole trade", () => {
+    expect(scrubText("Cannot find module 'crash-report'")).toContain(
+      "'crash-report'"
+    );
+    expect(
+      scrubText("Cannot read property 'sessionId' of undefined")
+    ).toContain("'sessionId'");
+  });
+
+  test("an apostrophe in prose is not treated as a quote", () => {
+    const scrubbed = scrubText("the worker didn't start and it's still down");
+
+    expect(scrubbed).toBe("the worker didn't start and it's still down");
+  });
+});
+
+test("scrubText truncates runaway text", () => {
+  const scrubbed = scrubText("x".repeat(10_000));
+
+  expect(scrubbed.length).toBeLessThanOrEqual(4001);
+});
+
+describe("hashId", () => {
+  test("is stable and does not leak the input", () => {
+    const id = "org_01JABCDEF";
+
+    expect(hashId(id)).toBe(hashId(id));
+    expect(hashId(id)).not.toContain(id);
+    expect(hashId(id)).toHaveLength(12);
+  });
+
+  test("is undefined for empty input", () => {
+    expect(hashId("")).toBeUndefined();
+    expect(hashId(null)).toBeUndefined();
+  });
+});

--- a/packages/core/src/crash-report.test.ts
+++ b/packages/core/src/crash-report.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import {
+  breadcrumb,
+  buildCrashReport,
+  type CrashReport,
+  createCrashContext,
+  currentCrashContext,
+  fingerprintError,
+  MAX_BREADCRUMBS,
+  reportError,
+  reportInvariant,
+  runWithCrashContext,
+  setCrashContextIds,
+  setCrashLogger,
+} from "./crash-report";
+
+beforeEach(() => {
+  setCrashLogger(() => {});
+});
+
+afterEach(() => {
+  setCrashLogger(null);
+});
+
+test("breadcrumbs are scoped to the running context", () => {
+  const context = createCrashContext({
+    route: "POST /v1/sessions",
+    source: "server",
+  });
+
+  runWithCrashContext(context, () => {
+    breadcrumb("route.enter");
+    expect(currentCrashContext()).toBe(context);
+  });
+
+  expect(context.breadcrumbs).toHaveLength(1);
+  expect(context.breadcrumbs[0]?.kind).toBe("route.enter");
+});
+
+test("breadcrumb outside a context is a no-op rather than a throw", () => {
+  expect(() => breadcrumb("orphan")).not.toThrow();
+});
+
+test("the breadcrumb buffer is bounded and keeps the most recent entries", () => {
+  const context = createCrashContext({ source: "server" });
+
+  runWithCrashContext(context, () => {
+    for (let index = 0; index < MAX_BREADCRUMBS + 10; index += 1) {
+      breadcrumb(`tool.call.${index}`);
+    }
+  });
+
+  expect(context.breadcrumbs).toHaveLength(MAX_BREADCRUMBS);
+  expect(context.breadcrumbs[0]?.kind).toBe("tool.call.10");
+  expect(context.breadcrumbs.at(-1)?.kind).toBe(
+    `tool.call.${MAX_BREADCRUMBS + 9}`
+  );
+});
+
+test("context ids are hashed, never carried raw", () => {
+  const context = createCrashContext({ source: "server" });
+
+  runWithCrashContext(context, () => {
+    setCrashContextIds({
+      orgId: "org_realid",
+      sessionId: null,
+      userId: "usr_realid",
+    });
+  });
+
+  const serialized = JSON.stringify(
+    buildCrashReport(new Error("boom"), { context })
+  );
+
+  expect(serialized).not.toContain("org_realid");
+  expect(serialized).not.toContain("usr_realid");
+  expect(context.orgIdHash).toHaveLength(12);
+  expect(context.sessionIdHash).toBeUndefined();
+});
+
+test("the same bug fingerprints the same across ids and line numbers", () => {
+  const first = fingerprintError(
+    "TypeError",
+    "profile prof_01JABCDEF23 not found",
+    "TypeError\n    at resolveProfile (~/src/profiles.ts:12:3)"
+  );
+  const second = fingerprintError(
+    "TypeError",
+    "profile prof_01JXYZGHI45 not found",
+    "TypeError\n    at resolveProfile (~/src/profiles.ts:48:9)"
+  );
+
+  expect(first).toBe(second);
+});
+
+test("a uuid in the message does not fragment the fingerprint", () => {
+  const stack = "Error\n    at runAutomation (~/src/automation.ts:20:5)";
+  const first = fingerprintError(
+    "Error",
+    "run 3f2504e0-4f89-11d3-9a0c-0305e82c3301 timed out after 30000ms",
+    stack
+  );
+  const second = fingerprintError(
+    "Error",
+    "run 7c9e6679-7425-40de-944b-e07fc1f90ae7 timed out after 45000ms",
+    stack
+  );
+
+  expect(first).toBe(second);
+});
+
+test("different bugs fingerprint differently", () => {
+  const first = fingerprintError(
+    "TypeError",
+    "a is undefined",
+    "TypeError\n    at a (~/a.ts:1:1)"
+  );
+  const second = fingerprintError(
+    "RangeError",
+    "b is out of range",
+    "RangeError\n    at b (~/b.ts:1:1)"
+  );
+
+  expect(first).not.toBe(second);
+});
+
+test("the report scrubs the message and stack", () => {
+  const error = new Error(
+    "auth failed with sk-ant-api03-abcdefghijklmnopqrstuvwxyz012345"
+  );
+  const report = buildCrashReport(error, { source: "server" });
+
+  expect(report.message).not.toContain("sk-ant-api03");
+  expect(report.name).toBe("Error");
+  expect(report.runtime.bun).toBe(Bun.version);
+});
+
+test("a non-Error rejection still produces a report", () => {
+  const report = buildCrashReport("plain string failure", {
+    source: "worker:discord",
+  });
+
+  expect(report.name).toBe("NonError");
+  expect(report.message).toBe("plain string failure");
+  expect(report.fingerprint).toHaveLength(16);
+});
+
+test("a logger that throws never surfaces to the caller", async () => {
+  setCrashLogger(() => {
+    throw new Error("logger is down");
+  });
+
+  await expect(
+    reportError(new Error("boom"), { source: "server" })
+  ).resolves.toBeDefined();
+});
+
+test("the local log always runs", async () => {
+  const logged: CrashReport[] = [];
+  setCrashLogger((report) => {
+    logged.push(report);
+  });
+
+  await reportError(new Error("boom"), { source: "cli" });
+
+  expect(logged).toHaveLength(1);
+  expect(logged[0]?.source).toBe("cli");
+});
+
+test("reportInvariant marks the report as an unmet expectation", async () => {
+  const report = await reportInvariant("automation run never completed", {
+    source: "worker:automation",
+  });
+
+  expect(report.kind).toBe("invariant");
+  expect(report.message).toBe("automation run never completed");
+});
+
+test("the report carries the request id and route for correlation", async () => {
+  const context = createCrashContext({
+    requestId: "req-123",
+    route: "POST /v1/sessions",
+    source: "server",
+  });
+
+  const report = await runWithCrashContext(context, () =>
+    reportError(new Error("boom"))
+  );
+
+  expect(report.requestId).toBe("req-123");
+  expect(report.route).toBe("POST /v1/sessions");
+  expect(report.source).toBe("server");
+});

--- a/packages/core/src/crash-report.ts
+++ b/packages/core/src/crash-report.ts
@@ -1,0 +1,353 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { createHash, randomUUID } from "node:crypto";
+import { homedir } from "node:os";
+import { NAKAMA_API_VERSION } from "./contract";
+
+export type CrashReportKind = "crash" | "invariant";
+export type CrashLogger = (report: CrashReport, error: unknown) => void;
+
+export const MAX_BREADCRUMBS = 50;
+
+export type Breadcrumb = { at: number; kind: string };
+export type CrashContext = {
+  breadcrumbs: Breadcrumb[];
+  orgIdHash?: string;
+  requestId: string;
+  route?: string;
+  sessionIdHash?: string;
+  source: string;
+  userIdHash?: string;
+};
+export type CrashReport = {
+  at: string;
+  breadcrumbs: Breadcrumb[];
+  fingerprint: string;
+  kind: CrashReportKind;
+  message: string;
+  name: string;
+  orgIdHash?: string;
+  requestId?: string;
+  route?: string;
+  runtime: { apiVersion: number; bun: string; platform: string; arch: string };
+  sessionIdHash?: string;
+  source: string;
+  stack?: string;
+  userIdHash?: string;
+};
+export type ReportErrorOptions = {
+  context?: CrashContext;
+  kind?: CrashReportKind;
+  source?: string;
+};
+
+const storage = new AsyncLocalStorage<CrashContext>();
+const installedSources = new Set<string>();
+const MAX_TEXT_LENGTH = 4000;
+const SECRET_PATTERNS: Array<[RegExp, string]> = [
+  [/\bBearer\s+[A-Za-z0-9._~+/-]{8,}={0,2}/gi, "Bearer <redacted>"],
+  [
+    /\b((?:Proxy-)?Authorization:\s*Basic\s+)[A-Za-z0-9+/=_-]+/gi,
+    "$1<redacted>",
+  ],
+  [/\bsk-[A-Za-z0-9_-]{8,}/g, "<redacted-key>"],
+  [/\bgh[pousr]_[A-Za-z0-9]{16,}/g, "<redacted-key>"],
+  [/\bxox[baprs]-[A-Za-z0-9-]{8,}/g, "<redacted-key>"],
+  [/\bAKIA[0-9A-Z]{16}\b/g, "<redacted-key>"],
+  [
+    /hooks\.slack\.com\/services\/[A-Za-z0-9/_-]+/gi,
+    "hooks.slack.com/services/<redacted>",
+  ],
+  [
+    /([A-Za-z][A-Za-z0-9+.-]*:\/\/)([^/\s:@]+):([^/\s@]+)@/g,
+    "$1<redacted>:<redacted>@",
+  ],
+  [
+    /([A-Za-z0-9_]*(?:api[_-]?key|apikey|token|secret|passwd|password|authorization|credential))(["']?\s*[:=]\s*["']?)([^\s"',;)}]{3,})/gi,
+    "$1$2<redacted>",
+  ],
+  [/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, "<email>"],
+  [/\b[A-Za-z0-9_-]{32,}\b/g, "<redacted-token>"],
+];
+
+let logger: CrashLogger = defaultLogger;
+
+export function hashId(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+
+  return trimmed
+    ? createHash("sha256").update(trimmed).digest("hex").slice(0, 12)
+    : undefined;
+}
+
+/**
+ * Allowlisting what may leave would mean knowing every shape an error message can
+ * take, so this denies instead: anything quoted, bracketed or braced is a payload
+ * until proven otherwise. It over-redacts, which is the side to be wrong on.
+ */
+export function scrubText(value: string): string {
+  if (!value) {
+    return "";
+  }
+
+  let out = value;
+  const home = homedir();
+
+  if (home && home !== "/") {
+    out = out.split(home).join("~");
+  }
+
+  for (const [pattern, replacement] of SECRET_PATTERNS) {
+    out = out.replace(pattern, replacement);
+  }
+
+  out = out
+    .replace(/\/(?:Users|home)\/[^/\s:"']+/g, "~")
+    .replace(/[A-Za-z]:\\Users\\[^\\\s:"']+/g, "~")
+    .replace(/"[^"\n]*"/g, '"<redacted>"');
+
+  // Nested structures need more than one pass, but a hostile payload should not
+  // decide how many. Four collapses anything realistic.
+  for (let pass = 0; pass < 4; pass += 1) {
+    const next = out
+      .replace(/\{[^{}]*\}/g, "<redacted>")
+      .replace(/\[[^[\]]*\]/g, "<redacted>");
+
+    if (next === out) {
+      break;
+    }
+
+    out = next;
+  }
+
+  return out.length > MAX_TEXT_LENGTH
+    ? `${out.slice(0, MAX_TEXT_LENGTH)}…`
+    : out;
+}
+
+export function createCrashContext(seed: {
+  source: string;
+  requestId?: string;
+  route?: string;
+}): CrashContext {
+  return {
+    breadcrumbs: [],
+    requestId: seed.requestId?.trim() || randomUUID(),
+    source: seed.source,
+    ...(seed.route ? { route: seed.route } : {}),
+  };
+}
+
+export function runWithCrashContext<T>(context: CrashContext, fn: () => T): T {
+  return storage.run(context, fn);
+}
+
+export function currentCrashContext(): CrashContext | undefined {
+  return storage.getStore();
+}
+
+export function setCrashContextIds(ids: {
+  orgId?: string | null;
+  userId?: string | null;
+  sessionId?: string | null;
+}): void {
+  const context = storage.getStore();
+
+  if (!context) {
+    return;
+  }
+
+  const orgIdHash = hashId(ids.orgId);
+  const userIdHash = hashId(ids.userId);
+  const sessionIdHash = hashId(ids.sessionId);
+
+  if (orgIdHash) {
+    context.orgIdHash = orgIdHash;
+  }
+
+  if (userIdHash) {
+    context.userIdHash = userIdHash;
+  }
+
+  if (sessionIdHash) {
+    context.sessionIdHash = sessionIdHash;
+  }
+}
+
+/**
+ * Kind only. A breadcrumb carrying data would be the one place user content enters a
+ * report without passing the scrubber.
+ */
+export function breadcrumb(kind: string): void {
+  const context = storage.getStore();
+
+  if (!context) {
+    return;
+  }
+
+  context.breadcrumbs.push({ at: Date.now(), kind });
+
+  if (context.breadcrumbs.length > MAX_BREADCRUMBS) {
+    context.breadcrumbs.shift();
+  }
+}
+
+/**
+ * Normalizes ids, uuids, quoted strings and numbers out of the message so one bug
+ * stays one fingerprint across installs and releases.
+ */
+export function fingerprintError(
+  name: string,
+  message: string,
+  stack: string | undefined
+): string {
+  const normalized = message
+    .replace(
+      /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi,
+      "<uuid>"
+    )
+    .replace(
+      /\b(?=[A-Za-z0-9_-]*\d)(?=[A-Za-z0-9_-]*[A-Za-z])[A-Za-z0-9_-]{8,}\b/g,
+      "<id>"
+    )
+    .replace(/'[^']*'|"[^"]*"/g, "<str>")
+    .replace(/\d+/g, "<n>")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  let frame = "";
+
+  if (stack) {
+    for (const line of stack.split("\n").slice(1)) {
+      const trimmed = line.trim();
+
+      if (
+        trimmed.startsWith("at ") &&
+        !trimmed.includes("node_modules") &&
+        !trimmed.includes("node:")
+      ) {
+        frame = trimmed.replace(/:\d+:\d+(\)?)$/, "$1").replace(/\s+/g, " ");
+        break;
+      }
+    }
+  }
+
+  return createHash("sha256")
+    .update([name, normalized, frame].join("|"))
+    .digest("hex")
+    .slice(0, 16);
+}
+
+export function buildCrashReport(
+  error: unknown,
+  options: ReportErrorOptions = {}
+): CrashReport {
+  const context = options.context ?? storage.getStore();
+  let name = "NonError";
+  let message: string;
+  let stack: string | undefined;
+
+  if (error instanceof Error) {
+    name = error.name || "Error";
+    message = error.message || String(error);
+    stack = error.stack;
+  } else if (typeof error === "string") {
+    message = error;
+  } else {
+    try {
+      message = JSON.stringify(error) ?? String(error);
+    } catch {
+      message = String(error);
+    }
+  }
+
+  const scrubbedStack = stack ? scrubText(stack) : undefined;
+
+  // Fingerprinted before scrubbing, so redaction cannot merge two distinct bugs.
+  return {
+    at: new Date().toISOString(),
+    breadcrumbs: context?.breadcrumbs ? [...context.breadcrumbs] : [],
+    fingerprint: fingerprintError(name, message, stack),
+    kind: options.kind ?? "crash",
+    message: scrubText(message),
+    name,
+    runtime: {
+      apiVersion: NAKAMA_API_VERSION,
+      arch: process.arch,
+      bun: Bun.version,
+      platform: process.platform,
+    },
+    source: options.source ?? context?.source ?? "unknown",
+    ...(scrubbedStack ? { stack: scrubbedStack } : {}),
+    ...(context?.requestId ? { requestId: context.requestId } : {}),
+    ...(context?.route ? { route: context.route } : {}),
+    ...(context?.orgIdHash ? { orgIdHash: context.orgIdHash } : {}),
+    ...(context?.userIdHash ? { userIdHash: context.userIdHash } : {}),
+    ...(context?.sessionIdHash ? { sessionIdHash: context.sessionIdHash } : {}),
+  };
+}
+
+function defaultLogger(report: CrashReport, error: unknown): void {
+  console.error(
+    `[nakama:${report.kind}] ${report.source} ${report.fingerprint}` +
+      `${report.requestId ? ` req=${report.requestId}` : ""}` +
+      `${report.route ? ` route=${report.route}` : ""}`,
+    error
+  );
+}
+
+export function setCrashLogger(next: CrashLogger | null): void {
+  logger = next ?? defaultLogger;
+}
+
+/**
+ * The one entry point. Always logs locally and in full; the scrubbed report is what a
+ * later change may ship somewhere else.
+ */
+export async function reportError(
+  error: unknown,
+  options: ReportErrorOptions = {}
+): Promise<CrashReport> {
+  const report = buildCrashReport(error, options);
+
+  try {
+    logger(report, error);
+  } catch {
+    // A broken logger must not take the process down on top of the original error.
+  }
+
+  return report;
+}
+
+/**
+ * For failures that never throw: a worker that did not start, a run that never
+ * finished. Users notice these and never report them.
+ */
+export async function reportInvariant(
+  message: string,
+  options: Omit<ReportErrorOptions, "kind"> = {}
+): Promise<CrashReport> {
+  return reportError(new Error(message), { ...options, kind: "invariant" });
+}
+
+export function installCrashHandlers(source: string): () => void {
+  if (installedSources.has(source)) {
+    return () => {};
+  }
+
+  installedSources.add(source);
+
+  const onCrash = (error: unknown) => {
+    void reportError(error, { source }).finally(() => {
+      process.exit(1);
+    });
+  };
+
+  process.on("uncaughtException", onCrash);
+  process.on("unhandledRejection", onCrash);
+
+  return () => {
+    process.off("uncaughtException", onCrash);
+    process.off("unhandledRejection", onCrash);
+    installedSources.delete(source);
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,7 @@ export * from "./composio";
 export * from "./composio-config";
 export * from "./config";
 export * from "./contract";
+export * from "./crash-report";
 export {
   DISCORD_ARTIFACT_ATTACHMENT_MAX_BYTES,
   formatDiscordAttachmentSizeLimitMessage,


### PR DESCRIPTION
First half of #195, which was 2000 lines and hard to review in one go. This half is the capture side and **nothing leaves the machine**: no sink, no consent file, no endpoint, no network call anywhere in the diff. Consent and delivery follow in a second PR once this lands.

Today only the whatsapp worker listens for uncaught exceptions, and no request carries an id, so "it broke" has nothing to reproduce from.

What this adds:

- An `AsyncLocalStorage` context per request: request id (echoed as `x-request-id`), hashed org/user/session ids, a bounded breadcrumb buffer of kinds only. Dropped when the request succeeds, so the happy path writes nothing.
- One `reportError` entry point that logs locally in full. Process handlers on the server, the CLI and the platform workers.
- Scrubbing on every report, with negative-side tests. The scrubber has to be right before anything can be built on it.
- 4xx is not reported, or real crashes drown under every bad password a public endpoint attracts.
- One failure that never throws: an enabled worker that could not start, which previously only `console.warn`'d and left the channel looking idle.

The whatsapp worker keeps its survive-after-crash behavior; only reporting was added there.

## What it looks like

Real run against the app this PR builds. Stack frames trimmed, nothing else edited.

```
$ curl -i localhost:4310/health
HTTP 200
x-request-id: eb9d02ad-5709-4389-9209-c3c7545dd105

$ curl -i -H 'x-request-id: from-the-client' localhost:4310/health
x-request-id: from-the-client

$ curl -i -H 'x-request-id: from-the-client' localhost:4310/health   # database down
[nakama:crash] server 0e47dc80609b0286 req=from-the-client route=GET /health
error: connect ECONNREFUSED 127.0.0.1:5432
      at .../apps/server/src/http/routes/system.ts:173:52
      at .../apps/server/src/http/app.ts:139:12
HTTP 500

$ curl -i localhost:4310/v1/system/status   # no credentials
HTTP 401  (nothing logged: 4xx is not a defect)

$ bun worker.ts   # uncaught exception in a platform worker
[nakama:crash] worker:telegram bac8c71682eb6160
error: bot polling died
exit code: 1
```

`0e47dc80609b0286` is the fingerprint, and `req=from-the-client` is the id the caller sent, so a user's "it broke at 14:03" and a server log line join up without asking them for anything. The full unscrubbed error stays in the local log; only the report copy is redacted.

`installCrashHandlers` was the one path a normal test cannot reach, since it calls `process.exit` and would take the runner with it. `crash-report-handlers.test.ts` runs each case in a real bun process and asserts on the stderr line and the exit code, including that the same bug fingerprints identically across two runs.

```
$ bun run test
@nakama/core test:  581 pass, 0 fail
@nakama/server test:  720 pass, 0 fail
```
plus agent, cli, telegram, discord, whatsapp, automation, all 0 fail.
