### PR TITLE
fix(core): cap web_fetch content so one call cannot flood the context

### DIFF
--- a/packages/core/src/tools/web-fetch.test.ts
+++ b/packages/core/src/tools/web-fetch.test.ts
@@ -295,3 +295,71 @@ describe("convertHtmlToMarkdown", () => {
     expect(md).toContain("Self-hosted AI agents");
   });
 });
+
+describe("web_fetch content cap", () => {
+  // Same shape as truncateComposioToolResult: the marker is inside the budget,
+  // so a capped result is exactly CAP characters and never one more.
+  const CAP = 16_000;
+  const MARKER = "\n...[truncated]";
+
+  test("leaves a small body whole", async () => {
+    stubFetch(async () => htmlResponse("<h1>Short</h1><p>Body.</p>"));
+
+    const out = await webFetchTool.run({ url: "https://example.com" }, CTX);
+
+    expect(out.truncated).toBe(false);
+    expect(out.content).toContain("# Short");
+    expect(out.content).not.toContain(MARKER);
+  });
+
+  test("caps a long body and reports the original size", async () => {
+    // Long enough that the markdown is still over the cap after conversion.
+    const paragraphs = "<p>lorem ipsum dolor sit amet</p>".repeat(4000);
+    stubFetch(async () => htmlResponse(`<h1>Long</h1>${paragraphs}`));
+
+    const out = await webFetchTool.run({ url: "https://example.com" }, CTX);
+
+    expect(out.truncated).toBe(true);
+    expect(out.content.length).toBe(CAP);
+    expect(out.content.endsWith(MARKER)).toBe(true);
+    expect(out.content).toContain("# Long");
+    expect(out.bytes).toBeGreaterThan(CAP);
+  });
+
+  test("caps a raw body too, since raw skips conversion entirely", async () => {
+    const html = `<div>${"x".repeat(50_000)}</div>`;
+    stubFetch(async () => htmlResponse(html));
+
+    const out = await webFetchTool.run(
+      { raw: true, url: "https://example.com" },
+      CTX
+    );
+
+    expect(out.truncated).toBe(true);
+    expect(out.content.length).toBe(CAP);
+    expect(out.content.endsWith(MARKER)).toBe(true);
+  });
+
+  test("caps a large JSON body, the case that motivated the limit", async () => {
+    // An OpenAPI spec fetched in one call is what put 913 KB into a real session.
+    const spec = JSON.stringify({
+      paths: Object.fromEntries(
+        Array.from({ length: 2000 }, (_, i) => [
+          `/v1/resource/${i}`,
+          { get: { summary: `read resource ${i}` } },
+        ])
+      ),
+    });
+    stubFetch(async () => jsonResponse(spec));
+
+    const out = await webFetchTool.run(
+      { url: "https://api.example.com/o.json" },
+      CTX
+    );
+
+    expect(out.bytes).toBeGreaterThan(CAP);
+    expect(out.truncated).toBe(true);
+    expect(out.content.length).toBe(CAP);
+    expect(out.content.endsWith(MARKER)).toBe(true);
+  });
+});

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -45,10 +45,21 @@ export interface WebFetchOutput {
   contentType: string;
   finalUrl: string;
   status: number;
+  truncated: boolean;
   url: string;
 }
 
 const MAX_BODY_BYTES = 1024 * 1024;
+/**
+ * MAX_BODY_BYTES bounds the transfer; this bounds what reaches the model. Without
+ * it a single fetch can spend a megabyte of context: one call in a local session
+ * pulled a 913 KB OpenAPI spec, which then rides along in history on every later
+ * turn. Number, marker and the subtraction below all follow
+ * `truncateComposioToolResult` in apps/server/src/services/composio-tool-bridge.ts,
+ * which answered the same question for Composio results.
+ */
+const MAX_CONTENT_CHARS = 16_000;
+const TRUNCATION_MARKER = "\n...[truncated]";
 const REQUEST_TIMEOUT_MS = 30_000;
 const MAX_REDIRECTS = 5;
 
