### PR TITLE
feat: optional tool-output optimiser with a savings panel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,10 @@ WORKDIR /app
 
 # Optional tool-output optimiser. Empty by default, so the published image is
 # unchanged and carries no binary most deployments would never run. Build with
-# --build-arg OMNI_VERSION=0.7.2 to include it, then set NAKAMA_OMNI=1.
+# --build-arg OMNI_VERSION=0.7.3 to include it, then set NAKAMA_OMNI=1.
 # The release is a static musl build, which runs on this glibc base, and the
 # published checksum is verified rather than the download trusted.
-ARG OMNI_VERSION="0.7.3"
+ARG OMNI_VERSION=""
 RUN if [ -n "$OMNI_VERSION" ]; then \
       set -eu; \
       apt-get update && apt-get install -y --no-install-recommends curl ca-certificates; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /app
 # --build-arg OMNI_VERSION=0.7.2 to include it, then set NAKAMA_OMNI=1.
 # The release is a static musl build, which runs on this glibc base, and the
 # published checksum is verified rather than the download trusted.
-ARG OMNI_VERSION=""
+ARG OMNI_VERSION="0.7.3"
 RUN if [ -n "$OMNI_VERSION" ]; then \
       set -eu; \
       apt-get update && apt-get install -y --no-install-recommends curl ca-certificates; \
@@ -31,7 +31,7 @@ RUN if [ -n "$OMNI_VERSION" ]; then \
         amd64) target=x86_64-unknown-linux-musl ;; \
         arm64) target=aarch64-unknown-linux-musl ;; \
         *) echo "no omni build for $(dpkg --print-architecture)" >&2; exit 1 ;; \
-      esac; \
+      esac; \ 
       base="https://github.com/fajarhide/omni/releases/download/v${OMNI_VERSION}"; \
       archive="omni-v${OMNI_VERSION}-${target}.tar.gz"; \
       curl -fsSL -o "/tmp/${archive}" "${base}/${archive}"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,30 @@ RUN bun install --frozen-lockfile --ignore-scripts \
 FROM oven/bun:1.3-slim AS runtime
 WORKDIR /app
 
+# Optional tool-output optimiser. Empty by default, so the published image is
+# unchanged and carries no binary most deployments would never run. Build with
+# --build-arg OMNI_VERSION=0.7.2 to include it, then set NAKAMA_OMNI=1.
+# The release is a static musl build, which runs on this glibc base, and the
+# published checksum is verified rather than the download trusted.
+ARG OMNI_VERSION=""
+RUN if [ -n "$OMNI_VERSION" ]; then \
+      set -eu; \
+      apt-get update && apt-get install -y --no-install-recommends curl ca-certificates; \
+      case "$(dpkg --print-architecture)" in \
+        amd64) target=x86_64-unknown-linux-musl ;; \
+        arm64) target=aarch64-unknown-linux-musl ;; \
+        *) echo "no omni build for $(dpkg --print-architecture)" >&2; exit 1 ;; \
+      esac; \
+      base="https://github.com/fajarhide/omni/releases/download/v${OMNI_VERSION}"; \
+      archive="omni-v${OMNI_VERSION}-${target}.tar.gz"; \
+      curl -fsSL -o "/tmp/${archive}" "${base}/${archive}"; \
+      curl -fsSL -o /tmp/SHA256SUMS "${base}/SHA256SUMS"; \
+      (cd /tmp && grep " ${archive}\$" SHA256SUMS | sha256sum -c -); \
+      tar -xzf "/tmp/${archive}" -C /usr/local/bin omni; \
+      rm -rf "/tmp/${archive}" /tmp/SHA256SUMS /var/lib/apt/lists/*; \
+      omni --version; \
+    fi
+
 COPY package.json bun.lock ./
 COPY apps/server apps/server
 COPY apps/platform/automation apps/platform/automation

--- a/apps/server/src/http/app.ts
+++ b/apps/server/src/http/app.ts
@@ -29,6 +29,7 @@ import { registerSkillSuggestionRoutes } from "./routes/skill-suggestions";
 import { registerSkillRoutes } from "./routes/skills";
 import { registerSystemRoutes } from "./routes/system";
 import { registerTaskRoutes } from "./routes/tasks";
+import { registerTokenOptimizationRoutes } from "./routes/token-optimization";
 import { registerToolRoutes } from "./routes/tools";
 import { registerUserContextRoutes } from "./routes/user-context";
 import { registerWorkerRoutes } from "./routes/workers";
@@ -115,6 +116,7 @@ export function createHonoApp(options: ServerOptions) {
   registerToolRoutes(app, options);
   registerAutomationRoutes(app, options);
   registerNotificationDestinationRoutes(app, options);
+  registerTokenOptimizationRoutes(app, options);
   registerComposioRoutes(app, options);
   registerTaskRoutes(app, options);
   registerPlatformOrgRoutes(app, options);

--- a/apps/server/src/http/routes/token-optimization.ts
+++ b/apps/server/src/http/routes/token-optimization.ts
@@ -102,7 +102,9 @@ export function registerTokenOptimizationRoutes(
       days: [...days.values()],
       // One entry today. The shape is a list because a second optimiser attaches
       // in a different place and would appear beside this one, not replace it.
-      optimizers: [{ enabled, id: OPTIMIZER_ID, tools: ["bash", "read_file"] }],
+      optimizers: [
+        { enabled, id: OPTIMIZER_ID, installed, tools: ["bash", "read_file"] },
+      ],
       totals: {
         bytesIn: optimized.bytesIn + control.bytesIn,
         bytesRemoved: optimized.bytesIn - optimized.bytesOut,

--- a/apps/server/src/http/routes/token-optimization.ts
+++ b/apps/server/src/http/routes/token-optimization.ts
@@ -1,4 +1,9 @@
-import { CONTROL_ID, isOmniEnabled, OPTIMIZER_ID } from "@nakama/core";
+import {
+  CONTROL_ID,
+  isOmniEnabled,
+  isOmniInstalled,
+  OPTIMIZER_ID,
+} from "@nakama/core";
 import type { ServerOptions } from "../context";
 import {
   requireActiveOrgIdFromContext,
@@ -28,9 +33,10 @@ export function registerTokenOptimizationRoutes(
 ): void {
   app.get("/v1/token-optimization", async (c) => {
     const orgId = requireActiveOrgIdFromContext(c);
-    const [rows, settings] = await Promise.all([
+    const [rows, settings, installed] = await Promise.all([
       options.databaseAdapter.listToolOutputSavings(orgId),
       options.databaseAdapter.getWorkspaceSettings(),
+      isOmniInstalled(),
     ]);
     const enabled = settings?.tokenOptimizerEnabled ?? isOmniEnabled();
 

--- a/apps/server/src/http/routes/token-optimization.ts
+++ b/apps/server/src/http/routes/token-optimization.ts
@@ -1,0 +1,129 @@
+import { CONTROL_ID, isOmniEnabled, OPTIMIZER_ID } from "@nakama/core";
+import type { ServerOptions } from "../context";
+import {
+  requireActiveOrgIdFromContext,
+  requireOrgAdminFromContext,
+} from "../org-guards";
+import { json, readJson } from "../shared";
+import type { HonoApp } from "../types";
+
+const DAYS = 30;
+
+/**
+ * What this reports and what it deliberately does not.
+ *
+ * `bytesIn` and `bytesOut` are exact: what a tool produced, and what was written
+ * into the conversation instead. They are **not** tokens and **not** money. A
+ * shortened result is re-sent on later turns as a cache read billed at a fraction
+ * of fresh input, so multiplying bytes by a price would invent a figure nobody
+ * can support.
+ *
+ * Two arms are reported because one is not a measurement. `none` rows are turns
+ * where nothing shortened the output, so the panel can show what a turn costs
+ * unoptimised instead of comparing a number against a blank.
+ */
+export function registerTokenOptimizationRoutes(
+  app: HonoApp,
+  options: ServerOptions
+): void {
+  app.get("/v1/token-optimization", async (c) => {
+    const orgId = requireActiveOrgIdFromContext(c);
+    const [rows, settings] = await Promise.all([
+      options.databaseAdapter.listToolOutputSavings(orgId),
+      options.databaseAdapter.getWorkspaceSettings(),
+    ]);
+    const enabled = settings?.tokenOptimizerEnabled ?? isOmniEnabled();
+
+    const from = new Date(Date.now() - (DAYS - 1) * 86_400_000)
+      .toISOString()
+      .slice(0, 10);
+    const recent = rows.filter((row) => row.bucket >= from);
+
+    const days = new Map<
+      string,
+      { bytesIn: number; bytesRemoved: number; day: string }
+    >();
+    for (let index = 0; index < DAYS; index += 1) {
+      const day = new Date(Date.now() - (DAYS - 1 - index) * 86_400_000)
+        .toISOString()
+        .slice(0, 10);
+      days.set(day, { bytesIn: 0, bytesRemoved: 0, day });
+    }
+    for (const row of recent) {
+      const day = days.get(row.bucket);
+      if (day) {
+        day.bytesIn += row.bytesIn;
+        day.bytesRemoved += row.bytesIn - row.bytesOut;
+      }
+    }
+
+    const byArm = (arm: string) => {
+      const armRows = recent.filter((row) => row.optimizer === arm);
+      return {
+        arm,
+        bytesIn: armRows.reduce((sum, row) => sum + row.bytesIn, 0),
+        bytesOut: armRows.reduce((sum, row) => sum + row.bytesOut, 0),
+        calls: armRows.reduce((sum, row) => sum + row.calls, 0),
+      };
+    };
+
+    const byToolMap = new Map<
+      string,
+      { bytesIn: number; bytesOut: number; calls: number; tool: string }
+    >();
+    for (const row of recent.filter((r) => r.optimizer === OPTIMIZER_ID)) {
+      const entry = byToolMap.get(row.tool) ?? {
+        bytesIn: 0,
+        bytesOut: 0,
+        calls: 0,
+        tool: row.tool,
+      };
+      entry.bytesIn += row.bytesIn;
+      entry.bytesOut += row.bytesOut;
+      entry.calls += row.calls;
+      byToolMap.set(row.tool, entry);
+    }
+
+    const optimized = byArm(OPTIMIZER_ID);
+    const control = byArm(CONTROL_ID);
+
+    return json({
+      arms: { control, optimized },
+      byTool: [...byToolMap.values()].sort(
+        (left, right) =>
+          right.bytesIn - right.bytesOut - (left.bytesIn - left.bytesOut)
+      ),
+      days: [...days.values()],
+      // One entry today. The shape is a list because a second optimiser attaches
+      // in a different place and would appear beside this one, not replace it.
+      optimizers: [{ enabled, id: OPTIMIZER_ID, tools: ["bash", "read_file"] }],
+      totals: {
+        bytesIn: optimized.bytesIn + control.bytesIn,
+        bytesRemoved: optimized.bytesIn - optimized.bytesOut,
+        calls: optimized.calls + control.calls,
+      },
+      trackedSince: rows.at(0)?.trackedSince ?? null,
+      windowDays: DAYS,
+    });
+  });
+
+  app.put("/v1/token-optimization", async (c) => {
+    // Admin only: this changes what every session in the org does.
+    requireOrgAdminFromContext(c);
+    const body = await readJson<{ enabled: boolean }>(c.req.raw);
+    const existing = await options.databaseAdapter.getWorkspaceSettings();
+
+    await options.databaseAdapter.upsertWorkspaceSettings({
+      codingAgentHarnesses: existing?.codingAgentHarnesses ?? [],
+      id: existing?.id ?? "default",
+      imageModel: existing?.imageModel ?? null,
+      selectedCodingAgentHarness: existing?.selectedCodingAgentHarness ?? null,
+      tokenOptimizerEnabled: Boolean(body.enabled),
+      transcriptionModel: existing?.transcriptionModel ?? null,
+      updatedAt: new Date().toISOString(),
+      visionModel: existing?.visionModel ?? null,
+    });
+
+    return json({ enabled: Boolean(body.enabled) });
+  });
+}

