### PR TITLE
feat(web): toggle rendered vs source in artifact preview

### DIFF
--- a/apps/web/src/components/ai-elements/code-block.tsx
+++ b/apps/web/src/components/ai-elements/code-block.tsx
@@ -128,29 +128,31 @@ export function CodeBlock({
       </div>
       <div
         className={cn(
-          "relative overflow-auto bg-muted/20",
+          "overflow-auto bg-muted/20",
           fillHeight ? "min-h-0 flex-1" : maxScrollHeightClass
         )}
         style={gridStyle}
       >
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute inset-y-0 left-0 w-(--code-block-gutter) border-border/70 border-r bg-muted/50"
-        />
-        <div className="relative grid min-w-full pb-2" style={gridStyle}>
-          {lines.map((line, index) => (
-            <Fragment key={index}>
-              <span
-                aria-hidden="true"
-                className="select-none py-0 pr-3 pl-2 text-right font-mono text-muted-foreground/80 text-xs tabular-nums leading-6"
-              >
-                {index + 1}
-              </span>
-              <code className="block min-w-0 whitespace-pre-wrap break-words px-2 pl-3 font-mono text-foreground text-xs leading-6">
-                {line || "\u00A0"}
-              </code>
-            </Fragment>
-          ))}
+        <div className="relative min-h-full" style={gridStyle}>
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-y-0 left-0 w-(--code-block-gutter) border-border/70 border-r bg-muted/50"
+          />
+          <div className="relative grid min-w-full pb-2" style={gridStyle}>
+            {lines.map((line, index) => (
+              <Fragment key={index}>
+                <span
+                  aria-hidden="true"
+                  className="select-none py-0 pr-3 pl-2 text-right font-mono text-muted-foreground/80 text-xs tabular-nums leading-6"
+                >
+                  {index + 1}
+                </span>
+                <code className="block min-w-0 whitespace-pre-wrap break-words px-2 pl-3 font-mono text-foreground text-xs leading-6">
+                  {line || "\u00A0"}
+                </code>
+              </Fragment>
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/src/components/chat/artifact-attachment-panel-body.shared.test.ts
+++ b/apps/web/src/components/chat/artifact-attachment-panel-body.shared.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import {
+  artifactCanTogglePreviewSource,
+  artifactPanelBodyClassName,
+  artifactPanelHeaderMeta,
+  artifactPanelHeadingName,
+  artifactPanelTypeLabel,
+} from "./artifact-attachment-panel-body.shared";
+
+describe("artifact preview source toggle", () => {
+  test("allows html and markdown only", () => {
+    expect(
+      artifactCanTogglePreviewSource({ isHtml: true, isMarkdown: false })
+    ).toBe(true);
+    expect(
+      artifactCanTogglePreviewSource({ isHtml: false, isMarkdown: true })
+    ).toBe(true);
+    expect(
+      artifactCanTogglePreviewSource({ isHtml: false, isMarkdown: false })
+    ).toBe(false);
+  });
+});
+
+describe("artifact panel header", () => {
+  test("strips the extension from the heading name", () => {
+    expect(artifactPanelHeadingName("Gpt2 slides.html")).toBe("Gpt2 slides");
+    expect(artifactPanelHeadingName("notes.md")).toBe("notes");
+    expect(artifactPanelHeadingName("README")).toBe("README");
+  });
+
+  test("labels html and markdown files", () => {
+    expect(
+      artifactPanelTypeLabel({
+        filename: "deck.html",
+        mimeType: "text/html",
+      })
+    ).toBe("HTML");
+    expect(
+      artifactPanelTypeLabel({
+        filename: "notes.md",
+        mimeType: "text/markdown",
+      })
+    ).toBe("Markdown");
+  });
+
+  test("replaces mime size subtitle with type when toggle is shown", () => {
+    expect(
+      artifactPanelHeaderMeta({
+        filename: "notes.md",
+        mimeType: "text/markdown",
+        showPreviewToggle: true,
+        sizeBytes: 7700,
+      })
+    ).toEqual({
+      subtitle: null,
+      title: "notes",
+      typeLabel: "Markdown",
+    });
+  });
+});
+
+describe("artifact panel body class", () => {
+  test("keeps padding for html source view", () => {
+    expect(
+      artifactPanelBodyClassName({
+        isHtml: true,
+        isImage: false,
+        isMarkdown: false,
+        previewMode: "source",
+      })
+    ).toBe("flex flex-col overflow-hidden");
+  });
+});

--- a/apps/web/src/components/chat/artifact-attachment-panel-body.shared.test.ts
+++ b/apps/web/src/components/chat/artifact-attachment-panel-body.shared.test.ts
@@ -60,7 +60,7 @@ describe("artifact panel header", () => {
 });
 
 describe("artifact panel body class", () => {
-  test("keeps padding for html source view", () => {
+  test("source view fills the panel with no padding", () => {
     expect(
       artifactPanelBodyClassName({
         isHtml: true,
@@ -68,6 +68,14 @@ describe("artifact panel body class", () => {
         isMarkdown: false,
         previewMode: "source",
       })
-    ).toBe("flex flex-col overflow-hidden");
+    ).toBe("flex flex-col overflow-hidden p-0");
+    expect(
+      artifactPanelBodyClassName({
+        isHtml: false,
+        isImage: false,
+        isMarkdown: true,
+        previewMode: "source",
+      })
+    ).toBe("flex flex-col overflow-hidden p-0");
   });
 });

--- a/apps/web/src/components/chat/artifact-attachment-panel-body.shared.ts
+++ b/apps/web/src/components/chat/artifact-attachment-panel-body.shared.ts
@@ -1,3 +1,4 @@
+import type { ArtifactPreviewMode } from "@/components/chat/artifact-preview-mode-toggle";
 import { clampAttachmentPanelWidth } from "@/components/chat/attachment-panel-width";
 import {
   artifactCodeLanguage,
@@ -36,22 +37,108 @@ export function artifactPanelDefaultWidth(
   return clampAttachmentPanelWidth(baseWidth);
 }
 
+export function artifactCanTogglePreviewSource({
+  isHtml,
+  isMarkdown,
+}: {
+  isHtml: boolean;
+  isMarkdown: boolean;
+}): boolean {
+  return isHtml || isMarkdown;
+}
+
+export function artifactPanelHeadingName(filename: string): string {
+  const slash = filename.lastIndexOf("/");
+  const base = slash >= 0 ? filename.slice(slash + 1) : filename;
+  const dot = base.lastIndexOf(".");
+  if (dot <= 0) {
+    return base;
+  }
+  return base.slice(0, dot);
+}
+
+export function artifactPanelTypeLabel({
+  filename,
+  mimeType,
+}: {
+  filename: string;
+  mimeType: string;
+}): string {
+  if (isHtmlArtifactMimeType(mimeType)) {
+    return "HTML";
+  }
+
+  if (
+    isMarkdownArtifactMimeType(mimeType) ||
+    isDocxFile(filename, mimeType) ||
+    isLegacyDocFile(filename, mimeType)
+  ) {
+    return "Markdown";
+  }
+
+  const language = artifactCodeLanguage(filename);
+  if (language) {
+    return language.toUpperCase();
+  }
+
+  const subtype = mimeType.split("/")[1]?.trim();
+  return subtype ? subtype.toUpperCase() : "FILE";
+}
+
+export function artifactPanelHeaderMeta({
+  filename,
+  mimeType,
+  sizeBytes = 0,
+  streaming = false,
+  showPreviewToggle,
+}: {
+  filename: string;
+  mimeType: string;
+  sizeBytes?: number;
+  streaming?: boolean;
+  showPreviewToggle: boolean;
+}): {
+  subtitle: string | null;
+  title: string;
+  typeLabel: string | null;
+} {
+  if (showPreviewToggle) {
+    return {
+      subtitle: null,
+      title: artifactPanelHeadingName(filename),
+      typeLabel: artifactPanelTypeLabel({ filename, mimeType }),
+    };
+  }
+
+  return {
+    subtitle: artifactPanelSubtitle({ mimeType, sizeBytes, streaming }),
+    title: filename,
+    typeLabel: null,
+  };
+}
+
 export function artifactPanelBodyClassName({
   isHtml,
   isImage,
   isVideo = false,
   isMarkdown,
+  previewMode = "preview",
 }: {
   isHtml: boolean;
   isImage: boolean;
   isVideo?: boolean;
   isMarkdown: boolean;
+  previewMode?: ArtifactPreviewMode;
 }): string | undefined {
+  if (isHtml && previewMode === "source") {
+    return "flex flex-col overflow-hidden";
+  }
+
   if (isHtml || isImage || isVideo) {
     return "flex flex-col overflow-hidden p-0";
   }
 
-  if (!isMarkdown) {
+  if (!isMarkdown || previewMode === "source") {
     return "flex flex-col overflow-hidden";
   }
 }

--- a/apps/web/src/components/chat/artifact-attachment-panel-body.shared.ts
+++ b/apps/web/src/components/chat/artifact-attachment-panel-body.shared.ts
@@ -130,16 +130,12 @@ export function artifactPanelBodyClassName({
   isMarkdown: boolean;
   previewMode?: ArtifactPreviewMode;
 }): string | undefined {
-  if (isHtml && previewMode === "source") {
-    return "flex flex-col overflow-hidden";
-  }
-
   if (isHtml || isImage || isVideo) {
     return "flex flex-col overflow-hidden p-0";
   }
 
   if (!isMarkdown || previewMode === "source") {
-    return "flex flex-col overflow-hidden";
+    return "flex flex-col overflow-hidden p-0";
   }
 }
 

--- a/apps/web/src/components/chat/artifact-attachment-panel-body.tsx
+++ b/apps/web/src/components/chat/artifact-attachment-panel-body.tsx
@@ -62,7 +62,7 @@ function renderTextContent({
 
   return (
     <CodeBlock
-      className="rounded-lg border border-border"
+      className="rounded-none border-0"
       code={content}
       fillHeight={fillHeight}
       lang={language}
@@ -215,7 +215,7 @@ function ArtifactAttachmentTextBody({
   return (
     <div
       className={cn(
-        showCodeBlock ? "flex min-h-0 flex-1 flex-col gap-4" : "space-y-4"
+        showCodeBlock ? "flex min-h-0 flex-1 flex-col" : "space-y-4"
       )}
     >
       {loading ? <LoadingState compact /> : null}

--- a/apps/web/src/components/chat/artifact-attachment-panel-body.tsx
+++ b/apps/web/src/components/chat/artifact-attachment-panel-body.tsx
@@ -1,5 +1,6 @@
 import { CodeBlock } from "@/components/ai-elements/code-block";
 import { MessageResponse } from "@/components/ai-elements/message";
+import type { ArtifactPreviewMode } from "@/components/chat/artifact-preview-mode-toggle";
 import { Spinner } from "@/components/ui/spinner";
 import {
   ARTIFACT_HTML_IFRAME_SANDBOX,
@@ -8,14 +9,12 @@ import {
 import type { ChatArtifactRef } from "@/lib/chat-artifacts";
 import { cn } from "@/lib/utils";
 
-/** Highlighting a very large file blocks the main thread, so show it as plain text. */
-const MAX_HIGHLIGHTED_CHARS = 200_000;
-
 type ArtifactPanelSharedProps = {
   loading: boolean;
   error: string | null;
   canPreview: boolean;
   artifact: ChatArtifactRef;
+  previewMode?: ArtifactPreviewMode;
 };
 
 export type ArtifactAttachmentPanelBodyProps =
@@ -40,26 +39,6 @@ export type ArtifactAttachmentPanelBodyProps =
       streaming?: boolean;
     });
 
-function toCodeFence(content: string, language: string): string {
-  const longestRun = Math.max(
-    0,
-    ...[...content.matchAll(/`+/g)].map((match) => match[0].length)
-  );
-  const fence = "`".repeat(Math.max(3, longestRun + 1));
-  return `${fence}${language}\n${content}\n${fence}`;
-}
-
-function usesPlainCodeBlock(
-  content: string,
-  format: "markdown" | "plain",
-  language: string | null
-): boolean {
-  return (
-    format !== "markdown" &&
-    !(language !== null && content.length <= MAX_HIGHLIGHTED_CHARS)
-  );
-}
-
 function renderTextContent({
   content,
   format,
@@ -81,15 +60,14 @@ function renderTextContent({
     );
   }
 
-  if (language && content.length <= MAX_HIGHLIGHTED_CHARS) {
-    return (
-      <MessageResponse className="text-sm" isAnimating={streaming}>
-        {toCodeFence(content, language)}
-      </MessageResponse>
-    );
-  }
-
-  return <CodeBlock code={content} fillHeight={fillHeight} lang={language} />;
+  return (
+    <CodeBlock
+      className="rounded-lg border border-border"
+      code={content}
+      fillHeight={fillHeight}
+      lang={language}
+    />
+  );
 }
 
 function LoadingState({ compact = false }: { compact?: boolean }) {
@@ -186,12 +164,23 @@ function ArtifactAttachmentHtmlBody({
   canPreview,
   artifact,
   htmlSandbox = ARTIFACT_HTML_IFRAME_SANDBOX,
+  previewMode = "preview",
 }: Extract<ArtifactAttachmentPanelBodyProps, { kind: "html" }>) {
+  const showSource = previewMode === "source" && Boolean(content);
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       {loading ? <LoadingState /> : null}
       {error ? <p className="p-4 text-destructive text-sm">{error}</p> : null}
-      {!(loading || error) && content ? (
+      {!(loading || error) && showSource && content
+        ? renderTextContent({
+            content,
+            fillHeight: true,
+            format: "plain",
+            language: "html",
+          })
+        : null}
+      {!(loading || error || showSource) && content ? (
         <iframe
           className="min-h-0 w-full flex-1 border-0 bg-background"
           sandbox={htmlSandbox}
@@ -214,10 +203,14 @@ function ArtifactAttachmentTextBody({
   language,
   streaming = false,
   canPreview,
+  previewMode = "preview",
 }: Extract<ArtifactAttachmentPanelBodyProps, { kind: "text" }>) {
-  const showCodeBlock = Boolean(
-    content && usesPlainCodeBlock(content, format, language)
-  );
+  const sourceFormat = previewMode === "source" ? "plain" : format;
+  const sourceLanguage =
+    previewMode === "source"
+      ? (language ?? (format === "markdown" ? "markdown" : null))
+      : language;
+  const showCodeBlock = Boolean(content && sourceFormat !== "markdown");
 
   return (
     <div
@@ -231,8 +224,8 @@ function ArtifactAttachmentTextBody({
         ? renderTextContent({
             content,
             fillHeight: showCodeBlock,
-            format,
-            language,
+            format: sourceFormat,
+            language: sourceLanguage,
             streaming,
           })
         : null}

--- a/apps/web/src/components/chat/artifact-attachment-preview.tsx
+++ b/apps/web/src/components/chat/artifact-attachment-preview.tsx
@@ -8,11 +8,16 @@ import { useEffect, useState } from "react";
 import { ArtifactAttachmentPanelActions } from "@/components/chat/artifact-attachment-panel-actions";
 import { ArtifactAttachmentPanelBody } from "@/components/chat/artifact-attachment-panel-body";
 import {
+  artifactCanTogglePreviewSource,
   artifactPanelBodyClassName,
   artifactPanelDefaultWidth,
-  artifactPanelSubtitle,
+  artifactPanelHeaderMeta,
   downloadActionLabel,
 } from "@/components/chat/artifact-attachment-panel-body.shared";
+import {
+  type ArtifactPreviewMode,
+  ArtifactPreviewModeToggle,
+} from "@/components/chat/artifact-preview-mode-toggle";
 import {
   ArtifactShareMenuItem,
   ArtifactSharePublishDialogFromState,
@@ -64,6 +69,7 @@ function ArtifactAttachmentPreviewPanelBody({
   videoPreviewUrl,
   canPreview,
   artifact,
+  previewMode,
 }: {
   kind: "image" | "video" | "html" | "text";
   textFormat: "markdown" | "plain";
@@ -75,6 +81,7 @@ function ArtifactAttachmentPreviewPanelBody({
   videoPreviewUrl: string | null;
   canPreview: boolean;
   artifact: ChatArtifactRef;
+  previewMode: ArtifactPreviewMode;
 }) {
   if (kind === "image") {
     return (
@@ -111,6 +118,7 @@ function ArtifactAttachmentPreviewPanelBody({
         error={error}
         kind="html"
         loading={loading}
+        previewMode={previewMode}
       />
     );
   }
@@ -125,6 +133,7 @@ function ArtifactAttachmentPreviewPanelBody({
       kind="text"
       language={language}
       loading={loading}
+      previewMode={previewMode}
     />
   );
 }
@@ -144,6 +153,8 @@ export function ArtifactAttachmentPreview({
   const open = activeId === id;
   const [fullscreen, setFullscreen] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [previewMode, setPreviewMode] =
+    useState<ArtifactPreviewMode>("preview");
   const downloadUrl = `${client.baseUrl}${buildArtifactContentUrl(profileId, artifact.path)}`;
   const mimeType = resolveArtifactMimeType(
     artifact.mimeType,
@@ -156,6 +167,16 @@ export function ArtifactAttachmentPreview({
     isDocxFile(artifact.filename, mimeType) ||
     isLegacyDocFile(artifact.filename, mimeType);
   const isMarkdown = isMarkdownArtifactMimeType(mimeType) || isWordDocument;
+  const showPreviewToggle = artifactCanTogglePreviewSource({
+    isHtml,
+    isMarkdown,
+  });
+  const header = artifactPanelHeaderMeta({
+    filename: artifact.filename,
+    mimeType,
+    showPreviewToggle,
+    sizeBytes: artifact.sizeBytes,
+  });
   const language = artifactCodeLanguage(artifact.filename);
   const canPreview =
     isHtml ||
@@ -192,7 +213,10 @@ export function ArtifactAttachmentPreview({
     return () => window.clearTimeout(timeout);
   }, [copied]);
 
-  function buildPanelBody(loadingOverride?: boolean) {
+  function buildPanelBody(
+    loadingOverride?: boolean,
+    mode: ArtifactPreviewMode = previewMode
+  ) {
     const panelKind = isImage
       ? "image"
       : isVideo
@@ -210,21 +234,23 @@ export function ArtifactAttachmentPreview({
         kind={panelKind}
         language={language}
         loading={loadingOverride ?? loading}
+        previewMode={mode}
         textFormat={isMarkdown ? "markdown" : "plain"}
         videoPreviewUrl={videoPreviewUrl}
       />
     );
   }
 
-  function buildPanelConfig() {
+  function buildPanelConfig(mode: ArtifactPreviewMode = previewMode) {
     return {
       bodyClassName: artifactPanelBodyClassName({
         isHtml,
         isImage,
         isMarkdown,
         isVideo,
+        previewMode: mode,
       }),
-      content: buildPanelBody(),
+      content: buildPanelBody(undefined, mode),
       fullscreen,
       headerActions: (
         <>
@@ -247,12 +273,13 @@ export function ArtifactAttachmentPreview({
           />
         </>
       ),
+      leading: showPreviewToggle ? (
+        <ArtifactPreviewModeToggle mode={mode} onChange={setPreviewMode} />
+      ) : null,
       resizable: !fullscreen,
-      subtitle: artifactPanelSubtitle({
-        mimeType,
-        sizeBytes: artifact.sizeBytes,
-      }),
-      title: artifact.filename,
+      subtitle: header.subtitle,
+      title: header.title,
+      typeLabel: header.typeLabel,
     };
   }
 
@@ -286,6 +313,11 @@ export function ArtifactAttachmentPreview({
     downloadUrl,
     share.busy,
     share.publishDialogOpen,
+    previewMode,
+    showPreviewToggle,
+    header.subtitle,
+    header.title,
+    header.typeLabel,
   ]);
 
   async function copyArtifact() {
@@ -318,14 +350,16 @@ export function ArtifactAttachmentPreview({
   function openPanel() {
     setFullscreen(false);
     setCopied(false);
+    setPreviewMode("preview");
     show({
-      ...buildPanelConfig(),
+      ...buildPanelConfig("preview"),
       content: buildPanelBody(
         canPreview &&
           (isImage || isVideo
             ? (isImage ? imagePreviewUrl : videoPreviewUrl) === null
             : content === null) &&
-          error === null
+          error === null,
+        "preview"
       ),
       defaultWidth: artifactPanelDefaultWidth(artifact.filename, mimeType),
       fullscreen: false,
@@ -333,11 +367,42 @@ export function ArtifactAttachmentPreview({
       onClose: () => {
         setFullscreen(false);
         setCopied(false);
+        setPreviewMode("preview");
       },
       resizable: true,
     });
   }
 
+  return (
+    <ArtifactAttachmentPreviewTrigger
+      artifact={artifact}
+      className={className}
+      imagePreviewUrl={imagePreviewUrl}
+      isImage={isImage}
+      isVideo={isVideo}
+      onOpen={openPanel}
+      variant={variant}
+    />
+  );
+}
+
+function ArtifactAttachmentPreviewTrigger({
+  artifact,
+  className,
+  imagePreviewUrl,
+  isImage,
+  isVideo,
+  onOpen,
+  variant,
+}: {
+  artifact: ChatArtifactRef;
+  className?: string;
+  imagePreviewUrl: string | null;
+  isImage: boolean;
+  isVideo: boolean;
+  onOpen: () => void;
+  variant: "chip" | "icon";
+}) {
   if (variant === "icon") {
     return (
       <Tooltip>
@@ -346,7 +411,7 @@ export function ArtifactAttachmentPreview({
             <Button
               aria-label="View"
               className={className}
-              onClick={openPanel}
+              onClick={onOpen}
               size="icon-sm"
               title="View"
               type="button"
@@ -370,7 +435,7 @@ export function ArtifactAttachmentPreview({
           "relative flex w-1/2 max-w-full shrink-0 flex-col gap-2 overflow-hidden rounded-lg border border-border bg-muted p-2 text-left transition-colors hover:bg-muted/70",
           className
         )}
-        onClick={openPanel}
+        onClick={onOpen}
         type="button"
       >
         {imagePreviewUrl ? (
@@ -405,7 +470,7 @@ export function ArtifactAttachmentPreview({
         "relative inline-flex max-w-full shrink-0 items-center gap-2 rounded-lg border border-border bg-muted px-2 py-2 text-left transition-colors hover:bg-muted/70",
         className
       )}
-      onClick={openPanel}
+      onClick={onOpen}
       type="button"
     >
       <div className="flex size-10 shrink-0 items-center justify-center rounded-md border border-border bg-background">

--- a/apps/web/src/components/chat/artifact-preview-mode-toggle.tsx
+++ b/apps/web/src/components/chat/artifact-preview-mode-toggle.tsx
@@ -1,0 +1,54 @@
+import { CodeIcon, EyeIcon } from "hugeicons-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type ArtifactPreviewMode = "preview" | "source";
+
+export function ArtifactPreviewModeToggle({
+  mode,
+  onChange,
+}: {
+  mode: ArtifactPreviewMode;
+  onChange: (mode: ArtifactPreviewMode) => void;
+}) {
+  return (
+    <div
+      aria-label="Preview mode"
+      className="inline-flex shrink-0 items-center rounded-full bg-muted p-0.5"
+      role="group"
+    >
+      <Button
+        aria-label="Rendered"
+        aria-pressed={mode === "preview"}
+        className={cn(
+          "size-6 rounded-md",
+          mode === "preview"
+            ? "border-border bg-background text-foreground shadow-sm hover:bg-background"
+            : "text-muted-foreground"
+        )}
+        onClick={() => onChange("preview")}
+        size="icon-xs"
+        type="button"
+        variant="ghost"
+      >
+        <EyeIcon aria-hidden className="size-3.5" />
+      </Button>
+      <Button
+        aria-label="Code"
+        aria-pressed={mode === "source"}
+        className={cn(
+          "size-6 rounded-md",
+          mode === "source"
+            ? "border-border bg-background text-foreground shadow-sm hover:bg-background"
+            : "text-muted-foreground"
+        )}
+        onClick={() => onChange("source")}
+        size="icon-xs"
+        type="button"
+        variant="ghost"
+      >
+        <CodeIcon aria-hidden className="size-3.5" />
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/artifact-preview-mode-toggle.tsx
+++ b/apps/web/src/components/chat/artifact-preview-mode-toggle.tsx
@@ -1,4 +1,4 @@
-import { CodeIcon, ViewIcon } from "hugeicons-react";
+import { CodeSquareIcon, ViewIcon } from "hugeicons-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -47,7 +47,7 @@ export function ArtifactPreviewModeToggle({
         type="button"
         variant="ghost"
       >
-        <CodeIcon aria-hidden className="size-3.5" />
+        <CodeSquareIcon aria-hidden className="size-3.5" />
       </Button>
     </div>
   );

--- a/apps/web/src/components/chat/artifact-preview-mode-toggle.tsx
+++ b/apps/web/src/components/chat/artifact-preview-mode-toggle.tsx
@@ -1,4 +1,4 @@
-import { CodeIcon, EyeIcon } from "hugeicons-react";
+import { CodeIcon, ViewIcon } from "hugeicons-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -14,14 +14,14 @@ export function ArtifactPreviewModeToggle({
   return (
     <div
       aria-label="Preview mode"
-      className="inline-flex shrink-0 items-center rounded-full bg-muted p-0.5"
+      className="inline-flex shrink-0 items-center rounded-md bg-muted p-0.5"
       role="group"
     >
       <Button
         aria-label="Rendered"
         aria-pressed={mode === "preview"}
         className={cn(
-          "size-6 rounded-md",
+          "size-6 rounded-sm",
           mode === "preview"
             ? "border-border bg-background text-foreground shadow-sm hover:bg-background"
             : "text-muted-foreground"
@@ -31,13 +31,13 @@ export function ArtifactPreviewModeToggle({
         type="button"
         variant="ghost"
       >
-        <EyeIcon aria-hidden className="size-3.5" />
+        <ViewIcon aria-hidden className="size-3.5" />
       </Button>
       <Button
         aria-label="Code"
         aria-pressed={mode === "source"}
         className={cn(
-          "size-6 rounded-md",
+          "size-6 rounded-sm",
           mode === "source"
             ? "border-border bg-background text-foreground shadow-sm hover:bg-background"
             : "text-muted-foreground"

--- a/apps/web/src/components/chat/artifact-streaming-panel-bridge.tsx
+++ b/apps/web/src/components/chat/artifact-streaming-panel-bridge.tsx
@@ -1,10 +1,15 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { ArtifactAttachmentPanelBody } from "@/components/chat/artifact-attachment-panel-body";
 import {
+  artifactCanTogglePreviewSource,
   artifactPanelBodyClassName,
   artifactPanelDefaultWidth,
-  artifactPanelSubtitle,
+  artifactPanelHeaderMeta,
 } from "@/components/chat/artifact-attachment-panel-body.shared";
+import {
+  type ArtifactPreviewMode,
+  ArtifactPreviewModeToggle,
+} from "@/components/chat/artifact-preview-mode-toggle";
 import { useChatAttachmentPanel } from "@/context/use-chat-attachment-panel";
 import {
   artifactCodeLanguage,
@@ -45,19 +50,47 @@ function buildStreamingArtifactRef(
   };
 }
 
-function buildStreamingPanelBody({
-  artifact,
-  content,
-}: {
-  artifact: ChatArtifactRef;
-  content: string;
-}) {
+function streamingPreviewFlags(artifact: ChatArtifactRef) {
   const mimeType = artifact.mimeType;
   const isWordDocument =
     isDocxFile(artifact.filename, mimeType) ||
     isLegacyDocFile(artifact.filename, mimeType);
   const isHtml = isHtmlArtifactMimeType(mimeType);
   const isMarkdown = isMarkdownArtifactMimeType(mimeType) || isWordDocument;
+  return { isHtml, isMarkdown, isWordDocument, mimeType };
+}
+
+function buildStreamingArtifactHeader(
+  artifact: ChatArtifactRef,
+  options: { sizeBytes?: number; streaming?: boolean } = {}
+) {
+  const { isHtml, isMarkdown, mimeType } = streamingPreviewFlags(artifact);
+  const showPreviewToggle = artifactCanTogglePreviewSource({
+    isHtml,
+    isMarkdown,
+  });
+  return {
+    ...artifactPanelHeaderMeta({
+      filename: artifact.filename,
+      mimeType,
+      showPreviewToggle,
+      sizeBytes: options.sizeBytes,
+      streaming: options.streaming,
+    }),
+    showPreviewToggle,
+  };
+}
+
+function buildStreamingPanelBody({
+  artifact,
+  content,
+  previewMode,
+}: {
+  artifact: ChatArtifactRef;
+  content: string;
+  previewMode: ArtifactPreviewMode;
+}) {
+  const { isHtml, isMarkdown } = streamingPreviewFlags(artifact);
   const language = artifactCodeLanguage(artifact.filename);
 
   return (
@@ -70,6 +103,7 @@ function buildStreamingPanelBody({
       kind="text"
       language={language}
       loading={false}
+      previewMode={previewMode}
       streaming
     />
   );
@@ -78,17 +112,15 @@ function buildStreamingPanelBody({
 function buildStablePanelBody({
   artifact,
   content,
+  previewMode,
 }: {
   artifact: ChatArtifactRef;
   content: string;
+  previewMode: ArtifactPreviewMode;
 }) {
-  const mimeType = artifact.mimeType;
-  const isWordDocument =
-    isDocxFile(artifact.filename, mimeType) ||
-    isLegacyDocFile(artifact.filename, mimeType);
-  const isMarkdown = isMarkdownArtifactMimeType(mimeType) || isWordDocument;
+  const { isHtml, isMarkdown } = streamingPreviewFlags(artifact);
 
-  if (isHtmlArtifactMimeType(mimeType)) {
+  if (isHtml) {
     return (
       <ArtifactAttachmentPanelBody
         artifact={artifact}
@@ -97,6 +129,7 @@ function buildStablePanelBody({
         error={null}
         kind="html"
         loading={false}
+        previewMode={previewMode}
       />
     );
   }
@@ -111,8 +144,32 @@ function buildStablePanelBody({
       kind="text"
       language={artifactCodeLanguage(artifact.filename)}
       loading={false}
+      previewMode={previewMode}
     />
   );
+}
+
+function withPanelPreviewMode(
+  current: Partial<Record<string, ArtifactPreviewMode>>,
+  panelId: string,
+  mode: ArtifactPreviewMode
+): Partial<Record<string, ArtifactPreviewMode>> {
+  if (current[panelId] === mode) {
+    return current;
+  }
+  return { ...current, [panelId]: mode };
+}
+
+function withoutPanelPreviewMode(
+  current: Partial<Record<string, ArtifactPreviewMode>>,
+  panelId: string
+): Partial<Record<string, ArtifactPreviewMode>> {
+  if (!(panelId in current)) {
+    return current;
+  }
+  const next = { ...current };
+  delete next[panelId];
+  return next;
 }
 
 export function ArtifactStreamingPanelBridge({
@@ -128,6 +185,14 @@ export function ArtifactStreamingPanelBridge({
   const lastEligibleRef = useRef<EligibleStreamTarget | null>(null);
   const handedOffRef = useRef(new Set<string>());
   const autoWidthAppliedRef = useRef(new Set<string>());
+  const [previewModeByPanel, setPreviewModeByPanel] = useState<
+    Partial<Record<string, ArtifactPreviewMode>>
+  >({});
+  const [stableContent, setStableContent] = useState<{
+    artifact: ChatArtifactRef;
+    content: string;
+    toolCallId: string;
+  } | null>(null);
   const streaming = useMemo(
     () => findLatestStreamingArtifact(messages),
     [messages]
@@ -155,6 +220,7 @@ export function ArtifactStreamingPanelBridge({
     }
 
     const panelId = streaming.toolCallId;
+    const previewMode = previewModeByPanel[panelId] ?? "preview";
 
     if (dismissedRef.current.has(panelId)) {
       return;
@@ -169,26 +235,30 @@ export function ArtifactStreamingPanelBridge({
     const body = buildStreamingPanelBody({
       artifact,
       content: streaming.parsed.content ?? "",
+      previewMode,
     });
     const defaultWidth = artifactPanelDefaultWidth(
       artifact.filename,
       artifact.mimeType
     );
-    const subtitle = artifactPanelSubtitle({
-      mimeType: artifact.mimeType,
-      streaming: true,
-    });
-    const isHtml = isHtmlArtifactMimeType(artifact.mimeType);
-    const isWordDocument =
-      isDocxFile(artifact.filename, artifact.mimeType) ||
-      isLegacyDocFile(artifact.filename, artifact.mimeType);
-    const isMarkdown =
-      isMarkdownArtifactMimeType(artifact.mimeType) || isWordDocument;
+    const header = buildStreamingArtifactHeader(artifact, { streaming: true });
+    const { isHtml, isMarkdown } = streamingPreviewFlags(artifact);
     const bodyClassName = artifactPanelBodyClassName({
       isHtml,
       isImage: false,
       isMarkdown,
+      previewMode,
     });
+    const leading = header.showPreviewToggle ? (
+      <ArtifactPreviewModeToggle
+        mode={previewMode}
+        onChange={(mode) =>
+          setPreviewModeByPanel((current) =>
+            withPanelPreviewMode(current, panelId, mode)
+          )
+        }
+      />
+    ) : null;
     const widthPatch =
       defaultWidth === 768 && !autoWidthAppliedRef.current.has(panelId)
         ? { defaultWidth }
@@ -202,8 +272,10 @@ export function ArtifactStreamingPanelBridge({
       update(panelId, {
         bodyClassName,
         content: body,
-        subtitle,
-        title: filename,
+        leading,
+        subtitle: header.subtitle,
+        title: header.title,
+        typeLabel: header.typeLabel,
         ...widthPatch,
       });
       return;
@@ -218,20 +290,43 @@ export function ArtifactStreamingPanelBridge({
       autoWidthAppliedRef.current.add(panelId);
     }
     show({
-      bodyClassName,
-      content: body,
+      bodyClassName: artifactPanelBodyClassName({
+        isHtml,
+        isImage: false,
+        isMarkdown,
+        previewMode: "preview",
+      }),
+      content: buildStreamingPanelBody({
+        artifact,
+        content: streaming.parsed.content ?? "",
+        previewMode: "preview",
+      }),
       defaultWidth,
       fullscreen: false,
       id: panelId,
+      leading: header.showPreviewToggle ? (
+        <ArtifactPreviewModeToggle
+          mode="preview"
+          onChange={(mode) =>
+            setPreviewModeByPanel((current) =>
+              withPanelPreviewMode(current, panelId, mode)
+            )
+          }
+        />
+      ) : null,
       onClose: () => {
         dismissedRef.current.add(panelId);
         openedRef.current = null;
+        setPreviewModeByPanel((current) =>
+          withoutPanelPreviewMode(current, panelId)
+        );
       },
       resizable: true,
-      subtitle,
-      title: filename,
+      subtitle: header.subtitle,
+      title: header.title,
+      typeLabel: header.typeLabel,
     });
-  }, [activeId, profileId, show, streaming, update]);
+  }, [activeId, previewModeByPanel, profileId, show, streaming, update]);
 
   const handoffTarget = useMemo(() => {
     const candidate = lastEligibleRef.current;
@@ -282,32 +377,10 @@ export function ArtifactStreamingPanelBridge({
           handoffTarget.relativePath,
           handoffTarget.tool
         );
-        const isHtml = isHtmlArtifactMimeType(artifact.mimeType);
-        const isWordDocument =
-          isDocxFile(artifact.filename, artifact.mimeType) ||
-          isLegacyDocFile(artifact.filename, artifact.mimeType);
-        const isMarkdown =
-          isMarkdownArtifactMimeType(artifact.mimeType) || isWordDocument;
-
-        update(handoffTarget.toolCallId, {
-          bodyClassName: artifactPanelBodyClassName({
-            isHtml,
-            isImage: false,
-            isMarkdown,
-          }),
-          content: buildStablePanelBody({
-            artifact,
-            content: text,
-          }),
-          defaultWidth: artifactPanelDefaultWidth(
-            artifact.filename,
-            artifact.mimeType
-          ),
-          subtitle: artifactPanelSubtitle({
-            mimeType: artifact.mimeType,
-            sizeBytes: new TextEncoder().encode(text).byteLength,
-          }),
-          title: filename,
+        setStableContent({
+          artifact,
+          content: text,
+          toolCallId: handoffTarget.toolCallId,
         });
       })
       .catch((error) => {
@@ -326,6 +399,52 @@ export function ArtifactStreamingPanelBridge({
       cancelled = true;
     };
   }, [activeId, handoffTarget, profileId, update]);
+
+  useEffect(() => {
+    if (!stableContent || activeId !== stableContent.toolCallId) {
+      return;
+    }
+
+    const previewMode =
+      previewModeByPanel[stableContent.toolCallId] ?? "preview";
+    const header = buildStreamingArtifactHeader(stableContent.artifact, {
+      sizeBytes: new TextEncoder().encode(stableContent.content).byteLength,
+    });
+    const { isHtml, isMarkdown } = streamingPreviewFlags(
+      stableContent.artifact
+    );
+
+    update(stableContent.toolCallId, {
+      bodyClassName: artifactPanelBodyClassName({
+        isHtml,
+        isImage: false,
+        isMarkdown,
+        previewMode,
+      }),
+      content: buildStablePanelBody({
+        artifact: stableContent.artifact,
+        content: stableContent.content,
+        previewMode,
+      }),
+      defaultWidth: artifactPanelDefaultWidth(
+        stableContent.artifact.filename,
+        stableContent.artifact.mimeType
+      ),
+      leading: header.showPreviewToggle ? (
+        <ArtifactPreviewModeToggle
+          mode={previewMode}
+          onChange={(mode) =>
+            setPreviewModeByPanel((current) =>
+              withPanelPreviewMode(current, stableContent.toolCallId, mode)
+            )
+          }
+        />
+      ) : null,
+      subtitle: header.subtitle,
+      title: header.title,
+      typeLabel: header.typeLabel,
+    });
+  }, [activeId, previewModeByPanel, stableContent, update]);
 
   return null;
 }

--- a/apps/web/src/components/chat/attachment-detail-panel.tsx
+++ b/apps/web/src/components/chat/attachment-detail-panel.tsx
@@ -16,17 +16,21 @@ interface AttachmentDetailPanelProps {
   className?: string;
   fullscreen?: boolean;
   headerActions?: ReactNode;
+  leading?: ReactNode;
   onClose: () => void;
   onWidthChange: (width: number) => void;
   resizable?: boolean;
   subtitle?: string | null;
   title: string;
+  typeLabel?: string | null;
   width: number;
 }
 
 export function AttachmentDetailPanel({
   title,
+  typeLabel,
   subtitle,
+  leading,
   children,
   headerActions,
   bodyClassName,
@@ -128,13 +132,24 @@ export function AttachmentDetailPanel({
       ) : null}
       <div className="relative flex min-h-0 flex-1 flex-col">
         <div className="flex items-center justify-between gap-3 border-border border-b px-4 py-3">
-          <div className="min-w-0 flex-1">
-            <h2 className="truncate font-medium text-sm">{title}</h2>
-            {subtitle ? (
-              <p className="mt-0.5 truncate text-muted-foreground text-xs">
-                {subtitle}
-              </p>
-            ) : null}
+          <div className="flex min-w-0 flex-1 items-center gap-2.5">
+            {leading}
+            <div className="min-w-0 flex-1">
+              <h2 className="truncate font-medium text-sm">
+                {title}
+                {typeLabel ? (
+                  <span className="font-normal text-muted-foreground">
+                    {" · "}
+                    {typeLabel}
+                  </span>
+                ) : null}
+              </h2>
+              {leading ? null : subtitle ? (
+                <p className="mt-0.5 truncate text-muted-foreground text-xs">
+                  {subtitle}
+                </p>
+              ) : null}
+            </div>
           </div>
           <div className="flex shrink-0 items-center gap-1">
             {headerActions}

--- a/apps/web/src/components/soul-tools/knowledge-document-preview.tsx
+++ b/apps/web/src/components/soul-tools/knowledge-document-preview.tsx
@@ -4,11 +4,16 @@ import { useEffect, useState } from "react";
 import { ArtifactAttachmentPanelActions } from "@/components/chat/artifact-attachment-panel-actions";
 import { ArtifactAttachmentPanelBody } from "@/components/chat/artifact-attachment-panel-body";
 import {
+  artifactCanTogglePreviewSource,
   artifactPanelBodyClassName,
   artifactPanelDefaultWidth,
-  artifactPanelSubtitle,
+  artifactPanelHeaderMeta,
   downloadActionLabel,
 } from "@/components/chat/artifact-attachment-panel-body.shared";
+import {
+  type ArtifactPreviewMode,
+  ArtifactPreviewModeToggle,
+} from "@/components/chat/artifact-preview-mode-toggle";
 import { useKnowledgeDocumentPreviewContent } from "@/components/soul-tools/use-knowledge-document-preview-content";
 import { Button } from "@/components/ui/button";
 import {
@@ -64,10 +69,22 @@ export function KnowledgeDocumentPreview({
   const open = activeId === id;
   const [fullscreen, setFullscreen] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [previewMode, setPreviewMode] =
+    useState<ArtifactPreviewMode>("preview");
 
   const canPreview = document.status === "ready";
   const downloadUrl = `${client.baseUrl}${buildKnowledgeDocumentContentUrl(profileId, document.id)}`;
   const isMarkdown = isMarkdownArtifactMimeType(document.mediaType);
+  const showPreviewToggle = artifactCanTogglePreviewSource({
+    isHtml: false,
+    isMarkdown,
+  });
+  const header = artifactPanelHeaderMeta({
+    filename: document.filename,
+    mimeType: document.mediaType,
+    showPreviewToggle,
+    sizeBytes: document.sizeBytes,
+  });
   const language = artifactCodeLanguage(document.filename);
   const downloadLabel = downloadActionLabel(document.mediaType);
   const artifactRef = toArtifactRef(document);
@@ -88,7 +105,10 @@ export function KnowledgeDocumentPreview({
     return () => window.clearTimeout(timeout);
   }, [copied]);
 
-  function buildPanelBody(loadingOverride?: boolean) {
+  function buildPanelBody(
+    loadingOverride?: boolean,
+    mode: ArtifactPreviewMode = previewMode
+  ) {
     return (
       <ArtifactAttachmentPanelBody
         artifact={artifactRef}
@@ -99,18 +119,20 @@ export function KnowledgeDocumentPreview({
         kind="text"
         language={language}
         loading={loadingOverride ?? loading}
+        previewMode={mode}
       />
     );
   }
 
-  function buildPanelConfig() {
+  function buildPanelConfig(mode: ArtifactPreviewMode = previewMode) {
     return {
       bodyClassName: artifactPanelBodyClassName({
         isHtml: false,
         isImage: false,
         isMarkdown,
+        previewMode: mode,
       }),
-      content: buildPanelBody(),
+      content: buildPanelBody(undefined, mode),
       fullscreen,
       headerActions: (
         <ArtifactAttachmentPanelActions
@@ -126,12 +148,13 @@ export function KnowledgeDocumentPreview({
           onToggleFullscreen={() => setFullscreen((current) => !current)}
         />
       ),
+      leading: showPreviewToggle ? (
+        <ArtifactPreviewModeToggle mode={mode} onChange={setPreviewMode} />
+      ) : null,
       resizable: !fullscreen,
-      subtitle: artifactPanelSubtitle({
-        mimeType: document.mediaType,
-        sizeBytes: document.sizeBytes,
-      }),
-      title: document.filename,
+      subtitle: header.subtitle,
+      title: header.title,
+      typeLabel: header.typeLabel,
     };
   }
 
@@ -157,6 +180,11 @@ export function KnowledgeDocumentPreview({
     copied,
     downloadLabel,
     downloadUrl,
+    previewMode,
+    showPreviewToggle,
+    header.subtitle,
+    header.title,
+    header.typeLabel,
   ]);
 
   async function copyDocument() {
@@ -182,9 +210,13 @@ export function KnowledgeDocumentPreview({
   function openPanel() {
     setFullscreen(false);
     setCopied(false);
+    setPreviewMode("preview");
     show({
-      ...buildPanelConfig(),
-      content: buildPanelBody(canPreview && content === null && error === null),
+      ...buildPanelConfig("preview"),
+      content: buildPanelBody(
+        canPreview && content === null && error === null,
+        "preview"
+      ),
       defaultWidth: artifactPanelDefaultWidth(
         document.filename,
         document.mediaType
@@ -194,6 +226,7 @@ export function KnowledgeDocumentPreview({
       onClose: () => {
         setFullscreen(false);
         setCopied(false);
+        setPreviewMode("preview");
       },
       resizable: true,
     });

--- a/apps/web/src/context/chat-attachment-panel-context-shared.ts
+++ b/apps/web/src/context/chat-attachment-panel-context-shared.ts
@@ -7,10 +7,12 @@ export interface ChatAttachmentPanelConfig {
   fullscreen?: boolean;
   headerActions?: ReactNode;
   id: string;
+  leading?: ReactNode;
   onClose?: () => void;
   resizable?: boolean;
   subtitle?: string | null;
   title: string;
+  typeLabel?: string | null;
 }
 
 export interface ChatAttachmentPanelContextValue {

--- a/apps/web/src/context/chat-attachment-panel-context.tsx
+++ b/apps/web/src/context/chat-attachment-panel-context.tsx
@@ -145,11 +145,13 @@ export function ChatAttachmentPanelProvider({
               )}
               fullscreen={fullscreen}
               headerActions={config.headerActions}
+              leading={config.leading}
               onClose={handlePanelClose}
               onWidthChange={setWidth}
               resizable={config.resizable ?? !fullscreen}
               subtitle={config.subtitle}
               title={config.title}
+              typeLabel={config.typeLabel}
               width={width}
             >
               {config.content}

--- a/apps/web/src/pages/files/files-artifact-views.tsx
+++ b/apps/web/src/pages/files/files-artifact-views.tsx
@@ -75,7 +75,7 @@ export function FilesArtifactViews({
   onShowMore: () => void;
 }) {
   return (
-    <div className="rounded-md border border-border">
+    <div className="overflow-hidden rounded-md border border-border bg-card">
       {isLoading ? (
         viewMode === "grid" ? (
           <ArtifactGridSkeleton />


### PR DESCRIPTION
## Summary

Files artifacts sat on the page background while Chat History used a card, and opening a markdown or HTML artifact only showed the rendered view. Admins can now scan files on the same card surface, then switch a preview between rendered and source with an eye/code control. Source uses the shared `CodeBlock` (language label, copy, line numbers) instead of a chat markdown fence.

Images and videos still show mime and size. Knowledge docs and streaming artifact panels get the same toggle when the file can render.

## Test plan

- [ ] Open `/files` and confirm the artifacts list uses the card background
- [ ] Open a `.md` artifact: eye shows rendered markdown, code shows `CodeBlock`
- [ ] Open an HTML artifact: eye shows the iframe, code shows source
- [ ] Open an image: no toggle, mime/size subtitle remains

Helper tests cover header labels and when the toggle is offered. React Doctor on the changed web files scored 100 after the split/reset fixes.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Cursor](https://img.shields.io/badge/Grok_4.6-000000)
