### PR TITLE
feat(skills): install a public GitHub SKILL.md onto a profile

### DIFF
--- a/apps/server/src/http/routes/skills-install.test.ts
+++ b/apps/server/src/http/routes/skills-install.test.ts
@@ -229,4 +229,103 @@ describe("POST /v1/skills/install", () => {
 
     expect(response.status).toBe(403);
   });
+
+  test("incomplete body returns 400, not 500", async () => {
+    const { app, databaseAdapter } = createApp();
+    const adminSession = await setupFreshInstallSession(
+      app,
+      databaseAdapter,
+      "admin-malformed@org.com"
+    );
+    const orgId = adminSession.orgId!;
+
+    const response = await app.fetch(
+      new Request(`${BASE}/v1/skills/install`, {
+        body: JSON.stringify({ profileId: "p" }),
+        headers: adminSession.headers(
+          {
+            "Content-Type": "application/json",
+            "X-CSRF-Token": adminSession.csrfToken,
+          },
+          orgId
+        ),
+        method: "POST",
+      })
+    );
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toMatch(/url is required/i);
+  });
+
+  test("installing the same skill onto a second profile returns 409", async () => {
+    globalThis.fetch = mock(
+      async () => new Response(VALID_SKILL, { status: 200 })
+    ) as typeof fetch;
+
+    const { app, databaseAdapter } = createApp();
+    const adminSession = await setupFreshInstallSession(
+      app,
+      databaseAdapter,
+      "admin-dup@org.com"
+    );
+    const orgId = adminSession.orgId!;
+    const profiles = await databaseAdapter.listProfilesForOrg(orgId);
+    const firstProfileId = profiles[0]!.id;
+
+    const first = await app.fetch(
+      new Request(`${BASE}/v1/skills/install`, {
+        body: JSON.stringify({
+          profileId: firstProfileId,
+          url: "https://github.com/acme/skills/blob/main/weather/SKILL.md",
+        }),
+        headers: adminSession.headers(
+          {
+            "Content-Type": "application/json",
+            "X-CSRF-Token": adminSession.csrfToken,
+          },
+          orgId
+        ),
+        method: "POST",
+      })
+    );
+    expect(first.status).toBe(201);
+
+    const now = new Date().toISOString();
+    const secondProfileId = "profile_second";
+    await databaseAdapter.upsertProfile({
+      createdAt: now,
+      id: secondProfileId,
+      isDefault: false,
+      isSuper: false,
+      model: null,
+      name: "Second",
+      orgId,
+      skillsPostTurnReview: false,
+      skillsWriteApproval: false,
+      systemPrompt: "",
+      updatedAt: now,
+    });
+
+    const second = await app.fetch(
+      new Request(`${BASE}/v1/skills/install`, {
+        body: JSON.stringify({
+          profileId: secondProfileId,
+          url: "https://github.com/acme/skills/blob/main/weather/SKILL.md",
+        }),
+        headers: adminSession.headers(
+          {
+            "Content-Type": "application/json",
+            "X-CSRF-Token": adminSession.csrfToken,
+          },
+          orgId
+        ),
+        method: "POST",
+      })
+    );
+
+    expect(second.status).toBe(409);
+    const body = (await second.json()) as { error: string };
+    expect(body.error).toMatch(/already exists|cannot be attached/i);
+  });
 });

