### PR TITLE
feat(mcp): preinstall Firecrawl keyless MCP

### DIFF
--- a/apps/server/src/services/mcp-service.test.ts
+++ b/apps/server/src/services/mcp-service.test.ts
@@ -293,6 +293,14 @@ describe("McpService", () => {
     expect(
       await db.getMcpServer(PREINSTALLED_MCP_SERVER_IDS.exa)
     ).not.toBeNull();
+
+    await expect(
+      service.deleteServer(PREINSTALLED_MCP_SERVER_IDS.firecrawl)
+    ).rejects.toThrow('Preinstalled MCP server "firecrawl" cannot be deleted.');
+
+    expect(
+      await db.getMcpServer(PREINSTALLED_MCP_SERVER_IDS.firecrawl)
+    ).not.toBeNull();
   });
 
   test("lists assigned profile counts on MCP servers", async () => {

--- a/docs/website/content/docs/agent-browser.mdx
+++ b/docs/website/content/docs/agent-browser.mdx
@@ -23,6 +23,7 @@ The product has no dedicated `browser` builtin. The workflow is **`bash` + the `
 | Need | Prefer |
 |------|--------|
 | Public page text / Markdown | [`web_fetch`](/builtin-tools#web_fetch) |
+| JS-heavy public page (no login) | Firecrawl scrape, when the profile has the preinstalled [firecrawl](/mcp#example-firecrawl) MCP server |
 | Discover sources on the open web | [`web_search`](/builtin-tools#web_search) |
 | Login walls, forms, clicks, client-rendered UI | **`agent-browser` skill + `bash`** |
 

--- a/docs/website/content/docs/mcp.mdx
+++ b/docs/website/content/docs/mcp.mdx
@@ -91,6 +91,34 @@ Nakama ships a preinstalled **exa** server (`https://mcp.exa.ai/mcp`) with `web_
 
 Tools appear as `exa__web_search_exa` and `exa__web_fetch_exa`.
 
+### Example: Firecrawl
+
+Nakama ships a preinstalled **firecrawl** server (`https://mcp.firecrawl.dev/v2/mcp`) with no API key. Assign it on **Agent → Profiles** when a profile needs JS-rendered public pages.
+
+Keyless tools appear as `firecrawl__firecrawl_search`, `firecrawl__firecrawl_scrape`, and `firecrawl__firecrawl_parse`. Use scrape for JS-heavy public pages. Search is extra surface next to Exa and builtin [`web_search`](/builtin-tools#web_search). Hosted parse is not for files in the profile workspace — use [`extract_document_text`](/builtin-tools#extract_document_text).
+
+Firecrawl Cloud fetches the URL. Unlike [`web_fetch`](/builtin-tools#web_fetch), the page is processed off the Nakama host. Keyless usage shares a daily cap on the host's public IP across every assigned profile, including automations and Telegram / WhatsApp / Discord.
+
+Keyless MCP does not include interact, crawl, or map. For login walls, forms, and clicks, use the [agent-browser](/agent-browser) skill.
+
+To raise limits or unlock crawl / interact / map, add a [Firecrawl API key](https://www.firecrawl.dev/app/api-keys) under **Headers**, then **Reconnect** or **Sync tools**:
+
+- **Key:** `Authorization`
+- **Value:** `Bearer YOUR_FIRECRAWL_API_KEY`
+
+That header is shared by every profile assigned to this server. After sync, keyed tools are available on all of them until you unassign or rotate the header.
+
+```json
+{
+  "mcpServers": {
+    "firecrawl": {
+      "url": "https://mcp.firecrawl.dev/v2/mcp",
+      "headers": { "Authorization": "Bearer YOUR_FIRECRAWL_API_KEY" }
+    }
+  }
+}
+```
+
 ### Import from an existing config
 
 Use **Import JSON** or paste a Cursor-style `mcpServers` block onto the form. A bare server object (top-level `command` or `url`) also works — the first entry fills the form for review.
@@ -136,10 +164,12 @@ MCP management is platform-admin only (same as profiles, builtins, and skills).
 - **No tools discovered** — server connected but returned zero tools; fix server-side config, then **Sync tools**
 - **"not connected" on tool call** — connection dropped; reconnect. For stdio, confirm the command is on PATH
 - **Exa rate limit** — add an `x-api-key` header with your [Exa API key](https://dashboard.exa.ai/api-keys), then reconnect
+- **Firecrawl rate limit** — add an `Authorization` header with `Bearer` plus your [Firecrawl API key](https://www.firecrawl.dev/app/api-keys), then reconnect. This also unlocks crawl / interact / map for every assigned profile
 - **Unexpected tool name** — names are sanitized to `a-zA-Z0-9_-`; `tools.list` on server `user.tolaria` becomes `user_tolaria__tools_list`
 
 ## Related
 
 - [Builtin tools](/builtin-tools) — tools that ship with Nakama
+- [Agent browser](/agent-browser) — login walls and interactive pages
 - [Profiles](/profiles) — designing bots and tool access
 - [Multi-tenancy](/multi-tenancy) — org roles and admin boundaries

--- a/packages/core/src/mcp/preinstalled.ts
+++ b/packages/core/src/mcp/preinstalled.ts
@@ -3,6 +3,7 @@ import type { McpHttpConfig, McpStdioConfig, McpTransport } from "../contract";
 export const PREINSTALLED_MCP_SERVER_IDS = {
   currency_conversion: "mcp_currency_conversion",
   exa: "mcp_exa",
+  firecrawl: "mcp_firecrawl",
 } as const;
 
 export type PreinstalledMcpServerDefinition = {
@@ -27,6 +28,14 @@ export const preinstalledMcpServers: PreinstalledMcpServerDefinition[] = [
     },
     id: PREINSTALLED_MCP_SERVER_IDS.currency_conversion,
     name: "currency-conversion",
+    transport: "http",
+  },
+  {
+    config: {
+      url: "https://mcp.firecrawl.dev/v2/mcp",
+    },
+    id: PREINSTALLED_MCP_SERVER_IDS.firecrawl,
+    name: "firecrawl",
     transport: "http",
   },
 ];

--- a/packages/db/src/seed.test.ts
+++ b/packages/db/src/seed.test.ts
@@ -266,6 +266,141 @@ describe("seed preinstalled MCP servers", () => {
     await ensurePreinstalledMcpServers(db);
     await ensurePreinstalledMcpServers(db);
 
-    expect((await db.listMcpServers()).length).toBe(2);
+    expect((await db.listMcpServers()).length).toBe(3);
+  });
+
+  test("seeds firecrawl keyless HTTP MCP unassigned", async () => {
+    const db = createInMemoryDatabaseAdapter();
+
+    await ensurePreinstalledMcpServers(db);
+
+    const firecrawl = await db.getMcpServer("mcp_firecrawl");
+
+    expect(firecrawl).toMatchObject({
+      enabled: true,
+      id: "mcp_firecrawl",
+      name: "firecrawl",
+      transport: "http",
+    });
+    expect(firecrawl?.config).toEqual({
+      url: "https://mcp.firecrawl.dev/v2/mcp",
+    });
+    expect(await db.listProfilesForMcpServer("mcp_firecrawl")).toEqual([]);
+  });
+
+  test("preserves HTTP headers and enabled on re-seed", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const now = new Date().toISOString();
+
+    await ensurePreinstalledMcpServers(db);
+
+    const firecrawl = await db.getMcpServer("mcp_firecrawl");
+    const exa = await db.getMcpServer("mcp_exa");
+
+    expect(firecrawl).not.toBeNull();
+    expect(exa).not.toBeNull();
+
+    await db.upsertMcpServer({
+      ...firecrawl!,
+      cachedTools: [{ description: "search", name: "firecrawl_search" }],
+      config: {
+        headers: { Authorization: "Bearer fc-test" },
+        url: "https://mcp.firecrawl.dev/v2/mcp",
+      },
+      enabled: false,
+      lastError: "previous error",
+      status: "error",
+      updatedAt: now,
+    });
+    await db.upsertMcpServer({
+      ...exa!,
+      config: {
+        headers: { "x-api-key": "exa-secret" },
+        url: "https://mcp.exa.ai/mcp",
+      },
+      updatedAt: now,
+    });
+
+    await ensurePreinstalledMcpServers(db);
+
+    const reseededFirecrawl = await db.getMcpServer("mcp_firecrawl");
+    const reseededExa = await db.getMcpServer("mcp_exa");
+
+    expect(reseededFirecrawl?.config).toEqual({
+      headers: { Authorization: "Bearer fc-test" },
+      url: "https://mcp.firecrawl.dev/v2/mcp",
+    });
+    expect(reseededFirecrawl?.enabled).toBe(false);
+    expect(reseededFirecrawl?.cachedTools).toEqual([
+      { description: "search", name: "firecrawl_search" },
+    ]);
+    expect(reseededFirecrawl?.lastError).toBe("previous error");
+    expect(reseededFirecrawl?.status).toBe("error");
+    expect(reseededExa?.config).toEqual({
+      headers: { "x-api-key": "exa-secret" },
+      url: "https://mcp.exa.ai/mcp",
+    });
+  });
+
+  test("skips insert when another server already owns the catalog name", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const now = new Date().toISOString();
+    const warns: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warns.push(args.map(String).join(" "));
+    };
+
+    await db.upsertMcpServer({
+      cachedTools: [],
+      config: {
+        headers: { Authorization: "Bearer fc-custom" },
+        url: "https://mcp.firecrawl.dev/v2/mcp",
+      },
+      createdAt: now,
+      enabled: true,
+      id: "mcp_custom_firecrawl",
+      lastError: null,
+      name: "firecrawl",
+      status: "disconnected",
+      transport: "http",
+      updatedAt: now,
+    });
+
+    try {
+      await ensurePreinstalledMcpServers(db);
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    expect(await db.getMcpServer("mcp_firecrawl")).toBeNull();
+    expect(await db.getMcpServerByName("firecrawl")).toMatchObject({
+      id: "mcp_custom_firecrawl",
+    });
+    expect(warns.join("\n")).toContain("mcp_custom_firecrawl");
+    expect(warns.join("\n")).not.toContain("fc-custom");
+    expect(warns.join("\n")).not.toContain("Authorization");
+  });
+
+  test("migrates a Firecrawl key-in-URL into an Authorization header", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const now = new Date().toISOString();
+
+    await ensurePreinstalledMcpServers(db);
+    const firecrawl = await db.getMcpServer("mcp_firecrawl");
+    expect(firecrawl).not.toBeNull();
+
+    await db.upsertMcpServer({
+      ...firecrawl!,
+      config: { url: "https://mcp.firecrawl.dev/fc-legacy/v2/mcp" },
+      updatedAt: now,
+    });
+
+    await ensurePreinstalledMcpServers(db);
+
+    expect((await db.getMcpServer("mcp_firecrawl"))?.config).toEqual({
+      headers: { Authorization: "Bearer fc-legacy" },
+      url: "https://mcp.firecrawl.dev/v2/mcp",
+    });
   });
 });

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1,4 +1,8 @@
-import { builtinTools } from "@nakama/core";
+import {
+  builtinTools,
+  type McpHttpConfig,
+  type McpStdioConfig,
+} from "@nakama/core";
 import { preinstalledMcpServers } from "@nakama/core/mcp/preinstalled";
 import {
   BUILTIN_TOOL_IDS,
@@ -173,6 +177,9 @@ export async function ensureSubAgentToolDefinition(
   });
 }
 
