### PR TITLE
fix(web): restore artifacts infinite query type inference

### DIFF
--- a/apps/web/src/hooks/use-resource-mutations.ts
+++ b/apps/web/src/hooks/use-resource-mutations.ts
@@ -464,7 +464,7 @@ export function useArtifactsInfiniteQuery(profileId: string | null) {
       return nextOffset < lastPage.total ? nextOffset : undefined;
     },
     initialPageParam: 0,
-    queryFn: ({ pageParam }) =>
+    queryFn: ({ pageParam }: { pageParam: number }) =>
       client.listProfileArtifacts(profileId!, {
         limit: ARTIFACTS_PAGE_SIZE,
         offset: pageParam,


### PR DESCRIPTION
## Summary
- Fix `useArtifactsInfiniteQuery` TypeScript inference under `@tanstack/react-query` 5.100.14 + TypeScript 5.9.3 by annotating `pageParam` on the `queryFn` context (destructured inference was falling back to `unknown`).
- Unblocks the Docker Publish workflow web build (`tsc --noEmit && vite build`), which failed on run [31353478752](https://github.com/ahmadrosid/nakama/actions/runs/31353478752) after #212.

## Test plan
- [x] `bun run --filter @nakama/web build` exits 0
- [x] `bunx tsc --noEmit` in `apps/web` reports zero errors
- [ ] Confirm Docker Publish workflow passes on this PR


Made with [Cursor](https://cursor.com)