--- a/apps/server/src/http/routes/skills-install.test.ts
+++ b/apps/server/src/http/routes/skills-install.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createInMemoryDatabaseAdapter } from "@nakama/db";
+import { SkillsService } from "../../services/skills-service";
+import { setupTestConfigDir } from "../../test-config-dir";
+import { createMinimalHonoApp } from "../test-app-helpers";
+import {
+  loginUserSession,
+  setupFreshInstallSession,
+} from "../test-session-helpers";
+
+setupTestConfigDir("nakama-skills-install-routes-test-");
+
+const VALID_SKILL = `---
+name: github-weather
+description: Get weather from a public GitHub skill.
+---
+
+Call the weather tool.
+`;
+
+const INVALID_SKILL = `# No frontmatter
+
+Just a body.
+`;
+
+function createApp() {
+  const databaseAdapter = createInMemoryDatabaseAdapter();
+  const skillsService = new SkillsService(databaseAdapter);
+  return {
+    ...createMinimalHonoApp({
+      agent: {
+        installSkillFromGitHub: (orgId: string, request: unknown) =>
+          skillsService.installSkillFromGitHub(
+            orgId,
+            request as { profileId: string; url: string }
+          ),
+        listProfiles: async () => ({ profiles: [] }),
+      },
+      databaseAdapter,
+    }),
+    skillsService,
+  };
+}
+
+const BASE = "http://localhost:4310";
+
+describe("POST /v1/skills/install", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("platform admin installs a valid public SKILL.md and assigns it", async () => {
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      expect(url).toBe(
+        "https://raw.githubusercontent.com/acme/skills/main/weather/SKILL.md"
+      );
+      return new Response(VALID_SKILL, { status: 200 });
+    }) as typeof fetch;
+
+    const { app, databaseAdapter } = createApp();
+    const adminSession = await setupFreshInstallSession(
+      app,
+      databaseAdapter,
+      "admin@org.com"
+    );
+    const orgId = adminSession.orgId!;
+    const profiles = await databaseAdapter.listProfilesForOrg(orgId);
+    const profileId = profiles[0]!.id;
+
+    const response = await app.fetch(
+      new Request(`${BASE}/v1/skills/install`, {
+        body: JSON.stringify({
+          profileId,
+          url: "https://github.com/acme/skills/blob/main/weather/SKILL.md",
+        }),
+        headers: adminSession.headers(
+          {
+            "Content-Type": "application/json",
+            "X-CSRF-Token": adminSession.csrfToken,
+          },
+          orgId
+        ),
+        method: "POST",
+      })
+    );
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as {
+      skill: { name: string; id: string };
+    };
+    expect(body.skill.name).toBe("github-weather");
+
+    const assigned = await databaseAdapter.listSkillsForProfile(profileId);
+    expect(assigned.some((skill) => skill.id === body.skill.id)).toBe(true);
+  });
+
+  test("invalid frontmatter returns 400 and writes no skill", async () => {
+    globalThis.fetch = mock(
+      async () => new Response(INVALID_SKILL, { status: 200 })
+    ) as typeof fetch;
+
+    const { app, databaseAdapter } = createApp();
+    const adminSession = await setupFreshInstallSession(
+      app,
+      databaseAdapter,
+      "admin@org.com"
+    );
+    const orgId = adminSession.orgId!;
+    const profiles = await databaseAdapter.listProfilesForOrg(orgId);
+    const profileId = profiles[0]!.id;
+    const before = await databaseAdapter.listSkills();
+
+    const response = await app.fetch(
+      new Request(`${BASE}/v1/skills/install`, {
+        body: JSON.stringify({
+          profileId,
+          url: "https://github.com/acme/skills/blob/main/broken/SKILL.md",
+        }),
+        headers: adminSession.headers(
+          {
+            "Content-Type": "application/json",
+            "X-CSRF-Token": adminSession.csrfToken,
+          },
+          orgId
+        ),
+        method: "POST",
+      })
+    );
+
+    expect(response.status).toBe(400);
+    const after = await databaseAdapter.listSkills();
+    expect(after).toHaveLength(before.length);
+  });
+
+  test("non-GitHub URL returns 400", async () => {
+    const { app, databaseAdapter } = createApp();
+    const adminSession = await setupFreshInstallSession(
+      app,
+      databaseAdapter,
+      "admin@org.com"
+    );
+    const orgId = adminSession.orgId!;
+    const profiles = await databaseAdapter.listProfilesForOrg(orgId);
+    const profileId = profiles[0]!.id;
+
+    const response = await app.fetch(
+      new Request(`${BASE}/v1/skills/install`, {
+        body: JSON.stringify({
+          profileId,
+          url: "https://example.com/skills/weather/SKILL.md",
+        }),
+        headers: adminSession.headers(
+          {
+            "Content-Type": "application/json",
+            "X-CSRF-Token": adminSession.csrfToken,
+          },
+          orgId
+        ),
+        method: "POST",
+      })
+    );
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toMatch(/GitHub/i);
+  });
+
+  test("non-admin returns 403", async () => {
+    const { app, databaseAdapter } = createApp();
+    const adminSession = await setupFreshInstallSession(
+      app,
+      databaseAdapter,
+      "admin@org.com"
+    );
+    const orgId = adminSession.orgId!;
+
+    const memberResp = await app.fetch(
+      new Request(`${BASE}/v1/orgs/${orgId}/members`, {
+        body: JSON.stringify({
+          email: "member@org.com",
+          name: "Member",
+          role: "member",
+        }),
+        headers: adminSession.headers(
+          {
+            "Content-Type": "application/json",
+            "X-CSRF-Token": adminSession.csrfToken,
+          },
+          orgId
+        ),
+        method: "POST",
+      })
+    );
+    const memberProvisioned = (await memberResp.json()) as {
+      temporaryPassword: string;
+    };
+    const memberSession = await loginUserSession(
+      app,
+      "member@org.com",
+      memberProvisioned.temporaryPassword,
+      orgId
+    );
+    const profiles = await databaseAdapter.listProfilesForOrg(orgId);
+    const profileId = profiles[0]!.id;
+
+    const response = await app.fetch(
+      new Request(`${BASE}/v1/skills/install`, {
+        body: JSON.stringify({
+          profileId,
+          url: "https://github.com/acme/skills/blob/main/weather/SKILL.md",
+        }),
+        headers: memberSession.headers(
+          {
+            "Content-Type": "application/json",
+            "X-CSRF-Token": memberSession.csrfToken,
+          },
+          orgId
+        ),
+        method: "POST",
+      })
+    );
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/apps/server/src/http/routes/skills-install.test.ts
+++ b/apps/server/src/http/routes/skills-install.test.ts
@@ -93,9 +93,10 @@ describe("POST /v1/skills/install", () => {
 
     expect(response.status).toBe(201);
     const body = (await response.json()) as {
-      skill: { name: string; id: string };
+      skill: { name: string; id: string; createdBy: string };
     };
     expect(body.skill.name).toBe("github-weather");
+    expect(body.skill.createdBy).toBe("human");
 
     const assigned = await databaseAdapter.listSkillsForProfile(profileId);
     expect(assigned.some((skill) => skill.id === body.skill.id)).toBe(true);

--- a/apps/server/src/http/routes/skills.ts
+++ b/apps/server/src/http/routes/skills.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import type {
   AssignSkillRequest,
   CreateSkillRequest,
+  InstallSkillRequest,
   ListSkillsResponse,
   PatchSkillRequest,
   ProfileResponse,
@@ -47,6 +48,10 @@ export function registerSkillRoutes(
     .object({})
     .passthrough()
     .openapi("CreateSkillRequest");
+  const installSkillSchema = z
+    .object({})
+    .passthrough()
+    .openapi("InstallSkillRequest");
   const patchSkillSchema = z
     .object({})
     .passthrough()
@@ -90,6 +95,39 @@ export function registerSkillRoutes(
         },
       },
       summary: "Create a skill",
+      tags: ["Skills"],
+    })
+  );
+  app.openAPIRegistry.registerPath(
+    createRoute({
+      method: "post",
+      operationId: "installSkill",
+      path: "/v1/skills/install",
+      request: {
+        body: {
+          content: { "application/json": { schema: installSkillSchema } },
+          required: true,
+        },
+      },
+      responses: {
+        201: {
+          content: { "application/json": { schema: skillSchema } },
+          description: "Installed skill",
+        },
+        400: {
+          content: { "application/json": { schema: errorSchema } },
+          description: "Error",
+        },
+        403: {
+          content: { "application/json": { schema: errorSchema } },
+          description: "Error",
+        },
+        404: {
+          content: { "application/json": { schema: errorSchema } },
+          description: "Error",
+        },
+      },
+      summary: "Install a skill from a public GitHub SKILL.md URL",
       tags: ["Skills"],
     })
   );
@@ -230,6 +268,16 @@ export function registerSkillRoutes(
     const orgId = requireActiveOrgIdFromContext(c);
     const body = await readJson<CreateSkillRequest>(c.req.raw);
     return json<SkillResponse>(await agent.createSkill(orgId, body));
+  });
+
+  app.post("/v1/skills/install", async (c) => {
+    requirePlatformAdminFromContext(c);
+    const orgId = requireActiveOrgIdFromContext(c);
+    const body = await readJson<InstallSkillRequest>(c.req.raw);
+    return json<SkillResponse>(
+      await agent.installSkillFromGitHub(orgId, body),
+      201
+    );
   });
 
   app.post("/v1/skills/sync", async (c) => {

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -40,6 +40,7 @@ import type {
   ImageGenerationSettingsResponse,
   InitSoulResponse,
   InitUserContextResponse,
+  InstallSkillRequest,
   ListArtifactsOptions,
   ListArtifactsResponse,
   ListKnowledgeBaseResponse,
@@ -2571,6 +2572,13 @@ export class AgentService {
     request: CreateSkillRequest
   ): Promise<SkillResponse> {
     return this.requireSkillsService().createSkill(orgId, request);
+  }
+
+  async installSkillFromGitHub(
+    orgId: string,
+    request: InstallSkillRequest
+  ): Promise<SkillResponse> {
+    return this.requireSkillsService().installSkillFromGitHub(orgId, request);
   }
 
   async patchSkill(

--- a/apps/server/src/services/skills-service.ts
+++ b/apps/server/src/services/skills-service.ts
@@ -271,7 +271,8 @@ export class SkillsService {
       const installed = await this.createAndAssignRawSkillToProfile(
         orgId,
         profileId,
-        content
+        content,
+        { createdBy: "human" }
       );
       return { skill: installed.skill };
     } catch (error) {
@@ -302,9 +303,11 @@ export class SkillsService {
   async createAndAssignRawSkillToProfile(
     orgId: string,
     profileId: string,
-    content: string
+    content: string,
+    options?: { createdBy?: SkillCreatedBy }
   ): Promise<SkillResponse & { created: boolean }> {
     const { name } = parseRawProfileSkillContent(content, orgId, profileId);
+    const createdBy = options?.createdBy ?? "agent";
 
     const existingByName = await this.db.getSkillByName(name);
     if (
@@ -347,7 +350,7 @@ export class SkillsService {
       written.directory,
       written.name,
       "written",
-      "agent"
+      createdBy
     );
 
     if (!isPathWithinProfileSkillsDir(orgId, profileId, record.sourcePath)) {

--- a/apps/server/src/services/skills-service.ts
+++ b/apps/server/src/services/skills-service.ts
@@ -2,6 +2,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type {
   CreateSkillRequest,
+  InstallSkillRequest,
   ListSkillsResponse,
   PatchSkillRequest,
   SkillDetail,
@@ -27,10 +28,12 @@ import {
   discoverSkillDirectory,
   discoverSkills,
   extractExplicitSkillName,
+  fetchGitHubSkillMarkdown,
   isGlobalSkillSourcePath,
   isPathWithinProfileSkillsDir,
   loadSkillTools,
   matchSkillsForMessage,
+  NakamaApiError,
   parseRawProfileSkillContent,
   parseSkillMarkdown,
   patchSkillFile,
@@ -229,6 +232,48 @@ export class SkillsService {
     await this.db.assignSkillToProfile(profileId, created.skill.id);
 
     return created;
+  }
+
+  async installSkillFromGitHub(
+    orgId: string,
+    request: InstallSkillRequest
+  ): Promise<SkillResponse> {
+    const profileId = request.profileId.trim();
+    const url = request.url.trim();
+
+    if (!profileId) {
+      throw new NakamaApiError("profileId is required.", 400);
+    }
+
+    if (!url) {
+      throw new NakamaApiError("url is required.", 400);
+    }
+
+    const profile = await this.db.getProfileForOrg(profileId, orgId);
+    if (!profile) {
+      throw new NakamaApiError("Profile not found.", 404);
+    }
+
+    const content = await fetchGitHubSkillMarkdown(url);
+
+    try {
+      parseSkillMarkdown(content, url);
+    } catch (error) {
+      throw new NakamaApiError(
+        error instanceof Error
+          ? error.message
+          : "Skill file is missing or has invalid frontmatter.",
+        400
+      );
+    }
+
+    const installed = await this.createAndAssignRawSkillToProfile(
+      orgId,
+      profileId,
+      content
+    );
+
+    return { skill: installed.skill };
   }
 
   /**

--- a/apps/server/src/services/skills-service.ts
+++ b/apps/server/src/services/skills-service.ts
@@ -238,8 +238,8 @@ export class SkillsService {
     orgId: string,
     request: InstallSkillRequest
   ): Promise<SkillResponse> {
-    const profileId = request.profileId.trim();
-    const url = request.url.trim();
+    const profileId = request.profileId?.trim() ?? "";
+    const url = request.url?.trim() ?? "";
 
     if (!profileId) {
       throw new NakamaApiError("profileId is required.", 400);
@@ -267,13 +267,31 @@ export class SkillsService {
       );
     }
 
-    const installed = await this.createAndAssignRawSkillToProfile(
-      orgId,
-      profileId,
-      content
-    );
+    try {
+      const installed = await this.createAndAssignRawSkillToProfile(
+        orgId,
+        profileId,
+        content
+      );
+      return { skill: installed.skill };
+    } catch (error) {
+      if (error instanceof NakamaApiError) {
+        throw error;
+      }
 
-    return { skill: installed.skill };
+      const message =
+        error instanceof Error ? error.message : "Failed to install skill.";
+
+      if (
+        /already exists|already assigned|cannot be attached|bundled/i.test(
+          message
+        )
+      ) {
+        throw new NakamaApiError(message, 409);
+      }
+
+      throw new NakamaApiError(message, 400);
+    }
   }
 
   /**

--- a/apps/web/src/components/SkillInstallDialog.tsx
+++ b/apps/web/src/components/SkillInstallDialog.tsx
@@ -1,0 +1,130 @@
+import type { InstallSkillRequest } from "@nakama/core/contract";
+import { type SubmitEvent, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import { formatError } from "@/lib/client";
+
+interface SkillInstallDialogProps {
+  busy: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (request: InstallSkillRequest) => Promise<void>;
+  open: boolean;
+  profileId: string | null;
+}
+
+export function SkillInstallDialog({
+  open,
+  busy,
+  profileId,
+  onOpenChange,
+  onSubmit,
+}: SkillInstallDialogProps) {
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      {open ? (
+        <SkillInstallDialogContent
+          busy={busy}
+          onOpenChange={onOpenChange}
+          onSubmit={onSubmit}
+          profileId={profileId}
+        />
+      ) : null}
+    </Dialog>
+  );
+}
+
+function SkillInstallDialogContent({
+  busy,
+  profileId,
+  onOpenChange,
+  onSubmit,
+}: {
+  busy: boolean;
+  profileId: string | null;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (request: InstallSkillRequest) => Promise<void>;
+}) {
+  const [url, setUrl] = useState("");
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const canSubmit = url.trim().length > 0;
+
+  async function handleSubmit(event: SubmitEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!canSubmit || busy || !profileId) {
+      return;
+    }
+
+    setSubmitError(null);
+
+    try {
+      await onSubmit({
+        profileId,
+        url: url.trim(),
+      });
+    } catch (error) {
+      setSubmitError(
+        error instanceof Error ? error.message : formatError(error)
+      );
+    }
+  }
+
+  return (
+    <DialogContent className="gap-6 p-6 sm:max-w-lg">
+      <form className="space-y-6" onSubmit={handleSubmit}>
+        <DialogHeader className="gap-2">
+          <DialogTitle>Install from GitHub</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-2.5">
+          <label
+            className="block font-medium text-foreground text-sm"
+            htmlFor="skill-install-url"
+          >
+            GitHub URL
+          </label>
+          <Input
+            autoFocus
+            disabled={busy}
+            id="skill-install-url"
+            onChange={(event) => setUrl(event.target.value)}
+            placeholder="https://github.com/org/repo/blob/main/skills/example/SKILL.md"
+            value={url}
+          />
+        </div>
+
+        {submitError ? (
+          <p
+            className="rounded-md bg-destructive/10 px-3 py-2.5 text-destructive text-sm"
+            role="alert"
+          >
+            {submitError}
+          </p>
+        ) : null}
+
+        <DialogFooter className="gap-3 border-t-0 bg-transparent pt-0 sm:justify-end">
+          <Button
+            disabled={busy}
+            onClick={() => onOpenChange(false)}
+            type="button"
+            variant="outline"
+          >
+            Cancel
+          </Button>
+          <Button disabled={busy || !canSubmit || !profileId} type="submit">
+            {busy ? <Spinner className="size-4" /> : "Install skill"}
+          </Button>
+        </DialogFooter>
+      </form>
+    </DialogContent>
+  );
+}

--- a/apps/web/src/hooks/use-resource-mutations.ts
+++ b/apps/web/src/hooks/use-resource-mutations.ts
@@ -320,6 +320,24 @@ export function useCreateSkillMutation() {
   });
 }
 
+export function useInstallSkillMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input: Parameters<typeof client.installSkill>[0]) =>
+      client.installSkill(input),
+    onSuccess: async (_data, variables) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.skills.all }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.profiles.all }),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.profiles.detail(variables.profileId),
+        }),
+      ]);
+    },
+  });
+}
+
 export function usePatchSkillMutation() {
   const queryClient = useQueryClient();
 

--- a/apps/web/src/pages/profiles/profile-config-assignments-section.tsx
+++ b/apps/web/src/pages/profiles/profile-config-assignments-section.tsx
@@ -28,6 +28,7 @@ export function ProfileConfigAssignmentsSection({
     allSkills,
     assignedSkillIds,
     setSkillCreateOpen,
+    setSkillInstallOpen,
     handleAssignSkill,
     handleDeleteSkill,
     selectedId,
@@ -73,6 +74,7 @@ export function ProfileConfigAssignmentsSection({
         onAssignBash={() => handleAssignTool(BASH_TOOL_ID)}
         onCreateOpen={() => setSkillCreateOpen(true)}
         onDelete={handleDeleteSkill}
+        onInstallOpen={() => setSkillInstallOpen(true)}
         onRemove={setRemoveConfirm}
         onViewDetail={(skillId) => {
           navigateToSkillDetail(skillId, {

--- a/apps/web/src/pages/profiles/profile-skills-section.tsx
+++ b/apps/web/src/pages/profiles/profile-skills-section.tsx
@@ -151,6 +151,7 @@ export function ProfileSkillsSection({
   allSkills,
   assignedSkillIds,
   onCreateOpen,
+  onInstallOpen,
   onAssign,
   onDelete,
   onViewDetail,
@@ -162,6 +163,7 @@ export function ProfileSkillsSection({
   allSkills: SkillSummary[];
   assignedSkillIds: ReadonlySet<string>;
   onCreateOpen: () => void;
+  onInstallOpen: () => void;
   onAssign: (skillId: string) => void;
   onDelete: (skillId: string) => void;
   onViewDetail: (skillId: string) => void;
@@ -202,6 +204,15 @@ export function ProfileSkillsSection({
             variant="outline"
           >
             Create skill
+          </Button>
+          <Button
+            disabled={busy}
+            onClick={onInstallOpen}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            Install from GitHub
           </Button>
           <SkillAssignPicker
             assignedSkillIds={assignedSkillIds}

--- a/apps/web/src/pages/profiles/profiles-dialogs.tsx
+++ b/apps/web/src/pages/profiles/profiles-dialogs.tsx
@@ -1,5 +1,6 @@
 import { ProfileCreateDialog } from "@/components/ProfileCreateDialog";
 import { SkillCreateDialog } from "@/components/SkillCreateDialog";
+import { SkillInstallDialog } from "@/components/SkillInstallDialog";
 import { McpServerDialog } from "@/components/soul-tools/mcp-tab/McpServerDialog";
 import { Button } from "@/components/ui/button";
 import {
@@ -23,10 +24,14 @@ export function ProfilesDialogs(state: ProfilesPageState) {
     setSelectedId,
     skillCreateOpen,
     setSkillCreateOpen,
+    skillInstallOpen,
+    setSkillInstallOpen,
     createSkillMutation,
+    installSkillMutation,
     assignSkillMutation,
     selectedId,
     handleCreateSkill,
+    handleInstallSkill,
     busy,
     setRemoveConfirm,
     mcpCreateOpen,
@@ -68,6 +73,14 @@ export function ProfilesDialogs(state: ProfilesPageState) {
         onOpenChange={setSkillCreateOpen}
         onSubmit={handleCreateSkill}
         open={skillCreateOpen}
+        profileId={selectedId}
+      />
+
+      <SkillInstallDialog
+        busy={installSkillMutation.isPending}
+        onOpenChange={setSkillInstallOpen}
+        onSubmit={handleInstallSkill}
+        open={skillInstallOpen}
         profileId={selectedId}
       />
 

--- a/apps/web/src/pages/profiles/use-profiles-page.ts
+++ b/apps/web/src/pages/profiles/use-profiles-page.ts
@@ -1,6 +1,7 @@
 import type {
   CreateMcpServerRequest,
   CreateSkillRequest,
+  InstallSkillRequest,
 } from "@nakama/core/contract";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
@@ -26,6 +27,7 @@ import {
   useDeleteProfileAvatarMutation,
   useDeleteProfileMutation,
   useDeleteSkillMutation,
+  useInstallSkillMutation,
   useUnassignMcpServerMutation,
   useUnassignSkillMutation,
   useUnassignToolMutation,
@@ -86,6 +88,7 @@ export function useProfilesPage() {
   const unassignMcpMutation = useUnassignMcpServerMutation();
   const createMcpMutation = useCreateMcpServerMutation();
   const createSkillMutation = useCreateSkillMutation();
+  const installSkillMutation = useInstallSkillMutation();
   const assignSkillMutation = useAssignSkillMutation();
   const unassignSkillMutation = useUnassignSkillMutation();
   const deleteSkillMutation = useDeleteSkillMutation();
@@ -99,6 +102,7 @@ export function useProfilesPage() {
     useState<RemoveAssignmentTarget | null>(null);
   const [mcpCreateOpen, setMcpCreateOpen] = useState(false);
   const [skillCreateOpen, setSkillCreateOpen] = useState(false);
+  const [skillInstallOpen, setSkillInstallOpen] = useState(false);
   const [editName, setEditName] = useState("");
   const [editPrompt, setEditPrompt] = useState("");
   const [editModel, setEditModel] = useState<string | null>(null);
@@ -154,6 +158,7 @@ export function useProfilesPage() {
     unassignMcpMutation.isPending ||
     createMcpMutation.isPending ||
     createSkillMutation.isPending ||
+    installSkillMutation.isPending ||
     assignSkillMutation.isPending ||
     unassignSkillMutation.isPending ||
     deleteSkillMutation.isPending ||
@@ -735,6 +740,23 @@ export function useProfilesPage() {
     }
   }
 
+  async function handleInstallSkill(request: InstallSkillRequest) {
+    if (!selectedId) {
+      return;
+    }
+
+    setError(null);
+
+    try {
+      await installSkillMutation.mutateAsync(request);
+      setSkillInstallOpen(false);
+    } catch (err) {
+      const message = formatError(err);
+      setError(message);
+      throw new Error(message);
+    }
+  }
+
   async function handleAssignComposioToolkit(toolkitId: string) {
     if (!(selectedId && profileComposioData)) {
       return;
@@ -909,8 +931,10 @@ export function useProfilesPage() {
     handleEditModelChange,
     handleEditNameChange,
     handleEditPromptChange,
+    handleInstallSkill,
     handleRemoveAssignmentConfirm,
     handleSelectProfile,
+    installSkillMutation,
     isDirty,
     mcpCreateOpen,
     modelInCatalog,
@@ -934,7 +958,9 @@ export function useProfilesPage() {
     setRemoveConfirm,
     setSelectedId,
     setSkillCreateOpen,
+    setSkillInstallOpen,
     skillCreateOpen,
+    skillInstallOpen,
     unassignMcpMutation,
     unassignMutation,
     unassignSkillMutation,

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -58,6 +58,7 @@ import type {
   ImageGenerationSettingsResponse,
   InitSoulResponse,
   InitUserContextResponse,
+  InstallSkillRequest,
   InviteOrgMemberRequest,
   ListArtifactsResponse,
   ListAutomationRunsResponse,
@@ -780,6 +781,13 @@ export class NakamaClient {
 
   async createSkill(request: CreateSkillRequest): Promise<SkillResponse> {
     return this.request<SkillResponse>("/v1/skills", {
+      body: JSON.stringify(request),
+      method: "POST",
+    });
+  }
+
+  async installSkill(request: InstallSkillRequest): Promise<SkillResponse> {
+    return this.request<SkillResponse>("/v1/skills/install", {
       body: JSON.stringify(request),
       method: "POST",
     });

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -1505,6 +1505,11 @@ export interface CreateSkillRequest {
   profileId?: string;
 }
 
+export interface InstallSkillRequest {
+  profileId: string;
+  url: string;
+}
+
 export interface PatchSkillRequest {
   body?: string;
   description?: string;

--- a/packages/core/src/skills/github-skill-fetch.test.ts
+++ b/packages/core/src/skills/github-skill-fetch.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { NakamaApiError } from "../api-error";
+import { fetchGitHubSkillMarkdown } from "./github-skill-fetch";
+
+describe("fetchGitHubSkillMarkdown size limits", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("rejects oversized Content-Length before reading the body", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response("ignored", {
+          headers: { "Content-Length": String(600 * 1024) },
+          status: 200,
+        })
+    ) as typeof fetch;
+
+    await expect(
+      fetchGitHubSkillMarkdown(
+        "https://raw.githubusercontent.com/acme/skills/main/weather/SKILL.md"
+      )
+    ).rejects.toBeInstanceOf(NakamaApiError);
+
+    try {
+      await fetchGitHubSkillMarkdown(
+        "https://raw.githubusercontent.com/acme/skills/main/weather/SKILL.md"
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(NakamaApiError);
+      expect((error as NakamaApiError).status).toBe(400);
+      expect((error as NakamaApiError).message).toMatch(/too large/i);
+    }
+  });
+
+  test("aborts while streaming once the body exceeds the cap", async () => {
+    const oversized = "x".repeat(513 * 1024);
+    globalThis.fetch = mock(
+      async () =>
+        new Response(oversized, {
+          headers: { "Content-Type": "text/plain" },
+          status: 200,
+        })
+    ) as typeof fetch;
+
+    try {
+      await fetchGitHubSkillMarkdown(
+        "https://raw.githubusercontent.com/acme/skills/main/weather/SKILL.md"
+      );
+      throw new Error("expected fetchGitHubSkillMarkdown to reject");
+    } catch (error) {
+      expect(error).toBeInstanceOf(NakamaApiError);
+      expect((error as NakamaApiError).status).toBe(400);
+      expect((error as NakamaApiError).message).toMatch(/too large/i);
+    }
+  });
+});

--- a/packages/core/src/skills/github-skill-fetch.ts
+++ b/packages/core/src/skills/github-skill-fetch.ts
@@ -63,13 +63,65 @@ export async function fetchGitHubSkillMarkdown(url: string): Promise<string> {
     );
   }
 
-  const buffer = await response.arrayBuffer();
-  if (buffer.byteLength > MAX_SKILL_BYTES) {
-    throw new NakamaApiError(
-      `Skill file is too large (max ${MAX_SKILL_BYTES} bytes).`,
-      400
-    );
+  const contentLength = response.headers.get("content-length");
+  if (contentLength) {
+    const declaredSize = Number(contentLength);
+    if (Number.isFinite(declaredSize) && declaredSize > MAX_SKILL_BYTES) {
+      throw new NakamaApiError(
+        `Skill file is too large (max ${MAX_SKILL_BYTES} bytes).`,
+        400
+      );
+    }
   }
 
-  return new TextDecoder().decode(buffer);
+  const bytes = await readResponseBodyCapped(response, MAX_SKILL_BYTES);
+  return new TextDecoder().decode(bytes);
+}
+
+async function readResponseBodyCapped(
+  response: Response,
+  maxBytes: number
+): Promise<Uint8Array> {
+  if (!response.body) {
+    const buffer = await response.arrayBuffer();
+    if (buffer.byteLength > maxBytes) {
+      throw new NakamaApiError(
+        `Skill file is too large (max ${maxBytes} bytes).`,
+        400
+      );
+    }
+    return new Uint8Array(buffer);
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    if (!value || value.byteLength === 0) {
+      continue;
+    }
+
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel().catch(() => undefined);
+      throw new NakamaApiError(
+        `Skill file is too large (max ${maxBytes} bytes).`,
+        400
+      );
+    }
+    chunks.push(value);
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return merged;
 }

--- a/packages/core/src/skills/github-skill-fetch.ts
+++ b/packages/core/src/skills/github-skill-fetch.ts
@@ -1,0 +1,75 @@
+import { NakamaApiError } from "../api-error";
+import { withDisabledFetchIdle } from "../fetch-idle";
+import { resolveGitHubSkillRawUrl } from "./github-skill-url";
+
+const RAW_HOST = "raw.githubusercontent.com";
+const MAX_SKILL_BYTES = 512 * 1024;
+const FETCH_TIMEOUT_MS = 15_000;
+
+export async function fetchGitHubSkillMarkdown(url: string): Promise<string> {
+  let rawUrl: string;
+  try {
+    rawUrl = resolveGitHubSkillRawUrl(url);
+  } catch (error) {
+    throw new NakamaApiError(
+      error instanceof Error ? error.message : "Invalid GitHub skill URL.",
+      400
+    );
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new NakamaApiError("Invalid GitHub skill URL.", 400);
+  }
+
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.hostname.toLowerCase() !== RAW_HOST
+  ) {
+    throw new NakamaApiError(
+      "Only public GitHub URLs are supported (github.com or raw.githubusercontent.com).",
+      400
+    );
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(
+      rawUrl,
+      withDisabledFetchIdle({
+        headers: {
+          Accept: "text/plain, text/markdown;q=0.9, */*;q=0.1",
+          "User-Agent": "nakama-skill-install",
+        },
+        redirect: "error",
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      })
+    );
+  } catch (error) {
+    throw new NakamaApiError(
+      error instanceof Error
+        ? `Failed to fetch skill from GitHub: ${error.message}`
+        : "Failed to fetch skill from GitHub.",
+      400
+    );
+  }
+
+  if (!response.ok) {
+    throw new NakamaApiError(
+      `Failed to fetch skill from GitHub (HTTP ${response.status}).`,
+      400
+    );
+  }
+
+  const buffer = await response.arrayBuffer();
+  if (buffer.byteLength > MAX_SKILL_BYTES) {
+    throw new NakamaApiError(
+      `Skill file is too large (max ${MAX_SKILL_BYTES} bytes).`,
+      400
+    );
+  }
+
+  return new TextDecoder().decode(buffer);
+}

--- a/packages/core/src/skills/github-skill-url.test.ts
+++ b/packages/core/src/skills/github-skill-url.test.ts
@@ -55,4 +55,32 @@ describe("resolveGitHubSkillRawUrl", () => {
       )
     ).toThrow(/SKILL\.md/);
   });
+
+  test("rejects encoded path separators that could escape owner/repo", () => {
+    expect(() =>
+      resolveGitHubSkillRawUrl(
+        "https://github.com/trusted-org/skills/blob/main/..%2F..%2F..%2Fattacker%2Fevil%2Fmain%2FSKILL.md"
+      )
+    ).toThrow(/encoded path separators/i);
+  });
+
+  test("rejects encoded hash that would become a fragment after decode", () => {
+    expect(() =>
+      resolveGitHubSkillRawUrl(
+        "https://github.com/acme/skills/blob/main/we%23ird/SKILL.md"
+      )
+    ).toThrow(/encoded path separators/i);
+  });
+
+  test("URL-normalized .. stays within the declared owner/repo", () => {
+    // `new URL` collapses literal `..` before we parse segments, so this
+    // becomes blob/attacker/SKILL.md under trusted-org/skills — same repo.
+    const resolved = resolveGitHubSkillRawUrl(
+      "https://github.com/trusted-org/skills/blob/main/../attacker/SKILL.md"
+    );
+    expect(resolved).toBe(
+      "https://raw.githubusercontent.com/trusted-org/skills/attacker/SKILL.md"
+    );
+    expect(resolved.includes("/../")).toBe(false);
+  });
 });

--- a/packages/core/src/skills/github-skill-url.test.ts
+++ b/packages/core/src/skills/github-skill-url.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { resolveGitHubSkillRawUrl } from "./github-skill-url";
+
+describe("resolveGitHubSkillRawUrl", () => {
+  test("rewrites blob URLs to raw.githubusercontent.com", () => {
+    expect(
+      resolveGitHubSkillRawUrl(
+        "https://github.com/acme/skills/blob/main/weather/SKILL.md"
+      )
+    ).toBe(
+      "https://raw.githubusercontent.com/acme/skills/main/weather/SKILL.md"
+    );
+  });
+
+  test("rewrites tree folder URLs by appending SKILL.md", () => {
+    expect(
+      resolveGitHubSkillRawUrl(
+        "https://github.com/acme/skills/tree/main/weather"
+      )
+    ).toBe(
+      "https://raw.githubusercontent.com/acme/skills/main/weather/SKILL.md"
+    );
+  });
+
+  test("accepts raw.githubusercontent.com SKILL.md URLs", () => {
+    expect(
+      resolveGitHubSkillRawUrl(
+        "https://raw.githubusercontent.com/acme/skills/main/weather/SKILL.md"
+      )
+    ).toBe(
+      "https://raw.githubusercontent.com/acme/skills/main/weather/SKILL.md"
+    );
+  });
+
+  test("accepts github.com raw URLs", () => {
+    expect(
+      resolveGitHubSkillRawUrl(
+        "https://github.com/acme/skills/raw/main/weather/SKILL.md"
+      )
+    ).toBe(
+      "https://raw.githubusercontent.com/acme/skills/main/weather/SKILL.md"
+    );
+  });
+
+  test("rejects non-GitHub hosts", () => {
+    expect(() =>
+      resolveGitHubSkillRawUrl("https://example.com/weather/SKILL.md")
+    ).toThrow(/Only public GitHub URLs/);
+  });
+
+  test("rejects blob URLs that are not SKILL.md", () => {
+    expect(() =>
+      resolveGitHubSkillRawUrl(
+        "https://github.com/acme/skills/blob/main/weather/README.md"
+      )
+    ).toThrow(/SKILL\.md/);
+  });
+});

--- a/packages/core/src/skills/github-skill-url.ts
+++ b/packages/core/src/skills/github-skill-url.ts
@@ -1,0 +1,122 @@
+const RAW_HOST = "raw.githubusercontent.com";
+const GITHUB_HOSTS = new Set(["github.com", "www.github.com"]);
+const SKILL_FILE_NAME = "SKILL.md";
+
+export function resolveGitHubSkillRawUrl(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error("GitHub skill URL is required.");
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error("Invalid GitHub skill URL.");
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("GitHub skill URL must use http or https.");
+  }
+
+  const host = parsed.hostname.toLowerCase();
+
+  if (host === RAW_HOST) {
+    return normalizeRawUrl(parsed);
+  }
+
+  if (!GITHUB_HOSTS.has(host)) {
+    throw new Error(
+      "Only public GitHub URLs are supported (github.com or raw.githubusercontent.com)."
+    );
+  }
+
+  return githubHtmlUrlToRaw(parsed);
+}
+
+function normalizeRawUrl(parsed: URL): string {
+  const segments = splitPath(parsed.pathname);
+  if (segments.length < 4) {
+    throw new Error(
+      "raw.githubusercontent.com URL must be /{owner}/{repo}/{ref}/…/SKILL.md."
+    );
+  }
+
+  const filePath = segments.slice(3).join("/");
+  const withSkillFile = ensureSkillFilePath(filePath, "file");
+  const owner = segments[0]!;
+  const repo = segments[1]!;
+  const ref = segments[2]!;
+
+  return `https://${RAW_HOST}/${owner}/${repo}/${ref}/${withSkillFile}`;
+}
+
+function githubHtmlUrlToRaw(parsed: URL): string {
+  const segments = splitPath(parsed.pathname);
+  if (segments.length < 4) {
+    throw new Error(
+      "GitHub URL must point to a SKILL.md blob/raw path or a tree folder that contains SKILL.md."
+    );
+  }
+
+  const owner = segments[0]!;
+  const repo = segments[1]!;
+  const kind = segments[2]!;
+
+  if (kind !== "blob" && kind !== "tree" && kind !== "raw") {
+    throw new Error(
+      "GitHub URL must use /blob/, /tree/, or /raw/ (or a raw.githubusercontent.com URL)."
+    );
+  }
+
+  if (segments.length < 5) {
+    throw new Error(
+      "GitHub URL must include a ref and path to SKILL.md or a skill folder."
+    );
+  }
+
+  const ref = segments[3]!;
+  const rest = segments.slice(4).join("/");
+  const mode = kind === "tree" ? "tree" : "file";
+  const filePath = ensureSkillFilePath(rest, mode);
+
+  return `https://${RAW_HOST}/${owner}/${repo}/${ref}/${filePath}`;
+}
+
+function ensureSkillFilePath(pathPart: string, mode: "file" | "tree"): string {
+  let normalized = pathPart;
+  while (normalized.endsWith("/")) {
+    normalized = normalized.slice(0, -1);
+  }
+  if (!normalized) {
+    throw new Error(
+      mode === "tree"
+        ? "GitHub tree URL must include a folder path that contains SKILL.md."
+        : "GitHub URL must point to a SKILL.md file."
+    );
+  }
+
+  const base = normalized.split("/").at(-1) ?? "";
+  if (base === SKILL_FILE_NAME) {
+    return normalized;
+  }
+
+  if (mode === "tree") {
+    return `${normalized}/${SKILL_FILE_NAME}`;
+  }
+
+  throw new Error("GitHub URL must point to a SKILL.md file.");
+}
+
+function splitPath(pathname: string): string[] {
+  return pathname
+    .split("/")
+    .map((segment) => {
+      try {
+        return decodeURIComponent(segment);
+      } catch {
+        return segment;
+      }
+    })
+    .filter((segment) => segment.length > 0);
+}

--- a/packages/core/src/skills/github-skill-url.ts
+++ b/packages/core/src/skills/github-skill-url.ts
@@ -1,6 +1,8 @@
 const RAW_HOST = "raw.githubusercontent.com";
 const GITHUB_HOSTS = new Set(["github.com", "www.github.com"]);
 const SKILL_FILE_NAME = "SKILL.md";
+/** Encoded path/query/fragment separators that must not become real separators after decode. */
+const ENCODED_SEPARATOR_PATTERN = /%(?:2[fF]|5[cC]|23|3[fF])/;
 
 export function resolveGitHubSkillRawUrl(input: string): string {
   const trimmed = input.trim();
@@ -42,13 +44,12 @@ function normalizeRawUrl(parsed: URL): string {
     );
   }
 
-  const filePath = segments.slice(3).join("/");
-  const withSkillFile = ensureSkillFilePath(filePath, "file");
   const owner = segments[0]!;
   const repo = segments[1]!;
   const ref = segments[2]!;
+  const filePath = ensureSkillFilePath(segments.slice(3).join("/"), "file");
 
-  return `https://${RAW_HOST}/${owner}/${repo}/${ref}/${withSkillFile}`;
+  return buildRawUrl(owner, repo, ref, filePath);
 }
 
 function githubHtmlUrlToRaw(parsed: URL): string {
@@ -80,7 +81,27 @@ function githubHtmlUrlToRaw(parsed: URL): string {
   const mode = kind === "tree" ? "tree" : "file";
   const filePath = ensureSkillFilePath(rest, mode);
 
-  return `https://${RAW_HOST}/${owner}/${repo}/${ref}/${filePath}`;
+  return buildRawUrl(owner, repo, ref, filePath);
+}
+
+function buildRawUrl(
+  owner: string,
+  repo: string,
+  ref: string,
+  filePath: string
+): string {
+  const pathSegments = [
+    owner,
+    repo,
+    ref,
+    ...filePath.split("/").filter((segment) => segment.length > 0),
+  ];
+
+  for (const segment of pathSegments) {
+    assertSafePathSegment(segment);
+  }
+
+  return `https://${RAW_HOST}/${pathSegments.map(encodeURIComponent).join("/")}`;
 }
 
 function ensureSkillFilePath(pathPart: string, mode: "file" | "tree"): string {
@@ -96,27 +117,61 @@ function ensureSkillFilePath(pathPart: string, mode: "file" | "tree"): string {
     );
   }
 
-  const base = normalized.split("/").at(-1) ?? "";
+  const parts = normalized.split("/").filter((segment) => segment.length > 0);
+  for (const part of parts) {
+    assertSafePathSegment(part);
+  }
+
+  const base = parts.at(-1) ?? "";
   if (base === SKILL_FILE_NAME) {
-    return normalized;
+    return parts.join("/");
   }
 
   if (mode === "tree") {
-    return `${normalized}/${SKILL_FILE_NAME}`;
+    return [...parts, SKILL_FILE_NAME].join("/");
   }
 
   throw new Error("GitHub URL must point to a SKILL.md file.");
 }
 
 function splitPath(pathname: string): string[] {
-  return pathname
-    .split("/")
-    .map((segment) => {
-      try {
-        return decodeURIComponent(segment);
-      } catch {
-        return segment;
-      }
-    })
-    .filter((segment) => segment.length > 0);
+  const decoded: string[] = [];
+
+  for (const segment of pathname.split("/")) {
+    if (segment.length === 0) {
+      continue;
+    }
+
+    if (ENCODED_SEPARATOR_PATTERN.test(segment)) {
+      throw new Error(
+        "GitHub skill URL path cannot contain encoded path separators."
+      );
+    }
+
+    let value: string;
+    try {
+      value = decodeURIComponent(segment);
+    } catch {
+      throw new Error("GitHub skill URL path is invalid.");
+    }
+
+    assertSafePathSegment(value);
+    decoded.push(value);
+  }
+
+  return decoded;
+}
+
+function assertSafePathSegment(segment: string): void {
+  if (
+    !segment ||
+    segment === "." ||
+    segment === ".." ||
+    segment.includes("/") ||
+    segment.includes("\\") ||
+    segment.includes("#") ||
+    segment.includes("?")
+  ) {
+    throw new Error("GitHub skill URL path is invalid.");
+  }
 }