+const FIRECRAWL_LEGACY_KEY_URL =
+  /^https:\/\/mcp\.firecrawl\.dev\/([^/]+)\/v2\/mcp\/?$/i;
+
 export async function ensurePreinstalledMcpServers(
   db: DatabaseAdapter
 ): Promise<void> {
@@ -181,11 +188,24 @@ export async function ensurePreinstalledMcpServers(
   for (const server of preinstalledMcpServers) {
     const existing = await db.getMcpServer(server.id);
 
+    if (!existing) {
+      const nameOwner = await db.getMcpServerByName(server.name);
+
+      if (nameOwner && nameOwner.id !== server.id) {
+        console.warn(
+          `Preinstalled MCP server "${server.name}" was not inserted: name already used by ${nameOwner.id}.`
+        );
+        continue;
+      }
+    }
+
     await db.upsertMcpServer({
       cachedTools: existing?.cachedTools ?? [],
-      config: server.config,
+      config: existing
+        ? mergePreinstalledHttpConfig(server.config, existing.config)
+        : server.config,
       createdAt: existing?.createdAt ?? now,
-      enabled: true,
+      enabled: existing?.enabled ?? true,
       id: server.id,
       lastError: existing?.lastError ?? null,
       name: server.name,
@@ -194,4 +214,68 @@ export async function ensurePreinstalledMcpServers(
       updatedAt: now,
     });
   }
+}
+
+function mergePreinstalledHttpConfig(
+  catalogConfig: McpHttpConfig | McpStdioConfig,
+  existingConfig: unknown
+): McpHttpConfig | McpStdioConfig {
+  if (!("url" in catalogConfig)) {
+    return catalogConfig;
+  }
+
+  const headers = { ...readHttpHeaders(existingConfig) };
+  const legacyBearer = firecrawlLegacyBearer(readHttpUrl(existingConfig));
+
+  if (legacyBearer && !headers.Authorization) {
+    headers.Authorization = legacyBearer;
+  }
+
+  if (Object.keys(headers).length === 0) {
+    return { url: catalogConfig.url };
+  }
+
+  return { headers, url: catalogConfig.url };
+}
+
+function readHttpUrl(config: unknown): string | undefined {
+  if (typeof config !== "object" || config === null) {
+    return;
+  }
+
+  const url = (config as Record<string, unknown>).url;
+
+  return typeof url === "string" && url.trim() ? url.trim() : undefined;
+}
+
+function readHttpHeaders(config: unknown): Record<string, string> {
+  if (typeof config !== "object" || config === null) {
+    return {};
+  }
+
+  const headers = (config as Record<string, unknown>).headers;
+
+  if (typeof headers !== "object" || headers === null) {
+    return {};
+  }
+
+  const result: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(headers)) {
+    if (typeof value === "string" && value.trim()) {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
+
+function firecrawlLegacyBearer(url: string | undefined): string | undefined {
+  if (!url) {
+    return;
+  }
+
+  const token = FIRECRAWL_LEGACY_KEY_URL.exec(url)?.[1]?.trim();
+
+  return token ? `Bearer ${token}` : undefined;
 }


### PR DESCRIPTION
## Summary
- Seed a preinstalled `firecrawl` HTTP MCP server at `https://mcp.firecrawl.dev/v2/mcp` (no API key) so platform admins can assign JS-rendered scrape without signup.
- Preserve operator HTTP headers and `enabled` on every re-seed so Firecrawl Bearer keys and Exa `x-api-key` values survive restarts; skip insert by name lookup if `firecrawl` is already taken; migrate legacy key-in-URL credentials into `Authorization`.
- Document keyless vs keyed tools, off-box processing, shared-IP caps, and routing vs `web_fetch` / Exa / agent-browser.

## Test plan
- [x] `bun test packages/db/src/seed.test.ts`
- [x] `bun test apps/server/src/services/mcp-service.test.ts`
- [ ] After deploy, confirm **Agent → System → MCP** lists `firecrawl` connected with search/scrape/parse
- [ ] Assign to one profile; confirm chat can scrape a JS-heavy public page
- [ ] Confirm Super Bot / default profiles are not auto-assigned
- [ ] Optional: add Bearer header, reconnect, confirm keyed tools appear on every assigned profile

## Post-Deploy Monitoring & Validation
- Watch server logs at startup for MCP connect of `firecrawl` (`Could not connect MCP servers` / `lastError`)
- Healthy: `firecrawl` status `connected`; tool cache includes `firecrawl_search`, `firecrawl_scrape`, `firecrawl_parse`
- Failure: 429s from Firecrawl (shared host IP); `error` status; name-collision warn `name already used by mcp_*` (no header values in logs)
- Rollback: revert this commit; existing Exa/Firecrawl header rows remain in SQLite
- Validation window: first boot after upgrade, plus one assigned-profile chat turn


Made with [Cursor](https://cursor.com)