### PR TITLE
fix(web): order MCP tool parameters deterministically

### DIFF
--- a/apps/web/src/lib/mcp-tool-schema.test.ts
+++ b/apps/web/src/lib/mcp-tool-schema.test.ts
@@ -39,4 +39,27 @@ describe("parseMcpToolParameters", () => {
       },
     ]);
   });
+
+  it("orders required parameters first, then alphabetically, whatever the schema order", () => {
+    // Built from an array rather than an object literal on purpose: the
+    // formatter sorts literal keys alphabetically, which would make both
+    // fixtures identical and leave this test asserting nothing.
+    const schemaDeclaring = (declarationOrder: string[]) => ({
+      properties: Object.fromEntries(
+        declarationOrder.map((name) => [name, { type: "string" }])
+      ),
+      required: ["target", "cursor"],
+      type: "object",
+    });
+    const names = (declarationOrder: string[]) =>
+      parseMcpToolParameters(schemaDeclaring(declarationOrder)).map(
+        (parameter) => parameter.name
+      );
+
+    const declarationOrder = ["zeta", "alpha", "target", "cursor"];
+    const expected = ["cursor", "target", "alpha", "zeta"];
+
+    expect(names(declarationOrder)).toEqual(expected);
+    expect(names([...declarationOrder].reverse())).toEqual(expected);
+  });
 });

--- a/apps/web/src/lib/mcp-tool-schema.ts
+++ b/apps/web/src/lib/mcp-tool-schema.ts
@@ -26,8 +26,8 @@ export function parseMcpToolParameters(
 
   const requiredNames = new Set(required);
 
-  return Object.entries(properties as Record<string, unknown>).map(
-    ([name, property]) => {
+  return Object.entries(properties as Record<string, unknown>)
+    .map(([name, property]) => {
       const propertyRecord =
         typeof property === "object" && property !== null
           ? (property as Record<string, unknown>)
@@ -42,8 +42,19 @@ export function parseMcpToolParameters(
         required: requiredNames.has(name),
         type: formatSchemaType(propertyRecord.type),
       };
-    }
-  );
+    })
+    .sort(compareParameters);
+}
+
+// JSON Schema gives `properties` no meaningful order, so Object.entries would
+// leak whatever order the MCP server happened to serialise. Callers render this
+// list, so pin it: required first, then alphabetical.
+function compareParameters(a: McpToolParameter, b: McpToolParameter): number {
+  if (a.required !== b.required) {
+    return a.required ? -1 : 1;
+  }
+
+  return a.name.localeCompare(b.name);
 }
 
 function formatSchemaType(value: unknown): string {


### PR DESCRIPTION
`parseMcpToolParameters` built its result with `Object.entries(properties)`, so the order came from however the MCP server serialised its schema. The test declares `encoding` before `path` and expects `path` first, so it has been red on main.

Pinned the order in the function rather than loosening the assertion, which is the option the issue prefers: required first, then alphabetical. `McpToolList` is the only caller and renders this list, so required params now sort to the top of it.

Before, on current `main`:

```
$ cd apps/web && bun test src/lib/mcp-tool-schema.test.ts
(fail) parseMcpToolParameters > extracts parameter metadata from JSON schema objects
 1 pass, 1 fail
```

After:

```
$ cd apps/web && bun test
 264 pass, 0 fail
Ran 264 tests across 47 files. [15.85s]
```

The added test builds its fixture from an array, not an object literal, because the formatter sorts literal keys and would otherwise make both halves of the order-independence check identical. Dropping the `.sort` turns both tests red.

Closes #215
