### PR TITLE
feat(server): env-gated first-boot seed so managed instances skip the setup wizard

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -23,6 +23,7 @@ import {
   seedDatabase,
 } from "@nakama/db";
 import { createHonoApp } from "./http/app";
+import { runFirstBootSeed } from "./seed";
 import { AgentService } from "./services/agent-service";
 import { AuthService } from "./services/auth-service";
 import { AutomationDeliveryService } from "./services/automation-delivery-service";
@@ -175,6 +176,15 @@ const skillSuggestionService = new SkillSuggestionService(
   skillProposalService
 );
 agent.setSkillSuggestionService(skillSuggestionService);
+
+const seedResult = await runFirstBootSeed({
+  authService,
+  databaseAdapter: database.adapter,
+  orgService,
+});
+if (seedResult.providerWritten) {
+  await agent.reloadAfterDataRestore();
+}
 
 const systemStatus = new SystemStatusService(
   agent,

--- a/apps/server/src/seed.test.ts
+++ b/apps/server/src/seed.test.ts
@@ -199,6 +199,10 @@ describe("runFirstBootSeed", () => {
     });
     expect(result.seeded).toBe(true);
 
+    const org =
+      await services.databaseAdapter.getOrganizationBySlug("personal");
+    expect(org?.name).toBe("Personal");
+
     const userConfig = await loadUserConfig();
     const provider = createProviderFromSources(process.env, userConfig);
     const { app } = createMinimalHonoApp({

--- a/apps/server/src/seed.test.ts
+++ b/apps/server/src/seed.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createProviderInstanceId,
+  isProviderConfigured,
+  loadUserConfig,
+  saveUserConfig,
+} from "@nakama/core";
+import { createInMemoryDatabaseAdapter } from "@nakama/db";
+import { createMinimalHonoApp } from "./http/test-app-helpers";
+import { createProviderFromSources } from "./providers";
+import { runFirstBootSeed } from "./seed";
+import { AuthService } from "./services/auth-service";
+import { OrgService } from "./services/org-service";
+
+const SEED_ENV_KEYS = [
+  "NAKAMA_SEED_ADMIN_EMAIL",
+  "NAKAMA_SEED_ADMIN_NAME",
+  "NAKAMA_SEED_ADMIN_PASSWORD",
+  "NAKAMA_SEED_ORG_NAME",
+  "NAKAMA_CONFIG_DIR",
+] as const;
+
+describe("runFirstBootSeed", () => {
+  let configDir = "";
+  const previousEnv: Partial<
+    Record<(typeof SEED_ENV_KEYS)[number], string | undefined>
+  > = {};
+
+  afterEach(async () => {
+    for (const key of SEED_ENV_KEYS) {
+      if (previousEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previousEnv[key];
+      }
+    }
+
+    if (configDir) {
+      await rm(configDir, { force: true, recursive: true });
+      configDir = "";
+    }
+  });
+
+  function snapshotEnv(): void {
+    for (const key of SEED_ENV_KEYS) {
+      previousEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  }
+
+  async function withFreshConfigDir(): Promise<void> {
+    snapshotEnv();
+    configDir = await mkdtemp(join(tmpdir(), "nakama-seed-"));
+    process.env.NAKAMA_CONFIG_DIR = configDir;
+  }
+
+  function createServices() {
+    const databaseAdapter = createInMemoryDatabaseAdapter();
+    const authService = new AuthService();
+    const orgService = new OrgService(databaseAdapter, authService);
+    return { authService, databaseAdapter, orgService };
+  }
+
+  test("no seed env is a no-op", async () => {
+    await withFreshConfigDir();
+    const services = createServices();
+
+    const result = await runFirstBootSeed(services);
+
+    expect(result).toEqual({ providerWritten: false, seeded: false });
+    expect(await services.databaseAdapter.countHumanUsers()).toBe(0);
+    expect(await loadUserConfig()).toBeNull();
+  });
+
+  test("partial seed env fails with missing var names", async () => {
+    await withFreshConfigDir();
+    const services = createServices();
+
+    await expect(
+      runFirstBootSeed({
+        ...services,
+        env: {
+          NAKAMA_SEED_ADMIN_EMAIL: "admin@example.com",
+          NAKAMA_SEED_ADMIN_NAME: "",
+          NAKAMA_SEED_ADMIN_PASSWORD: "seedpass123",
+        },
+      })
+    ).rejects.toThrow(/NAKAMA_SEED_ADMIN_NAME/);
+
+    expect(await services.databaseAdapter.countHumanUsers()).toBe(0);
+  });
+
+  test("already-configured database skips silently", async () => {
+    await withFreshConfigDir();
+    const services = createServices();
+    await services.orgService.bootstrapInitialSetup({
+      admin: {
+        email: "existing@example.com",
+        name: "Existing",
+        passwordHash: await services.authService.hashPassword("password123"),
+        phone: "",
+      },
+      organization: { name: "Existing", slug: "existing" },
+    });
+
+    const result = await runFirstBootSeed({
+      ...services,
+      env: {
+        NAKAMA_SEED_ADMIN_EMAIL: "admin@example.com",
+        NAKAMA_SEED_ADMIN_NAME: "Admin",
+        NAKAMA_SEED_ADMIN_PASSWORD: "seedpass123",
+      },
+    });
+
+    expect(result).toEqual({ providerWritten: false, seeded: false });
+    expect(await services.databaseAdapter.countHumanUsers()).toBe(1);
+    expect(await loadUserConfig()).toBeNull();
+  });
+
+  test("writes OpenCode Zen provider with exact shape and merges existing config", async () => {
+    await withFreshConfigDir();
+    const services = createServices();
+    const existingId = createProviderInstanceId();
+    await saveUserConfig({
+      defaultProviderId: existingId,
+      providers: [
+        {
+          apiKey: "sk-existing",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          id: existingId,
+          label: "OpenAI",
+          type: "openai",
+        },
+      ],
+      thinkingEnabled: false,
+      timezone: "America/New_York",
+    });
+
+    const result = await runFirstBootSeed({
+      ...services,
+      env: {
+        NAKAMA_SEED_ADMIN_EMAIL: "admin@example.com",
+        NAKAMA_SEED_ADMIN_NAME: "Admin",
+        NAKAMA_SEED_ADMIN_PASSWORD: "seedpass123",
+      },
+    });
+
+    expect(result).toEqual({ providerWritten: true, seeded: true });
+    expect(await services.databaseAdapter.countHumanUsers()).toBe(1);
+
+    const loaded = await loadUserConfig();
+    expect(loaded?.timezone).toBe("America/New_York");
+    expect(loaded?.thinkingEnabled).toBe(false);
+    expect(loaded?.providers).toHaveLength(2);
+    expect(loaded?.providers[0]?.id).toBe(existingId);
+    expect(loaded?.providers[0]?.label).toBe("OpenAI");
+    expect(loaded?.providers[0]?.apiKey).toBe("sk-existing");
+
+    const zen = loaded?.providers.find(
+      (provider) => provider.label === "OpenCode Zen"
+    );
+    expect(zen).toMatchObject({
+      apiKey: "public",
+      baseUrl: "https://opencode.ai/zen/v1",
+      customModels: [
+        {
+          id: "big-pickle",
+          name: "Big Pickle",
+          supportsThinking: true,
+        },
+        {
+          id: "hy3-free",
+          name: "Hy3 Free",
+          supportsThinking: true,
+        },
+      ],
+      label: "OpenCode Zen",
+      type: "openai_compatible",
+    });
+    expect(zen?.customModels?.[0]).not.toHaveProperty("default");
+    expect(loaded?.defaultProviderId).toBe(zen?.id);
+    expect(isProviderConfigured(loaded)).toBe(true);
+  });
+
+  test("boot-level health reports userConfigured and providerConfigured after seed", async () => {
+    await withFreshConfigDir();
+    const services = createServices();
+
+    const result = await runFirstBootSeed({
+      ...services,
+      env: {
+        NAKAMA_SEED_ADMIN_EMAIL: "admin@example.com",
+        NAKAMA_SEED_ADMIN_NAME: "Admin",
+        NAKAMA_SEED_ADMIN_PASSWORD: "seedpass123",
+      },
+    });
+    expect(result.seeded).toBe(true);
+
+    const userConfig = await loadUserConfig();
+    const provider = createProviderFromSources(process.env, userConfig);
+    const { app } = createMinimalHonoApp({
+      agent: {
+        listProfiles: async () => ({ profiles: [{ id: "default" }] }),
+        providerConfigured:
+          isProviderConfigured(userConfig) && provider !== null,
+      },
+      authService: services.authService,
+      databaseAdapter: services.databaseAdapter,
+      orgService: services.orgService,
+    });
+
+    const response = await app.fetch(
+      new Request("http://localhost:4310/health")
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      providerConfigured: true,
+      userConfigured: true,
+    });
+  });
+});

--- a/apps/server/src/seed.ts
+++ b/apps/server/src/seed.ts
@@ -1,0 +1,141 @@
+import {
+  createProviderInstanceId,
+  loadUserConfig,
+  NakamaApiError,
+  type ProviderInstance,
+  saveUserConfig,
+  type UserConfig,
+} from "@nakama/core";
+import type { DatabaseAdapter } from "@nakama/db";
+import type { AuthService } from "./services/auth-service";
+import type { OrgService } from "./services/org-service";
+
+const SEED_ADMIN_EMAIL = "NAKAMA_SEED_ADMIN_EMAIL";
+const SEED_ADMIN_NAME = "NAKAMA_SEED_ADMIN_NAME";
+const SEED_ADMIN_PASSWORD = "NAKAMA_SEED_ADMIN_PASSWORD";
+const SEED_ORG_NAME = "NAKAMA_SEED_ORG_NAME";
+
+const REQUIRED_SEED_ENV_KEYS = [
+  SEED_ADMIN_EMAIL,
+  SEED_ADMIN_NAME,
+  SEED_ADMIN_PASSWORD,
+] as const;
+
+const OPENCODE_ZEN_BASE_URL = "https://opencode.ai/zen/v1";
+const OPENCODE_ZEN_LABEL = "OpenCode Zen";
+const MIN_PASSWORD_LENGTH = 8;
+
+export type FirstBootSeedDeps = {
+  authService: AuthService;
+  databaseAdapter: DatabaseAdapter;
+  env?: Record<string, string | undefined>;
+  orgService: OrgService;
+};
+
+export type FirstBootSeedResult = {
+  providerWritten: boolean;
+  seeded: boolean;
+};
+
+export async function runFirstBootSeed(
+  deps: FirstBootSeedDeps
+): Promise<FirstBootSeedResult> {
+  const env = deps.env ?? process.env;
+  const present = REQUIRED_SEED_ENV_KEYS.filter((key) => {
+    const value = env[key]?.trim();
+    return Boolean(value);
+  });
+
+  if (present.length === 0) {
+    return { providerWritten: false, seeded: false };
+  }
+
+  if (present.length < REQUIRED_SEED_ENV_KEYS.length) {
+    const missing = REQUIRED_SEED_ENV_KEYS.filter((key) => !env[key]?.trim());
+    throw new Error(
+      `First-boot seed is partially configured. Missing: ${missing.join(", ")}. Set all of ${REQUIRED_SEED_ENV_KEYS.join(", ")} or none.`
+    );
+  }
+
+  if ((await deps.databaseAdapter.countHumanUsers()) > 0) {
+    return { providerWritten: false, seeded: false };
+  }
+
+  const adminEmail = env[SEED_ADMIN_EMAIL]!.trim();
+  const adminName = env[SEED_ADMIN_NAME]!.trim();
+  const adminPassword = env[SEED_ADMIN_PASSWORD]!.trim();
+  const orgName = env[SEED_ORG_NAME]?.trim() || "Personal";
+  const orgSlug = slugifyOrgName(orgName);
+
+  if (adminPassword.length < MIN_PASSWORD_LENGTH) {
+    throw new Error(
+      `First-boot seed failed: ${SEED_ADMIN_PASSWORD} must be at least ${MIN_PASSWORD_LENGTH} characters.`
+    );
+  }
+
+  try {
+    await deps.orgService.bootstrapInitialSetup({
+      admin: {
+        email: adminEmail,
+        name: adminName,
+        passwordHash: await deps.authService.hashPassword(adminPassword),
+        phone: "",
+      },
+      organization: {
+        name: orgName,
+        slug: orgSlug,
+      },
+    });
+  } catch (error) {
+    if (error instanceof NakamaApiError) {
+      throw new Error(`First-boot seed failed: ${error.message}`);
+    }
+    throw error;
+  }
+
+  await writeOpenCodeZenProvider();
+
+  return { providerWritten: true, seeded: true };
+}
+
+function slugifyOrgName(name: string): string {
+  const slug = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return slug || "personal";
+}
+
+async function writeOpenCodeZenProvider(): Promise<void> {
+  const existing = await loadUserConfig();
+  const instance: ProviderInstance = {
+    apiKey: "public",
+    baseUrl: OPENCODE_ZEN_BASE_URL,
+    createdAt: new Date().toISOString(),
+    customModels: [
+      {
+        id: "big-pickle",
+        name: "Big Pickle",
+        supportsThinking: true,
+      },
+      {
+        id: "hy3-free",
+        name: "Hy3 Free",
+        supportsThinking: true,
+      },
+    ],
+    id: createProviderInstanceId(),
+    label: OPENCODE_ZEN_LABEL,
+    type: "openai_compatible",
+  };
+
+  const next: UserConfig = {
+    ...(existing ?? { defaultProviderId: null, providers: [] }),
+    defaultProviderId: instance.id,
+    providers: [...(existing?.providers ?? []), instance],
+  };
+
+  await saveUserConfig(next);
+}

--- a/docs/website/content/docs/docker.mdx
+++ b/docs/website/content/docs/docker.mdx
@@ -32,6 +32,27 @@ The data root follows `NAKAMA_CONFIG_DIR` when set. By default it is `/nakama/da
 
 On first run, complete the setup wizard in the browser and add your LLM provider. See [Providers](/providers) and [First-time setup](/first-time-setup).
 
+### First-boot seed (optional)
+
+To skip the setup wizard on a fresh data volume, set all three admin seed variables before the first boot. Nakama creates the admin account, a `Personal` org (override with `NAKAMA_SEED_ORG_NAME`), and an OpenCode Zen provider. Self-hosted installs without these variables behave as today.
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `NAKAMA_SEED_ADMIN_EMAIL` | Yes (with the other two) | Platform admin email |
+| `NAKAMA_SEED_ADMIN_NAME` | Yes (with the other two) | Platform admin display name |
+| `NAKAMA_SEED_ADMIN_PASSWORD` | Yes (with the other two) | Platform admin password (min 8 characters) |
+| `NAKAMA_SEED_ORG_NAME` | No | Organization name (default `Personal`) |
+
+Partial seed config fails boot with a clear error. Restarting a seeded instance is a no-op (idempotent).
+
+```bash
+docker run -d -p 4310:4310 -v nakama-data:/nakama/data \
+  -e NAKAMA_SEED_ADMIN_EMAIL=admin@example.com \
+  -e NAKAMA_SEED_ADMIN_NAME=Admin \
+  -e NAKAMA_SEED_ADMIN_PASSWORD=seedpass123 \
+  --name nakama ghcr.io/ahmadrosid/nakama:latest
+```
+
 ## Reset a local Docker install
 
 To remove the container, volume, and image and start fresh:

--- a/docs/website/content/docs/first-time-setup.mdx
+++ b/docs/website/content/docs/first-time-setup.mdx
@@ -15,6 +15,8 @@ Where you open the dashboard depends on how you deployed:
 
 On a fresh install, Nakama redirects you to the setup wizard automatically.
 
+Managed or Docker installs can skip the wizard by setting `NAKAMA_SEED_ADMIN_EMAIL`, `NAKAMA_SEED_ADMIN_NAME`, and `NAKAMA_SEED_ADMIN_PASSWORD` before first boot. See [Docker → First-boot seed](/docker#first-boot-seed-optional).
+
 ## Step 1: Admin account
 
 Create the first platform admin. This account can manage organizations, profiles, providers, and system settings.


### PR DESCRIPTION
## Summary
- Adds `apps/server/src/seed.ts` (`runFirstBootSeed`) gated on `NAKAMA_SEED_ADMIN_EMAIL` / `NAME` / `PASSWORD` (all-or-nothing; optional `NAKAMA_SEED_ORG_NAME`, default `Personal`).
- On first boot with seed env: creates admin+org via `orgService.bootstrapInitialSetup`, merges an OpenCode Zen `openai_compatible` provider into user config, then reloads the agent so `/health` reports `userConfigured` and `providerConfigured` before serving.
- Idempotent when human users already exist; no seed env remains a no-op. Docs updated under Docker / first-time setup.

Closes #217

## Test plan
- [x] `bun test apps/server/src/seed.test.ts` (no-op, partial env error, skip when configured, provider shape+merge, health integration)
- [x] `bun test packages/core` and `bun test apps/server`
- [x] E2E: boot with seed env + fresh `NAKAMA_CONFIG_DIR` → `/health` both true
- [x] E2E: second boot reusing config dir → still both true (idempotent)
- [x] E2E: fresh dir without seed env → both false


Made with [Cursor](https://cursor.com)