### PR TITLE
feat(docs): add demo use-case recipes to the docs site

### DIFF
--- a/docs/website/content/docs/docs.mdx
+++ b/docs/website/content/docs/docs.mdx
@@ -36,6 +36,13 @@ Then open the dashboard, complete the setup wizard, and send your first message.
 - [First-time setup](/first-time-setup) — admin account, org, provider, and profiles
 - [Providers](/providers) — LLM API keys and model configuration
 
+## Use cases
+
+- [Use Cases](/use-cases) — plug-and-play profile recipes (needs an instance you administer)
+- [Codebase Explorer](/use-cases/codebase-explorer) — Q&A over uploaded code
+- [Automated PR Reviewer](/use-cases/automated-pr-reviewer) — review a pasted diff
+- [Dev Planner](/use-cases/dev-planner) — turn a goal into a plan artifact
+
 ## Deploy
 
 - [Quickstart](/quickstart) — demo, managed hosting, Docker, or local Bun

--- a/docs/website/content/docs/meta.json
+++ b/docs/website/content/docs/meta.json
@@ -6,6 +6,8 @@
     "overview",
     "first-time-setup",
     "providers",
+    "---Use cases---",
+    "use-cases",
     "---Deploy---",
     "docker",
     "backup-restore",

--- a/docs/website/content/docs/overview.mdx
+++ b/docs/website/content/docs/overview.mdx
@@ -113,6 +113,7 @@ It is less about writing one prompt and more about assembling and operating your
 ## Next steps
 
 - [Multi-tenancy](/multi-tenancy) — org model, members, and roles
+- [Use Cases](/use-cases) — specialist profile recipes on an instance you administer
 - [Profiles](/profiles) — how each bot is defined
 - [Builtin tools](/builtin-tools) — what profiles can do
 - [MCP servers](/mcp) — extend profiles with external tools

--- a/docs/website/content/docs/quickstart.mdx
+++ b/docs/website/content/docs/quickstart.mdx
@@ -92,6 +92,7 @@ Most of Nakama fits four ideas: organization, profile, tool access, and channel.
 
 ## Next steps
 
+- [Use Cases](/use-cases) — specialist profile recipes (needs an instance you administer, not the shared demo)
 - [Overview](/overview) — what Nakama is and how to think about it
 - [Providers](/providers) — LLM API keys and model setup
 - [Profiles](/profiles) — how to define each bot

--- a/docs/website/content/docs/use-cases/automated-pr-reviewer.mdx
+++ b/docs/website/content/docs/use-cases/automated-pr-reviewer.mdx
@@ -1,0 +1,74 @@
+---
+title: "Automated PR Reviewer"
+description: "Configure a Nakama profile to review a pasted diff and save a written review artifact."
+---
+
+Use this profile when you want a structured review of a change you can paste into chat. The first-hour path does not need `gh` or a coding CLI on the host.
+
+## Scenario
+
+You have a diff, a patch, or a PR description plus changed files, and you want findings, risk, and a saved review you can share. Deep review of a live git working copy is an optional later step — see [Coding agent](/coding-agent).
+
+## Configuration recipe
+
+Create a new profile (for example **PR Reviewer**) under **Agent → Profiles**. Open its **Prompt** tab and paste both files.
+
+### SOUL.md
+
+```md
+# PR Reviewer
+
+You review code changes the user pastes or attaches. You are a careful reviewer, not a co-author rewriting the change unless asked.
+
+Lead with blocking issues, then suggestions. Every finding cites a file and hunk when the diff includes them. If the user did not paste a diff, ask for one before reviewing.
+```
+
+### INSTRUCTIONS.md
+
+```md
+# Review procedure
+
+1. Restate the change in two sentences.
+2. List blocking defects (correctness, security, data loss).
+3. List non-blocking suggestions (clarity, tests, edge cases).
+4. Note residual risk and what you could not see (missing tests, unseen callers).
+5. Save the written review as an artifact when `save-artifact` is available.
+
+Do not approve a change you have not seen. Do not claim you opened GitHub unless the user provided the diff or you were asked to use a coding agent on the host.
+```
+
+## Tool requirements
+
+Assign these from **Agent → Profiles** → this profile → **Config**.
+
+| Tool / skill | Why | Assign from |
+|---|---|---|
+| `read_file` / `search_files` | Read context the user uploaded or that lives in the workspace | **Config** → tools |
+| `write_file` | Needed by `save-artifact` | **Config** → tools |
+| `save-artifact` | Persist the review under `artifacts/` | **Config** → skills |
+| `sub_agent` (optional) | Second-pass review of the same diff | **Config** → tools |
+
+See [Skills](/skills) for `save-artifact` and [Builtin tools](/builtin-tools) for `sub_agent`.
+
+## Sample prompts
+
+Select **PR Reviewer** in chat. Paste a real diff after the first line:
+
+> Review this diff. List blocking issues first, then suggestions. Save the review as an artifact.
+>
+> ```diff
+> (paste your diff here)
+> ```
+
+> Here is a pull request title, description, and the changed files. Write a review I can paste back to the author. Save it as an artifact.
+
+## Optional: review a host checkout
+
+If the change lives in a git working copy on the Nakama host and you have `bash` plus the `coding-agent` skill, the agent can inspect that tree. That path needs a host-installed coding CLI (`gh` only if you want it to fetch a GitHub PR). It is not required for the prompts above.
+
+## Next steps
+
+- [Coding agent](/coding-agent) — host checkout and CLI backends
+- [Skills](/skills) — `save-artifact`
+- [Builtin tools](/builtin-tools) — file tools and `sub_agent`
+- [Dev Planner](/use-cases/dev-planner) — turn a goal into a plan

