### PR TITLE
fix(server): stop a hung provider holding a session for 30 minutes

### DIFF
--- a/apps/server/src/http/routes/sessions.stream.test.ts
+++ b/apps/server/src/http/routes/sessions.stream.test.ts
@@ -33,6 +33,26 @@ function createCancellableSession(): {
   return { sawSignal: () => signal, session };
 }
 
+/** Emits once and then stalls: a healthy turn sitting in a long tool run. */
+function createChattyThenStalledSession(): AgentChatSession {
+  return {
+    getContextUsage: () => null,
+    sendStream: (
+      _input: unknown,
+      handlers: { onChunk: (delta: string) => void },
+      options?: { signal?: AbortSignal }
+    ) =>
+      new Promise<string>((_resolve, reject) => {
+        handlers.onChunk("working");
+        options?.signal?.addEventListener(
+          "abort",
+          () => reject(options.signal?.reason),
+          { once: true }
+        );
+      }),
+  } as unknown as AgentChatSession;
+}
+
 async function waitForTurnToEnd(sessionId: string): Promise<void> {
   for (let attempt = 0; attempt < 50; attempt += 1) {
     if (!sessionTurnRegistry.isActive(sessionId)) {
@@ -152,6 +172,59 @@ describe("streamMessage timeout", () => {
     // The session is usable again rather than 409ing for the rest of the window.
     expect(sessionTurnRegistry.beginTurn(sessionId).started).toBe(true);
     sessionTurnRegistry.endTurn(sessionId, { reply: "ok", type: "done" });
+  });
+
+  test("a silent provider is released on the first-token deadline, not the stream deadline", async () => {
+    const sessionId = `session_first_token_test_${Date.now()}`;
+    const { session, sawSignal } = createCancellableSession();
+
+    expect(sessionTurnRegistry.beginTurn(sessionId).started).toBe(true);
+    const startedAt = Bun.nanoseconds();
+    const response = streamMessage(
+      sessionId,
+      session,
+      { message: "hi" },
+      undefined,
+      undefined,
+      5000,
+      50
+    );
+
+    const body = await new Response(response.body).text();
+    const heldMs = (Bun.nanoseconds() - startedAt) / 1e6;
+    await waitForTurnToEnd(sessionId);
+
+    expect(body).toContain("sent nothing for");
+    expect(sawSignal()?.aborted).toBe(true);
+    expect(sessionTurnRegistry.isActive(sessionId)).toBe(false);
+    // The point of the whole change: the session comes back on the short
+    // deadline instead of being held for the long one.
+    expect(heldMs).toBeLessThan(2500);
+  });
+
+  test("a provider that has produced output keeps the full stream deadline", async () => {
+    const sessionId = `session_slow_tool_test_${Date.now()}`;
+    const session = createChattyThenStalledSession();
+
+    expect(sessionTurnRegistry.beginTurn(sessionId).started).toBe(true);
+    const response = streamMessage(
+      sessionId,
+      session,
+      { message: "hi" },
+      undefined,
+      undefined,
+      400,
+      50
+    );
+
+    const body = await new Response(response.body).text();
+    await waitForTurnToEnd(sessionId);
+
+    expect(body).toContain('"delta":"working"');
+    // It outlived the 50ms first-token deadline and died on the stream one, so
+    // a long tool run is not collateral damage.
+    expect(body).not.toContain("sent nothing for");
+    expect(body).toContain("timed out after");
   });
 
   test("a completed turn clears its deadline instead of leaving a timer behind", async () => {

--- a/apps/server/src/http/routes/sessions.stream.test.ts
+++ b/apps/server/src/http/routes/sessions.stream.test.ts
@@ -123,3 +123,93 @@ describe("streamMessage cancellation", () => {
     expect(sessionTurnRegistry.isActive(sessionId)).toBe(false);
   });
 });
+
+describe("streamMessage timeout", () => {
+  test("a provider that goes quiet is timed out, aborted, and reported as a timeout", async () => {
+    const sessionId = `session_timeout_test_${Date.now()}`;
+    const { session, sawSignal } = createCancellableSession();
+
+    expect(sessionTurnRegistry.beginTurn(sessionId).started).toBe(true);
+    const response = streamMessage(
+      sessionId,
+      session,
+      { message: "hi" },
+      undefined,
+      undefined,
+      10
+    );
+
+    const body = await new Response(response.body).text();
+    await waitForTurnToEnd(sessionId);
+
+    expect(body).toContain("timed out after");
+    // The deadline aborts the turn, so this is the message the user would get
+    // if the abort were mistaken for a cancel.
+    expect(body).not.toContain("Turn cancelled.");
+    // Nothing else stops the provider request once the race is lost.
+    expect(sawSignal()?.aborted).toBe(true);
+    expect(sessionTurnRegistry.isActive(sessionId)).toBe(false);
+    // The session is usable again rather than 409ing for the rest of the window.
+    expect(sessionTurnRegistry.beginTurn(sessionId).started).toBe(true);
+    sessionTurnRegistry.endTurn(sessionId, { reply: "ok", type: "done" });
+  });
+
+  test("a completed turn clears its deadline instead of leaving a timer behind", async () => {
+    const sessionId = `session_deadline_test_${Date.now()}`;
+    const realSetTimeout = globalThis.setTimeout;
+    const realClearTimeout = globalThis.clearTimeout;
+    const pending = new Set<ReturnType<typeof setTimeout>>();
+    // Distinctive enough that only the stream deadline matches.
+    const deadlineMs = 300_000;
+
+    globalThis.setTimeout = ((
+      handler: TimerHandler,
+      delay?: number,
+      ...rest: unknown[]
+    ) => {
+      const handle = realSetTimeout(
+        handler as () => void,
+        delay,
+        ...(rest as [])
+      );
+      if (delay === deadlineMs) {
+        pending.add(handle);
+      }
+      return handle;
+    }) as typeof globalThis.setTimeout;
+    globalThis.clearTimeout = ((handle?: ReturnType<typeof setTimeout>) => {
+      if (handle !== undefined) {
+        pending.delete(handle);
+      }
+      realClearTimeout(handle);
+    }) as typeof globalThis.clearTimeout;
+
+    try {
+      const session = {
+        getContextUsage: () => null,
+        sendStream: () => Promise.resolve("done"),
+      } as unknown as AgentChatSession;
+
+      expect(sessionTurnRegistry.beginTurn(sessionId).started).toBe(true);
+      const response = streamMessage(
+        sessionId,
+        session,
+        { message: "hi" },
+        undefined,
+        undefined,
+        deadlineMs
+      );
+
+      await new Response(response.body).text();
+      await waitForTurnToEnd(sessionId);
+
+      expect(pending.size).toBe(0);
+    } finally {
+      globalThis.setTimeout = realSetTimeout;
+      globalThis.clearTimeout = realClearTimeout;
+      for (const handle of pending) {
+        realClearTimeout(handle);
+      }
+    }
+  });
+});

--- a/apps/server/src/http/shared.ts
+++ b/apps/server/src/http/shared.ts
@@ -8,6 +8,7 @@ import {
   formatServerError,
   LOCAL_CLIENT_EMAIL,
   NakamaApiError,
+  resolveChatFirstTokenTimeoutMs,
   resolveChatStreamTimeoutMs,
   type SendMessageInput,
   type StreamEvent,
@@ -400,6 +401,7 @@ export function parseChannel(value: string | undefined): AgentChannel {
 }
 
 const STREAM_TIMEOUT_MS = resolveChatStreamTimeoutMs();
+const FIRST_TOKEN_TIMEOUT_MS = resolveChatFirstTokenTimeoutMs();
 
 function createStreamSenders(
   sessionId: string,
@@ -551,9 +553,10 @@ export function streamMessage(
   input: SendMessageInput,
   onComplete?: (terminal: StreamEvent) => void,
   requestSignal?: AbortSignal,
-  // Only tests pass this. The resolved value clamps to 60s minimum, which is far
-  // too long to wait for in a suite.
-  timeoutMs: number = STREAM_TIMEOUT_MS
+  // Only tests pass these. The resolved values clamp to 60s and 5s minimums,
+  // which are far too long to wait for in a suite.
+  timeoutMs: number = STREAM_TIMEOUT_MS,
+  firstTokenTimeoutMs: number = FIRST_TOKEN_TIMEOUT_MS
 ): Response {
   const encoder = new TextEncoder();
   const keepaliveIntervalMs = 4000;
@@ -572,9 +575,21 @@ export function streamMessage(
       turnAbort.abort();
     },
     async start(controller) {
-      const { send, getTerminal } = createStreamSenders(sessionId, (chunk) => {
-        controller.enqueue(chunk);
-      });
+      const { send: publish, getTerminal } = createStreamSenders(
+        sessionId,
+        (chunk) => {
+          controller.enqueue(chunk);
+        }
+      );
+
+      // Anything the provider produces clears the first-token deadline. The
+      // keepalive below deliberately does not go through here: it is the
+      // server's own ping and says nothing about whether the provider is alive.
+      let sawProviderOutput = false;
+      const send = (event: StreamEvent) => {
+        sawProviderOutput = true;
+        publish(event);
+      };
 
       const keepalive = setInterval(() => {
         try {
@@ -584,32 +599,52 @@ export function streamMessage(
         }
       }, keepaliveIntervalMs);
 
-      let deadline: ReturnType<typeof setTimeout> | undefined;
-      // The timeout aborts the turn, so turnSignal.aborted alone can no longer
-      // tell a cancel from a deadline. Without this the user sees "Turn
+      const deadlines: ReturnType<typeof setTimeout>[] = [];
+      // A deadline aborts the turn, so turnSignal.aborted alone can no longer
+      // tell a cancel from a timeout. Without this the user sees "Turn
       // cancelled." for a provider that simply went quiet.
       let timedOut = false;
 
-      try {
-        const reply = await Promise.race([
-          session.sendStream(input, buildAgentStreamHandlers(send), {
-            signal: turnSignal,
-          }),
-          new Promise<never>((_, reject) => {
-            deadline = setTimeout(() => {
+      const failAfter = (ms: number, message: string, when?: () => boolean) =>
+        new Promise<never>((_, reject) => {
+          deadlines.push(
+            setTimeout(() => {
+              if (when && !when()) {
+                return;
+              }
+
               timedOut = true;
-              reject(
-                new Error(
-                  `Chat timed out after ${Math.round(timeoutMs / 1000)}s waiting for the provider. Try another model or check provider settings.`
-                )
-              );
+              reject(new Error(message));
               // After rejecting, so the race reports the timeout and not the
               // abort. The provider request is still open at this point and
               // nothing else ever stops it.
               turnAbort.abort();
-            }, timeoutMs);
+            }, ms)
+          );
+        });
+
+      try {
+        const raced: Promise<string>[] = [
+          session.sendStream(input, buildAgentStreamHandlers(send), {
+            signal: turnSignal,
           }),
-        ]);
+          failAfter(
+            timeoutMs,
+            `Chat timed out after ${Math.round(timeoutMs / 1000)}s waiting for the provider. Try another model or check provider settings.`
+          ),
+        ];
+
+        if (firstTokenTimeoutMs > 0) {
+          raced.push(
+            failAfter(
+              firstTokenTimeoutMs,
+              `The provider accepted the request but sent nothing for ${Math.round(firstTokenTimeoutMs / 1000)}s. Try another model or check provider settings.`,
+              () => !sawProviderOutput
+            )
+          );
+        }
+
+        const reply = await Promise.race(raced);
 
         const contextUsage = session.getContextUsage() ?? undefined;
         send({
@@ -626,9 +661,11 @@ export function streamMessage(
           type: "error",
         });
       } finally {
-        // Every turn scheduled one of these. Left pending, a long-running server
-        // accumulates a live timer per turn for the whole timeout window.
-        clearTimeout(deadline);
+        // Every turn scheduled these. Left pending, a long-running server
+        // accumulates live timers per turn for the whole timeout window.
+        for (const handle of deadlines) {
+          clearTimeout(handle);
+        }
         clearInterval(keepalive);
 
         const terminal =

--- a/apps/server/src/http/shared.ts
+++ b/apps/server/src/http/shared.ts
@@ -550,7 +550,10 @@ export function streamMessage(
   session: AgentChatSession,
   input: SendMessageInput,
   onComplete?: (terminal: StreamEvent) => void,
-  requestSignal?: AbortSignal
+  requestSignal?: AbortSignal,
+  // Only tests pass this. The resolved value clamps to 60s minimum, which is far
+  // too long to wait for in a suite.
+  timeoutMs: number = STREAM_TIMEOUT_MS
 ): Response {
   const encoder = new TextEncoder();
   const keepaliveIntervalMs = 4000;
@@ -581,19 +584,30 @@ export function streamMessage(
         }
       }, keepaliveIntervalMs);
 
+      let deadline: ReturnType<typeof setTimeout> | undefined;
+      // The timeout aborts the turn, so turnSignal.aborted alone can no longer
+      // tell a cancel from a deadline. Without this the user sees "Turn
+      // cancelled." for a provider that simply went quiet.
+      let timedOut = false;
+
       try {
         const reply = await Promise.race([
           session.sendStream(input, buildAgentStreamHandlers(send), {
             signal: turnSignal,
           }),
           new Promise<never>((_, reject) => {
-            setTimeout(() => {
+            deadline = setTimeout(() => {
+              timedOut = true;
               reject(
                 new Error(
-                  `Chat timed out after ${Math.round(STREAM_TIMEOUT_MS / 1000)}s waiting for the provider. Try another model or check provider settings.`
+                  `Chat timed out after ${Math.round(timeoutMs / 1000)}s waiting for the provider. Try another model or check provider settings.`
                 )
               );
-            }, STREAM_TIMEOUT_MS);
+              // After rejecting, so the race reports the timeout and not the
+              // abort. The provider request is still open at this point and
+              // nothing else ever stops it.
+              turnAbort.abort();
+            }, timeoutMs);
           }),
         ]);
 
@@ -605,12 +619,16 @@ export function streamMessage(
         });
       } catch (error) {
         send({
-          error: turnSignal.aborted
-            ? "Turn cancelled."
-            : formatServerError(error),
+          error:
+            turnSignal.aborted && !timedOut
+              ? "Turn cancelled."
+              : formatServerError(error),
           type: "error",
         });
       } finally {
+        // Every turn scheduled one of these. Left pending, a long-running server
+        // accumulates a live timer per turn for the whole timeout window.
+        clearTimeout(deadline);
         clearInterval(keepalive);
 
         const terminal =

--- a/packages/core/src/chat-stream-timeout.test.ts
+++ b/packages/core/src/chat-stream-timeout.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_CHAT_FIRST_TOKEN_TIMEOUT_MS,
+  MIN_CHAT_FIRST_TOKEN_TIMEOUT_MS,
+  resolveChatFirstTokenTimeoutMs,
+} from "./chat-stream-timeout";
+
+describe("resolveChatFirstTokenTimeoutMs", () => {
+  test("falls back to the default when unset or unparseable", () => {
+    expect(resolveChatFirstTokenTimeoutMs({})).toBe(
+      DEFAULT_CHAT_FIRST_TOKEN_TIMEOUT_MS
+    );
+    expect(
+      resolveChatFirstTokenTimeoutMs({
+        NAKAMA_CHAT_FIRST_TOKEN_TIMEOUT_MS: " ",
+      })
+    ).toBe(DEFAULT_CHAT_FIRST_TOKEN_TIMEOUT_MS);
+    expect(
+      resolveChatFirstTokenTimeoutMs({
+        NAKAMA_CHAT_FIRST_TOKEN_TIMEOUT_MS: "soon",
+      })
+    ).toBe(DEFAULT_CHAT_FIRST_TOKEN_TIMEOUT_MS);
+  });
+
+  test("takes an explicit value and floors it at the minimum", () => {
+    expect(
+      resolveChatFirstTokenTimeoutMs({
+        NAKAMA_CHAT_FIRST_TOKEN_TIMEOUT_MS: "45000",
+      })
+    ).toBe(45_000);
+    expect(
+      resolveChatFirstTokenTimeoutMs({
+        NAKAMA_CHAT_FIRST_TOKEN_TIMEOUT_MS: "1",
+      })
+    ).toBe(MIN_CHAT_FIRST_TOKEN_TIMEOUT_MS);
+  });
+
+  test("zero or negative disables the deadline rather than clamping it", () => {
+    // The escape hatch for a deployment whose model thinks for minutes before
+    // emitting anything. Clamping here would leave no way to turn it off.
+    expect(
+      resolveChatFirstTokenTimeoutMs({
+        NAKAMA_CHAT_FIRST_TOKEN_TIMEOUT_MS: "0",
+      })
+    ).toBe(0);
+    expect(
+      resolveChatFirstTokenTimeoutMs({
+        NAKAMA_CHAT_FIRST_TOKEN_TIMEOUT_MS: "-1",
+      })
+    ).toBe(0);
+  });
+});

--- a/packages/core/src/chat-stream-timeout.ts
+++ b/packages/core/src/chat-stream-timeout.ts
@@ -28,3 +28,39 @@ export function resolveChatStreamTimeoutMs(
     Math.max(MIN_CHAT_STREAM_TIMEOUT_MS, Math.floor(parsed))
   );
 }
+
+/**
+ * A separate, much shorter budget for the provider's *first* output of a turn.
+ *
+ * The stream timeout has to stay long because a healthy turn can spend half an
+ * hour in a tool loop. That same budget is far too generous for a provider that
+ * accepted the connection and then said nothing at all, which is the case that
+ * holds a session hostage with no way to reach it. Anything the provider emits
+ * (a chunk, a thinking delta, a tool call) satisfies this deadline; the 4s
+ * server keepalive does not, since it proves nothing about the provider.
+ *
+ * Set NAKAMA_CHAT_FIRST_TOKEN_TIMEOUT_MS to 0 to turn it off, for a deployment
+ * whose model really does think for minutes before emitting anything.
+ */
+export const DEFAULT_CHAT_FIRST_TOKEN_TIMEOUT_MS = 120_000;
+export const MIN_CHAT_FIRST_TOKEN_TIMEOUT_MS = 5000;
+
+export function resolveChatFirstTokenTimeoutMs(
+  env: Record<string, string | undefined> = process.env
+): number {
+  const raw = readTimeoutEnvValue(env, "NAKAMA_CHAT_FIRST_TOKEN_TIMEOUT_MS");
+  if (!raw) {
+    return DEFAULT_CHAT_FIRST_TOKEN_TIMEOUT_MS;
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_CHAT_FIRST_TOKEN_TIMEOUT_MS;
+  }
+
+  if (parsed <= 0) {
+    return 0;
+  }
+
+  return Math.max(MIN_CHAT_FIRST_TOKEN_TIMEOUT_MS, Math.floor(parsed));
+}


### PR DESCRIPTION
A provider that accepts the connection and then goes quiet held its session for the full 30 minute stream timeout. Nothing else could reach that turn, so every following message got a 409 and the only way out was to start a new session and lose the thread.

Three separate things were wrong in `streamMessage`, all in the same few lines.

**The deadline was the only thing that could end a silent turn, and it was 30 minutes.** That budget exists for a healthy turn sitting in a long tool loop, which really can take that long. It is far too generous for a provider that has sent nothing at all. This adds a second, much shorter deadline covering only the provider's first output. Any chunk, thinking delta or tool call satisfies it. The 4s keepalive deliberately does not, because it is the server's own ping and proves nothing about the provider. Default 120s, `NAKAMA_CHAT_FIRST_TOKEN_TIMEOUT_MS` to change it, `0` to switch it off.

**The `setTimeout` was never cleared.** Every turn scheduled one and left it pending for the rest of the window, so a long-running server holds a live timer per turn.

**A timeout never aborted `sendStream`.** The turn ended but the provider request stayed open against a closed stream. It aborts now, after the reject so the race still reports the timeout rather than the abort.

## Demo

`bun .local-poc/hung-provider-demo.ts`, deadlines scaled to 8s/1s so it finishes quickly. Production is 1800s/120s, same ratio.

```
stream deadline 8000ms, first-token deadline 1000ms

silent provider, first-token deadline OFF (behaviour before this PR)
  session held        8021ms of a 8000ms budget
  2nd message 409'd   true
  user is told        {"error":"Chat timed out after 8s waiting for the provider. ..."}

silent provider, first-token deadline ON
  session held        1007ms of a 8000ms budget
  2nd message 409'd   true
  user is told        {"error":"The provider accepted the request but sent nothing for 1s. ..."}

provider streamed then sat in a tool run, first-token deadline ON
  session held        8004ms of a 8000ms budget
  2nd message 409'd   true
  user is told        {"error":"Chat timed out after 8s waiting for the provider. ..."}
```

The third row is the one that matters for regressions: a turn that produced output keeps the full budget, so a long tool run is not collateral damage.

## Seen in the UI

Driven with Playwright against a throwaway instance (separate `NAKAMA_CONFIG_DIR`, black-hole provider, stream deadline pinned to its 60s floor so the run is watchable). One message, nothing queued behind it, measured from send to the composer coming back:

| | user waited | what the composer said |
| --- | --- | --- |
| first-token deadline off, which is `main` | 60.4s | `Chat timed out after 60s waiting for the provider.` |
| first-token deadline 5s | 5.6s | `The provider accepted the request but sent nothing for 5s.` |

60s there is the clamp floor, not the default. On the shipped default the first row is 30 minutes.

Worth knowing if you only ever test through the web client: it never shows the 409. A second message sent during a hung turn sits in the composer marked **Queued** and goes out when the turn ends, so the symptom a web user reports is a chat that has silently stopped accepting input, not an error. The 409 is what Discord, the CLI and direct API callers get.

## The issue's own repro, at the HTTP layer

#237 states it as "send a message, then send a second one. The second returns 409 for the full 60s". Run against a live server with the stream deadline pinned to its 60s floor, polling `POST /v1/sessions/:id/messages?stream=true` every 500ms until it stops returning 409:

| | second message stayed 409 | turn active, single message | error delivered |
| --- | --- | --- | --- |
| `main` | 63.8s | 60.2s | `Chat timed out after 60s waiting for the provider.` |
| this branch | 8.5s | 5.0s | `The provider accepted the request but sent nothing for 5s.` |

Both runs asserted the 409 before measuring, so the harness is not silently passing.

## Reproduce on a real instance

A black hole that accepts the connection and never answers:

```
bun -e 'Bun.serve({port:9099, fetch: () => new Promise(() => {})})'
```

Point a profile's provider Base URL at `http://localhost:9099/v1`, send a message, then send a second one. On `main` the second returns 409 until the stream timeout expires. With this branch it clears after the first-token deadline. Shorten both with `NAKAMA_CHAT_STREAM_TIMEOUT_MS=60000 NAKAMA_CHAT_FIRST_TOKEN_TIMEOUT_MS=5000` so you are not waiting 30 minutes to see it.

## Tests

```
$ cd apps/server && bun test src/http/routes/sessions.stream.test.ts
 8 pass, 0 fail

$ bun run test      # all workspaces
 exit 0
```

Each new test was checked against a broken build: disarming the first-token deadline reddens only the silent-provider test, never latching the sawProviderOutput flag reddens only the long-tool-run test, dropping `clearTimeout` reddens only the leak test, dropping the abort reddens only the original timeout test.

## Calls I would like your opinion on

**I did not shorten the 30 minute default.** With the first-token deadline in place, that budget only applies to turns the provider is actively feeding, and cutting it would kill legitimate long tool runs. Happy to lower it too if you would rather have both.

**I did not build a way to force-release a stuck turn**, which is the third option in the issue. The obvious version, calling `sessionTurnRegistry.endTurn` from a route, is the same mistake #236 rejected: the agent's `history` array is shared, so dropping the lock while the turn is still inside `executeToolCalls` lets the next turn append its user message and then `rollbackFailedSend` pops it back off. Doing it safely means the registry holds each turn's `AbortController` so a route can abort cooperatively, which is a new surface I did not want to invent unasked. Say the word and I will open it as its own issue.

Is 120s the right default? It is a guess at the worst honest first-token latency, and you have better data on which models people actually run here.

Closes #237. Both halves of the issue are covered: the hold is now bounded by the first-token deadline, and the timer is cleared. The force-release option it listed is the one alternative I did not take, and it belongs in its own issue rather than keeping this one open, since a turn that streams once and then hangs is a different failure from a provider that never speaks.
