### PR TITLE
test: remove low-value tests

### DIFF
--- a/apps/platform/discord/src/send-artifact-attachment.test.ts
+++ b/apps/platform/discord/src/send-artifact-attachment.test.ts
@@ -6,10 +6,6 @@ import {
 } from "./send-artifact-attachment";
 
 describe("sendDiscordArtifactAttachment limits", () => {
-  test("exports an 8 MB discord cap", () => {
-    expect(DISCORD_ARTIFACT_ATTACHMENT_MAX_BYTES).toBe(8 * 1024 * 1024);
-  });
-
   test("accepts common Discord attachment types", () => {
     expect(
       isDiscordAttachableArtifact({

--- a/apps/server/src/tools/send-discord-artifact-tool.test.ts
+++ b/apps/server/src/tools/send-discord-artifact-tool.test.ts
@@ -3,10 +3,7 @@ import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { getProfileArtifactsDir } from "@nakama/core";
-import {
-  SEND_DISCORD_ARTIFACT_TOOL_NAME,
-  sendDiscordArtifactTool,
-} from "./send-discord-artifact-tool";
+import { sendDiscordArtifactTool } from "./send-discord-artifact-tool";
 
 const previousConfigDir = process.env.NAKAMA_CONFIG_DIR;
 
@@ -19,10 +16,6 @@ afterEach(() => {
 });
 
 describe("sendDiscordArtifactTool", () => {
-  test("is named send_discord_artifact", () => {
-    expect(sendDiscordArtifactTool.name).toBe(SEND_DISCORD_ARTIFACT_TOOL_NAME);
-  });
-
   test("rejects non-discord channels", async () => {
     const result = await sendDiscordArtifactTool.run(
       { path: "report.pdf" },

--- a/apps/server/src/tools/sub-agent-tool.test.ts
+++ b/apps/server/src/tools/sub-agent-tool.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { canRunToolCallsInParallel } from "@nakama/agent";
 import type { SubAgentRunResult } from "./sub-agent-shared";
-import {
-  createSubAgentTool,
-  runSubAgentTool,
-  SUB_AGENT_TOOL_NAME,
-} from "./sub-agent-tool";
+import { createSubAgentTool, runSubAgentTool } from "./sub-agent-tool";
 
 const ORG_ID = "org_test";
 const PROFILE_ID = "profile_default";
@@ -78,10 +74,6 @@ describe("sub_agent tool", () => {
     await tool.run({ task: "timed", timeoutMs: 999_999 }, TOOL_CONTEXT);
 
     expect(capturedTimeout).toBe(600_000);
-  });
-
-  test("exposes stable tool name", () => {
-    expect(SUB_AGENT_TOOL_NAME).toBe("sub_agent");
   });
 
   test("is parallelSafe so sibling sub-agents can run concurrently from the parent", () => {

--- a/packages/core/src/fetch-idle.test.ts
+++ b/packages/core/src/fetch-idle.test.ts
@@ -1,17 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import {
-  BUN_FETCH_DISABLE_IDLE_TIMEOUT_S,
-  LLM_FETCH_TIMEOUT_MS,
-  withDisabledFetchIdle,
-  withLlmFetchDeadline,
-} from "./fetch-idle";
+import { withDisabledFetchIdle, withLlmFetchDeadline } from "./fetch-idle";
 
 describe("withDisabledFetchIdle", () => {
   test("sets Bun idleTimeout to 0 and keeps the original init", () => {
     const init = withDisabledFetchIdle({ method: "POST" });
 
     expect(init.method).toBe("POST");
-    expect(init.idleTimeout).toBe(BUN_FETCH_DISABLE_IDLE_TIMEOUT_S);
     expect(init.idleTimeout).toBe(0);
   });
 });
@@ -23,7 +17,6 @@ describe("withLlmFetchDeadline", () => {
     expect(init.idleTimeout).toBe(0);
     expect(init.signal).toBeInstanceOf(AbortSignal);
     expect(init.signal?.aborted).toBe(false);
-    expect(LLM_FETCH_TIMEOUT_MS).toBe(600_000);
   });
 
   test("aborts when the caller signal is already aborted", () => {


### PR DESCRIPTION
## Summary
Removes three tautological tests and two constant-only assertions that asserted nothing beyond literal/module wiring already covered by behavioral siblings.

## Removed tests
- `apps/server/src/tools/sub-agent-tool.test.ts` — `exposes stable tool name`: asserts `SUB_AGENT_TOOL_NAME === "sub_agent"` (constant identity); tool name is already exercised by parallel-safe call wiring.
- `apps/platform/discord/src/send-artifact-attachment.test.ts` — `exports an 8 MB discord cap`: asserts `DISCORD_ARTIFACT_ATTACHMENT_MAX_BYTES === 8 * 1024 * 1024` (constant identity); size enforcement is already covered by the oversize rejection test (including the `8.0 MB` error copy).
- `apps/server/src/tools/send-discord-artifact-tool.test.ts` — `is named send_discord_artifact`: asserts `tool.name === SEND_DISCORD_ARTIFACT_TOOL_NAME` where the tool is constructed from that same constant (tautological).

## Assertion cleanup (no test deleted)
- `packages/core/src/fetch-idle.test.ts`: dropped `expect(idleTimeout).toBe(BUN_FETCH_DISABLE_IDLE_TIMEOUT_S)` (same value immediately asserted as `0`) and `expect(LLM_FETCH_TIMEOUT_MS).toBe(600_000)` (constant identity); kept behavioral checks for idle disable + deadline signal.

## Test plan
- [x] `bun test` green before changes (2076 pass)
- [x] `bun test` green after changes (2073 pass)
- [x] `bun x ultracite check` clean


Made with [Cursor](https://cursor.com)