### PR TITLE
fix: keep channel SSE streams alive through long agent turns

### DIFF
--- a/apps/platform/discord/src/active-stream.test.ts
+++ b/apps/platform/discord/src/active-stream.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  clearActiveStream,
+  hasActiveStreams,
+  registerActiveStream,
+  resetActiveStreamsForTests,
+  stopActiveStream,
+} from "./active-stream";
+
+// Telegram/WhatsApp keep identical active-stream.ts copies — cover the Discord one.
+
+afterEach(() => {
+  resetActiveStreamsForTests();
+});
+
+describe("active-stream", () => {
+  test("registerActiveStream returns a signal and tracks the chat", () => {
+    expect(hasActiveStreams()).toBe(false);
+
+    const signal = registerActiveStream("chat-1");
+
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal.aborted).toBe(false);
+    expect(hasActiveStreams()).toBe(true);
+  });
+
+  test("a new register aborts the previous controller for the same chat", () => {
+    const first = registerActiveStream("chat-1");
+    const second = registerActiveStream("chat-1");
+
+    expect(first.aborted).toBe(true);
+    expect(second.aborted).toBe(false);
+    expect(hasActiveStreams()).toBe(true);
+  });
+
+  test("clearActiveStream removes the chat", () => {
+    registerActiveStream("chat-1");
+    clearActiveStream("chat-1");
+
+    expect(hasActiveStreams()).toBe(false);
+    expect(stopActiveStream("chat-1")).toBe(false);
+  });
+
+  test("stopActiveStream aborts and returns true only when present", () => {
+    expect(stopActiveStream("missing")).toBe(false);
+
+    const signal = registerActiveStream("chat-1");
+    expect(stopActiveStream("chat-1")).toBe(true);
+    expect(signal.aborted).toBe(true);
+    // stop leaves the entry until clear; size still reflects an active registration
+    expect(hasActiveStreams()).toBe(true);
+
+    clearActiveStream("chat-1");
+    expect(hasActiveStreams()).toBe(false);
+    expect(stopActiveStream("chat-1")).toBe(false);
+  });
+
+  test("hasActiveStreams reflects map size across chats", () => {
+    registerActiveStream("chat-1");
+    registerActiveStream("chat-2");
+    expect(hasActiveStreams()).toBe(true);
+
+    clearActiveStream("chat-1");
+    expect(hasActiveStreams()).toBe(true);
+
+    clearActiveStream("chat-2");
+    expect(hasActiveStreams()).toBe(false);
+  });
+});

--- a/apps/platform/discord/src/active-stream.ts
+++ b/apps/platform/discord/src/active-stream.ts
@@ -29,3 +29,15 @@ export function stopActiveStream(chatId: string): boolean {
   controller.abort();
   return true;
 }
+
+export function hasActiveStreams(): boolean {
+  return activeByChat.size > 0;
+}
+
+export function resetActiveStreamsForTests(): void {
+  for (const controller of activeByChat.values()) {
+    controller.abort();
+  }
+
+  activeByChat.clear();
+}

--- a/apps/platform/discord/src/index.ts
+++ b/apps/platform/discord/src/index.ts
@@ -15,6 +15,7 @@ import {
 } from "@nakama/core/ensure-server";
 import { loadLocalAuthToken } from "@nakama/core/local-auth";
 import { resolveWebPublicUrl } from "@nakama/core/runtime";
+import { hasActiveStreams } from "./active-stream";
 import { DiscordAuthStore } from "./auth-store";
 import { createBot } from "./bot";
 import { loadConfig } from "./config";
