### PR TITLE
test: run the web, db and client suites in CI

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,8 @@
     "build": "tsc --noEmit && vite build",
     "dev": "bun run scripts/dev.ts",
     "preview": "vite preview",
-    "start": "vite preview"
+    "start": "vite preview",
+    "test": "bun test"
   },
   "dependencies": {
     "@base-ui/react": "^1.5.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -6,7 +6,8 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "build": "bun build ./src/index.ts --outdir dist --target bun"
+    "build": "bun build ./src/index.ts --outdir dist --target bun",
+    "test": "bun test"
   },
   "dependencies": {
     "@nakama/core": "workspace:*"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -6,7 +6,8 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "build": "bun build ./src/index.ts --outdir dist --target bun"
+    "build": "bun build ./src/index.ts --outdir dist --target bun",
+    "test": "bun test"
   },
   "dependencies": {
     "@nakama/core": "workspace:*",

--- a/packages/db/src/reopen.test.ts
+++ b/packages/db/src/reopen.test.ts
@@ -14,6 +14,10 @@ describe("database reopen after restore", () => {
     }
   });
 
+  // 632ms locally, but it runs migrations twice against a real sqlite file and
+  // has gone past bun's 5s default on a runner building nine workspaces at once.
+  // The ENOENT that follows such a timeout is afterEach removing the temp dir
+  // underneath the timed-out body, not a second fault.
   test("reopen reads the replacement sqlite file at the same path", async () => {
     rootDir = await mkdtemp(join(tmpdir(), "nakama-db-reopen-"));
     const databaseUrl = `file:${join(rootDir, "sqlite", "nakama.sqlite")}`;
@@ -69,5 +73,5 @@ describe("database reopen after restore", () => {
     ).toBeNull();
 
     database.close();
-  });
+  }, 30_000);
 });


### PR DESCRIPTION
Closes #243.

Three `"test": "bun test"` lines and one timeout.

`bun run test` is `bun run --workspaces --if-present test`, so a workspace with no `test` script is skipped without a word. `apps/web`, `packages/db` and `packages/client` had none, which kept 62 test files and 342 tests out of every CI run since they were written.

That is what let #215 sit red on `main`. Its test is `apps/web/src/lib/mcp-tool-schema.test.ts`, so no PR in that window ever ran it, and it took someone noticing by hand to file it.

Before and after, same machine:

```
before   8 workspaces, 1,656 tests, 0 fail
after   11 workspaces, 1,998 tests, 0 fail
```

Nothing turns red, because all three suites already pass. `apps/web` 264, `packages/db` 55, `packages/client` 23. Roughly ten seconds on top.

The one non-obvious line is the 30s on `packages/db`'s reopen test. It runs migrations twice against a real sqlite file, 632ms here, and has gone past bun's 5s default on a runner building nine workspaces at once. The ENOENT that follows such a timeout is `afterEach` removing the temp dir underneath the timed-out body, not a second fault. The comment says so in place.

For the record, #233 proposed the `packages/db` third of this and I closed it myself: at the time the script had only been switched on as a side effect of other work, which was not a reason to change how CI fans out. #215 is the reason that was missing.
