### PR TITLE
fix(discord): stop endless typing indicator after agent finishes

### DIFF
--- a/apps/platform/discord/src/typing-indicator.test.ts
+++ b/apps/platform/discord/src/typing-indicator.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, test } from "bun:test";
 import type { DiscordMessenger } from "./messenger";
 import { createTypingLoop } from "./typing-indicator";
 
+/** Drain the serialized typing promise chain. */
+async function flushTypingChain(): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+  }
+}
+
 function createFakeMessenger() {
   const calls: string[] = [];
   const messenger: DiscordMessenger = {
@@ -16,30 +23,86 @@ function createFakeMessenger() {
   return { calls, messenger };
 }
 
+function createBlockingMessenger() {
+  const releases: Array<() => void> = [];
+  let sendCount = 0;
+  const messenger: DiscordMessenger = {
+    async edit() {},
+    async send() {
+      return null;
+    },
+    async sendTyping() {
+      sendCount += 1;
+      await new Promise<void>((resolve) => {
+        releases.push(resolve);
+      });
+    },
+  };
+
+  return {
+    getSendCount: () => sendCount,
+    messenger,
+    releaseAll: () => {
+      for (const release of releases.splice(0)) {
+        release();
+      }
+    },
+  };
+}
+
 describe("createTypingLoop", () => {
   test("stop prevents later ping from sending typing", async () => {
     const { messenger, calls } = createFakeMessenger();
     const loop = createTypingLoop(messenger);
 
     loop.start();
+    await flushTypingChain();
     expect(calls).toHaveLength(1);
 
     loop.stop();
     loop.ping();
+    await flushTypingChain();
 
     expect(calls).toHaveLength(1);
   });
 
-  test("start replaces a previous interval without leaking", () => {
+  test("start replaces a previous interval without leaking", async () => {
     const { messenger, calls } = createFakeMessenger();
     const loop = createTypingLoop(messenger);
 
     loop.start();
+    await flushTypingChain();
     loop.start();
+    await flushTypingChain();
     expect(calls).toHaveLength(2);
 
     loop.stop();
     loop.ping();
+    await flushTypingChain();
     expect(calls).toHaveLength(2);
+  });
+
+  test("stop drops queued typing sends that have not started yet", async () => {
+    const { getSendCount, messenger, releaseAll } = createBlockingMessenger();
+    const loop = createTypingLoop(messenger);
+
+    loop.start();
+    await flushTypingChain();
+    expect(getSendCount()).toBe(1);
+
+    // Flood like onThinking deltas during a long generation.
+    loop.ping();
+    loop.ping();
+    loop.ping();
+    await flushTypingChain();
+    // Serialized: only the first send is in flight.
+    expect(getSendCount()).toBe(1);
+
+    loop.stop();
+    releaseAll();
+    await flushTypingChain();
+
+    // Queued pings must not call Discord after stop().
+    expect(getSendCount()).toBe(1);
   });
 });

--- a/apps/platform/discord/src/typing-indicator.ts
+++ b/apps/platform/discord/src/typing-indicator.ts
@@ -11,6 +11,9 @@ export interface TypingLoop {
 export function createTypingLoop(messenger: DiscordMessenger): TypingLoop {
   let interval: ReturnType<typeof setInterval> | null = null;
   let active = false;
+  // Serialize typing POSTs and re-check `active` before each send so a ping
+  // flood (e.g. onThinking) cannot keep refreshing Discord after stop().
+  let sendChain: Promise<void> = Promise.resolve();
 
   function clear() {
     if (interval) {
@@ -19,26 +22,34 @@ export function createTypingLoop(messenger: DiscordMessenger): TypingLoop {
     }
   }
 
+  function queueTyping() {
+    if (!active) {
+      return;
+    }
+
+    sendChain = sendChain
+      .then(async () => {
+        if (!active) {
+          return;
+        }
+
+        await messenger.sendTyping();
+      })
+      .catch(() => {
+        // Best-effort; keep the chain healthy.
+      });
+  }
+
   return {
     ping() {
-      // Ignore late stream callbacks after stop() so we do not refresh Discord typing.
-      if (!active) {
-        return;
-      }
-
-      void messenger.sendTyping();
+      queueTyping();
     },
     start() {
       clear();
       active = true;
-      void messenger.sendTyping();
+      queueTyping();
       interval = setInterval(() => {
-        if (!active) {
-          clear();
-          return;
-        }
-
-        void messenger.sendTyping();
+        queueTyping();
       }, TYPING_REFRESH_MS);
     },
     stop() {


### PR DESCRIPTION
## Summary
- **Root cause:** `onThinking` / tool pings fired `sendTyping()` without serialization. `stop()` only blocked new pings, so in-flight and queued sends kept refreshing Discord typing (~10s each).
- **Fix:** Serialize typing POSTs and re-check `active` before each send so queued pings drop after stop.
- **Verify:** `bun test apps/platform/discord` — 77 pass / 0 fail; regression test covers ping flood after stop.
- **Remaining risk:** One in-flight send can still finish after stop (max ~10s of typing).

## Test plan
- [x] `bun test apps/platform/discord` (77 pass, 0 fail)
- [ ] Manual: long Discord turn with tools → typing stops when the reply lands (no lingering indicator)


Made with [Cursor](https://cursor.com)