--- a/packages/core/src/skills/index.ts
+++ b/packages/core/src/skills/index.ts
@@ -7,6 +7,8 @@ export * from "./bundled-names";
 export * from "./compose";
 export * from "./dedupe";
 export * from "./discover";
+export * from "./github-skill-fetch";
+export * from "./github-skill-url";
 export * from "./load-tool";
 export * from "./match";
 export * from "./parse";


### PR DESCRIPTION
## Summary

Closes #262.

Platform admins can paste a public GitHub URL to a `SKILL.md` (or a folder that contains one) and install it onto the active profile in one step — no copy-paste into **Create skill**.

This is intentionally small: fetch one markdown file from an allowlisted host, validate frontmatter with the existing parser, then reuse `createAndAssignRawSkillToProfile`. No marketplace, no supporting files, no private repos, no update-from-upstream loop.

### Why

Today the only ways to get a public skill into a profile are typing it into **Create skill** or asking an agent with `skill_manage`. Public GitHub skills still require manual copy-paste. Operators already share skills as repo folders; Nakama should accept that URL directly.

### API

`POST /v1/skills/install`

```ts
interface InstallSkillRequest {
  url: string;
  profileId: string;
}
```

- **Auth:** platform admin + active org (`X-Org-Id`)
- **Response:** `SkillResponse` with **201**
- Registered **before** `/v1/skills/:skillId` so `"install"` is not captured as an id