@@ -31,7 +32,13 @@ registerCleanupHandlers(() => {
     clearInterval(heartbeatTimer);
   }
   void clearDiscordWorkerHeartbeat();
-  stopSpawnedServer(spawnedChild);
+  if (hasActiveStreams()) {
+    console.warn(
+      "Leaving the spawned Nakama server running so in-flight agent turns can finish; the next worker start will reuse it."
+    );
+  } else {
+    stopSpawnedServer(spawnedChild);
+  }
 });
 
 try {

--- a/apps/platform/telegram/src/active-stream.ts
+++ b/apps/platform/telegram/src/active-stream.ts
@@ -29,3 +29,15 @@ export function stopActiveStream(chatId: string): boolean {
   controller.abort();
   return true;
 }
+
+export function hasActiveStreams(): boolean {
+  return activeByChat.size > 0;
+}
+
+export function resetActiveStreamsForTests(): void {
+  for (const controller of activeByChat.values()) {
+    controller.abort();
+  }
+
+  activeByChat.clear();
+}

--- a/apps/platform/telegram/src/index.ts
+++ b/apps/platform/telegram/src/index.ts
@@ -15,6 +15,7 @@ import {
   readTelegramWorkerHeartbeat,
   writeTelegramWorkerHeartbeat,
 } from "@nakama/core/telegram-worker";
+import { hasActiveStreams } from "./active-stream";
 import { TelegramAuthStore } from "./auth-store";
 import { createBot } from "./bot";
 import { loadConfig } from "./config";
@@ -30,7 +31,13 @@ registerCleanupHandlers(() => {
     clearInterval(heartbeatTimer);
   }
   void clearTelegramWorkerHeartbeat();
-  stopSpawnedServer(spawnedChild);
+  if (hasActiveStreams()) {
+    console.warn(
+      "Leaving the spawned Nakama server running so in-flight agent turns can finish; the next worker start will reuse it."
+    );
+  } else {
+    stopSpawnedServer(spawnedChild);
+  }
 });
 
 try {

--- a/apps/platform/whatsapp/src/active-stream.ts
+++ b/apps/platform/whatsapp/src/active-stream.ts
@@ -30,6 +30,10 @@ export function stopActiveStream(chatId: string): boolean {
   return true;
 }
 
+export function hasActiveStreams(): boolean {
+  return activeByChat.size > 0;
+}
+
 export function resetActiveStreamsForTests(): void {
   for (const controller of activeByChat.values()) {
     controller.abort();

--- a/apps/platform/whatsapp/src/index.ts
+++ b/apps/platform/whatsapp/src/index.ts
@@ -16,6 +16,7 @@ import {
   writeWhatsAppQrCode,
   writeWhatsAppWorkerHeartbeat,
 } from "@nakama/core/whatsapp-worker";
+import { hasActiveStreams } from "./active-stream";
 import { WhatsAppAuthStore } from "./auth-store";
 import { createChatHandler } from "./chat-handler";
 import { loadConfig } from "./config";
@@ -51,7 +52,13 @@ registerCleanupHandlers(() => {
   }
   void clearWhatsAppWorkerHeartbeat();
   void clearWhatsAppQrCode();
-  stopSpawnedServer(spawnedChild);
+  if (hasActiveStreams()) {
+    console.warn(
+      "Leaving the spawned Nakama server running so in-flight agent turns can finish; the next worker start will reuse it."
+    );
+  } else {
+    stopSpawnedServer(spawnedChild);
+  }
 });
 
 try {

--- a/apps/server/src/http/routes/sessions.stream.test.ts
+++ b/apps/server/src/http/routes/sessions.stream.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import type { AgentChatSession } from "@nakama/agent";
+import type { StreamEvent } from "@nakama/core";
 import { sessionTurnRegistry } from "../../services/session-turn-registry";
 import { streamMessage, streamTurnSubscribe } from "../shared";
 
@@ -141,6 +142,55 @@ describe("streamMessage cancellation", () => {
     await waitForTurnToEnd(sessionId);
 
     expect(sessionTurnRegistry.isActive(sessionId)).toBe(false);
+  });
+
+  test("a mid-flight drop without a terminal event records the fallback and warns", async () => {
+    const sessionId = `session_drop_test_${Date.now()}`;
+    const { session } = createCancellableSession();
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    const publish = sessionTurnRegistry.publish.bind(sessionTurnRegistry);
+    const publishSpy = spyOn(sessionTurnRegistry, "publish").mockImplementation(
+      (id, event) => {
+        if (event.type === "done" || event.type === "error") {
+          throw new Error("simulated transport drop before terminal publish");
+        }
+        publish(id, event);
+      }
+    );
+
+    let completed: StreamEvent | undefined;
+
+    try {
+      expect(sessionTurnRegistry.beginTurn(sessionId).started).toBe(true);
+      const response = streamMessage(
+        sessionId,
+        session,
+        { message: "hi" },
+        (terminal) => {
+          completed = terminal;
+        }
+      );
+
+      await Bun.sleep(10);
+      await response.body?.cancel();
+      await waitForTurnToEnd(sessionId);
+
+      expect(completed).toEqual({
+        error: "Stream closed before the agent finished.",
+        type: "error",
+      });
+      expect(
+        warn.mock.calls.some(
+          (args) =>
+            typeof args[0] === "string" &&
+            args[0].includes(sessionId) &&
+            args[0].includes("Stream closed before the agent finished.")
+        )
+      ).toBe(true);
+    } finally {
+      publishSpy.mockRestore();
+      warn.mockRestore();
+    }
   });
 });
 

--- a/apps/server/src/http/shared.ts
+++ b/apps/server/src/http/shared.ts
@@ -668,8 +668,15 @@ export function streamMessage(
         }
         clearInterval(keepalive);
 
+        const observedTerminal = getTerminal();
+        if (!observedTerminal) {
+          console.warn(
+            `Session ${sessionId}: Stream closed before the agent finished.`
+          );
+        }
+
         const terminal =
-          getTerminal() ??
+          observedTerminal ??
           ({
             error: "Stream closed before the agent finished.",
             type: "error",

--- a/apps/server/src/http/sse-idle-timeout.test.ts
+++ b/apps/server/src/http/sse-idle-timeout.test.ts
@@ -1,62 +1,56 @@
 import { describe, expect, test } from "bun:test";
-import { disableBunIdleTimeoutForSse, isSseRequest } from "./sse-idle-timeout";
+import { disableBunIdleTimeoutForSse, isSseResponse } from "./sse-idle-timeout";
 
-describe("isSseRequest", () => {
-  test("matches Accept text/event-stream", () => {
+describe("isSseResponse", () => {
+  test("matches text/event-stream Content-Type", () => {
     expect(
-      isSseRequest(
-        new Request("http://127.0.0.1:4310/v1/sessions/abc/messages", {
-          headers: { Accept: "text/event-stream" },
-          method: "POST",
+      isSseResponse(
+        new Response(null, {
+          headers: { "Content-Type": "text/event-stream" },
         })
       )
     ).toBe(true);
   });
 
-  test("matches stream=true query even without Accept", () => {
+  test("matches text/event-stream with charset", () => {
     expect(
-      isSseRequest(
-        new Request(
-          "http://127.0.0.1:4310/v1/sessions/abc/messages?stream=true",
-          {
-            method: "POST",
-          }
-        )
-      )
-    ).toBe(true);
-  });
-
-  test("matches session subscribe path", () => {
-    expect(
-      isSseRequest(
-        new Request("http://127.0.0.1:4310/v1/sessions/abc/stream", {
-          method: "GET",
+      isSseResponse(
+        new Response(null, {
+          headers: { "Content-Type": "text/event-stream; charset=utf-8" },
         })
       )
     ).toBe(true);
   });
 
-  test("does not match ordinary JSON chat", () => {
+  test("does not match ordinary JSON", () => {
     expect(
-      isSseRequest(
-        new Request("http://127.0.0.1:4310/v1/sessions/abc/messages", {
-          headers: { Accept: "application/json" },
-          method: "POST",
+      isSseResponse(
+        new Response(null, {
+          headers: { "Content-Type": "application/json; charset=utf-8" },
         })
       )
     ).toBe(false);
   });
+
+  test("does not match missing Content-Type", () => {
+    expect(isSseResponse(new Response(null))).toBe(false);
+  });
 });
 
 describe("disableBunIdleTimeoutForSse", () => {
-  test("calls server.timeout(request, 0) for SSE", () => {
+  test("calls server.timeout(request, 0) for SSE responses", () => {
     const request = new Request(
-      "http://127.0.0.1:4310/v1/sessions/abc/messages?stream=true",
-      { method: "POST" }
+      "http://127.0.0.1:4310/v1/sessions/abc/messages",
+      {
+        method: "POST",
+      }
     );
+    const response = new Response(null, {
+      headers: { "Content-Type": "text/event-stream; charset=utf-8" },
+    });
     const calls: Array<{ request: Request; seconds: number }> = [];
 
-    disableBunIdleTimeoutForSse(request, {
+    disableBunIdleTimeoutForSse(request, response, {
       timeout(req, seconds) {
         calls.push({ request: req, seconds });
       },
@@ -65,11 +59,12 @@ describe("disableBunIdleTimeoutForSse", () => {
     expect(calls).toEqual([{ request, seconds: 0 }]);
   });
 
-  test("leaves non-SSE requests on the default idle timeout", () => {
+  test("leaves non-SSE responses on the default idle timeout", () => {
     const request = new Request("http://127.0.0.1:4310/health");
+    const response = new Response("ok");
     let called = false;
 
-    disableBunIdleTimeoutForSse(request, {
+    disableBunIdleTimeoutForSse(request, response, {
       timeout() {
         called = true;
       },

--- a/apps/server/src/http/sse-idle-timeout.ts
+++ b/apps/server/src/http/sse-idle-timeout.ts
@@ -1,37 +1,24 @@
 /**
  * Bun.serve closes idle connections after `idleTimeout` seconds (max 255).
  * Chat SSE can sit quiet for minutes during a tool run; `: ping` comments do
- * not reliably reset that timer. Disable it per-request for SSE.
+ * not reliably reset that timer. Disable it per-request for SSE responses.
+ *
+ * Detect via the response Content-Type after the handler returns — do not
+ * duplicate route knowledge on the request.
  *
  * @see https://bun.com/docs/guides/http/sse
  */
-export function isSseRequest(request: Request): boolean {
-  const accept = request.headers.get("Accept") ?? "";
-
-  if (accept.includes("text/event-stream")) {
-    return true;
-  }
-
-  let url: URL;
-
-  try {
-    url = new URL(request.url);
-  } catch {
-    return false;
-  }
-
-  if (url.searchParams.get("stream") === "true") {
-    return true;
-  }
-
-  return /\/v1\/sessions\/[^/]+\/stream$/.test(url.pathname);
+export function isSseResponse(response: Response): boolean {
+  const contentType = response.headers.get("Content-Type") ?? "";
+  return contentType.startsWith("text/event-stream");
 }
 
 export function disableBunIdleTimeoutForSse(
   request: Request,
+  response: Response,
   server: { timeout(request: Request, seconds: number): void }
 ): void {
-  if (isSseRequest(request)) {
+  if (isSseResponse(response)) {
     server.timeout(request, 0);
   }
 }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,5 +1,6 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import type { Server } from "bun";
 import { ensureProcessPath } from "./lib/ensure-process-path";
 
 ensureProcessPath();
@@ -322,9 +323,10 @@ function startServer(options: {
   for (let port = options.preferredPort; port <= lastPort; port += 1) {
     try {
       return Bun.serve({
-        fetch(request, bunServer) {
-          disableBunIdleTimeoutForSse(request, bunServer);
-          return options.fetch(request);
+        async fetch(request, server: Server) {
+          const response = await options.fetch(request);
+          disableBunIdleTimeoutForSse(request, response, server);
+          return response;
         },
         hostname: options.host,
         idleTimeout: 255,


### PR DESCRIPTION
## Summary

Channel workers were surfacing *"The connection closed before the agent finished. Restart the Nakama server, then try again. Long automations can take a minute or more."* when the SSE link to Nakama dropped mid-turn. This PR closes three causes of that drop:

1. Discord/Telegram/WhatsApp cleanup no longer calls `stopSpawnedServer` while `hasActiveStreams()` is true, so in-flight turns keep their server.
2. `Bun.serve` now calls `server.timeout(request, 0)` for any response whose `Content-Type` starts with `text/event-stream` (idleTimeout 255 remains for everything else), matching Bun's SSE guidance without hard-coding routes.
3. When a turn ends without a terminal event, the server logs a `console.warn` with the session id so transport drops are visible instead of silent.

## Test plan

- [x] `bun test apps/server/src/http/routes/sessions.stream.test.ts`
- [x] `bun test apps/platform/discord/src/active-stream.test.ts`
- [x] `bun test` in `apps/server`, `apps/platform/discord`, `apps/platform/telegram`, `apps/platform/whatsapp`
- [x] `bun run check` on changed files
- [ ] Manual: start a long Discord tool turn, stop/restart the Discord worker mid-stream, confirm the spawned server is left running and the user does not get the disconnect message solely from worker cleanup
