### PR TITLE
Review asserts: remove meaningless, add meaningful

### DIFF
--- a/apps/server/src/http/org-middleware.ts
+++ b/apps/server/src/http/org-middleware.ts
@@ -1,4 +1,5 @@
 import type { OrgRole } from "@nakama/core";
+import { ORG_ROLES } from "@nakama/db";
 import type { MiddlewareHandler } from "hono";
 import type { ServerOptions } from "./context";
 import { isPublicRouteRequest } from "./public-routes";
@@ -13,6 +14,12 @@ function isPlatformRoute(pathname: string): boolean {
 
 function isAuthRoute(pathname: string): boolean {
   return pathname === "/v1/auth" || pathname.startsWith("/v1/auth/");
+}
+
+function assertOrgRole(role: string): asserts role is OrgRole {
+  if (!(ORG_ROLES as readonly string[]).includes(role)) {
+    throw new Error(`Invalid organization role: ${role}`);
+  }
 }
 
 function resolveOrgId(
@@ -73,10 +80,12 @@ export function createOrgContextMiddleware(
       return;
     }
 
+    assertOrgRole(member.role);
+
     c.set("auth", {
       ...auth,
       activeOrgId: orgId,
-      orgRole: member.role as OrgRole,
+      orgRole: member.role,
     });
 
     await next();

--- a/apps/server/src/services/skill-proposal-service.ts
+++ b/apps/server/src/services/skill-proposal-service.ts
@@ -276,7 +276,6 @@ export class SkillProposalService {
       input.orgId,
       input.profileId
     );
-    assertNotBundledSkillName(name);
 
     const db = this.requireDatabase();
     const existingByName = await db.getSkillByName(name);

--- a/packages/core/src/skills/write.ts
+++ b/packages/core/src/skills/write.ts
@@ -273,7 +273,6 @@ export async function writeProfileSkillSupportingFile(options: {
     options.relativePath
   );
 
-  await assertSupportingPathIsNotSymlink(absolutePath);
   await mkdir(path.dirname(absolutePath), { recursive: true });
   await assertSupportingPathIsNotSymlink(absolutePath);
   await writeFile(absolutePath, options.content, "utf8");
@@ -328,7 +327,7 @@ export async function removeProfileSkillSupportingFile(options: {
 export async function createSkillFile(
   options: CreateSkillFileOptions
 ): Promise<string> {
-  const name = options.name.trim().toLowerCase();
+  const name = assertValidSkillName(options.name);
   const description = options.description.trim();
   const skillsRoot =
     options.orgId && options.profileId
@@ -438,17 +437,14 @@ export async function patchSkillFile(options: {
     options.profileId,
     options.name
   );
+  // resolveProfileSkillDirectory already assertValidSkillName + assertNotBundledSkillName
+  // and keeps the directory inside the profile skills root; SKILL.md under it cannot escape.
+  const expectedName = options.name.trim().toLowerCase();
   const skillFilePath = path.join(directory, SKILL_FILE_NAME);
 
   if (!(await pathExists(skillFilePath))) {
     throw new Error(`Skill "${options.name}" not found.`);
   }
-
-  assertPathWithinProfileSkillsDir(
-    options.orgId,
-    options.profileId,
-    skillFilePath
-  );
 
   const existing = await readFile(skillFilePath, "utf8");
   const occurrences = existing.split(options.oldString).length - 1;
@@ -465,7 +461,6 @@ export async function patchSkillFile(options: {
 
   const next = existing.replace(options.oldString, options.newString);
   const parsed = parseSkillMarkdown(next, skillFilePath);
-  const expectedName = assertValidSkillName(options.name);
 
   if (parsed.frontmatter.name !== expectedName) {
     throw new Error(
@@ -473,7 +468,6 @@ export async function patchSkillFile(options: {
     );
   }
 
-  assertNotBundledSkillName(parsed.frontmatter.name);
   await writeFile(
     skillFilePath,
     next.endsWith("\n") ? next : `${next}\n`,

--- a/packages/core/src/soul/memory-paths.ts
+++ b/packages/core/src/soul/memory-paths.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import { getProfileSoulDir } from "./resolve";
+import { assertYearMonth, getProfileSoulDir } from "./resolve";
 
 export const MEMORY_ARCHIVE_RELATIVE_DIR = "memory-archive";
 
@@ -12,7 +12,10 @@ export function getMemoryArchiveFilePath(
   profileId: string,
   yearMonth: string
 ): string {
-  return join(getMemoryArchiveDir(orgId, profileId), `${yearMonth}.md`);
+  return join(
+    getMemoryArchiveDir(orgId, profileId),
+    `${assertYearMonth(yearMonth)}.md`
+  );
 }
 
 export function formatMemoryArchiveYearMonth(date: Date): string {

--- a/packages/core/src/soul/resolve.ts
+++ b/packages/core/src/soul/resolve.ts
@@ -22,6 +22,17 @@ export function assertConfigPathSegment(value: string, label: string): string {
   return trimmed;
 }
 
+/** Archive filenames are `YYYY-MM.md` — reject anything that could escape the archive dir. */
+export function assertYearMonth(value: string): string {
+  const trimmed = value.trim();
+
+  if (!/^\d{4}-(0[1-9]|1[0-2])$/.test(trimmed)) {
+    throw new Error(`Invalid yearMonth (expected YYYY-MM): ${value}`);
+  }
+
+  return trimmed;
+}
+
 /** Per-profile soul stack: ~/.nakama/orgs/{orgId}/profiles/{profileId}/ */
 export function getProfileSoulDir(orgId: string, profileId: string): string {
   return join(
@@ -87,7 +98,10 @@ export function getOrgMemoryArchiveFilePath(
   yearMonth: string,
   configDir?: string
 ): string {
-  return join(getOrgMemoryArchiveDir(orgId, configDir), `${yearMonth}.md`);
+  return join(
+    getOrgMemoryArchiveDir(orgId, configDir),
+    `${assertYearMonth(yearMonth)}.md`
+  );
 }
 
 export async function resolveSoulStackForProfile(

--- a/packages/core/src/tools/builtin.ts
+++ b/packages/core/src/tools/builtin.ts
@@ -731,6 +731,12 @@ function assertNoOverlappingEdits(plans: PlannedEdit[]): void {
     const previous = plans[index - 1]!;
     const current = plans[index]!;
 
+    if (current.start < previous.start) {
+      throw new Error(
+        "Edit plans must be sorted by start offset before applying."
+      );
+    }
+
     if (current.start < previous.end) {
       throw new Error(
         `Edit ${current.index + 1} overlaps with edit ${previous.index + 1}.`

--- a/packages/core/src/tools/context.ts
+++ b/packages/core/src/tools/context.ts
@@ -1,9 +1,16 @@
+import path from "node:path";
 import type { ToolContext } from "../contract";
 import { getProfileSoulDir } from "../soul/resolve";
 
 export function buildToolExecutionContext(context: ToolContext): ToolContext {
   if (context.workspaceRoot?.trim()) {
-    return context;
+    const workspaceRoot = context.workspaceRoot.trim();
+    if (!path.isAbsolute(workspaceRoot)) {
+      throw new Error(
+        "workspaceRoot must be an absolute path; relative roots resolve against process.cwd() and break profile isolation."
+      );
+    }
+    return { ...context, workspaceRoot };
   }
 
   const orgId = context.orgId?.trim();

--- a/packages/core/src/tools/paths.ts
+++ b/packages/core/src/tools/paths.ts
@@ -50,17 +50,22 @@ export async function guardFilePath(
   const cwdOption = options.cwd?.trim() || null;
   const allowedOption = options.allowedDirs?.filter((dir) => dir.trim()) ?? [];
 
-  if (!(cwdOption || allowedOption.length > 0)) {
+  let rawAllowedDirs: string[];
+  if (allowedOption.length > 0) {
+    rawAllowedDirs = allowedOption;
+  } else if (cwdOption) {
+    rawAllowedDirs = [cwdOption];
+  } else {
     throw new PathGuardError(WORKSPACE_REQUIRED_MESSAGE, "TRAVERSAL");
   }
 
-  const rawAllowedDirs =
-    allowedOption.length > 0 ? allowedOption : [cwdOption!];
   const allowedDirs = await resolveAllowedDirs(rawAllowedDirs);
   const maxBytes = options.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES;
-  const defaultCwd = await resolveDirectoryPath(
-    cwdOption ?? rawAllowedDirs[0]!
-  );
+  const defaultCwdSource = cwdOption ?? rawAllowedDirs[0];
+  if (!defaultCwdSource) {
+    throw new PathGuardError(WORKSPACE_REQUIRED_MESSAGE, "TRAVERSAL");
+  }
+  const defaultCwd = await resolveDirectoryPath(defaultCwdSource);
 
   if (rawPath.includes("\0")) {
     throw new PathGuardError("Path contains null byte", "NULL_BYTE");


### PR DESCRIPTION
## What changed

Assert review across the codebase (branch `asserts-review-20260814`).

### Removed — five meaningless/duplicate asserts
1. `SkillProposalService.stageCreate`: dropped `assertNotBundledSkillName` — `parseRawProfileSkillContent` already validates the name and the bundled set.
2. `patchSkillFile`: dropped `assertPathWithinProfileSkillsDir` on `join(directory, SKILL.md)` — `resolveProfileSkillDirectory` already resolves with realpath and enforces containment inside the profile skills root.
3. `patchSkillFile`: dropped the second `assertValidSkillName` (same input already validated on entry).
4. `patchSkillFile`: dropped the post-equality `assertNotBundledSkillName` — name is identical to the one already checked in `resolveProfileSkillDirectory`.
5. `writeProfileSkillSupportingFile`: dropped the pre-`mkdir` symlink assert; kept the one immediately before `writeFile`.

Also replaced the non-null `!` casts in `guardFilePath` with explicit branches (same workspace-required contract, no silent casts).

### Added — five contract asserts (negative space)
1. `createSkillFile`: `assertValidSkillName` before `path.join` (blocks `../` / invalid names).
2. `getMemoryArchiveFilePath` / `getOrgMemoryArchiveFilePath`: `assertYearMonth` enforces `YYYY-MM` and blocks path escape via the `yearMonth` segment.
3. `buildToolExecutionContext`: `workspaceRoot` must be absolute — relative roots silently resolve against `process.cwd()` and break profile isolation.
4. `assertNoOverlappingEdits`: plans must be sorted by `start` — the caller sorts at builtin.ts:481; the check now enforces that contract explicitly.
5. `org-middleware`: `assertOrgRole` type guard replaces the unchecked `as OrgRole` cast.

## Verified
- `bun test packages/core/src/skills/write.test.ts packages/core/src/tools/context.test.ts packages/core/src/tools/paths.test.ts packages/core/src/tools/builtin.test.ts packages/core/src/soul/resolve.test.ts packages/core/src/soul/memory-archive.test.ts apps/server/src/services/skill-proposal-service.test.ts apps/server/src/services/skills-service.test.ts` → 104 pass, 0 fail
- `bun test apps/server/src/services/skill-proposal-service.test.ts apps/server/src/http/routes/skill-proposals.test.ts` → 13 pass, 0 fail
- `bun test apps/server/src/http/org-members.test.ts apps/server/src/http/org-guards.test.ts` → 8 pass, 0 fail
- `bun x ultracite check` on all 8 changed files → clean
- Full monorepo `bun test` was NOT run (targeted subset only).

## Remaining risks
- `buildToolExecutionContext` now throws on a relative `workspaceRoot`. No current call site passes one (verified), but any future client that does will fail loudly rather than silently.
- `assertYearMonth` hardens archive paths; all current callers derive the value from a `Date`, so no behavior change expected.
- Full test suite not executed; only the relevant subsets.