### Flow

1. Accept a GitHub `blob` / `raw` URL to `SKILL.md`, a `tree` URL to a skill folder, or a `raw.githubusercontent.com` URL
2. Normalize to `https://raw.githubusercontent.com/{owner}/{repo}/{ref}/…/SKILL.md`
3. Fetch **only** from `raw.githubusercontent.com` (allowlist; redirects rejected; size + timeout capped)
4. `parseSkillMarkdown` — reject missing/invalid frontmatter before writing
5. `createAndAssignRawSkillToProfile` — same write + assign path as agent `skill_manage` create

### URL examples that work

| Input | Resolved raw URL |
| --- | --- |
| `https://github.com/org/repo/blob/main/skills/foo/SKILL.md` | `…/main/skills/foo/SKILL.md` |
| `https://github.com/org/repo/tree/main/skills/foo` | appends `SKILL.md` |
| `https://github.com/org/repo/raw/main/skills/foo/SKILL.md` | same raw target |
| `https://raw.githubusercontent.com/org/repo/main/skills/foo/SKILL.md` | used as-is (after normalize) |

Non-GitHub hosts and blob paths that are not `SKILL.md` return **400**.

### UI

On **System → Profiles → Skills**, next to **Create skill**:

- **Install from GitHub** opens a dialog with a single URL field
- Submit installs and assigns; the skill appears on the profile list
- Errors (bad URL, bad markdown, fetch failure) surface in the dialog