--- a/docs/website/content/docs/use-cases/codebase-explorer.mdx
+++ b/docs/website/content/docs/use-cases/codebase-explorer.mdx
@@ -1,0 +1,67 @@
+---
+title: "Codebase Explorer"
+description: "Configure a Nakama profile to answer questions about code you upload to its workspace or knowledge base."
+---
+
+Give one profile a clear explorer identity so it can search and explain code you put in front of it — without treating the host disk as a repo.
+
+## Scenario
+
+You want to ask "where is auth handled?" or "what does this module do?" and get answers grounded in files the profile can see. This is Q&A over an uploaded tree or knowledge-base documents, not a checkout of your laptop or Docker host.
+
+## Configuration recipe
+
+Create a new profile (for example **Codebase Explorer**) under **Agent → Profiles**. Open its **Prompt** tab and paste the soul files below.
+
+### SOUL.md
+
+```md
+# Codebase Explorer
+
+You help the team understand code they have placed in this profile's workspace or knowledge base.
+
+Be concrete. Cite file paths and quote the lines that support your answer. If the files you can see do not contain the answer, say so and ask for a more specific path or another upload.
+
+Do not invent APIs, folder layouts, or behavior that is not in the files. Do not assume you can see the host filesystem or a git remote unless those files were uploaded here.
+```
+
+## Tool requirements
+
+Assign these from **Agent → Profiles** → this profile → **Config**. New custom profiles often already have the file and knowledge tools.
+
+| Tool / skill | Why | Assign from |
+|---|---|---|
+| `read_file` | Open a specific file | **Config** → tools |
+| `search_files` | Find symbols and phrases in the profile workspace | **Config** → tools |
+| `knowledge_base_search` | Search documents you uploaded on the Knowledge tab | **Config** → tools |
+
+`search_files` only walks the profile workspace. It does not walk an arbitrary host path. See [Builtin tools](/builtin-tools).
+
+## Put code where the profile can see it
+
+Do this **before** the first sample prompt. An empty workspace and empty knowledge base will produce empty answers.
+
+1. Open the profile's **Knowledge** tab
+2. Upload the files or archive you want searched
+3. Wait until uploaded documents show as ready
+
+On a local Bun install you can also copy a tree into the profile workspace at `~/.nakama/orgs/{orgId}/profiles/{profileId}/`. That path is not something you browse on managed hosting or inside Docker without a volume. Prefer the Knowledge tab unless you already know the data-root layout.
+
+For a full git working copy and host CLIs, use [Coding agent](/coding-agent) instead of this recipe.
+
+## Sample prompts
+
+Select **Codebase Explorer** in chat, then paste:
+
+> Search the uploaded code for where user sessions are created. List the files and quote the relevant functions.
+
+> Explain how errors from the HTTP layer reach the client. Cite paths.
+
+> What public types does the client package export? If you cannot see that package in the knowledge base or workspace, say what is missing.
+
+## Next steps
+
+- [Profiles](/profiles) — soul files and the Knowledge tab
+- [Builtin tools](/builtin-tools) — `read_file`, `search_files`, `knowledge_base_search`
+- [Automated PR Reviewer](/use-cases/automated-pr-reviewer) — review a pasted diff
+- [Coding agent](/coding-agent) — work in a real host checkout

