### PR TITLE
fix(web): show generate_image previews instead of broken thumbnails

### DIFF
--- a/apps/server/src/http/app.test.ts
+++ b/apps/server/src/http/app.test.ts
@@ -458,6 +458,20 @@ describe("createHonoApp", () => {
     });
   });
 
+  test("allows blob: media so authenticated artifact previews can render", async () => {
+    const options = createServerOptions();
+    const app = createHonoApp(options);
+    const response = await app.fetch(
+      new Request("http://localhost:4310/v1/profiles", {
+        headers: { Authorization: "Bearer invalid_token" },
+      })
+    );
+
+    const csp = response.headers.get("Content-Security-Policy") ?? "";
+    expect(csp).toContain("img-src 'self' data: blob:");
+    expect(csp).toContain("media-src 'self' blob:");
+  });
+
   test("rotates the local auth token from a browser session", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "nakama-rotate-auth-"));
     process.env.NAKAMA_CONFIG_DIR = configDir;

--- a/apps/server/src/http/app.ts
+++ b/apps/server/src/http/app.ts
@@ -67,7 +67,7 @@ export function createHonoApp(options: ServerOptions) {
       }
       headers.set(
         "Content-Security-Policy",
-        "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self';"
+        "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob:; font-src 'self' data:; connect-src 'self';"
       );
       // Only enable HSTS if the request is secure (HTTPS)
       if (new URL(c.req.url).protocol === "https:") {

--- a/apps/web/src/components/chat/ImageGenerationToolRow.tsx
+++ b/apps/web/src/components/chat/ImageGenerationToolRow.tsx
@@ -1,4 +1,5 @@
 import { ImageGeneration } from "@/components/chat/ImageGeneration";
+import { useAuthenticatedImagePreview } from "@/components/chat/use-artifact-preview-content";
 import type { ChatListItem } from "@/lib/chat-history";
 import {
   buildGenerateImageToolState,
@@ -12,18 +13,31 @@ export function ImageGenerationToolRow({
   message: ChatListItem;
   profileId?: string | null;
 }) {
+  const state = buildGenerateImageToolState(message);
+  const shouldFetch =
+    shouldRenderGenerateImageToolRow(message) && state.status === "done";
+  const preview = useAuthenticatedImagePreview(
+    shouldFetch ? profileId : null,
+    shouldFetch ? state.artifactPath : null
+  );
+
   if (!shouldRenderGenerateImageToolRow(message)) {
     return null;
   }
 
-  const state = buildGenerateImageToolState(message, profileId);
+  const missingProfile =
+    shouldFetch && !(typeof profileId === "string" && profileId.trim());
+  const error =
+    state.error ??
+    preview.error ??
+    (missingProfile ? "Image ready, but preview is unavailable." : null);
 
   return (
     <div className="w-full max-w-full">
       <ImageGeneration
         aspect={state.aspect}
-        error={state.error}
-        imageUrl={state.imageUrl}
+        error={error}
+        imageUrl={preview.url}
         prompt={state.prompt}
         resolution={state.resolution}
       />

--- a/apps/web/src/components/chat/use-artifact-preview-content.ts
+++ b/apps/web/src/components/chat/use-artifact-preview-content.ts
@@ -10,6 +10,62 @@ import {
 } from "@/lib/chat-artifacts";
 import { client, formatError } from "@/lib/client";
 
+export function useAuthenticatedImagePreview(
+  profileId: string | null | undefined,
+  artifactPath: string | null | undefined
+): { error: string | null; url: string | null } {
+  const [blob, setBlob] = useState<Blob | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const url = useBlobObjectUrl(blob);
+
+  useEffect(() => {
+    if (!(profileId?.trim() && artifactPath?.trim())) {
+      setBlob(null);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setBlob(null);
+    setError(null);
+
+    void client
+      .readProfileArtifactContent(profileId, artifactPath, { inline: true })
+      .then((result) => {
+        if (cancelled) {
+          return;
+        }
+
+        const filename = artifactPath.split("/").pop() ?? artifactPath;
+        const contentType = resolveArtifactMimeType(
+          result.contentType,
+          filename
+        );
+        if (!isImageArtifactMimeType(contentType)) {
+          setBlob(null);
+          setError(
+            "Preview is not available for this file type. Download instead."
+          );
+          return;
+        }
+
+        setBlob(new Blob([result.data], { type: contentType }));
+      })
+      .catch((fetchError) => {
+        if (!cancelled) {
+          setBlob(null);
+          setError(formatError(fetchError));
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [artifactPath, profileId]);
+
+  return { error, url };
+}
+
 function useBlobObjectUrl(blob: Blob | null) {
   const [url, setUrl] = useState<string | null>(null);
 

--- a/apps/web/src/lib/chat-stream-image-generation.test.ts
+++ b/apps/web/src/lib/chat-stream-image-generation.test.ts
@@ -61,21 +61,20 @@ describe("chat-stream-image-generation", () => {
           size: "1024x1536",
         },
         toolStatus: "running",
-      }),
-      "profile_1"
+      })
     );
 
     expect(state).toEqual({
+      artifactPath: null,
       aspect: "portrait",
       error: null,
-      imageUrl: null,
       prompt: "a calm mountain lake at dawn",
       resolution: "1024 × 1536",
       status: "running",
     });
   });
 
-  test("buildGenerateImageToolState done builds artifact image URL", () => {
+  test("buildGenerateImageToolState done exposes artifacts-relative path", () => {
     const state = buildGenerateImageToolState(
       toolMessage({
         toolInput: { prompt: "logo", size: "1024x1024" },
@@ -87,15 +86,11 @@ describe("chat-stream-image-generation", () => {
           sizeBytes: 1200,
         },
         toolStatus: "done",
-      }),
-      "profile_1"
+      })
     );
 
     expect(state.status).toBe("done");
-    expect(state.imageUrl).toContain(
-      "/v1/profiles/profile_1/artifacts/content?path=logo.png"
-    );
-    expect(state.imageUrl).toContain("inline=1");
+    expect(state.artifactPath).toBe("logo.png");
     expect(state.error).toBeNull();
   });
 
@@ -104,13 +99,12 @@ describe("chat-stream-image-generation", () => {
       toolMessage({
         toolResult: { error: "Configure an image generation model" },
         toolStatus: "done",
-      }),
-      "profile_1"
+      })
     );
 
     expect(state).toMatchObject({
+      artifactPath: null,
       error: "Configure an image generation model",
-      imageUrl: null,
       status: "error",
     });
   });

--- a/apps/web/src/lib/chat-stream-image-generation.ts
+++ b/apps/web/src/lib/chat-stream-image-generation.ts
@@ -1,8 +1,5 @@
 import type { ImageGenerationAspect } from "@/components/chat/ImageGeneration";
-import {
-  buildArtifactContentUrl,
-  toArtifactsRelativePath,
-} from "@/lib/chat-artifacts";
+import { toArtifactsRelativePath } from "@/lib/chat-artifacts";
 import type { ChatListItem } from "@/lib/chat-history";
 
 export const GENERATE_IMAGE_TOOL_NAME = "generate_image";
@@ -10,9 +7,9 @@ export const GENERATE_IMAGE_TOOL_NAME = "generate_image";
 export type ImageGenerationToolStatus = "running" | "done" | "error";
 
 export interface ImageGenerationToolState {
+  artifactPath: string | null;
   aspect: ImageGenerationAspect;
   error: string | null;
-  imageUrl: string | null;
   prompt: string;
   resolution: string;
   status: ImageGenerationToolStatus;
@@ -116,8 +113,7 @@ function parseGenerateImagePath(result: unknown): string | null {
 }
 
 export function buildGenerateImageToolState(
-  item: ChatListItem,
-  profileId?: string | null
+  item: ChatListItem
 ): ImageGenerationToolState {
   const prompt = parseGenerateImagePrompt(item.toolInput) ?? DEFAULT_PROMPT;
   const size = parseGenerateImageSize(item.toolInput);
@@ -126,9 +122,9 @@ export function buildGenerateImageToolState(
 
   if (item.toolStatus === "running") {
     return {
+      artifactPath: null,
       aspect,
       error: null,
-      imageUrl: null,
       prompt,
       resolution,
       status: "running",
@@ -138,9 +134,9 @@ export function buildGenerateImageToolState(
   const error = parseGenerateImageError(item.toolResult);
   if (error) {
     return {
+      artifactPath: null,
       aspect,
       error,
-      imageUrl: null,
       prompt,
       resolution,
       status: "error",
@@ -148,18 +144,11 @@ export function buildGenerateImageToolState(
   }
 
   const relativePath = parseGenerateImagePath(item.toolResult);
-  const imageUrl =
-    relativePath && profileId
-      ? buildArtifactContentUrl(profileId, relativePath, true)
-      : null;
-
-  if (!imageUrl) {
+  if (!relativePath) {
     return {
+      artifactPath: null,
       aspect,
-      error: relativePath
-        ? "Image ready, but preview is unavailable."
-        : "Image generation returned no path.",
-      imageUrl: null,
+      error: "Image generation returned no path.",
       prompt,
       resolution,
       status: "error",
@@ -167,9 +156,9 @@ export function buildGenerateImageToolState(
   }
 
   return {
+    artifactPath: relativePath,
     aspect,
     error: null,
-    imageUrl,
     prompt,
     resolution,
     status: "done",


### PR DESCRIPTION
## Summary

Generated images showed a broken-image icon in chat even though the PNG was saved (filename and size were correct). The artifact chip and the generation canvas now render the actual image.

The chip already fetched bytes with auth and used a `blob:` URL; the document CSP blocked `blob:`. The canvas pointed an `<img>` at `/v1/profiles/.../artifacts/content`, which does not send the API client headers. CSP now allows `blob:` (and `media-src` for video previews), and the canvas uses the same authenticated fetch path as the chip.

## Test plan

- [ ] `bun test apps/server/src/http/app.test.ts apps/web/src/lib/chat-stream-image-generation.test.ts`
- [ ] On the bundled dashboard (`http://localhost:4310`, not Vite-only), generate an image and confirm the generation canvas and the artifact card both show the PNG
- [ ] Hard-refresh after deploy so the updated CSP is on the HTML document

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/Cursor_Grok_4.6-000000)