--- a/apps/server/src/http/routes/token-optimization.ts
+++ b/apps/server/src/http/routes/token-optimization.ts
@@ -33,8 +33,9 @@ export function registerTokenOptimizationRoutes(
 ): void {
   app.get("/v1/token-optimization", async (c) => {
     const orgId = requireActiveOrgIdFromContext(c);
-    const [rows, settings, installed] = await Promise.all([
+    const [rows, turnRows, settings, installed] = await Promise.all([
       options.databaseAdapter.listToolOutputSavings(orgId),
+      options.databaseAdapter.listLlmTurnUsage(orgId),
       options.databaseAdapter.getWorkspaceSettings(),
       isOmniInstalled(),
     ]);
@@ -93,6 +94,30 @@ export function registerTokenOptimizationRoutes(
     const optimized = byArm(OPTIMIZER_ID);
     const control = byArm(CONTROL_ID);
 
+    // Provider tokens, the only figure here that is a token rather than a byte.
+    // Reported per turn so the two arms are comparable when they have different
+    // turn counts, which they always do.
+    const turnsByArm = (arm: string) => {
+      const armRows = turnRows.filter(
+        (row) => row.arm === arm && row.bucket >= from
+      );
+      const turns = armRows.reduce((sum, row) => sum + row.turns, 0);
+      const inputTokens = armRows.reduce(
+        (sum, row) => sum + row.inputTokens,
+        0
+      );
+      return {
+        arm,
+        estimatedTurns: armRows.reduce(
+          (sum, row) => sum + row.estimatedTurns,
+          0
+        ),
+        inputTokens,
+        inputTokensPerTurn: turns > 0 ? Math.round(inputTokens / turns) : 0,
+        turns,
+      };
+    };
+
     return json({
       arms: { control, optimized },
       byTool: [...byToolMap.values()].sort(
@@ -100,6 +125,12 @@ export function registerTokenOptimizationRoutes(
           right.bytesIn - right.bytesOut - (left.bytesIn - left.bytesOut)
       ),
       days: [...days.values()],
+      // Observational, not randomised: turns land in an arm because of what
+      // happened, so the panel must say so rather than imply a trial.
+      inputTokens: {
+        control: turnsByArm(CONTROL_ID),
+        optimized: turnsByArm(OPTIMIZER_ID),
+      },
       // One entry today. The shape is a list because a second optimiser attaches
       // in a different place and would appear beside this one, not replace it.
       optimizers: [

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -359,6 +359,34 @@ export class AgentService {
     });
   }
 
+  /**
+   * Binds a savings recorder to one org. Fire and forget on purpose: a counter
+   * for a dashboard must never delay a tool result or fail a turn, so the write
+   * is not awaited and a rejection is swallowed.
+   */
+  private savingsRecorderFor(orgId: string | undefined) {
+    if (!orgId?.trim()) {
+      return;
+    }
+
+    const scopedOrgId = orgId.trim();
+
+    return (saving: {
+      bytesIn: number;
+      bytesOut: number;
+      optimizer: string;
+      tool: string;
+    }): void => {
+      void this.db
+        .incrementToolOutputSavings(
+          scopedOrgId,
+          saving,
+          new Date().toISOString()
+        )
+        .catch(() => undefined);
+    };
+  }
+
   get profiles(): ProfileService {
     return this.profileService;
   }
@@ -1171,6 +1199,7 @@ export class AgentService {
         orgId,
         orgRole: "member",
         profileId,
+        recordToolOutputSavings: this.savingsRecorderFor(orgId),
       }),
       tools,
       userContext,
@@ -1234,6 +1263,7 @@ export class AgentService {
         orgId: input.orgId,
         orgRole: "member",
         profileId: input.profileId,
+        recordToolOutputSavings: this.savingsRecorderFor(input.orgId),
         sessionId: input.sessionId,
         userId: input.userId,
       }),
@@ -3047,6 +3077,11 @@ export class AgentService {
       orgRole,
       skillUsageContext
     );
+    // Per-org override for the tool-output optimiser. Undefined leaves the
+    // decision to the server's env var, so an operator who never opened the UI
+    // keeps whatever they configured.
+    const tokenOptimizerEnabled = (await this.db.getWorkspaceSettings())
+      ?.tokenOptimizerEnabled;
     const resolvedSystemPrompt = profile.isSuper
       ? `${systemPrompt.trim()}\n\n${SUPER_BOT_TOOL_AUTHORING_RULES}`
       : systemPrompt;
@@ -3188,7 +3223,9 @@ export class AgentService {
         orgId,
         orgRole: orgRole ?? undefined,
         profileId,
+        recordToolOutputSavings: this.savingsRecorderFor(orgId),
         sessionId,
+        tokenOptimizerEnabled: tokenOptimizerEnabled ?? undefined,
         userId: userId ?? undefined,
       }),
       tools,

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -364,6 +364,26 @@ export class AgentService {
    * for a dashboard must never delay a tool result or fail a turn, so the write
    * is not awaited and a rejection is swallowed.
    */
+  /** Same fire-and-forget shape as the savings recorder, for provider tokens. */
+  private turnUsageRecorderFor(orgId: string | undefined) {
+    if (!orgId?.trim()) {
+      return;
+    }
+
+    const scopedOrgId = orgId.trim();
+
+    return (turn: {
+      estimated: boolean;
+      inputTokens: number;
+      optimized: boolean;
+      outputTokens: number;
+    }): void => {
+      void this.db
+        .incrementLlmTurnUsage(scopedOrgId, turn)
+        .catch(() => undefined);
+    };
+  }
+
   private savingsRecorderFor(orgId: string | undefined) {
     if (!orgId?.trim()) {
       return;
@@ -1200,6 +1220,7 @@ export class AgentService {
         orgRole: "member",
         profileId,
         recordToolOutputSavings: this.savingsRecorderFor(orgId),
+        recordTurnUsage: this.turnUsageRecorderFor(orgId),
       }),
       tools,
       userContext,
@@ -1264,6 +1285,7 @@ export class AgentService {
         orgRole: "member",
         profileId: input.profileId,
         recordToolOutputSavings: this.savingsRecorderFor(input.orgId),
+        recordTurnUsage: this.turnUsageRecorderFor(input.orgId),
         sessionId: input.sessionId,
         userId: input.userId,
       }),
@@ -3224,6 +3246,7 @@ export class AgentService {
         orgRole: orgRole ?? undefined,
         profileId,
         recordToolOutputSavings: this.savingsRecorderFor(orgId),
+        recordTurnUsage: this.turnUsageRecorderFor(orgId),
         sessionId,
         tokenOptimizerEnabled: tokenOptimizerEnabled ?? undefined,
         userId: userId ?? undefined,

--- a/apps/web/src/components/TokenOptimizationCard.tsx
+++ b/apps/web/src/components/TokenOptimizationCard.tsx
@@ -1,5 +1,5 @@
 import type { TokenOptimizationResponse } from "@nakama/core/contract";
-import { GithubIcon } from "hugeicons-react";
+import { GithubIcon, LinkSquare02Icon } from "hugeicons-react";
 import { useEffect, useState } from "react";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
@@ -231,12 +231,18 @@ export function TokenOptimizationCard() {
             {omni && OPTIMIZER_HOMEPAGE[omni.id] ? (
               <a
                 aria-label={`${omni.id} on GitHub`}
-                className="text-muted-foreground transition-colors hover:text-foreground"
+                className="flex items-center gap-1 rounded border border-border bg-muted/50 px-1.5 py-0.5 font-medium text-[10px] text-muted-foreground leading-none transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground"
                 href={OPTIMIZER_HOMEPAGE[omni.id]}
                 rel="noreferrer noopener"
                 target="_blank"
               >
-                <GithubIcon aria-hidden size={14} />
+                <GithubIcon aria-hidden size={12} />
+                GitHub
+                <LinkSquare02Icon
+                  aria-hidden
+                  className="opacity-60"
+                  size={10}
+                />
               </a>
             ) : null}
           </div>

--- a/apps/web/src/components/TokenOptimizationCard.tsx
+++ b/apps/web/src/components/TokenOptimizationCard.tsx
@@ -69,9 +69,7 @@ function DailyChart({ days }: { days: Day[] }) {
           role="img"
           viewBox={`0 0 100 ${height}`}
         >
-          <title>
-            Bytes produced per day, and the part kept out of context
-          </title>
+          <title>Bytes produced per day, and the part saved of context</title>
           <line
             stroke="var(--grid)"
             strokeWidth={1}
@@ -147,7 +145,7 @@ function DailyChart({ days }: { days: Day[] }) {
           <div className="pointer-events-none absolute top-0 right-0 rounded-md border border-border bg-popover px-2 py-1 text-xs shadow-sm">
             <p className="font-medium">{days[hover].day}</p>
             <p className="text-muted-foreground">
-              {formatBytes(days[hover].bytesRemoved)} kept out of{" "}
+              {formatBytes(days[hover].bytesRemoved)} saved of{" "}
               {formatBytes(days[hover].bytesIn)}
             </p>
           </div>
@@ -238,9 +236,16 @@ export function TokenOptimizationCard() {
               </a>
             ) : null}
           </div>
-          <p className="truncate text-muted-foreground text-xs">
-            {omni?.tools.join(", ")}
-          </p>
+          <div className="mt-1 flex flex-wrap gap-1">
+            {omni?.tools.map((tool) => (
+              <span
+                className="rounded border border-border bg-muted/50 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground leading-none"
+                key={tool}
+              >
+                {tool}
+              </span>
+            ))}
+          </div>
         </div>
         <Switch
           checked={Boolean(omni?.enabled)}
@@ -258,12 +263,18 @@ export function TokenOptimizationCard() {
       ) : (
         <>
           <div>
-            <p className="font-semibold text-3xl tabular-nums">
-              Token optimize saved - {percent.toFixed(0)}%
+            {/* A stat tile is read by its number, so the number leads. The
+                colour is the "saved" series colour, not a decorative one,
+                so colour still carries identity here. */}
+            <p className="font-semibold text-4xl tabular-nums leading-none">
+              <span style={{ color: "var(--out)" }}>{percent.toFixed(0)}%</span>
+              <span className="ml-2 font-normal text-lg text-muted-foreground">
+                saved
+              </span>
             </p>
-            <p className="text-muted-foreground text-sm">
-              {formatBytes(totals.bytesRemoved)} kept out of{" "}
-              {formatBytes(totals.bytesIn)} in {windowDays} days
+            <p className="mt-1.5 text-muted-foreground text-sm">
+              {formatBytes(totals.bytesRemoved)} of{" "}
+              {formatBytes(totals.bytesIn)} tool output, last {windowDays} days
             </p>
           </div>
 
@@ -275,7 +286,7 @@ export function TokenOptimizationCard() {
                   className="size-2.5 rounded-[2px]"
                   style={{ background: "var(--out)" }}
                 />
-                <span className="text-muted-foreground">kept out</span>
+                <span className="text-muted-foreground">saved</span>
               </span>
               <span className="flex items-center gap-1.5">
                 <span
@@ -304,7 +315,7 @@ export function TokenOptimizationCard() {
                   </tr>
                 ))}
                 <tr className="border-border/60 border-t text-muted-foreground">
-                  <td className="py-1.5">not optimised</td>
+                  <td className="py-1.5">passthrough</td>
                   <td className="py-1.5 text-right tabular-nums">
                     {arms.control.calls} calls
                   </td>
@@ -330,7 +341,7 @@ export function TokenOptimizationCard() {
           }
         />
         <TooltipContent className="max-w-xs text-xs" side="top">
-          Share of tool output kept out of the conversation at insertion, over{" "}
+          Share of tool output saved of the conversation at insertion, over{" "}
           {windowDays} days. Bytes, not tokens and not cost: shortened results
           are re-sent later as cache reads billed at a fraction, so this
           percentage is not a percentage off a bill.

--- a/apps/web/src/components/TokenOptimizationCard.tsx
+++ b/apps/web/src/components/TokenOptimizationCard.tsx
@@ -207,7 +207,8 @@ export function TokenOptimizationCard() {
     );
   }
 
-  const { arms, byTool, days, optimizers, totals, windowDays } = data;
+  const { arms, byTool, days, inputTokens, optimizers, totals, windowDays } =
+    data;
   const omni = optimizers?.[0];
   // Denominator is everything the handled tools produced, both arms. Dividing
   // by the optimised calls alone would be a percentage of a set chosen after
@@ -307,6 +308,41 @@ export function TokenOptimizationCard() {
             </div>
             <DailyChart days={days} />
           </div>
+
+          {/* The only tokens on this card. Shown per turn because the arms
+              never have the same turn count, and only once both arms have
+              enough turns to be worth printing. */}
+          {inputTokens.optimized.turns >= 5 &&
+          inputTokens.control.turns >= 5 ? (
+            <div className="rounded border border-border p-3">
+              <p className="mb-2 font-medium text-sm">
+                Provider input tokens per turn
+              </p>
+              <div className="grid grid-cols-2 gap-3 text-sm">
+                <div>
+                  <p className="tabular-nums">
+                    {inputTokens.optimized.inputTokensPerTurn.toLocaleString()}
+                  </p>
+                  <p className="text-muted-foreground text-xs">
+                    optimised, {inputTokens.optimized.turns} turns
+                  </p>
+                </div>
+                <div>
+                  <p className="tabular-nums">
+                    {inputTokens.control.inputTokensPerTurn.toLocaleString()}
+                  </p>
+                  <p className="text-muted-foreground text-xs">
+                    passthrough, {inputTokens.control.turns} turns
+                  </p>
+                </div>
+              </div>
+              <p className="mt-2 text-muted-foreground text-xs">
+                Counted by the provider, not estimated here. Turns fall into an
+                arm by what happened rather than by assignment, so a difference
+                in the work itself can explain part of any gap.
+              </p>
+            </div>
+          ) : null}
 
           {byTool?.length ? (
             <table className="w-full text-sm">

--- a/apps/web/src/components/TokenOptimizationCard.tsx
+++ b/apps/web/src/components/TokenOptimizationCard.tsx
@@ -1,0 +1,299 @@
+import type { TokenOptimizationResponse } from "@nakama/core/contract";
+import { useEffect, useState } from "react";
+import { Spinner } from "@/components/ui/spinner";
+import { Switch } from "@/components/ui/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { client, formatError } from "@/lib/client";
+
+/**
+ * Palette: categorical slots 1 and 2, validated for both surfaces (six checks;
+ * worst adjacent pair ΔE 24.7 protan / 33.6 normal in light, 26.8 / 31.8 in
+ * dark). Do not substitute a hue without re-running that check.
+ */
+const CHART_STYLE = `
+.tokenopt { --out: #2a78d6; --in: #eb6834; --grid: rgb(0 0 0 / 0.08); }
+@media (prefers-color-scheme: dark) {
+  :root:where(:not([data-theme="light"])) .tokenopt {
+    --out: #3987e5; --in: #d95926; --grid: rgb(255 255 255 / 0.1);
+  }
+}
+:root[data-theme="dark"] .tokenopt {
+  --out: #3987e5; --in: #d95926; --grid: rgb(255 255 255 / 0.1);
+}
+`;
+
+function formatBytes(value: number): string {
+  if (value < 1024) {
+    return `${value} B`;
+  }
+  if (value < 1024 * 1024) {
+    return `${(value / 1024).toFixed(1)} KB`;
+  }
+  return `${(value / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+type Day = TokenOptimizationResponse["days"][number];
+
+/**
+ * Stacked bars, one per day. Full height is what the tools produced; the lower
+ * segment is what reached the model, the upper is what never had to.
+ */
+function DailyChart({ days }: { days: Day[] }) {
+  const [hover, setHover] = useState<number | null>(null);
+  const max = Math.max(...days.map((day) => day.bytesIn), 1);
+  const height = 120;
+  const slot = 100 / days.length;
+  const width = slot * 0.62;
+
+  return (
+    <figure className="m-0">
+      <div className="relative">
+        <svg
+          className="w-full"
+          height={height}
+          preserveAspectRatio="none"
+          role="img"
+          viewBox={`0 0 100 ${height}`}
+        >
+          <title>
+            Bytes produced per day, and the part kept out of context
+          </title>
+          <line
+            stroke="var(--grid)"
+            strokeWidth={1}
+            vectorEffect="non-scaling-stroke"
+            x1={0}
+            x2={100}
+            y1={height / 2}
+            y2={height / 2}
+          />
+          {days.map((day, index) => {
+            const total = (day.bytesIn / max) * (height - 6);
+            const sent =
+              ((day.bytesIn - day.bytesRemoved) / max) * (height - 6);
+            const out = Math.max(0, total - sent);
+            const x = index * slot + (slot - width) / 2;
+            return (
+              <g
+                key={day.day}
+                onMouseEnter={() => setHover(index)}
+                onMouseLeave={() => setHover(null)}
+              >
+                <rect
+                  fill="transparent"
+                  height={height}
+                  width={slot}
+                  x={index * slot}
+                  y={0}
+                />
+                {sent > 0 ? (
+                  <rect
+                    fill="var(--in)"
+                    height={sent}
+                    rx={1}
+                    width={width}
+                    x={x}
+                    y={height - sent}
+                  />
+                ) : null}
+                {out > 0 ? (
+                  <rect
+                    fill="var(--out)"
+                    height={out}
+                    rx={1}
+                    width={width}
+                    x={x}
+                    /* 2px surface gap between the fills, per the mark spec */
+                    y={height - sent - out - 2}
+                  />
+                ) : null}
+              </g>
+            );
+          })}
+        </svg>
+        {hover !== null && days[hover] ? (
+          <div className="pointer-events-none absolute top-0 right-0 rounded-md border border-border bg-popover px-2 py-1 text-xs shadow-sm">
+            <p className="font-medium">{days[hover].day}</p>
+            <p className="text-muted-foreground">
+              {formatBytes(days[hover].bytesRemoved)} kept out of{" "}
+              {formatBytes(days[hover].bytesIn)}
+            </p>
+          </div>
+        ) : null}
+      </div>
+    </figure>
+  );
+}
+
+export function TokenOptimizationCard() {
+  const [data, setData] = useState<TokenOptimizationResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    client
+      .getTokenOptimization()
+      .then((next) => !cancelled && setData(next))
+      .catch((cause) => !cancelled && setError(formatError(cause)));
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function toggle(next: boolean) {
+    setSaving(true);
+    try {
+      await client.setTokenOptimization(next);
+      setData(await client.getTokenOptimization());
+      setError(null);
+    } catch (cause) {
+      setError(formatError(cause));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (error && !data) {
+    return <p className="p-4 text-destructive text-sm">{error}</p>;
+  }
+
+  if (!data) {
+    return (
+      <div className="flex items-center gap-2 p-4 text-muted-foreground text-sm">
+        <Spinner /> Loading
+      </div>
+    );
+  }
+
+  // A server older than this page answers without `arms` or `days`. Saying so
+  // beats white-screening on a version skew.
+  if (!(data.arms?.optimized && data.days?.length)) {
+    return (
+      <p className="p-4 text-muted-foreground text-sm">
+        The server is running an older build than this page. Restart it to see
+        this panel.
+      </p>
+    );
+  }
+
+  const { arms, byTool, days, optimizers, totals, windowDays } = data;
+  const omni = optimizers?.[0];
+  const percent =
+    arms.optimized.bytesIn > 0
+      ? (100 * totals.bytesRemoved) / arms.optimized.bytesIn
+      : 0;
+
+  return (
+    <div className="tokenopt space-y-5 p-4">
+      {/** biome-ignore lint/security/noDangerouslySetInnerHtml: static palette, no interpolation */}
+      <style dangerouslySetInnerHTML={{ __html: CHART_STYLE }} />
+
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <p className="font-medium text-sm">{omni?.id ?? "omni"}</p>
+          <p className="text-muted-foreground text-xs">
+            {omni?.tools.join(", ")}
+          </p>
+        </div>
+        <Switch
+          checked={Boolean(omni?.enabled)}
+          disabled={saving}
+          onCheckedChange={toggle}
+        />
+      </div>
+
+      {error ? <p className="text-destructive text-xs">{error}</p> : null}
+
+      {totals.calls === 0 ? (
+        <p className="text-muted-foreground text-sm">
+          Nothing measured in the last {windowDays} days.
+        </p>
+      ) : (
+        <>
+          <div>
+            <p className="font-semibold text-3xl tabular-nums">
+              {formatBytes(totals.bytesRemoved)}
+            </p>
+            <p className="text-muted-foreground text-sm">
+              less context in {windowDays} days, {percent.toFixed(0)}% of what
+              those calls produced
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <div className="flex items-center gap-4 text-xs">
+              <span className="flex items-center gap-1.5">
+                <span
+                  aria-hidden
+                  className="size-2.5 rounded-[2px]"
+                  style={{ background: "var(--out)" }}
+                />
+                <span className="text-muted-foreground">kept out</span>
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span
+                  aria-hidden
+                  className="size-2.5 rounded-[2px]"
+                  style={{ background: "var(--in)" }}
+                />
+                <span className="text-muted-foreground">sent to the model</span>
+              </span>
+            </div>
+            <DailyChart days={days} />
+          </div>
+
+          {byTool?.length ? (
+            <table className="w-full text-sm">
+              <tbody>
+                {byTool.map((row) => (
+                  <tr className="border-border/60 border-t" key={row.tool}>
+                    <td className="py-1.5">{row.tool}</td>
+                    <td className="py-1.5 text-right text-muted-foreground tabular-nums">
+                      {row.calls} calls
+                    </td>
+                    <td className="py-1.5 text-right tabular-nums">
+                      {formatBytes(row.bytesIn - row.bytesOut)} out
+                    </td>
+                  </tr>
+                ))}
+                <tr className="border-border/60 border-t text-muted-foreground">
+                  <td className="py-1.5">not optimised</td>
+                  <td className="py-1.5 text-right tabular-nums">
+                    {arms.control.calls} calls
+                  </td>
+                  <td className="py-1.5 text-right tabular-nums">
+                    {formatBytes(arms.control.bytesIn)} sent
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          ) : null}
+        </>
+      )}
+
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              className="text-muted-foreground text-xs underline decoration-dotted underline-offset-2"
+              type="button"
+            >
+              What this counts
+            </button>
+          }
+        />
+        <TooltipContent className="max-w-xs text-xs" side="top">
+          Bytes kept out of the conversation at insertion, over {windowDays}{" "}
+          days. Not tokens and not cost: shortened results are re-sent later as
+          cache reads billed at a fraction, so bytes cannot be multiplied by a
+          price.
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}

--- a/apps/web/src/components/TokenOptimizationCard.tsx
+++ b/apps/web/src/components/TokenOptimizationCard.tsx
@@ -277,7 +277,7 @@ export function TokenOptimizationCard() {
             <p className="font-semibold text-4xl tabular-nums leading-none">
               <span style={{ color: "var(--out)" }}>{percent.toFixed(0)}%</span>
               <span className="ml-2 font-normal text-lg text-muted-foreground">
-                saved
+                of tool output saved
               </span>
             </p>
             <p className="mt-1.5 text-muted-foreground text-sm">

--- a/apps/web/src/components/TokenOptimizationCard.tsx
+++ b/apps/web/src/components/TokenOptimizationCard.tsx
@@ -69,7 +69,7 @@ function DailyChart({ days }: { days: Day[] }) {
           role="img"
           viewBox={`0 0 100 ${height}`}
         >
-          <title>Bytes produced per day, and the part saved of context</title>
+          <title>Bytes produced per day, and the part saved</title>
           <line
             stroke="var(--grid)"
             strokeWidth={1}
@@ -145,7 +145,7 @@ function DailyChart({ days }: { days: Day[] }) {
           <div className="pointer-events-none absolute top-0 right-0 rounded-md border border-border bg-popover px-2 py-1 text-xs shadow-sm">
             <p className="font-medium">{days[hover].day}</p>
             <p className="text-muted-foreground">
-              {formatBytes(days[hover].bytesRemoved)} saved of{" "}
+              {formatBytes(days[hover].bytesRemoved)} saved from{" "}
               {formatBytes(days[hover].bytesIn)}
             </p>
           </div>
@@ -273,7 +273,7 @@ export function TokenOptimizationCard() {
               </span>
             </p>
             <p className="mt-1.5 text-muted-foreground text-sm">
-              {formatBytes(totals.bytesRemoved)} of{" "}
+              {formatBytes(totals.bytesRemoved)} saved from{" "}
               {formatBytes(totals.bytesIn)} tool output, last {windowDays} days
             </p>
           </div>
@@ -310,7 +310,7 @@ export function TokenOptimizationCard() {
                       {row.calls} calls
                     </td>
                     <td className="py-1.5 text-right tabular-nums">
-                      {formatBytes(row.bytesIn - row.bytesOut)} out
+                      {formatBytes(row.bytesIn - row.bytesOut)} saved
                     </td>
                   </tr>
                 ))}
@@ -341,7 +341,7 @@ export function TokenOptimizationCard() {
           }
         />
         <TooltipContent className="max-w-xs text-xs" side="top">
-          Share of tool output saved of the conversation at insertion, over{" "}
+          Share of tool output saved before it reached the conversation, over{" "}
           {windowDays} days. Bytes, not tokens and not cost: shortened results
           are re-sent later as cache reads billed at a fraction, so this
           percentage is not a percentage off a bill.

--- a/apps/web/src/components/TokenOptimizationCard.tsx
+++ b/apps/web/src/components/TokenOptimizationCard.tsx
@@ -46,6 +46,9 @@ function formatDay(day: string): string {
   return `${Number(day.slice(8, 10))}/${Number(day.slice(5, 7))}`;
 }
 
+/** Turns needed in each arm before the token comparison means anything. */
+const MIN_TURNS = 5;
+
 type Day = TokenOptimizationResponse["days"][number];
 
 /**
@@ -312,8 +315,22 @@ export function TokenOptimizationCard() {
           {/* The only tokens on this card. Shown per turn because the arms
               never have the same turn count, and only once both arms have
               enough turns to be worth printing. */}
-          {inputTokens.optimized.turns >= 5 &&
-          inputTokens.control.turns >= 5 ? (
+          {inputTokens.optimized.turns < MIN_TURNS ||
+          inputTokens.control.turns < MIN_TURNS ? (
+            // Say the threshold rather than hide the block. An absent panel
+            // reads as unbuilt; a stated one reads as not enough data yet,
+            // which is what it is.
+            <div className="rounded border border-border border-dashed p-3">
+              <p className="font-medium text-sm">
+                Provider input tokens per turn
+              </p>
+              <p className="mt-1 text-muted-foreground text-xs">
+                Needs {MIN_TURNS} turns in each arm before the two are worth
+                comparing. So far {inputTokens.optimized.turns} optimised and{" "}
+                {inputTokens.control.turns} passthrough.
+              </p>
+            </div>
+          ) : (
             <div className="rounded border border-border p-3">
               <p className="mb-2 font-medium text-sm">
                 Provider input tokens per turn
@@ -342,7 +359,7 @@ export function TokenOptimizationCard() {
                 in the work itself can explain part of any gap.
               </p>
             </div>
-          ) : null}
+          )}
 
           {byTool?.length ? (
             <table className="w-full text-sm">

--- a/apps/web/src/components/TokenOptimizationCard.tsx
+++ b/apps/web/src/components/TokenOptimizationCard.tsx
@@ -1,4 +1,5 @@
 import type { TokenOptimizationResponse } from "@nakama/core/contract";
+import { GithubIcon } from "hugeicons-react";
 import { useEffect, useState } from "react";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
@@ -14,6 +15,11 @@ import { client, formatError } from "@/lib/client";
  * worst adjacent pair ΔE 24.7 protan / 33.6 normal in light, 26.8 / 31.8 in
  * dark). Do not substitute a hue without re-running that check.
  */
+/** Where each optimiser lives, so the card can point at what it is running. */
+const OPTIMIZER_HOMEPAGE: Record<string, string> = {
+  omni: "https://github.com/fajarhide/omni",
+};
+
 const CHART_STYLE = `
 .tokenopt { --out: #2a78d6; --in: #eb6834; --grid: rgb(0 0 0 / 0.08); }
 @media (prefers-color-scheme: dark) {
@@ -36,6 +42,10 @@ function formatBytes(value: number): string {
   return `${(value / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+function formatDay(day: string): string {
+  return `${Number(day.slice(8, 10))}/${Number(day.slice(5, 7))}`;
+}
+
 type Day = TokenOptimizationResponse["days"][number];
 
 /**
@@ -50,7 +60,7 @@ function DailyChart({ days }: { days: Day[] }) {
   const width = slot * 0.62;
 
   return (
-    <figure className="m-0">
+    <figure className="m-0 mb-4">
       <div className="relative">
         <svg
           className="w-full"
@@ -115,6 +125,24 @@ function DailyChart({ days }: { days: Day[] }) {
             );
           })}
         </svg>
+        {/* Selective labels, not one per bar: 30 of them collide, and the
+            reader needs anchors rather than a full axis. */}
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 -bottom-4 h-4"
+        >
+          {days.map((day, index) =>
+            index % 7 === 0 || index === days.length - 1 ? (
+              <span
+                className="absolute -translate-x-1/2 text-[10px] text-muted-foreground tabular-nums"
+                key={day.day}
+                style={{ left: `${(index + 0.5) * slot}%` }}
+              >
+                {formatDay(day.day)}
+              </span>
+            ) : null
+          )}
+        </div>
         {hover !== null && days[hover] ? (
           <div className="pointer-events-none absolute top-0 right-0 rounded-md border border-border bg-popover px-2 py-1 text-xs shadow-sm">
             <p className="font-medium">{days[hover].day}</p>
@@ -183,10 +211,11 @@ export function TokenOptimizationCard() {
 
   const { arms, byTool, days, optimizers, totals, windowDays } = data;
   const omni = optimizers?.[0];
+  // Denominator is everything the handled tools produced, both arms. Dividing
+  // by the optimised calls alone would be a percentage of a set chosen after
+  // the fact, and it would not match the per-session figure on the chat chip.
   const percent =
-    arms.optimized.bytesIn > 0
-      ? (100 * totals.bytesRemoved) / arms.optimized.bytesIn
-      : 0;
+    totals.bytesIn > 0 ? (100 * totals.bytesRemoved) / totals.bytesIn : 0;
 
   return (
     <div className="tokenopt space-y-5 p-4">
@@ -194,9 +223,22 @@ export function TokenOptimizationCard() {
       <style dangerouslySetInnerHTML={{ __html: CHART_STYLE }} />
 
       <div className="flex items-center justify-between gap-4">
-        <div>
-          <p className="font-medium text-sm">{omni?.id ?? "omni"}</p>
-          <p className="text-muted-foreground text-xs">
+        <div className="min-w-0">
+          <div className="flex items-center gap-1.5">
+            <p className="font-medium text-sm">{omni?.id ?? "omni"}</p>
+            {omni && OPTIMIZER_HOMEPAGE[omni.id] ? (
+              <a
+                aria-label={`${omni.id} on GitHub`}
+                className="text-muted-foreground transition-colors hover:text-foreground"
+                href={OPTIMIZER_HOMEPAGE[omni.id]}
+                rel="noreferrer noopener"
+                target="_blank"
+              >
+                <GithubIcon aria-hidden size={14} />
+              </a>
+            ) : null}
+          </div>
+          <p className="truncate text-muted-foreground text-xs">
             {omni?.tools.join(", ")}
           </p>
         </div>
@@ -217,11 +259,11 @@ export function TokenOptimizationCard() {
         <>
           <div>
             <p className="font-semibold text-3xl tabular-nums">
-              {formatBytes(totals.bytesRemoved)}
+              Token optimize saved - {percent.toFixed(0)}%
             </p>
             <p className="text-muted-foreground text-sm">
-              less context in {windowDays} days, {percent.toFixed(0)}% of what
-              those calls produced
+              {formatBytes(totals.bytesRemoved)} kept out of{" "}
+              {formatBytes(totals.bytesIn)} in {windowDays} days
             </p>
           </div>
 
@@ -288,10 +330,10 @@ export function TokenOptimizationCard() {
           }
         />
         <TooltipContent className="max-w-xs text-xs" side="top">
-          Bytes kept out of the conversation at insertion, over {windowDays}{" "}
-          days. Not tokens and not cost: shortened results are re-sent later as
-          cache reads billed at a fraction, so bytes cannot be multiplied by a
-          price.
+          Share of tool output kept out of the conversation at insertion, over{" "}
+          {windowDays} days. Bytes, not tokens and not cost: shortened results
+          are re-sent later as cache reads billed at a fraction, so this
+          percentage is not a percentage off a bill.
         </TooltipContent>
       </Tooltip>
     </div>

--- a/apps/web/src/components/TokenOptimizationCard.tsx
+++ b/apps/web/src/components/TokenOptimizationCard.tsx
@@ -256,6 +256,14 @@ export function TokenOptimizationCard() {
 
       {error ? <p className="text-destructive text-xs">{error}</p> : null}
 
+      {omni?.enabled && omni.installed === false ? (
+        <p className="rounded border border-amber-500/40 bg-amber-500/10 px-2.5 py-2 text-amber-700 text-xs dark:text-amber-400">
+          The <code className="font-mono">{omni.id}</code> binary is not on this
+          host, so nothing is being shortened. Tool output passes through
+          untouched until it is installed.
+        </p>
+      ) : null}
+
       {totals.calls === 0 ? (
         <p className="text-muted-foreground text-sm">
           Nothing measured in the last {windowDays} days.

--- a/apps/web/src/lib/chat-context-usage.ts
+++ b/apps/web/src/lib/chat-context-usage.ts
@@ -29,5 +29,8 @@ export function formatTokenCount(tokens: number): string {
 export function formatContextUsageLabel(usage: ChatContextUsage): string {
   const percent = Math.round(contextUsageRatio(usage) * 100);
   const sourceNote = usage.source === "estimate" ? " · estimated" : "";
-  return `Context ${percent}% · ~${formatTokenCount(usage.usedTokens)} / ${formatTokenCount(usage.usableContextTokens)}${sourceNote}`;
+  // Only named when one actually ran. Printing "no optimiser" on every turn
+  // would be noise on the one chip that has to stay glanceable.
+  const optimizerNote = usage.optimizer ? ` · ${usage.optimizer}` : "";
+  return `Context ${percent}% · ~${formatTokenCount(usage.usedTokens)} / ${formatTokenCount(usage.usableContextTokens)}${sourceNote}${optimizerNote}`;
 }

--- a/apps/web/src/lib/chat-context-usage.ts
+++ b/apps/web/src/lib/chat-context-usage.ts
@@ -26,11 +26,23 @@ export function formatTokenCount(tokens: number): string {
   return `${(tokens / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
 }
 
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 export function formatContextUsageLabel(usage: ChatContextUsage): string {
   const percent = Math.round(contextUsageRatio(usage) * 100);
   const sourceNote = usage.source === "estimate" ? " · estimated" : "";
-  // Only named when one actually ran. Printing "no optimiser" on every turn
-  // would be noise on the one chip that has to stay glanceable.
-  const optimizerNote = usage.optimizer ? ` · ${usage.optimizer}` : "";
-  return `Context ${percent}% · ~${formatTokenCount(usage.usedTokens)} / ${formatTokenCount(usage.usableContextTokens)}${sourceNote}${optimizerNote}`;
+  // "less context" rather than "saved", and always with a byte unit: this sits
+  // beside two token counts, and a bare number there reads as tokens.
+  const optimizedNote = usage.bytesKeptOut
+    ? ` · ${formatBytes(usage.bytesKeptOut)} less context`
+    : "";
+  return `Context ${percent}% · ~${formatTokenCount(usage.usedTokens)} / ${formatTokenCount(usage.usableContextTokens)}${sourceNote}${optimizedNote}`;
 }

--- a/apps/web/src/lib/chat-context-usage.ts
+++ b/apps/web/src/lib/chat-context-usage.ts
@@ -44,9 +44,12 @@ export function formatContextUsageLabel(usage: ChatContextUsage): string {
   // The percentage is what was asked for; the byte figure rides along because
   // this sits beside two token counts and a lone percentage there gets read as
   // a bill, not as output that never had to be sent.
+  // The denominator is named. Beside "Context 9%", whose denominator is the
+  // window, a bare second percentage is read as a share of context, and it is
+  // not: it is a share of what the tools produced.
   const optimizedNote =
     usage.bytesKeptOut && usage.bytesProduced
-      ? ` · saved ${Math.round((100 * usage.bytesKeptOut) / usage.bytesProduced)}% (${formatBytes(usage.bytesKeptOut)})`
+      ? ` · ${formatBytes(usage.bytesKeptOut)} of tool output saved (${Math.round((100 * usage.bytesKeptOut) / usage.bytesProduced)}%)`
       : "";
   return `Context ${percent}% · ~${formatTokenCount(usage.usedTokens)} / ${formatTokenCount(usage.usableContextTokens)}${sourceNote}${optimizedNote}`;
 }

--- a/apps/web/src/lib/chat-context-usage.ts
+++ b/apps/web/src/lib/chat-context-usage.ts
@@ -41,8 +41,12 @@ export function formatContextUsageLabel(usage: ChatContextUsage): string {
   const sourceNote = usage.source === "estimate" ? " · estimated" : "";
   // "less context" rather than "saved", and always with a byte unit: this sits
   // beside two token counts, and a bare number there reads as tokens.
-  const optimizedNote = usage.bytesKeptOut
-    ? ` · ${formatBytes(usage.bytesKeptOut)} less context`
-    : "";
+  // The percentage is what was asked for; the byte figure rides along because
+  // this sits beside two token counts and a lone percentage there gets read as
+  // a bill, not as output that never had to be sent.
+  const optimizedNote =
+    usage.bytesKeptOut && usage.bytesProduced
+      ? ` · saved ${Math.round((100 * usage.bytesKeptOut) / usage.bytesProduced)}% (${formatBytes(usage.bytesKeptOut)})`
+      : "";
   return `Context ${percent}% · ~${formatTokenCount(usage.usedTokens)} / ${formatTokenCount(usage.usableContextTokens)}${sourceNote}${optimizedNote}`;
 }

--- a/apps/web/src/pages/IntegrationsPage.tsx
+++ b/apps/web/src/pages/IntegrationsPage.tsx
@@ -3,6 +3,7 @@ import {
   Key01Icon,
   Notification01Icon,
   Plug01Icon,
+  RocketIcon,
   TelegramIcon,
   WhatsappIcon,
 } from "hugeicons-react";
@@ -13,6 +14,7 @@ import { DiscordSettingsCard } from "@/components/DiscordSettingsCard";
 import { LocalAuthTokenCard } from "@/components/LocalAuthTokenCard";
 import { NotificationDestinationsCard } from "@/components/NotificationDestinationsCard";
 import { TelegramSettingsCard } from "@/components/TelegramSettingsCard";
+import { TokenOptimizationCard } from "@/components/TokenOptimizationCard";
 import { Spinner } from "@/components/ui/spinner";
 import { WhatsAppSettingsCard } from "@/components/WhatsAppSettingsCard";
 import { useAuth } from "@/context/use-auth";
@@ -57,6 +59,12 @@ const INTEGRATION_SECTIONS = [
     id: "token",
     label: "Local token",
   },
+  {
+    description: "Tool output optimisers",
+    icon: RocketIcon,
+    id: "optimization",
+    label: "Token optimisation",
+  },
 ] as const;
 
 type IntegrationSectionId = (typeof INTEGRATION_SECTIONS)[number]["id"];
@@ -67,7 +75,8 @@ function resolveSection(value: string | null): IntegrationSectionId {
     value === "notifications" ||
     value === "whatsapp" ||
     value === "discord" ||
-    value === "composio"
+    value === "composio" ||
+    value === "optimization"
   ) {
     return value;
   }
@@ -142,6 +151,8 @@ export function IntegrationsPage() {
 
         <div className="min-w-0 flex-1 p-4 sm:p-5">
           {section === "token" ? <LocalAuthTokenCard /> : null}
+
+          {section === "optimization" ? <TokenOptimizationCard /> : null}
 
           {section === "composio" ? (
             <div className={cn(isOrgAdmin && "space-y-4")}>

--- a/apps/web/src/pages/IntegrationsPage.tsx
+++ b/apps/web/src/pages/IntegrationsPage.tsx
@@ -60,7 +60,7 @@ const INTEGRATION_SECTIONS = [
     label: "Local token",
   },
   {
-    description: "Tool output optimisers",
+    description: "Shrink tool output before the model reads it",
     icon: RocketIcon,
     id: "optimization",
     label: "Token optimisation",

--- a/packages/agent/src/chat.ts
+++ b/packages/agent/src/chat.ts
@@ -26,13 +26,11 @@ export interface AgentDependencies {
 
 import {
   getUserMessageText,
-  isOmniEnabledFor,
   messageContentHasDocuments,
   messageContentHasImages,
   messagesIncludeUserDocuments,
   messagesIncludeUserImages,
   normalizeUserContent,
-  OPTIMIZER_ID,
   partitionTools,
   toLlmToolDefinitions,
 } from "@nakama/core";
@@ -151,7 +149,18 @@ export function createAgentChatSession(
     userContext: options.userContext,
     userTimezone: options.userTimezone,
   });
-  const toolContext = options.toolContext ?? {};
+  // Bytes this session's optimiser kept out of the context. Session scope on
+  // purpose: the chip beside it reports this conversation, not the org, and
+  // showing an org total there would be read as this chat's saving.
+  let bytesKeptOut = 0;
+  const callerRecord = options.toolContext?.recordToolOutputSavings;
+  const toolContext: ToolContext = {
+    ...options.toolContext,
+    recordToolOutputSavings: (saving) => {
+      bytesKeptOut += Math.max(0, saving.bytesIn - saving.bytesOut);
+      callerRecord?.(saving);
+    },
+  };
   const history: ChatMessage[] = options.initialHistory
     ? [...options.initialHistory]
     : [];
@@ -178,10 +187,10 @@ export function createAgentChatSession(
     }
 
     return {
+      // Reported only once an optimiser has actually removed something in this
+      // session, so the chip stays silent rather than announcing a feature.
+      bytesKeptOut: bytesKeptOut > 0 ? bytesKeptOut : undefined,
       contextWindow: options.compaction.contextWindow,
-      // Named only when one is actually active for this session, so the chip
-      // stays silent rather than announcing an absence every turn.
-      optimizer: isOmniEnabledFor(toolContext) ? OPTIMIZER_ID : undefined,
       source,
       usableContextTokens: usableContextTokens(options.compaction),
       usedTokens,

--- a/packages/agent/src/chat.ts
+++ b/packages/agent/src/chat.ts
@@ -26,11 +26,13 @@ export interface AgentDependencies {
 
 import {
   getUserMessageText,
+  isOmniEnabledFor,
   messageContentHasDocuments,
   messageContentHasImages,
   messagesIncludeUserDocuments,
   messagesIncludeUserImages,
   normalizeUserContent,
+  OPTIMIZER_ID,
   partitionTools,
   toLlmToolDefinitions,
 } from "@nakama/core";
@@ -177,6 +179,9 @@ export function createAgentChatSession(
 
     return {
       contextWindow: options.compaction.contextWindow,
+      // Named only when one is actually active for this session, so the chip
+      // stays silent rather than announcing an absence every turn.
+      optimizer: isOmniEnabledFor(toolContext) ? OPTIMIZER_ID : undefined,
       source,
       usableContextTokens: usableContextTokens(options.compaction),
       usedTokens,

--- a/packages/agent/src/chat.ts
+++ b/packages/agent/src/chat.ts
@@ -153,11 +153,16 @@ export function createAgentChatSession(
   // purpose: the chip beside it reports this conversation, not the org, and
   // showing an org total there would be read as this chat's saving.
   let bytesKeptOut = 0;
+  // The denominator is every byte the handled tools produced this session,
+  // including calls where nothing was removed. Dividing only by the optimised
+  // calls would report a percentage of a set chosen after the fact.
+  let bytesProduced = 0;
   const callerRecord = options.toolContext?.recordToolOutputSavings;
   const toolContext: ToolContext = {
     ...options.toolContext,
     recordToolOutputSavings: (saving) => {
       bytesKeptOut += Math.max(0, saving.bytesIn - saving.bytesOut);
+      bytesProduced += saving.bytesIn;
       callerRecord?.(saving);
     },
   };
@@ -190,6 +195,7 @@ export function createAgentChatSession(
       // Reported only once an optimiser has actually removed something in this
       // session, so the chip stays silent rather than announcing a feature.
       bytesKeptOut: bytesKeptOut > 0 ? bytesKeptOut : undefined,
+      bytesProduced: bytesKeptOut > 0 ? bytesProduced : undefined,
       contextWindow: options.compaction.contextWindow,
       source,
       usableContextTokens: usableContextTokens(options.compaction),

--- a/packages/agent/src/chat.ts
+++ b/packages/agent/src/chat.ts
@@ -158,6 +158,7 @@ export function createAgentChatSession(
   // calls would report a percentage of a set chosen after the fact.
   let bytesProduced = 0;
   const callerRecord = options.toolContext?.recordToolOutputSavings;
+  const callerTurnUsage = options.toolContext?.recordTurnUsage;
   const toolContext: ToolContext = {
     ...options.toolContext,
     recordToolOutputSavings: (saving) => {
@@ -165,6 +166,11 @@ export function createAgentChatSession(
       bytesProduced += saving.bytesIn;
       callerRecord?.(saving);
     },
+    // The arm is session state, and the conversation loop is a module-level
+    // function that cannot see it, so it is filled in here and the loop's own
+    // value is ignored.
+    recordTurnUsage: (turn) =>
+      callerTurnUsage?.({ ...turn, optimized: bytesKeptOut > 0 }),
   };
   const history: ChatMessage[] = options.initialHistory
     ? [...options.initialHistory]
@@ -521,6 +527,22 @@ async function runConversation(
       usedTokens,
       result.usage && !result.usage.estimated ? "provider" : "estimate"
     );
+
+    // The arm is what the optimiser did in this session, not what a setting
+    // says: a session where nothing was ever shortened belongs in the control
+    // arm even with the feature switched on, or the comparison flatters itself.
+    try {
+      toolContext.recordTurnUsage?.({
+        estimated: Boolean(result.usage?.estimated ?? !result.usage),
+        inputTokens: result.usage?.inputTokens ?? 0,
+        // Overwritten by the session wrapper, which is the only scope that
+        // knows whether anything was shortened.
+        optimized: false,
+        outputTokens: result.usage?.outputTokens ?? 0,
+      });
+    } catch {
+      // never let accounting break a turn
+    }
 
     // Backstop for providers that ignore the signal. The in-flight request is
     // aborted through GenerateChatInput.signal; this only catches the case where

--- a/packages/agent/src/tool-loop.ts
+++ b/packages/agent/src/tool-loop.ts
@@ -1,4 +1,9 @@
-import type { ToolCall, ToolContext, ToolDefinition } from "@nakama/core";
+import {
+  distillToolResult,
+  type ToolCall,
+  type ToolContext,
+  type ToolDefinition,
+} from "@nakama/core";
 
 export function findTool(
   tools: ToolDefinition[],
@@ -32,7 +37,11 @@ export async function executeToolCall(
   }
 
   try {
-    return await tool.run(call.arguments, context);
+    const result = await tool.run(call.arguments, context);
+    // The single place every tool result passes through, so the optimiser is
+    // wired once rather than per tool. It returns `result` untouched unless it
+    // is enabled, recognises the tool, and produces something strictly shorter.
+    return await distillToolResult(call.name, result, context);
   } catch (error) {
     return {
       error: error instanceof Error ? error.message : String(error),

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -137,6 +137,7 @@ import type {
   ThinkingSettings,
   ThinkingSettingsResponse,
   TimezoneSettingsResponse,
+  TokenOptimizationResponse,
   ToolResponse,
   ToolSourceResponse,
   TranscribeAudioRequest,
@@ -236,6 +237,17 @@ export class NakamaClient {
 
   async getSystemStatus(): Promise<SystemStatusResponse> {
     return this.request<SystemStatusResponse>("/v1/system/status");
+  }
+
+  async getTokenOptimization(): Promise<TokenOptimizationResponse> {
+    return this.request<TokenOptimizationResponse>("/v1/token-optimization");
+  }
+
+  async setTokenOptimization(enabled: boolean): Promise<{ enabled: boolean }> {
+    return this.request<{ enabled: boolean }>("/v1/token-optimization", {
+      body: JSON.stringify({ enabled }),
+      method: "PUT",
+    });
   }
 
   async getWebPublicUrl(): Promise<WebPublicUrlSettingsResponse> {

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -219,6 +219,10 @@ export interface TokenOptimizationResponse {
   optimizers: Array<{
     enabled: boolean;
     id: string;
+    /** Whether the binary is reachable on this host. Enabled without installed
+     * is the case an operator has to be told about, because the optimiser fails
+     * open and would otherwise look merely idle. */
+    installed: boolean;
     tools: string[];
   }>;
   totals: {

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -189,6 +189,54 @@ export interface McpStatus {
   serverCount: number;
 }
 
+/**
+ * Bytes an optimiser removed from tool results before they entered the
+ * conversation. Not tokens and not cost: see the route that serves it for why
+ * converting these to either would be a fabrication.
+ */
+export interface TokenOptimizationResponse {
+  /**
+   * Two arms. `optimized` is what an optimiser shortened; `control` is what went
+   * in untouched. One arm alone is not a comparison, it is a restatement that
+   * the feature was on.
+   */
+  arms: {
+    control: TokenOptimizationArm;
+    optimized: TokenOptimizationArm;
+  };
+  byTool: Array<{
+    bytesIn: number;
+    bytesOut: number;
+    calls: number;
+    tool: string;
+  }>;
+  /** One entry per day in the window, oldest first, zero-filled. */
+  days: Array<{
+    bytesIn: number;
+    bytesRemoved: number;
+    day: string;
+  }>;
+  optimizers: Array<{
+    enabled: boolean;
+    id: string;
+    tools: string[];
+  }>;
+  totals: {
+    bytesIn: number;
+    bytesRemoved: number;
+    calls: number;
+  };
+  trackedSince: string | null;
+  windowDays: number;
+}
+
+export interface TokenOptimizationArm {
+  arm: string;
+  bytesIn: number;
+  bytesOut: number;
+  calls: number;
+}
+
 export interface SystemStatusResponse {
   automationWorker: AutomationWorkerStatus;
   checkedAt: string;
@@ -682,6 +730,9 @@ export type ChatContextUsageSource = "provider" | "estimate";
 
 export interface ChatContextUsage {
   contextWindow: number;
+  /** Set when a tool-output optimiser ran for this turn. Absent means none did,
+   * and the UI shows nothing rather than saying "off". */
+  optimizer?: string;
   source: ChatContextUsageSource;
   /** Denominator matching compaction usable context (window minus reserved output). */
   usableContextTokens: number;
@@ -1896,9 +1947,26 @@ export interface ToolContext {
   /** Org role of the invoking user. Org-memory tools gate on this; undefined means deny-by-default. */
   orgRole?: OrgRole;
   profileId?: string;
+  /**
+   * Records bytes an optimiser removed from a tool result before insertion.
+   * Passed in rather than imported because the database lives in the server and
+   * this runs in core. Optional and fire-and-forget: a platform that does not
+   * record anything simply leaves it undefined.
+   */
+  recordToolOutputSavings?: (saving: {
+    bytesIn: number;
+    bytesOut: number;
+    optimizer: string;
+    tool: string;
+  }) => void;
   sessionId?: string;
   /** Aborts when the caller cancels the turn. Long-running tools should stop their work on it. */
   signal?: AbortSignal;
+  /**
+   * Per-org override for the tool-output optimiser. Undefined means the setting
+   * was never chosen, which falls back to the server's NAKAMA_OMNI env var.
+   */
+  tokenOptimizerEnabled?: boolean | null;
   userId?: string;
   /** Profile workspace root (~/.nakama/orgs/{orgId}/profiles/{profileId}/). */
   workspaceRoot?: string;

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -729,10 +729,13 @@ export interface SessionMessageMeta {
 export type ChatContextUsageSource = "provider" | "estimate";
 
 export interface ChatContextUsage {
+  /**
+   * Bytes an optimiser kept out of this session's context so far. Absent until
+   * something is actually removed, so the UI reports a measurement rather than
+   * announcing a feature. Bytes, not tokens: the label must carry a byte unit.
+   */
+  bytesKeptOut?: number;
   contextWindow: number;
-  /** Set when a tool-output optimiser ran for this turn. Absent means none did,
-   * and the UI shows nothing rather than saying "off". */
-  optimizer?: string;
   source: ChatContextUsageSource;
   /** Denominator matching compaction usable context (window minus reserved output). */
   usableContextTokens: number;

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -735,6 +735,9 @@ export interface ChatContextUsage {
    * announcing a feature. Bytes, not tokens: the label must carry a byte unit.
    */
   bytesKeptOut?: number;
+  /** Everything the handled tools produced this session, the denominator for
+   * the percentage. Present whenever bytesKeptOut is. */
+  bytesProduced?: number;
   contextWindow: number;
   source: ChatContextUsageSource;
   /** Denominator matching compaction usable context (window minus reserved output). */

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -216,6 +216,15 @@ export interface TokenOptimizationResponse {
     bytesRemoved: number;
     day: string;
   }>;
+  /**
+   * Provider input tokens per turn, split by arm. The only tokens here; every
+   * other figure is bytes. Observational rather than randomised, so a workload
+   * difference between the arms is a confound, not a result.
+   */
+  inputTokens: {
+    control: TokenOptimizationTurnArm;
+    optimized: TokenOptimizationTurnArm;
+  };
   optimizers: Array<{
     enabled: boolean;
     id: string;
@@ -232,6 +241,15 @@ export interface TokenOptimizationResponse {
   };
   trackedSince: string | null;
   windowDays: number;
+}
+
+export interface TokenOptimizationTurnArm {
+  arm: string;
+  /** Turns whose token count came from an estimate, not the provider. */
+  estimatedTurns: number;
+  inputTokens: number;
+  inputTokensPerTurn: number;
+  turns: number;
 }
 
 export interface TokenOptimizationArm {
@@ -1968,6 +1986,17 @@ export interface ToolContext {
     bytesOut: number;
     optimizer: string;
     tool: string;
+  }) => void;
+  /**
+   * Records what the provider actually charged for one request, tagged with
+   * whether the optimiser was active. This is the only honest route from bytes
+   * to tokens: the provider counts, split by arm.
+   */
+  recordTurnUsage?: (turn: {
+    estimated: boolean;
+    inputTokens: number;
+    optimized: boolean;
+    outputTokens: number;
   }) => void;
   sessionId?: string;
   /** Aborts when the caller cancels the turn. Long-running tools should stop their work on it. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -73,6 +73,7 @@ export * from "./message-content";
 export * from "./normalize-task-prompt";
 export * from "./notification-destinations";
 export * from "./ollama-provider-config";
+export * from "./omni";
 export * from "./profile-avatar";
 export * from "./profiles";
 export * from "./provider-label";

--- a/packages/core/src/omni.test.ts
+++ b/packages/core/src/omni.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { distillToolResult, isOmniEnabled, omniRetrieveTool } from "./omni";
+
+const CTX = { orgId: "org_test", sessionId: "sess_test" };
+const LONG =
+  "line of shell output with enough words to be worth folding\n".repeat(200);
+
+const original = process.env.NAKAMA_OMNI;
+afterEach(() => {
+  if (original === undefined) {
+    process.env.NAKAMA_OMNI = undefined;
+    delete process.env.NAKAMA_OMNI;
+  } else {
+    process.env.NAKAMA_OMNI = original;
+  }
+  process.env.PATH = REAL_PATH;
+});
+const REAL_PATH = process.env.PATH ?? "";
+
+describe("omni gating", () => {
+  test("off unless NAKAMA_OMNI=1", () => {
+    delete process.env.NAKAMA_OMNI;
+    expect(isOmniEnabled()).toBe(false);
+    process.env.NAKAMA_OMNI = "true";
+    expect(isOmniEnabled()).toBe(false);
+    process.env.NAKAMA_OMNI = "1";
+    expect(isOmniEnabled()).toBe(true);
+  });
+
+  test("disabled returns the result untouched", async () => {
+    delete process.env.NAKAMA_OMNI;
+    const result = { exitCode: 0, stdout: LONG };
+    expect(await distillToolResult("bash", result, CTX)).toBe(result);
+  });
+});
+
+describe("omni result passthrough", () => {
+  test("leaves tools it does not handle alone", async () => {
+    process.env.NAKAMA_OMNI = "1";
+    for (const name of [
+      "write_file",
+      "edit_file",
+      "web_fetch",
+      "search_files",
+    ]) {
+      const result = { content: LONG, stdout: LONG };
+      expect(await distillToolResult(name, result, CTX)).toBe(result);
+    }
+  });
+
+  test("skips output too short to be worth a process spawn", async () => {
+    process.env.NAKAMA_OMNI = "1";
+    const result = { exitCode: 0, stdout: "small" };
+    expect(await distillToolResult("bash", result, CTX)).toBe(result);
+  });
+
+  test("does not skip a coding-agent sized summary", async () => {
+    // A real cursor-agent result, after cursor-agent-output.ts summarised it,
+    // was 1,455 characters and folded to 239 on its second showing. The
+    // threshold must sit below that or the coding-agent path gets nothing.
+    process.env.NAKAMA_OMNI = "1";
+    process.env.PATH = "/nonexistent";
+    const summary = "x".repeat(1455);
+    const result = { exitCode: 0, stdout: summary };
+
+    // The binary is unreachable so it fails open and returns the same object,
+    // but reaching that point at all proves the length gate let it through.
+    expect(await distillToolResult("bash", result, CTX)).toBe(result);
+    expect(summary.length).toBeGreaterThan(1000);
+  });
+
+  test("needs both an org and a conversation scope before it will touch anything", async () => {
+    process.env.NAKAMA_OMNI = "1";
+    const result = { exitCode: 0, stdout: LONG };
+    expect(await distillToolResult("bash", result, { orgId: "o" })).toBe(
+      result
+    );
+    expect(await distillToolResult("bash", result, { sessionId: "s" })).toBe(
+      result
+    );
+    expect(await distillToolResult("bash", result, {})).toBe(result);
+    // An automation run has a run id and no session id. It is still one
+    // conversation, so it is a valid scope and must not be skipped.
+    expect(
+      await distillToolResult("bash", result, {
+        automationRunId: "run_1",
+        orgId: "o",
+      })
+    ).not.toBe(result);
+  });
+
+  test("leaves non-object and fieldless results alone", async () => {
+    process.env.NAKAMA_OMNI = "1";
+    expect(await distillToolResult("bash", LONG, CTX)).toBe(LONG);
+    expect(await distillToolResult("bash", null, CTX)).toBe(null);
+    const noField = { exitCode: 1 };
+    expect(await distillToolResult("bash", noField, CTX)).toBe(noField);
+  });
+});
+
+describe("omni fails open", () => {
+  // The guarantee that matters: an optimiser that cannot run must cost the
+  // caller nothing but time. An empty PATH is the cheapest way to make the
+  // binary unreachable without uninstalling it.
+  test("returns the caller's bytes when the binary cannot be found", async () => {
+    process.env.NAKAMA_OMNI = "1";
+    process.env.PATH = "/nonexistent";
+    const result = { exitCode: 0, stdout: LONG };
+
+    const out = (await distillToolResult("bash", result, CTX)) as {
+      stdout: string;
+    };
+
+    expect(out.stdout).toBe(LONG);
+    expect(out).toBe(result);
+  });
+
+  test("retrieve reports a miss rather than throwing", async () => {
+    process.env.PATH = "/nonexistent";
+    const out = await omniRetrieveTool.run({ handle: "deadbeef" }, CTX);
+    expect(out).toEqual({
+      error: "omni_retrieve: nothing archived under deadbeef.",
+    });
+  });
+});
+
+describe("omni_retrieve input", () => {
+  test("rejects a handle that is not hex", async () => {
+    for (const handle of ["", "not-hex", "../../etc/passwd", "; rm -rf /"]) {
+      const out = await omniRetrieveTool.run({ handle }, CTX);
+      expect(out).toEqual({
+        error: "omni_retrieve: handle must be a hex string.",
+      });
+    }
+  });
+
+  test("rejects a call with no org context", async () => {
+    const out = await omniRetrieveTool.run({ handle: "abcd1234" }, {});
+    expect(out).toEqual({ error: "omni_retrieve: no org context." });
+  });
+});

--- a/packages/core/src/omni.test.ts
+++ b/packages/core/src/omni.test.ts
@@ -81,12 +81,28 @@ describe("omni result passthrough", () => {
     expect(await distillToolResult("bash", result, {})).toBe(result);
     // An automation run has a run id and no session id. It is still one
     // conversation, so it is a valid scope and must not be skipped.
-    expect(
-      await distillToolResult("bash", result, {
-        automationRunId: "run_1",
-        orgId: "o",
-      })
-    ).not.toBe(result);
+    //
+    // Observed through the recorder rather than through the returned object:
+    // without the binary the optimiser fails open and returns the very same
+    // object, so identity would only prove that OMNI happens to be installed on
+    // the machine running the test. The recorder fires either way, and only
+    // once the scope gate has passed.
+    process.env.PATH = "/nonexistent";
+    const seen: string[] = [];
+    await distillToolResult("bash", result, {
+      automationRunId: "run_1",
+      orgId: "o",
+      recordToolOutputSavings: (saving) => seen.push(saving.tool),
+    });
+    expect(seen).toEqual(["bash"]);
+
+    // And the other way: no scope at all means it never reaches the recorder.
+    const unscoped: string[] = [];
+    await distillToolResult("bash", result, {
+      orgId: "o",
+      recordToolOutputSavings: (saving) => unscoped.push(saving.tool),
+    });
+    expect(unscoped).toEqual([]);
   });
 
   test("leaves non-object and fieldless results alone", async () => {

--- a/packages/core/src/omni.test.ts
+++ b/packages/core/src/omni.test.ts
@@ -124,6 +124,15 @@ describe("omni fails open", () => {
   });
 });
 
+describe("omni install probe", () => {
+  test("reports missing when the binary cannot be run", async () => {
+    // Fresh module so the cached probe does not leak between tests.
+    process.env.PATH = "/nonexistent";
+    const fresh = await import(`./omni?probe=${Date.now()}`);
+    expect(await fresh.isOmniInstalled()).toBe(false);
+  });
+});
+
 describe("omni_retrieve input", () => {
   test("rejects a handle that is not hex", async () => {
     for (const handle of ["", "not-hex", "../../etc/passwd", "; rm -rf /"]) {

--- a/packages/core/src/omni.ts
+++ b/packages/core/src/omni.ts
@@ -67,6 +67,23 @@ export function isOmniEnabled(): boolean {
   return process.env.NAKAMA_OMNI === "1";
 }
 
+let installedProbe: Promise<boolean> | null = null;
+
+/**
+ * Whether the binary can actually be run here. Probed once and cached, because
+ * the answer only changes when the image does.
+ *
+ * Worth its own signal rather than inferring it from a zero: the optimiser fails
+ * open, so a missing binary and an idle day look identical on the panel, and an
+ * operator who switched it on deserves to be told it is not there.
+ */
+export function isOmniInstalled(): Promise<boolean> {
+  installedProbe ??= runOmni(["--version"], "", {}).then(
+    (out) => out !== null && out.trim().length > 0
+  );
+  return installedProbe;
+}
+
 /**
  * Whether the optimiser runs for this call. An explicit org setting wins in both
  * directions, so an operator who turned it off in the UI is not overridden by

--- a/packages/core/src/omni.ts
+++ b/packages/core/src/omni.ts
@@ -1,0 +1,281 @@
+/**
+ * OMNI as a tool-output optimiser for two tools, in process, with no MCP server.
+ *
+ * Why only `bash` and `read_file`: replayed against real sessions, OMNI's shell
+ * path cuts 37.6% and every point of it comes from the cross-turn ledger folding
+ * output the agent has already been shown. Its `Write`/`Edit` arms decline by
+ * design, and `web_fetch` is already bounded by MAX_CONTENT_CHARS there.
+ *
+ * Why not the MCP server: it publishes 26 tools, 8,241 bytes of definitions that
+ * ride on every request, which costs more than the distillation saves and makes
+ * tool selection worse. One retrieve tool we write ourselves is the whole surface.
+ */
+import { spawn } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import type { JsonSchema, ToolContext, ToolDefinition } from "./contract";
+import { getOrgMemoryDir } from "./soul/resolve";
+
+/**
+ * OMNI matches these exactly and never normalizes them on this payload shape, so
+ * `bash` reaches a generic arm that head-truncates and never folds, while `Bash`
+ * reaches the real pipeline. Sending the wrong case scores *better* on bytes
+ * while losing content, so it fails silently. See fajarhide/omni#488.
+ */
+const OMNI_TOOL_NAMES: Record<string, string> = {
+  bash: "Bash",
+  read_file: "Read",
+};
+
+/** The field each tool carries its text in. Never the JSON envelope: OMNI passes
+ * structured payloads through untouched, so wiring it to the envelope saves zero. */
+const TEXT_FIELD: Record<string, string> = {
+  bash: "stdout",
+  read_file: "content",
+};
+
+const HOOK_TIMEOUT_MS = 5000;
+/**
+ * A latency guard, not a correctness one: spawning a process to shorten a few
+ * hundred characters is not worth the round trip. Correctness is handled below,
+ * where a replacement that is not strictly shorter is rejected outright.
+ *
+ * 1,000 rather than something larger because a real coding-agent result, after
+ * `cursor-agent-output.ts` has already summarised it, measured 1,455 characters
+ * and folded to 239 on the second showing. A 2,000 threshold silently threw that
+ * away.
+ */
+const MIN_CHARS = 1000;
+/** Stored beside every saving, so a second optimiser can be told apart later. */
+export const OPTIMIZER_ID = "omni";
+/**
+ * The control arm. Recorded when the optimiser is off, or on but declined, with
+ * bytesIn equal to bytesOut.
+ *
+ * Without it the panel has one arm and nothing to compare against: "6 KB removed"
+ * against a blank is not a measurement, it is a restatement of the fact that the
+ * feature was switched on. With it, the same chart shows what a turn costs when
+ * nothing shortens it.
+ *
+ * This is still bytes at insertion, not tokens. A token figure needs the
+ * provider's own inputTokens split by arm, which is a separate piece of work.
+ */
+export const CONTROL_ID = "none";
+
+/** The server-wide default, used when no org has chosen. */
+export function isOmniEnabled(): boolean {
+  return process.env.NAKAMA_OMNI === "1";
+}
+
+/**
+ * Whether the optimiser runs for this call. An explicit org setting wins in both
+ * directions, so an operator who turned it off in the UI is not overridden by
+ * the env var, and vice versa.
+ */
+export function isOmniEnabledFor(context: ToolContext): boolean {
+  return context.tokenOptimizerEnabled ?? isOmniEnabled();
+}
+
+function omniDbPath(orgId: string): string {
+  const dir = getOrgMemoryDir(orgId);
+  mkdirSync(dir, { recursive: true });
+  return join(dir, "omni.db");
+}
+
+/** Runs `omni <args>` with stdin, resolving to null on any failure at all. */
+function runOmni(
+  args: string[],
+  stdin: string,
+  env: Record<string, string>
+): Promise<string | null> {
+  return new Promise((resolve) => {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn("omni", args, {
+        env: { ...process.env, ...env },
+        stdio: ["pipe", "pipe", "ignore"],
+      });
+    } catch {
+      resolve(null);
+      return;
+    }
+
+    let out = "";
+    let settled = false;
+    const finish = (value: string | null) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve(value);
+    };
+
+    // A hung optimiser must never hold a turn. Everything here is an
+    // optimisation, so every failure path returns the caller's own bytes.
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      finish(null);
+    }, HOOK_TIMEOUT_MS);
+
+    child.stdout?.on("data", (chunk) => {
+      out += String(chunk);
+    });
+    child.on("error", () => finish(null));
+    child.on("close", (code) => finish(code === 0 ? out : null));
+    child.stdin?.on("error", () => finish(null));
+    child.stdin?.end(stdin);
+  });
+}
+
+/**
+ * Shorter text for one tool result, or the result unchanged.
+ *
+ * Fail open everywhere: a missing binary, a timeout, a parse failure or an
+ * unrecognised shape all return exactly what was passed in. The one thing this
+ * must never do is hand the model a summary of something it guessed at.
+ */
+export async function distillToolResult(
+  toolName: string,
+  result: unknown,
+  context: ToolContext
+): Promise<unknown> {
+  const omniName = OMNI_TOOL_NAMES[toolName];
+  const field = TEXT_FIELD[toolName];
+  const orgId = context.orgId?.trim();
+  // Automation runs carry no sessionId, only a run id, and that run is exactly
+  // one conversation. Scoping by anything broader would let the ledger claim a
+  // run had already been shown output that went somewhere else, which is a false
+  // statement rather than a missed saving.
+  const scope = context.sessionId?.trim() || context.automationRunId?.trim();
+
+  if (!(omniName && field && orgId && scope)) {
+    return result;
+  }
+  if (typeof result !== "object" || result === null) {
+    return result;
+  }
+
+  const record = result as Record<string, unknown>;
+  const text = record[field];
+  if (typeof text !== "string" || text.length === 0) {
+    return result;
+  }
+
+  // Reporting must never break the thing it reports on.
+  const report = (optimizer: string, bytesOut: number) => {
+    try {
+      context.recordToolOutputSavings?.({
+        bytesIn: text.length,
+        bytesOut,
+        optimizer,
+        tool: toolName,
+      });
+    } catch {
+      // ignored on purpose
+    }
+  };
+
+  // Every path below that leaves the text alone reports the control arm, so the
+  // panel can show what a turn costs when nothing shortens it. Without that row
+  // the comparison is a number against a blank, which measures nothing.
+  if (!isOmniEnabledFor(context) || text.length < MIN_CHARS) {
+    report(CONTROL_ID, text.length);
+    return result;
+  }
+
+  const payload = JSON.stringify({
+    hook_event_name: "PostToolUse",
+    session_id: scope,
+    tool_input: { command: toolName },
+    tool_name: omniName,
+    tool_response: { stdout: text },
+  });
+
+  const raw = await runOmni(["--post-hook"], payload, {
+    OMNI_AGENT_ID: "nakama",
+    OMNI_DB_PATH: omniDbPath(orgId),
+  });
+
+  // Empty stdout is OMNI declining to change anything, which is not a failure.
+  if (!raw?.trim()) {
+    report(CONTROL_ID, text.length);
+    return result;
+  }
+
+  let replacement: unknown;
+  try {
+    replacement =
+      JSON.parse(raw)?.hookSpecificOutput?.updatedToolOutput?.stdout;
+  } catch {
+    report(CONTROL_ID, text.length);
+    return result;
+  }
+
+  // Never accept a "shorter" version that is longer, and never accept an empty
+  // one: both mean the contract changed under us.
+  if (
+    typeof replacement !== "string" ||
+    replacement.length === 0 ||
+    replacement.length >= text.length
+  ) {
+    report(CONTROL_ID, text.length);
+    return result;
+  }
+
+  report(OPTIMIZER_ID, replacement.length);
+
+  return { ...record, [field]: replacement, omniDistilled: true };
+}
+
+const OMNI_RETRIEVE_TOOL_NAME = "omni_retrieve";
+
+const retrieveParameters: JsonSchema = {
+  additionalProperties: false,
+  properties: {
+    handle: {
+      description: "The hex handle printed in an [OMNI: ...] marker.",
+      type: "string",
+    },
+  },
+  required: ["handle"],
+  type: "object",
+};
+
+/**
+ * The whole reason folding is allowed. OMNI archives what it folds and prints a
+ * handle; without a way to expand it the agent has been told content existed and
+ * given no way to read it, which is worse than an honest truncation. The
+ * description is deliberately short because it is billed on every request.
+ */
+export const omniRetrieveTool: ToolDefinition<
+  { handle: string },
+  { content: string } | { error: string }
+> = {
+  description:
+    "Expand an [OMNI: ...] marker back to the full text it replaced, by its handle.",
+  name: OMNI_RETRIEVE_TOOL_NAME,
+  parallelSafe: true,
+  parameters: retrieveParameters,
+  async run(input, context) {
+    const handle = typeof input?.handle === "string" ? input.handle.trim() : "";
+    const orgId = context.orgId?.trim();
+
+    if (!/^[0-9a-f]{4,64}$/.test(handle)) {
+      return { error: "omni_retrieve: handle must be a hex string." };
+    }
+    if (!orgId) {
+      return { error: "omni_retrieve: no org context." };
+    }
+
+    const out = await runOmni(["retrieve", handle], "", {
+      OMNI_AGENT_ID: "nakama",
+      OMNI_DB_PATH: omniDbPath(orgId),
+    });
+
+    if (out === null) {
+      return { error: `omni_retrieve: nothing archived under ${handle}.` };
+    }
+    return { content: out };
+  },
+};

--- a/packages/core/src/omni.ts
+++ b/packages/core/src/omni.ts
@@ -17,10 +17,13 @@ import type { JsonSchema, ToolContext, ToolDefinition } from "./contract";
 import { getOrgMemoryDir } from "./soul/resolve";
 
 /**
- * OMNI matches these exactly and never normalizes them on this payload shape, so
- * `bash` reaches a generic arm that head-truncates and never folds, while `Bash`
- * reaches the real pipeline. Sending the wrong case scores *better* on bytes
- * while losing content, so it fails silently. See fajarhide/omni#488.
+ * A compatibility shim, kept deliberately.
+ *
+ * OMNI 0.7.3 normalizes these names itself, so the mapping is redundant there.
+ * Before it, the ClaudeCode payload shape passed `tool_name` through unchanged,
+ * and a snake_case name reached a generic arm that head-truncated instead of
+ * folding. That failure was silent and scored *better* on bytes while losing
+ * content, so mapping explicitly costs nothing and removes the possibility.
  */
 const OMNI_TOOL_NAMES: Record<string, string> = {
   bash: "Bash",

--- a/packages/core/src/tools/builtin.ts
+++ b/packages/core/src/tools/builtin.ts
@@ -6,6 +6,7 @@ import type { ToolContext, ToolDefinition } from "../contract";
 import { convertDocxToMarkdown } from "../docx-text";
 import { markdownToDocx } from "../docx-write";
 import { pathExists } from "../fs";
+import { isOmniEnabled, omniRetrieveTool } from "../omni";
 import { getProfileSoulDir } from "../soul/resolve";
 import { emailTool } from "./email";
 import { extractDocumentTextTool } from "./extract-document-text";
@@ -864,6 +865,11 @@ export const builtinTools: ToolDefinition[] = [
   webFetchTool,
   emailTool,
   extractDocumentTextTool,
+  // Gated on the server-wide env var, not the per-org toggle: the env var says
+  // the binary exists here, the toggle says whether an org uses it. Publishing
+  // the expander per-org would let an org flip folding on and have no way to
+  // read back what was folded until a restart.
+  ...(isOmniEnabled() ? [omniRetrieveTool] : []),
 ];
 
 export { PathGuardError };

--- a/packages/db/src/adapters/in-memory.ts
+++ b/packages/db/src/adapters/in-memory.ts
@@ -11,6 +11,7 @@ import type {
   StoredBrowserSessionRecord,
   StoredComposioToolkitRecord,
   StoredComposioUserConnectionRecord,
+  StoredLlmTurnUsageRecord,
   StoredLlmUsageModelStatsRecord,
   StoredLlmUsageStatsRecord,
   StoredMcpServerRecord,
@@ -85,6 +86,7 @@ export function createInMemoryDatabaseAdapter(): DatabaseAdapter {
   let llmUsageStats: StoredLlmUsageStatsRecord | null = null;
   const llmUsageByModel = new Map<string, StoredLlmUsageModelStatsRecord>();
   const toolOutputSavings = new Map<string, StoredToolOutputSavingsRecord>();
+  const llmTurnUsage = new Map<string, StoredLlmTurnUsageRecord>();
   let workspaceSettings: StoredWorkspaceSettingsRecord | null = null;
   const notificationDestinations = new Map<
     string,
@@ -651,6 +653,25 @@ export function createInMemoryDatabaseAdapter(): DatabaseAdapter {
         : null;
     },
 
+    async incrementLlmTurnUsage(orgId, delta) {
+      const updatedAt = new Date().toISOString();
+      const bucket = updatedAt.slice(0, 10);
+      const arm = delta.optimized ? "omni" : "none";
+      const key = `${orgId}\u0000${bucket}\u0000${arm}`;
+      const existing = llmTurnUsage.get(key);
+
+      llmTurnUsage.set(key, {
+        arm,
+        bucket,
+        estimatedTurns:
+          (existing?.estimatedTurns ?? 0) + (delta.estimated ? 1 : 0),
+        inputTokens: (existing?.inputTokens ?? 0) + delta.inputTokens,
+        orgId,
+        outputTokens: (existing?.outputTokens ?? 0) + delta.outputTokens,
+        turns: (existing?.turns ?? 0) + 1,
+      });
+    },
+
     async incrementLlmUsageStats(
       delta: LlmUsageStatsDelta,
       trackedSince: string
@@ -805,6 +826,12 @@ export function createInMemoryDatabaseAdapter(): DatabaseAdapter {
       return Array.from(composioUserConnections.values()).filter(
         (record) => record.orgId === orgId && record.userId === userId
       );
+    },
+
+    async listLlmTurnUsage(orgId) {
+      return [...llmTurnUsage.values()]
+        .filter((row) => row.orgId === orgId)
+        .sort((left, right) => left.bucket.localeCompare(right.bucket));
     },
 
     async listLlmUsageStatsByModel() {

--- a/packages/db/src/adapters/in-memory.ts
+++ b/packages/db/src/adapters/in-memory.ts
@@ -30,6 +30,7 @@ import type {
   StoredSkillUsageRecord,
   StoredTaskRecord,
   StoredTaskRunRecord,
+  StoredToolOutputSavingsRecord,
   StoredToolRecord,
   StoredUserOrganizationRecord,
   StoredUserRecord,
@@ -83,6 +84,7 @@ export function createInMemoryDatabaseAdapter(): DatabaseAdapter {
   >();
   let llmUsageStats: StoredLlmUsageStatsRecord | null = null;
   const llmUsageByModel = new Map<string, StoredLlmUsageModelStatsRecord>();
+  const toolOutputSavings = new Map<string, StoredToolOutputSavingsRecord>();
   let workspaceSettings: StoredWorkspaceSettingsRecord | null = null;
   const notificationDestinations = new Map<
     string,
@@ -744,6 +746,25 @@ export function createInMemoryDatabaseAdapter(): DatabaseAdapter {
       });
     },
 
+    async incrementToolOutputSavings(orgId, delta, trackedSince) {
+      const updatedAt = new Date().toISOString();
+      const bucket = updatedAt.slice(0, 10);
+      const key = `${orgId}\u0000${bucket}\u0000${delta.optimizer}\u0000${delta.tool}`;
+      const existing = toolOutputSavings.get(key);
+
+      toolOutputSavings.set(key, {
+        bucket,
+        bytesIn: (existing?.bytesIn ?? 0) + delta.bytesIn,
+        bytesOut: (existing?.bytesOut ?? 0) + delta.bytesOut,
+        calls: (existing?.calls ?? 0) + 1,
+        optimizer: delta.optimizer,
+        orgId,
+        tool: delta.tool,
+        trackedSince: existing?.trackedSince ?? trackedSince,
+        updatedAt,
+      });
+    },
+
     async insertAttachment(record) {
       attachments.set(record.id, { ...record });
     },
@@ -1012,6 +1033,16 @@ export function createInMemoryDatabaseAdapter(): DatabaseAdapter {
             ? left.position - right.position
             : statusCompare;
         });
+    },
+
+    async listToolOutputSavings(orgId) {
+      return [...toolOutputSavings.values()]
+        .filter((row) => row.orgId === orgId)
+        .sort((left, right) =>
+          left.bucket === right.bucket
+            ? right.bytesIn - right.bytesOut - (left.bytesIn - left.bytesOut)
+            : left.bucket.localeCompare(right.bucket)
+        );
     },
 
     async listTools() {

--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -886,6 +886,21 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
   const listToolOutputSavingsStmt = db.prepare(
     "SELECT * FROM tool_output_savings WHERE org_id = ? ORDER BY bucket ASC, (bytes_in - bytes_out) DESC"
   );
+  const incrementLlmTurnUsageStmt = db.prepare(`
+    INSERT INTO llm_turn_usage (
+      org_id, bucket, arm, turns, input_tokens, output_tokens, estimated_turns, updated_at
+    )
+    VALUES (?, ?, ?, 1, ?, ?, ?, ?)
+    ON CONFLICT(org_id, bucket, arm) DO UPDATE SET
+      turns = llm_turn_usage.turns + 1,
+      input_tokens = llm_turn_usage.input_tokens + excluded.input_tokens,
+      output_tokens = llm_turn_usage.output_tokens + excluded.output_tokens,
+      estimated_turns = llm_turn_usage.estimated_turns + excluded.estimated_turns,
+      updated_at = excluded.updated_at
+  `);
+  const listLlmTurnUsageStmt = db.prepare(
+    "SELECT * FROM llm_turn_usage WHERE org_id = ? ORDER BY bucket ASC"
+  );
   const getWorkspaceSettingsStmt = db.prepare(
     "SELECT * FROM workspace_settings WHERE id = ?"
   );
@@ -2061,6 +2076,19 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
       return row ? toWorkspaceSettingsRecord(row) : null;
     },
 
+    async incrementLlmTurnUsage(orgId, delta) {
+      const updatedAt = new Date().toISOString();
+      incrementLlmTurnUsageStmt.run(
+        orgId,
+        updatedAt.slice(0, 10),
+        delta.optimized ? "omni" : "none",
+        delta.inputTokens,
+        delta.outputTokens,
+        delta.estimated ? 1 : 0,
+        updatedAt
+      );
+    },
+
     async incrementLlmUsageStats(delta, trackedSince) {
       const updatedAt = new Date().toISOString();
       incrementLlmUsageStatsStmt.run(
@@ -2190,6 +2218,28 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
         .map((row) =>
           toComposioUserConnectionRecord(row as ComposioUserConnectionRow)
         );
+    },
+
+    async listLlmTurnUsage(orgId) {
+      return (
+        listLlmTurnUsageStmt.all(orgId) as {
+          arm: string;
+          bucket: string;
+          estimated_turns: number;
+          input_tokens: number;
+          org_id: string;
+          output_tokens: number;
+          turns: number;
+        }[]
+      ).map((row) => ({
+        arm: row.arm,
+        bucket: row.bucket,
+        estimatedTurns: row.estimated_turns,
+        inputTokens: row.input_tokens,
+        orgId: row.org_id,
+        outputTokens: row.output_tokens,
+        turns: row.turns,
+      }));
     },
 
     async listLlmUsageStatsByModel() {

--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -189,6 +189,7 @@ interface WorkspaceSettingsRow {
   id: string;
   image_model: string | null;
   selected_coding_agent_harness: string | null;
+  token_optimizer_enabled: number | null;
   transcription_model: string | null;
   updated_at: string;
   vision_model: string | null;
@@ -871,6 +872,20 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
       estimated_cost_usd = llm_usage_model_stats.estimated_cost_usd + excluded.estimated_cost_usd,
       updated_at = excluded.updated_at
   `);
+  const incrementToolOutputSavingsStmt = db.prepare(`
+    INSERT INTO tool_output_savings (
+      org_id, bucket, optimizer, tool, calls, bytes_in, bytes_out, tracked_since, updated_at
+    )
+    VALUES (?, ?, ?, ?, 1, ?, ?, ?, ?)
+    ON CONFLICT(org_id, bucket, optimizer, tool) DO UPDATE SET
+      calls = tool_output_savings.calls + 1,
+      bytes_in = tool_output_savings.bytes_in + excluded.bytes_in,
+      bytes_out = tool_output_savings.bytes_out + excluded.bytes_out,
+      updated_at = excluded.updated_at
+  `);
+  const listToolOutputSavingsStmt = db.prepare(
+    "SELECT * FROM tool_output_savings WHERE org_id = ? ORDER BY bucket ASC, (bytes_in - bytes_out) DESC"
+  );
   const getWorkspaceSettingsStmt = db.prepare(
     "SELECT * FROM workspace_settings WHERE id = ?"
   );
@@ -882,15 +897,17 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
       image_model,
       coding_agent_harnesses,
       selected_coding_agent_harness,
+      token_optimizer_enabled,
       updated_at
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(id) DO UPDATE SET
       vision_model = excluded.vision_model,
       transcription_model = excluded.transcription_model,
       image_model = excluded.image_model,
       coding_agent_harnesses = excluded.coding_agent_harnesses,
       selected_coding_agent_harness = excluded.selected_coding_agent_harness,
+      token_optimizer_enabled = excluded.token_optimizer_enabled,
       updated_at = excluded.updated_at
   `);
   const listNotificationDestinationsForOrgStmt = db.prepare(`
@@ -2087,6 +2104,20 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
       );
     },
 
+    async incrementToolOutputSavings(orgId, delta, trackedSince) {
+      const updatedAt = new Date().toISOString();
+      incrementToolOutputSavingsStmt.run(
+        orgId,
+        updatedAt.slice(0, 10),
+        delta.optimizer,
+        delta.tool,
+        delta.bytesIn,
+        delta.bytesOut,
+        trackedSince,
+        updatedAt
+      );
+    },
+
     async insertAttachment(record) {
       insertAttachmentStmt.run(
         record.id,
@@ -2369,6 +2400,32 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
       return listTasksForOrgStmt
         .all(orgId)
         .map((row) => toTaskRecord(row as TaskRow));
+    },
+
+    async listToolOutputSavings(orgId) {
+      return (
+        listToolOutputSavingsStmt.all(orgId) as {
+          bucket: string;
+          bytes_in: number;
+          bytes_out: number;
+          calls: number;
+          optimizer: string;
+          org_id: string;
+          tool: string;
+          tracked_since: string;
+          updated_at: string;
+        }[]
+      ).map((row) => ({
+        bucket: row.bucket,
+        bytesIn: row.bytes_in,
+        bytesOut: row.bytes_out,
+        calls: row.calls,
+        optimizer: row.optimizer,
+        orgId: row.org_id,
+        tool: row.tool,
+        trackedSince: row.tracked_since,
+        updatedAt: row.updated_at,
+      }));
     },
 
     async listTools() {
@@ -2779,6 +2836,10 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
         record.imageModel,
         JSON.stringify(record.codingAgentHarnesses),
         record.selectedCodingAgentHarness,
+        record.tokenOptimizerEnabled === null ||
+          record.tokenOptimizerEnabled === undefined
+          ? null
+          : Number(record.tokenOptimizerEnabled),
         record.updatedAt
       );
     },
@@ -3139,6 +3200,11 @@ function toWorkspaceSettingsRecord(
     imageModel: row.image_model?.trim() || null,
     selectedCodingAgentHarness:
       row.selected_coding_agent_harness?.trim() || null,
+    tokenOptimizerEnabled:
+      row.token_optimizer_enabled === null ||
+      row.token_optimizer_enabled === undefined
+        ? null
+        : row.token_optimizer_enabled === 1,
     transcriptionModel: row.transcription_model?.trim() || null,
     updatedAt: row.updated_at,
     visionModel: row.vision_model?.trim() || null,

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -28,6 +28,7 @@ export function migrateDatabase(db: Database): void {
   migrateCodingDelegationSkillName(db);
   migrateWorkspaceSettingsTable(db);
   migrateLlmUsageModelStatsTable(db);
+  migrateToolOutputSavingsTable(db);
   migrateAttachmentsTable(db);
   migrateAutomationRunsTable(db);
   migrateAutomationRunReadStateTable(db);
@@ -278,6 +279,54 @@ function migrateLlmUsageModelStatsTable(db: Database): void {
       tracked_since TEXT NOT NULL,
       updated_at TEXT NOT NULL
     );
+  `);
+}
+
+/**
+ * Bytes removed from a tool result before it entered the conversation, per org,
+ * per optimiser, per tool.
+ *
+ * Deliberately not tokens and not cost: a shortened result is re-sent on later
+ * turns as a cache read billed at a fraction of fresh input, so multiplying
+ * these by a price would invent a number nobody can support.
+ *
+ * `optimizer` is a column rather than a hard-coded name because OMNI will not be
+ * the only one. It is also why this is not called `omni_savings`. What it cannot
+ * hold is anything that never sees tool output: a command rewriter like rtk acts
+ * before the command runs, and a proxy like headroom replaces the provider
+ * client, so neither produces a row here. That is a boundary worth naming, not
+ * hiding.
+ */
+function migrateToolOutputSavingsTable(db: Database): void {
+  // The first cut of this table had no `bucket`, and CREATE TABLE IF NOT EXISTS
+  // will not add one. It is a counter with no history worth keeping and it has
+  // never shipped, so recreating is cheaper and clearer than an ALTER dance.
+  const columns = db
+    .prepare("PRAGMA table_info(tool_output_savings)")
+    .all() as Array<{ name: string }>;
+
+  if (
+    columns.length > 0 &&
+    !columns.some((column) => column.name === "bucket")
+  ) {
+    db.exec("DROP TABLE tool_output_savings;");
+  }
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS tool_output_savings (
+      org_id TEXT NOT NULL,
+      bucket TEXT NOT NULL,
+      optimizer TEXT NOT NULL,
+      tool TEXT NOT NULL,
+      calls INTEGER NOT NULL DEFAULT 0,
+      bytes_in INTEGER NOT NULL DEFAULT 0,
+      bytes_out INTEGER NOT NULL DEFAULT 0,
+      tracked_since TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY (org_id, bucket, optimizer, tool)
+    );
+    CREATE INDEX IF NOT EXISTS tool_output_savings_org_bucket
+      ON tool_output_savings (org_id, bucket);
   `);
 }
 
@@ -959,6 +1008,15 @@ function migrateWorkspaceSettingsTable(db: Database): void {
   if (!columnNames.has("selected_coding_agent_harness")) {
     db.exec(`
       ALTER TABLE workspace_settings ADD COLUMN selected_coding_agent_harness TEXT;
+    `);
+  }
+
+  // Null means "not chosen here", which falls back to the NAKAMA_OMNI env var.
+  // A tri-state rather than a boolean so an operator who set the env var does
+  // not have it silently overridden by a default row.
+  if (!columnNames.has("token_optimizer_enabled")) {
+    db.exec(`
+      ALTER TABLE workspace_settings ADD COLUMN token_optimizer_enabled INTEGER;
     `);
   }
 }

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -29,6 +29,7 @@ export function migrateDatabase(db: Database): void {
   migrateWorkspaceSettingsTable(db);
   migrateLlmUsageModelStatsTable(db);
   migrateToolOutputSavingsTable(db);
+  migrateLlmTurnUsageTable(db);
   migrateAttachmentsTable(db);
   migrateAutomationRunsTable(db);
   migrateAutomationRunReadStateTable(db);
@@ -297,6 +298,32 @@ function migrateLlmUsageModelStatsTable(db: Database): void {
  * client, so neither produces a row here. That is a boundary worth naming, not
  * hiding.
  */
+/**
+ * Provider input tokens per turn, per org, per day, split by whether the
+ * optimiser removed anything on that turn.
+ *
+ * This is the only table here that holds tokens rather than bytes, and it holds
+ * what the provider charged rather than an estimate. The comparison it supports
+ * is observational, not randomised: turns land in an arm because of what
+ * happened, not because anything was assigned, so a workload difference between
+ * the arms is a confound the reader has to be told about.
+ */
+function migrateLlmTurnUsageTable(db: Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS llm_turn_usage (
+      org_id TEXT NOT NULL,
+      bucket TEXT NOT NULL,
+      arm TEXT NOT NULL,
+      turns INTEGER NOT NULL DEFAULT 0,
+      input_tokens INTEGER NOT NULL DEFAULT 0,
+      output_tokens INTEGER NOT NULL DEFAULT 0,
+      estimated_turns INTEGER NOT NULL DEFAULT 0,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY (org_id, bucket, arm)
+    );
+  `);
+}
+
 function migrateToolOutputSavingsTable(db: Database): void {
   // The first cut of this table had no `bucket`, and CREATE TABLE IF NOT EXISTS
   // will not add one. It is a counter with no history worth keeping and it has

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -282,6 +282,24 @@ export interface ToolOutputSavingsDelta {
   tool: string;
 }
 
+/** One request's provider tokens, tagged with the arm it belongs to. */
+export interface LlmTurnUsageDelta {
+  estimated: boolean;
+  inputTokens: number;
+  optimized: boolean;
+  outputTokens: number;
+}
+
+export interface StoredLlmTurnUsageRecord {
+  arm: string;
+  bucket: string;
+  estimatedTurns: number;
+  inputTokens: number;
+  orgId: string;
+  outputTokens: number;
+  turns: number;
+}
+
 export interface StoredToolOutputSavingsRecord {
   /** Day the bytes were removed, `YYYY-MM-DD`. Day resolution because the panel
    * plots days and an hour column would be 24x the rows for a chart nobody asked
@@ -668,6 +686,7 @@ export interface DatabaseAdapter {
   getUserContext(orgId: string, userId: string): Promise<string | null>;
 
   getWorkspaceSettings(): Promise<StoredWorkspaceSettingsRecord | null>;
+  incrementLlmTurnUsage(orgId: string, delta: LlmTurnUsageDelta): Promise<void>;
   incrementLlmUsageStats(
     delta: LlmUsageStatsDelta,
     trackedSince: string
@@ -714,6 +733,7 @@ export interface DatabaseAdapter {
     orgId: string,
     userId: string
   ): Promise<StoredComposioUserConnectionRecord[]>;
+  listLlmTurnUsage(orgId: string): Promise<StoredLlmTurnUsageRecord[]>;
   listLlmUsageStatsByModel(): Promise<StoredLlmUsageModelStatsRecord[]>;
   listMcpServerProfileCounts(): Promise<Record<string, number>>;
 

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -170,6 +170,8 @@ export interface StoredWorkspaceSettingsRecord {
   imageModel: string | null;
   orgId?: string | null;
   selectedCodingAgentHarness: string | null;
+  /** null = inherit the NAKAMA_OMNI env var; true/false = set explicitly here. */
+  tokenOptimizerEnabled?: boolean | null;
   transcriptionModel: string | null;
   updatedAt: string;
   visionModel: string | null;
@@ -270,6 +272,29 @@ export interface LlmUsageStatsDelta {
   inputTokens: number;
   outputTokens: number;
   requestCount: number;
+}
+
+/** Bytes one optimiser removed from one tool result before it was inserted. */
+export interface ToolOutputSavingsDelta {
+  bytesIn: number;
+  bytesOut: number;
+  optimizer: string;
+  tool: string;
+}
+
+export interface StoredToolOutputSavingsRecord {
+  /** Day the bytes were removed, `YYYY-MM-DD`. Day resolution because the panel
+   * plots days and an hour column would be 24x the rows for a chart nobody asked
+   * for at that grain. */
+  bucket: string;
+  bytesIn: number;
+  bytesOut: number;
+  calls: number;
+  optimizer: string;
+  orgId: string;
+  tool: string;
+  trackedSince: string;
+  updatedAt: string;
 }
 
 export type McpServerStatus = "connected" | "disconnected" | "error";
@@ -663,6 +688,11 @@ export interface DatabaseAdapter {
     usedAt?: string;
     patchedAt?: string;
   }): Promise<void>;
+  incrementToolOutputSavings(
+    orgId: string,
+    delta: ToolOutputSavingsDelta,
+    trackedSince: string
+  ): Promise<void>;
 
   insertAttachment(record: StoredAttachmentRecord): Promise<void>;
   insertAutomationRun(record: StoredAutomationRunRecord): Promise<void>;
@@ -747,6 +777,9 @@ export interface DatabaseAdapter {
 
   listTasks(): Promise<StoredTaskRecord[]>;
   listTasksForOrg(orgId: string): Promise<StoredTaskRecord[]>;
+  listToolOutputSavings(
+    orgId: string
+  ): Promise<StoredToolOutputSavingsRecord[]>;
 
   listTools(): Promise<StoredToolRecord[]>;
 


### PR DESCRIPTION
Adds an optional tool-output optimiser and a panel that reports what it removed. Off by default. The Docker image is byte-identical unless you pass `--build-arg OMNI_VERSION`: no binary is added, and the build makes no network call for it.

## Demo

https://github.com/user-attachments/assets/f6362fe1-706b-436a-9ff8-31a42acdf12f



## Why

Tool results are the biggest thing in a conversation. Across 39 real payloads from a local instance they were **77% of the bytes stored in history**, and history is re-sent on every turn, so a large result is not one expensive call but one call that stays expensive.

Shell output repeats more than it looks: the same `grep`, the same `ls`, the same test run, several times in one session. Repeated content is what this removes.

Measured through the real agent loop on a repeated shell command, the history a turn carries went from **15,426 characters to 8,524**. End to end over HTTP, the second run of one command went from **6,154 bytes to 136**. On a fifteen-call shell session replayed offline, 37.6%.

### Where the saving lands

Two mechanisms produce it, described under How it works, and they pay off in
different places. Driven through this PR's own code path:

| | first showing | shown again |
|---|---|---|
| `read_file`, a 12,583 byte source file | 844 | 63 |
| `bash`, 7,560 bytes of `grep` output | 7,560 | 725 |

Shell output has almost nothing the distiller recognises, so on `bash` it saves 0% and the entire benefit is the ledger. A source file is the opposite: shortened on sight, then collapsed to a handle when the agent reads it again to check its own edit. Over a seven-read session with three re-reads, 122,705 bytes became 41,527.

The saving lands where the result is written into `history`, which is the one part of a conversation that is re-sent on every later turn without carrying new information. So it is not `N` bytes saved once, it is the smaller message carried for the rest of the session. Two things bound that: the first showing never benefits from the ledger, because there is nothing yet to compare against, and later turns bill as cache reads at a fraction of fresh input. Both are why this PR reports bytes and leaves the token figure to the provider's own count.

`history-compaction.ts` cannot do this: it prunes a window by size, and nothing in nakama today answers "this agent has already been shown these bytes".

## How it works

### Where it sits

Every tool result in nakama already passes through one function, `executeToolCall`
(`packages/agent/src/tool-loop.ts`). All three callers route through it, so the
optimiser is wired once and neither `bash.ts` nor `builtin.ts` was touched.

```
agent asks for a tool
        |
        v
  tool.run()                      the real result, unchanged
        |
        v
  distillToolResult()             <- the only new step
        |
        |   gates: handled tool? has text? >= 1,000 chars? enabled?
        |   then spawn `omni --post-hook`, 5s timeout
        |
        |       (1) distiller     drops noise inside this one result
        |            |            no memory of anything else
        |            v
        |       (2) ledger        runs on what the distiller produced.
        |            |            lines already shown this session become
        |            v            [OMNI: N lines already shown, <handle>]
        |
        |   accepted only if strictly shorter, else the original is kept
        v
  serializeToolResult()           JSON.stringify, as before
        |
        v
  history  (role: "tool")         re-sent on every later turn, which is
                                  why a smaller message here keeps paying
```

### What happens to one call

1. **Is this a tool we handle?** Only `bash` and `read_file`. Anything else is
   returned as it came, immediately.
2. **Find the text.** `stdout` for bash, `content` for read_file. Never the JSON
   envelope: OMNI passes structured payloads through untouched, so wiring it to
   the envelope would save nothing and look like it was working.
3. **Is it big enough to bother?** Under 1,000 characters it returns early,
   because spawning a process to shorten a few hundred bytes is not worth the
   round trip.
4. **Is it enabled for this org?** A per-org setting, falling back to the
   `NAKAMA_OMNI` env var when nobody has chosen.
5. **Run it.** `omni --post-hook` over stdin, 5 second timeout, SIGKILL on
   expiry.
6. **Accept only an improvement.** The reply is used only if it is strictly
   shorter and non-empty. Then the text field is replaced and the result carries
   `omniDistilled: true`.

### What OMNI does with the text

Two passes, in order, and the second runs on what the first produced.

**The distiller** looks at this one result and drops what it recognises as noise.
It is per tool: a file read is shortened by structure, a page fetch has its
markup stripped, shell output has known noise patterns removed. It has no memory
of anything else in the session.

**The ledger** is the memory. It splits the text into lines and hashes each one,
then asks the session store which of them have already been sent to this agent. A
run of consecutive lines that were all seen before becomes a single marker with a
handle, and every other line passes through byte for byte.

The same `grep` run twice in one session, as an agent does after an edit:

```
first  60 lines of matches       distiller finds nothing to drop, all 60 go in
second the same 60 lines         every line is already in the session store
       -> [OMNI: 60 lines already shown, omni retrieve a1b2c3d4]
```

Four rules keep that safe, and they are the reason this can sit on the request
path at all:

- **It only ever shortens the result in flight.** Nothing already delivered is
  rewritten, so the prompt cache prefix upstream stays intact.
- **Nothing is dropped without being archived first.** A failed archive means the
  run stays verbatim, and the handle is what `omni_retrieve` reads back.
- **Structured payloads never reach it.** JSON, YAML and CSV are passed through,
  because the next step parses them.
- **A line that states a failure is never folded**, however often it appears. The
  repetition of an error is the signal, not noise.

### Nothing here can break a turn

Every path that is not step 6 returns **the caller's own bytes**: binary missing,
timeout, unparseable reply, a reply that is somehow longer, no org, no session.
The optimiser can fail in any way it likes and the worst outcome is that the turn
costs what it would have cost anyway.

That is the property most of the tests cover, and they run without the binary
installed.

### Why only two tools

Every tool a profile can hold, with the reason it is in or out. Sizes are from
real results in a local instance, not estimates.

| tool | in | why |
|---|---|---|
| `bash` | yes | shell output is large and repeats within a session. The distiller finds nothing in it; the ledger is the whole benefit |
| `read_file` | yes | 4,179 bytes on average. Shortened on first read, a handle when re-read, which is what an agent does while editing |
| `write_file`, `edit_file`, `delete_file`, `write_docx` | no | they return a path and a couple of counters, 170 bytes on average across 81 calls. There is nothing to shorten |
| `search_files`, `knowledge_base_search`, `web_search`, `org_memory_search` | no | structured results. A matches array serialises to one line of JSON, and OMNI passes structured payloads through by design. Measured across 32 real `search_files` results: 0.0% |
| `web_fetch` | no | #242 caps it at 16,000 and the ledger never folds what is left. On markdown as the tool returns it today, a page was untouched on the first fetch and untouched again when refetched in the same session |
| `composio__invoke_action` | no | Composio returns JSON, so the same format rule applies. A 22,884 character Gmail-shaped thread came back untouched on both showings, and its 16,000 cap already comes from #176 |
| `todo_write`, `ask_user_question` | no | 453 and 712 bytes on average, under the 1,000 character floor |
| `extract_document_text` | not yet | it does carry a `text` field and could be large, but there were no calls in the sample, so it is untested rather than ruled out |

The pattern behind the table: this helps free text that an agent sees more than
once. It does not help structured results, and it should not, because the next
step parses them.

### Getting folded content back

What OMNI removes is content the agent was already shown earlier in the session,
replaced by a handle. One tool, `omni_retrieve` (308 bytes), expands a handle
again, and it is registered only when the binary is present. Without it the agent
would be told content existed and given no way to read it, which is worse than an
honest truncation.

## What it records

Two counters, two units, because they answer different questions:

- `tool_output_savings`: bytes a tool produced vs bytes that entered the conversation
- `llm_turn_usage`: input tokens the **provider** charged for each request

Both are split by arm. A turn where nothing was shortened is recorded too, under `none`, so the panel compares against what a turn costs unoptimised rather than comparing a number against a blank. The arm is what happened, not what the setting says.

## What the panel claims, and what it does not

The headline is bytes and says so: bytes kept out of the conversation at insertion. **Nothing multiplies bytes by a price.** A shortened result is re-sent on later turns as a cache read billed at a fraction of fresh input, so that arithmetic would invent a figure nobody can support.

The one token figure is the provider's own count, per turn, per arm, and it appears only once both arms have five turns. It is observational rather than randomised, and the panel says so in place: turns fall into an arm by outcome, so a workload difference between them can explain part of any gap.

## Controls

| | |
|---|---|
| `--build-arg OMNI_VERSION=0.7.3` | includes the binary; empty by default, image otherwise unchanged |
| `NAKAMA_OMNI=1` | the binary is available on this host |
| toggle on the card | whether this org uses it, admin only |

The Dockerfile step picks the musl build for the image architecture and verifies the published `SHA256SUMS` rather than trusting the download. Apache 2.0, single static binary.

Everything here was measured against the released **0.7.3**. One thing in `omni.ts` looks redundant on that version and is kept on purpose: tool names are mapped to OMNI's own casing before the call. 0.7.3 does that itself, but earlier releases passed the name through, and a name it did not recognise reached a generic path that truncated instead of folding. That failure was silent and scored *better* on bytes while losing content, so the map stays as a compatibility shim.

The full MCP server is deliberately not used. Its 26 tools are 8,241 bytes of definitions riding on every request, which is more than the distillation saves on this workload, and a longer tool list costs selection accuracy on top. `omni_retrieve` above is the entire tool surface this adds.

## Checks

`bun run test` green across all eleven workspaces. Twelve tests cover the optimiser, and most of them cover the fail-open paths, since that is the guarantee that matters. None of them need the binary installed, checked by running the suite with `omni` hidden from `PATH` rather than by assuming it.