--- a/docs/website/content/docs/use-cases/dev-planner.mdx
+++ b/docs/website/content/docs/use-cases/dev-planner.mdx
@@ -1,0 +1,67 @@
+---
+title: "Dev Planner"
+description: "Configure a Nakama profile to turn a goal into a sequenced plan and save it as an artifact."
+---
+
+Use this profile when you want a requirements-first plan you can edit, not a coding agent that implements the work.
+
+## Scenario
+
+You have a feature or fix in mind and want a sequenced plan: problem, constraints, steps, and open questions. The planner writes an artifact. It does not open a GitHub pull request.
+
+## Configuration recipe
+
+Create a new profile (for example **Dev Planner**) under **Agent → Profiles**. Open its **Prompt** tab and paste both files.
+
+### SOUL.md
+
+```md
+# Dev Planner
+
+You help the team turn a goal into a plan they can execute. Stay requirements-first. Prefer fewer, clearer steps over a large design.
+
+Ask for missing constraints before inventing them. When you must assume, label the assumption.
+```
+
+### INSTRUCTIONS.md
+
+```md
+# Planning procedure
+
+1. Restate the goal and who it is for.
+2. List in-scope and out-of-scope items.
+3. Propose a short sequence of implementation steps.
+4. Name risks and open questions.
+5. Save the plan as an artifact when `save-artifact` is available.
+
+Do not start implementing in the host repo. Do not claim you created a pull request.
+```
+
+## Tool requirements
+
+Assign these from **Agent → Profiles** → this profile → **Config**.
+
+| Tool / skill | Why | Assign from |
+|---|---|---|
+| `write_file` | Needed by `save-artifact` | **Config** → tools |
+| `save-artifact` | Persist the plan under `artifacts/` | **Config** → skills |
+| `sub_agent` (optional) | A second pass to stress-test the plan | **Config** → tools |
+
+No source upload is required. If the user pastes existing docs or tickets, the planner can use them as-is.
+
+## Sample prompts
+
+Select **Dev Planner** in chat:
+
+> We need org-level weekly usage summaries in the dashboard. Draft a plan with scope, steps, and open questions. Save it as an artifact.
+
+> Turn this bug report into an implementation plan. Do not write code. Save the plan as an artifact.
+>
+> (paste the report)
+
+## Next steps
+
+- [Skills](/skills) — `save-artifact`
+- [Builtin tools](/builtin-tools) — `sub_agent` and file tools
+- [Profiles](/profiles) — soul files and artifacts
+- [Codebase Explorer](/use-cases/codebase-explorer) — Q&A over uploaded code