### Client / contract

- `InstallSkillRequest` in `@nakama/core`
- `client.installSkill(request)` in `@nakama/client`
- `useInstallSkillMutation` invalidates skills + profile queries

### Out of scope (per #262)

- Supporting files / `tool.js`
- Global library install (profile only)
- Preview endpoint
- Write-approval proposals
- Private repos / `GITHUB_TOKEN`
- Re-install / update from upstream
- Non-GitHub hosts

## Test plan

- [x] `bun test packages/core/src/skills/github-skill-url.test.ts`
- [x] `bun test apps/server/src/http/routes/skills-install.test.ts`
  - [x] Valid public `SKILL.md` URL → **201**, skill created and assigned
  - [x] Missing / invalid frontmatter → **400**, no skill row written
  - [x] Non-GitHub URL → **400**
  - [x] Non-platform-admin → **403**
- [x] Manual: open a profile as platform admin → **Install from GitHub** → paste a public `SKILL.md` blob URL → skill shows as assigned
- [x] Manual: paste a bad URL or markdown-without-frontmatter → error shown, list unchanged
- [x] Manual: org member / viewer cannot call install (API 403; UI is platform-admin gated with other skill mutations)

## Implementation map

| Area | Files |
| --- | --- |
| URL normalize | `packages/core/src/skills/github-skill-url.ts` |
| Allowlisted fetch | `packages/core/src/skills/github-skill-fetch.ts` |
| Service | `SkillsService.installSkillFromGitHub` |
| Route + OpenAPI | `apps/server/src/http/routes/skills.ts` |
| Tests | `skills-install.test.ts`, `github-skill-url.test.ts` |
| UI | `SkillInstallDialog.tsx` + profile Skills section |


Made with [Cursor](https://cursor.com)