### PR TITLE
Review asserts: remove meaningless, add meaningful

### DIFF
--- a/apps/server/src/services/skill-proposal-service.ts
+++ b/apps/server/src/services/skill-proposal-service.ts
@@ -642,10 +642,10 @@ export class SkillProposalService {
     name: string
   ): Promise<void> {
     const db = this.requireDatabase();
-    const skillName = assertValidSkillName(name);
-    const record = await db.getSkillByName(skillName);
+    // Callers pass names from readSkillName (already assertValidSkillName).
+    const record = await db.getSkillByName(name);
     if (!record) {
-      throw new NakamaApiError(`Skill "${skillName}" not found.`, 404);
+      throw new NakamaApiError(`Skill "${name}" not found.`, 404);
     }
     if (isGlobalSkillSourcePath(record.sourcePath)) {
       throw new NakamaApiError(
@@ -655,7 +655,7 @@ export class SkillProposalService {
     }
     if (!isPathWithinProfileSkillsDir(orgId, profileId, record.sourcePath)) {
       throw new NakamaApiError(
-        `Skill "${skillName}" is not owned by this profile.`,
+        `Skill "${name}" is not owned by this profile.`,
         403
       );
     }

--- a/packages/core/src/skills/paths.ts
+++ b/packages/core/src/skills/paths.ts
@@ -16,10 +16,18 @@ export function getProfileSkillsDir(orgId: string, profileId: string): string {
 export async function resolveSkillDiscoveryDirs(
   options: { orgId?: string; profileId?: string } = {}
 ): Promise<string[]> {
+  const orgId = options.orgId?.trim();
+  const profileId = options.profileId?.trim();
+  if (Boolean(orgId) !== Boolean(profileId)) {
+    throw new Error(
+      "resolveSkillDiscoveryDirs requires both orgId and profileId, or neither."
+    );
+  }
+
   const dirs = [getGlobalSkillsDir()];
 
-  if (options.orgId && options.profileId) {
-    dirs.push(getProfileSkillsDir(options.orgId, options.profileId));
+  if (orgId && profileId) {
+    dirs.push(getProfileSkillsDir(orgId, profileId));
   }
 
   return [...new Set(dirs)];

--- a/packages/core/src/skills/write.ts
+++ b/packages/core/src/skills/write.ts
@@ -226,7 +226,7 @@ export function resolveProfileSkillSupportingFilePath(
   profileId: string,
   name: string,
   relativePath: string
-): string {
+): { absolutePath: string; relativePath: string } {
   const directory = resolveProfileSkillDirectory(orgId, profileId, name);
   const trimmed = relativePath.trim();
   if (!trimmed) {
@@ -247,16 +247,17 @@ export function resolveProfileSkillSupportingFilePath(
   }
 
   const target = path.join(directory, ...segments);
-  const resolved = assertPathWithinProfileSkillsDir(orgId, profileId, target);
+  // resolveProfileSkillDirectory already locked `directory` inside the profile
+  // skills root; realpath containment under that skill dir is the remaining check.
   const skillRoot = resolveWithRealpath(directory);
-  const resolvedTarget = resolveWithRealpath(resolved);
+  const absolutePath = resolveWithRealpath(target);
 
-  if (!isResolvedWithinRoot(skillRoot, resolvedTarget)) {
+  if (!isResolvedWithinRoot(skillRoot, absolutePath)) {
     throw new Error("Path escapes the skill directory.");
   }
 
-  assertSupportingFileAllowed(resolved);
-  return resolved;
+  assertSupportingFileAllowed(absolutePath);
+  return { absolutePath, relativePath: segments.join("/") };
 }
 
 export async function writeProfileSkillSupportingFile(options: {
@@ -266,7 +267,7 @@ export async function writeProfileSkillSupportingFile(options: {
   relativePath: string;
   content: string;
 }): Promise<{ absolutePath: string; relativePath: string }> {
-  const absolutePath = resolveProfileSkillSupportingFilePath(
+  const { absolutePath, relativePath } = resolveProfileSkillSupportingFilePath(
     options.orgId,
     options.profileId,
     options.name,
@@ -277,16 +278,6 @@ export async function writeProfileSkillSupportingFile(options: {
   await assertSupportingPathIsNotSymlink(absolutePath);
   await writeFile(absolutePath, options.content, "utf8");
 
-  const skillRoot = resolveProfileSkillDirectory(
-    options.orgId,
-    options.profileId,
-    options.name
-  );
-  const relativePath = path
-    .relative(skillRoot, absolutePath)
-    .split(path.sep)
-    .join("/");
-
   return { absolutePath, relativePath };
 }
 
@@ -296,7 +287,7 @@ export async function removeProfileSkillSupportingFile(options: {
   name: string;
   relativePath: string;
 }): Promise<{ absolutePath: string; relativePath: string }> {
-  const absolutePath = resolveProfileSkillSupportingFilePath(
+  const { absolutePath, relativePath } = resolveProfileSkillSupportingFilePath(
     options.orgId,
     options.profileId,
     options.name,
@@ -311,16 +302,6 @@ export async function removeProfileSkillSupportingFile(options: {
 
   await unlink(absolutePath);
 
-  const skillRoot = resolveProfileSkillDirectory(
-    options.orgId,
-    options.profileId,
-    options.name
-  );
-  const relativePath = path
-    .relative(skillRoot, absolutePath)
-    .split(path.sep)
-    .join("/");
-
   return { absolutePath, relativePath };
 }
 
@@ -329,9 +310,16 @@ export async function createSkillFile(
 ): Promise<string> {
   const name = assertValidSkillName(options.name);
   const description = options.description.trim();
+  const orgId = options.orgId?.trim();
+  const profileId = options.profileId?.trim();
+  if (Boolean(orgId) !== Boolean(profileId)) {
+    throw new Error(
+      "createSkillFile requires both orgId and profileId for profile skills, or neither for global skills."
+    );
+  }
   const skillsRoot =
-    options.orgId && options.profileId
-      ? getProfileSkillsDir(options.orgId, options.profileId)
+    orgId && profileId
+      ? getProfileSkillsDir(orgId, profileId)
       : getGlobalSkillsDir();
   const directory = path.join(skillsRoot, name);
   const skillFilePath = path.join(directory, SKILL_FILE_NAME);

--- a/packages/core/src/tools/builtin.ts
+++ b/packages/core/src/tools/builtin.ts
@@ -244,12 +244,21 @@ function buildFileGuardOptions(
   const { orgId, profileId } = requireProfileScope(context);
   const workspaceRoot =
     options.workspaceRoot ?? getProfileSoulDir(orgId, profileId);
+  assertAbsoluteWorkspaceRoot(workspaceRoot);
 
   return {
     ...defaultGuardOptions,
     allowedDirs: [workspaceRoot, getCustomToolsDir()],
     cwd: workspaceRoot,
   };
+}
+
+function assertAbsoluteWorkspaceRoot(workspaceRoot: string): void {
+  if (!path.isAbsolute(workspaceRoot)) {
+    throw new Error(
+      "workspaceRoot must be an absolute path; relative roots resolve against process.cwd() and break profile isolation."
+    );
+  }
 }
 
 export const writeFileTool: ToolDefinition<WriteFileInput, WriteFileOutput> = {

--- a/packages/core/src/tools/knowledge-base-search.ts
+++ b/packages/core/src/tools/knowledge-base-search.ts
@@ -160,6 +160,11 @@ async function resolveSearchTarget(
 }
 
 async function resolveWorkspaceRoot(rawWorkspaceRoot: string): Promise<string> {
+  if (!path.isAbsolute(rawWorkspaceRoot)) {
+    throw new Error(
+      "workspaceRoot must be an absolute path; relative roots resolve against process.cwd() and break profile isolation."
+    );
+  }
   try {
     return await realpath(rawWorkspaceRoot);
   } catch {

--- a/packages/core/src/tools/paths.ts
+++ b/packages/core/src/tools/paths.ts
@@ -61,11 +61,8 @@ export async function guardFilePath(
 
   const allowedDirs = await resolveAllowedDirs(rawAllowedDirs);
   const maxBytes = options.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES;
-  const defaultCwdSource = cwdOption ?? rawAllowedDirs[0];
-  if (!defaultCwdSource) {
-    throw new PathGuardError(WORKSPACE_REQUIRED_MESSAGE, "TRAVERSAL");
-  }
-  const defaultCwd = await resolveDirectoryPath(defaultCwdSource);
+  // rawAllowedDirs is non-empty: either allowedOption or [cwdOption] from above.
+  const defaultCwd = await resolveDirectoryPath(cwdOption ?? rawAllowedDirs[0]);
 
   if (rawPath.includes("\0")) {
     throw new PathGuardError("Path contains null byte", "NULL_BYTE");

--- a/packages/core/src/tools/search-files.ts
+++ b/packages/core/src/tools/search-files.ts
@@ -113,6 +113,11 @@ async function resolveSearchRoot(
 }
 
 async function resolveWorkspaceRoot(rawWorkspaceRoot: string): Promise<string> {
+  if (!path.isAbsolute(rawWorkspaceRoot)) {
+    throw new Error(
+      "workspaceRoot must be an absolute path; relative roots resolve against process.cwd() and break profile isolation."
+    );
+  }
   try {
     return await realpath(rawWorkspaceRoot);
   } catch {


### PR DESCRIPTION
## What changed

Assert review across the repo: 5 dead/no-op asserts removed, 5 contract asserts added.

### Removed (meaningless / already guaranteed)
1. `guardFilePath` (packages/core/src/tools/paths.ts) — dropped the `if (!defaultCwdSource)` branch; `rawAllowedDirs` is provably non-empty by that point (allowedOption, else [cwdOption], else throw), so the check was unreachable.
2. `resolveProfileSkillSupportingFilePath` (packages/core/src/skills/write.ts) — dropped `assertPathWithinProfileSkillsDir`; `resolveProfileSkillDirectory` already realpaths and enforces containment within the profile skills root, and the function keeps its own realpath containment check.
3. `writeProfileSkillSupportingFile` — stopped re-calling `resolveProfileSkillDirectory` and recomputing relativePath; the resolver already returns that. The resolver now returns `{ absolutePath, relativePath }` instead of a bare string.
4. `removeProfileSkillSupportingFile` — same dedup as (3).
5. `SkillProposalService.assertProfileOwnedSkill` (apps/server) — dropped `assertValidSkillName`; every caller (5 sites) passes names from `readSkillName`, which already runs that assert.

### Added (negative-space contracts)
1. `createSkillFile` — requires both orgId and profileId, or neither; no silent global-skill fallback.
2. `resolveSkillDiscoveryDirs` — same both-or-neither rule.
3. `buildFileGuardOptions` (tools/builtin.ts) — `workspaceRoot` must be absolute.
4. `search-files` `resolveWorkspaceRoot` — same absolute-root rule.
5. `knowledge-base-search` `resolveWorkspaceRoot` — same.

## What was verified
- `bun test` on 10 affected test files (skills write/paths, tools paths/context/builtin/search-files/knowledge-base-search, skill-proposal-service, skills-service, skill-proposals routes): **108 pass, 0 fail**.
- `bunx ultracite check` on all 7 changed files: clean.
- `bunx tsc --noEmit`: zero errors in changed files. Full-repo tsc has ~7.5k pre-existing errors (mostly apps/cli tests); worktree count is not higher than main.

## Remaining risks
- `resolveProfileSkillSupportingFilePath` return-type change is a small public API change; all callers verified, but it is not purely an assert edit (removes real duplication, so worth it).
- The absolute-`workspaceRoot` asserts change runtime behavior: an LLM-supplied relative root now fails loudly instead of silently resolving against process.cwd(). That is the intended contract (profile isolation), but no longer works by accident.
- Full monorepo `bun test` was not run; verification is limited to the affected areas.