@@ -402,6 +413,8 @@ export async function convertHtmlToMarkdown(html: string): Promise<string> {
 export const webFetchTool: ToolDefinition<WebFetchInput, WebFetchOutput> = {
   description:
     "Fetch a single public HTTP(S) URL and return its content. HTML pages are converted to Markdown. " +
+    `Content is capped at ${MAX_CONTENT_CHARS} characters; when truncated is true the tail was dropped, ` +
+    "so fetch a more specific URL rather than assuming you have the whole document. " +
     "Use for retrieving a known URL; use web_search when you need to discover sources.",
   name: WEB_FETCH_TOOL_NAME,
   parallelSafe: true,
@@ -455,12 +468,21 @@ export const webFetchTool: ToolDefinition<WebFetchInput, WebFetchOutput> = {
         content = await convertHtmlToMarkdown(body);
       }
 
+      // After conversion, so the cap applies to what the model actually reads
+      // rather than to the markup it never sees.
+      const truncated = content.length > MAX_CONTENT_CHARS;
+      if (truncated) {
+        const keep = Math.max(0, MAX_CONTENT_CHARS - TRUNCATION_MARKER.length);
+        content = `${content.slice(0, keep)}${TRUNCATION_MARKER}`;
+      }
+
       return {
         bytes,
         content,
         contentType,
         finalUrl,
         status: response.status,
+        truncated,
         url: url.toString(),
       };
     } catch (err) {


### PR DESCRIPTION
`web_fetch` is the only tool that can put an unbounded amount of text into the model context. `bash` caps at 32,000 chars, `read_file` and `search_files` cap and report `truncated`, and #176 capped Composio results at 16,000. `web_fetch` has `MAX_BODY_BYTES` at 1 MB, but that bounds the transfer and throws above it, so anything under 1 MB goes in whole.

## Reproduce

Same command on both branches:

```sh
bun -e '
import { webFetchTool } from "./packages/core/src/tools/web-fetch";
const o = await webFetchTool.run(
  { raw: true, url: "https://backend.composio.dev/api/v3.1/openapi.json" }, {}
);
console.log(`body ${o.bytes} -> content ${o.content.length}, truncated ${o.truncated}`);
'
```

```
main    body 915095 -> content 914971, truncated undefined
branch  body 915095 -> content 16000,  truncated true
```

## What it fixes

That 914,971 character string is pushed into `history` as a `role: "tool"` message (`chat.ts:585`, `:611`) and re-sent on every later turn of the session until compaction runs. So it is not one expensive call, it is one call that stays expensive.

## The change

This follows `truncateComposioToolResult` in `apps/server/src/services/composio-tool-bridge.ts` rather than inventing anything: same 16,000, same `\n...[truncated]` marker, and the marker length subtracted from the budget so a capped result is exactly 16,000 characters and never one more. `truncated` joins the existing `bytes` on `WebFetchOutput`.

The cap runs after markdown conversion, so it bounds what the model reads rather than markup it never sees, and it applies to `raw: true` since that path skips conversion.

## What it costs

Checked against live URLs, not stubs. One ordinary page in my sample does get truncated:

| url | body | content | truncated |
|---|---|---|---|
| `backend.composio.dev/.../openapi.json` | 915,095 | 16,000 | true |
| `nakama/coding-agent.html` | 123,725 | 16,000 | true |

That page converts to 16,591 characters and loses 606 of them. The dropped tail is the page's own anchor-link nav, which VitePress emits at the end:

```
[How the pieces fit together](#how-the-pieces-fit-together)
[Supported coding agents](#supported-coding-agents)
[Setup](#setup)
```

Worth knowing rather than hiding: 16,000 is tight enough that a long documentation page can lose its last section, not just its nav. 32,000 would clear that and still catch the megabyte case. I went with 16,000 to match #176; happy to raise it if you would rather documentation pages always arrive whole.

Four tests cover it and three fail if `MAX_CONTENT_CHARS` is raised out of the way. `bun run test` is green across all eight workspaces.
