### PR TITLE
fix(server): prune coding-agent run logs to the newest 10

### DIFF
--- a/apps/server/src/tools/bash.test.ts
+++ b/apps/server/src/tools/bash.test.ts
@@ -200,18 +200,18 @@ describe("bash tool", () => {
     expect(result.stdout).toContain("Full coding-agent log:");
   });
 
-  test("prunes coding-agent logs to the newest 20 and leaves other artifacts", async () => {
+  test("prunes coding-agent logs to the newest 10 and leaves other artifacts", async () => {
     workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "nakama-bash-"));
     const logDir = path.join(workspaceRoot, "artifacts", "coding-agent-runs");
     await mkdir(logDir, { recursive: true });
     await writeFile(path.join(logDir, "keep-me.txt"), "user file", "utf8");
 
     const now = Date.now();
-    for (let i = 0; i < 25; i++) {
+    for (let i = 0; i < 15; i++) {
       const name = `old-${String(i).padStart(2, "0")}.log`;
       const filePath = path.join(logDir, name);
       await writeFile(filePath, `old ${i}`, "utf8");
-      const stamp = new Date(now - (25 - i) * 60_000);
+      const stamp = new Date(now - (15 - i) * 60_000);
       await utimes(filePath, stamp, stamp);
     }
 
@@ -231,7 +231,7 @@ describe("bash tool", () => {
     expect(result.exitCode).toBe(0);
     const remaining = await readdir(logDir);
     const logs = remaining.filter((name) => name.endsWith(".log"));
-    expect(logs).toHaveLength(20);
+    expect(logs).toHaveLength(10);
     expect(remaining).toContain("keep-me.txt");
     expect(remaining).not.toContain("old-00.log");
     expect(logs.some((name) => !name.startsWith("old-"))).toBe(true);

--- a/apps/server/src/tools/bash.test.ts
+++ b/apps/server/src/tools/bash.test.ts
@@ -7,6 +7,7 @@ import {
   readFile,
   realpath,
   rm,
+  utimes,
   writeFile,
 } from "node:fs/promises";
 import os from "node:os";
@@ -197,5 +198,42 @@ describe("bash tool", () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("TAIL_MARKER_OK");
     expect(result.stdout).toContain("Full coding-agent log:");
+  });
+
+  test("prunes coding-agent logs to the newest 20 and leaves other artifacts", async () => {
+    workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "nakama-bash-"));
+    const logDir = path.join(workspaceRoot, "artifacts", "coding-agent-runs");
+    await mkdir(logDir, { recursive: true });
+    await writeFile(path.join(logDir, "keep-me.txt"), "user file", "utf8");
+
+    const now = Date.now();
+    for (let i = 0; i < 25; i++) {
+      const name = `old-${String(i).padStart(2, "0")}.log`;
+      const filePath = path.join(logDir, name);
+      await writeFile(filePath, `old ${i}`, "utf8");
+      const stamp = new Date(now - (25 - i) * 60_000);
+      await utimes(filePath, stamp, stamp);
+    }
+
+    const agentPath = path.join(workspaceRoot, "agent");
+    await writeFile(agentPath, "#!/bin/bash\necho done\n", "utf8");
+    await chmod(agentPath, 0o755);
+
+    const result = await runBash(
+      {
+        codingAgent: true,
+        command: "./agent -p 'hello' --output-format text --yolo",
+      },
+      { orgId: "org_test", profileId: "profile_test" },
+      { workspaceRoot }
+    );
+
+    expect(result.exitCode).toBe(0);
+    const remaining = await readdir(logDir);
+    const logs = remaining.filter((name) => name.endsWith(".log"));
+    expect(logs).toHaveLength(20);
+    expect(remaining).toContain("keep-me.txt");
+    expect(remaining).not.toContain("old-00.log");
+    expect(logs.some((name) => !name.startsWith("old-"))).toBe(true);
   });
 });

--- a/apps/server/src/tools/bash.ts
+++ b/apps/server/src/tools/bash.ts
@@ -26,7 +26,7 @@ const MAX_OUTPUT_CHARS = 32_000;
 /** In-memory capture for coding-agent runs before summarize / keep-tail. */
 const CODING_AGENT_MAX_CAPTURE_CHARS = 5_000_000;
 /** Keep the newest N coding-agent logs; prune the rest after each write. */
-const CODING_AGENT_LOG_RETENTION = 20;
+const CODING_AGENT_LOG_RETENTION = 10;
 
 export interface BashInput {
   codingAgent?: boolean;

--- a/apps/server/src/tools/bash.ts
+++ b/apps/server/src/tools/bash.ts
@@ -1,5 +1,12 @@
 import { spawn } from "node:child_process";
-import { mkdir, realpath, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  readdir,
+  realpath,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import path from "node:path";
 import {
   getProfileSoulDir,
@@ -18,6 +25,8 @@ const MAX_TIMEOUT_MS = 30 * 60_000;
 const MAX_OUTPUT_CHARS = 32_000;
 /** In-memory capture for coding-agent runs before summarize / keep-tail. */
 const CODING_AGENT_MAX_CAPTURE_CHARS = 5_000_000;
+/** Keep the newest N coding-agent logs; prune the rest after each write. */
+const CODING_AGENT_LOG_RETENTION = 20;
 
 export interface BashInput {
   codingAgent?: boolean;
@@ -265,9 +274,34 @@ async function writeCodingAgentLog(
       "",
     ].join("\n");
     await writeFile(absolutePath, body, "utf8");
+    await pruneCodingAgentLogs(dir);
     return path.join("artifacts", "coding-agent-runs", fileName);
   } catch {
     return null;
+  }
+}
+
+async function pruneCodingAgentLogs(dir: string): Promise<void> {
+  const names = await readdir(dir);
+  const logs = names.filter((name) => name.endsWith(".log"));
+  if (logs.length <= CODING_AGENT_LOG_RETENTION) {
+    return;
+  }
+
+  const ranked = await Promise.all(
+    logs.map(async (name) => {
+      try {
+        const info = await stat(path.join(dir, name));
+        return { mtimeMs: info.mtimeMs, name };
+      } catch {
+        return { mtimeMs: 0, name };
+      }
+    })
+  );
+  ranked.sort((a, b) => b.mtimeMs - a.mtimeMs || (a.name < b.name ? 1 : -1));
+
+  for (const stale of ranked.slice(CODING_AGENT_LOG_RETENTION)) {
+    await unlink(path.join(dir, stale.name)).catch(() => undefined);
   }
 }
 


### PR DESCRIPTION
## Summary

The Files → Artifacts tab used to list every coding-agent run log forever, so busy profiles filled the panel. After this change, each new coding-agent bash run keeps only the newest 10 `*.log` files under `artifacts/coding-agent-runs/` and leaves other artifacts alone. Existing piles shrink on the next run, not on deploy.

`bun test apps/server/src/tools/bash.test.ts` — 10 pass, including prune-to-10 while keeping a non-log file.

## Test plan

- [ ] Run `bun test apps/server/src/tools/bash.test.ts`
- [ ] On a profile with more than 10 coding-agent logs, start one coding-agent turn and confirm Artifacts shows 10 logs plus any non-log files

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Cursor](https://img.shields.io/badge/Cursor_Grok_4.6-000000)