--- a/docs/website/content/docs/use-cases/index.mdx
+++ b/docs/website/content/docs/use-cases/index.mdx
@@ -1,0 +1,31 @@
+---
+title: "Use Cases"
+description: "Plug-and-play Nakama profile recipes: Codebase Explorer, Automated PR Reviewer, and Dev Planner."
+---
+
+These recipes turn a fresh install into a specialist agent you can chat with. Each one is a named profile with soul text, tools, and sample prompts — not a new product feature.
+
+You need an instance you administer (local, Docker, or [managed hosting](https://getnakama.cloud/)) and a **platform admin** account so you can create a profile and edit soul. The [shared demo](https://demo.getnakama.cloud) is for exploring the dashboard. It does not persist a custom soul you can keep.
+
+Create a **new** profile for each recipe. Do not overwrite **Default Bot**.
+
+## Recipes
+
+- [Codebase Explorer](/use-cases/codebase-explorer) — answer questions about code you upload to the profile
+- [Automated PR Reviewer](/use-cases/automated-pr-reviewer) — review a pasted diff and save a written review
+- [Dev Planner](/use-cases/dev-planner) — turn a goal into a sequenced plan artifact
+
+## Before you start
+
+1. Finish [Quickstart](/quickstart) and [First-time setup](/first-time-setup)
+2. Open **Agent → Profiles**
+3. Create a profile named for the recipe
+4. Follow that recipe's soul, tools, and prompts
+
+File tools see the **profile workspace** and uploaded knowledge — not your host filesystem. See [Profiles](/profiles) for soul files and the Knowledge tab.
+
+## Next steps
+
+- [Profiles](/profiles) — soul files, Prompt tab, and workspace layout
+- [Builtin tools](/builtin-tools) — what you can assign
+- [Skills](/skills) — bundled workflows including `save-artifact`

--- a/docs/website/content/docs/use-cases/meta.json
+++ b/docs/website/content/docs/use-cases/meta.json
@@ -1,0 +1,3 @@
+{
+  "pages": ["index", "codebase-explorer", "automated-pr-reviewer", "dev-planner"]
+}

--- a/docs/website/lib/site-meta.ts
+++ b/docs/website/lib/site-meta.ts
@@ -57,6 +57,16 @@ export const pageDescriptions: Record<string, string> = {
     "Learn how reusable skills extend Nakama profiles, including bundled memory, artifact, automation, and skill-authoring workflows.",
   "telegram.md":
     "Set up Nakama as a Telegram bot with pairing, commands, and group behavior.",
+  "use-cases.md":
+    "Plug-and-play Nakama profile recipes: Codebase Explorer, Automated PR Reviewer, and Dev Planner.",
+  "use-cases/index.md":
+    "Plug-and-play Nakama profile recipes: Codebase Explorer, Automated PR Reviewer, and Dev Planner.",
+  "use-cases/automated-pr-reviewer.md":
+    "Configure a Nakama profile to review a pasted diff and save a written review artifact.",
+  "use-cases/codebase-explorer.md":
+    "Configure a Nakama profile to answer questions about code you upload to its workspace or knowledge base.",
+  "use-cases/dev-planner.md":
+    "Configure a Nakama profile to turn a goal into a sequenced plan and save it as an artifact.",
   "whatsapp.md":
     "Set up Nakama on WhatsApp with linking, commands, and troubleshooting.",
 };
@@ -86,6 +96,11 @@ export const pageTitles: Record<string, string> = {
   "self-improving-skills.md": "Self-improving Skills",
   "skills.md": "Skills",
   "telegram.md": "Telegram",
+  "use-cases.md": "Use Cases",
+  "use-cases/index.md": "Use Cases",
+  "use-cases/automated-pr-reviewer.md": "Automated PR Reviewer",
+  "use-cases/codebase-explorer.md": "Codebase Explorer",
+  "use-cases/dev-planner.md": "Dev Planner",
   "whatsapp.md": "WhatsApp",
 };
 
@@ -249,6 +264,25 @@ export function buildLlmsTxt(pages: string[]) {
         "what is Nakama, mental model, organizations, profiles, tools, channels, managed hosting, deployment options",
     },
     {
+      page: "use-cases/index.md",
+      topics:
+        "use cases, examples, recipes, demo profiles, Codebase Explorer, PR Reviewer, Dev Planner",
+    },
+    {
+      page: "use-cases/codebase-explorer.md",
+      topics:
+        "codebase explorer, search uploaded code, knowledge base Q&A, profile workspace",
+    },
+    {
+      page: "use-cases/automated-pr-reviewer.md",
+      topics:
+        "PR reviewer, review a diff, save-artifact review, pull request review recipe",
+    },
+    {
+      page: "use-cases/dev-planner.md",
+      topics: "dev planner, implementation plan, save plan artifact, requirements-first",
+    },
+    {
       page: "multi-tenancy.md",
       topics:
         "organizations, tenants, roles, members, invites, org admin, multi-tenant",
@@ -315,6 +349,15 @@ export function buildLlmsTxt(pages: string[]) {
         "overview.md",
         "first-time-setup.md",
         "providers.md",
+      ] as const,
+    },
+    {
+      heading: "Use cases",
+      pages: [
+        "use-cases/index.md",
+        "use-cases/codebase-explorer.md",
+        "use-cases/automated-pr-reviewer.md",
+        "use-cases/dev-planner.md",
       ] as const,
     },
     {


### PR DESCRIPTION
## Summary
- Adds a **Use Cases** docs section with three plug-and-play profile recipes (Codebase Explorer, Automated PR Reviewer, Dev Planner): scenario, copy-paste soul, tools/skills, and sample prompts.
- Registers nav, hub/overview/quickstart links, and `site-meta` / `llms.txt` titles so the pages are discoverable.
- States platform-admin + own-instance prerequisites; the shared demo is not a complete setup path. Explorer uses Knowledge-tab upload; PR Reviewer is pasted-diff first.

Closes #17

## Test plan
- [ ] `bun run build:docs` (or `bun run build` in `docs/website`) succeeds
- [ ] Sidebar shows **Use cases** after Start here, with the three child pages
- [ ] `/use-cases`, `/use-cases/codebase-explorer`, `/use-cases/automated-pr-reviewer`, `/use-cases/dev-planner` render
- [ ] Documentation hub, Overview, and Quickstart link to `/use-cases`
- [ ] Recipes do not present demo credentials as enough to finish setup
- [ ] Explorer tells you to upload code before the first prompt; PR Reviewer works from a pasted diff without `gh`

## Post-Deploy Monitoring & Validation
No additional operational monitoring required — this is static documentation on the docs site with no runtime product change.


Made with [Cursor](https://cursor.com)