### PR TITLE
Review asserts: remove meaningless, add meaningful

### DIFF
--- a/apps/server/src/services/automation-delivery-service.ts
+++ b/apps/server/src/services/automation-delivery-service.ts
@@ -75,12 +75,18 @@ export class AutomationDeliveryService {
     let result: { ok: boolean; error?: string };
 
     if (delivery.channel === "email") {
+      const to = delivery.to?.trim();
+      if (!to) {
+        throw new Error(
+          "delivery.to is required when delivery.channel is email."
+        );
+      }
       result = await this.email.send({
         orgId: automation.orgId,
         profileId: automation.profileId,
         subject: formatted.subject,
         text: formatted.text,
-        to: delivery.to!.trim(),
+        to,
       });
     } else if (delivery.channel === "telegram") {
       result = await this.telegram.send({

--- a/apps/server/src/services/org-memory-service.ts
+++ b/apps/server/src/services/org-memory-service.ts
@@ -191,14 +191,15 @@ export class OrgMemoryService {
       2,
       this.options.configDir
     );
-    if (history.length < 2) {
+    const previous = history[1];
+    if (!previous) {
       throw new NakamaApiError(
         "No previous org memory revision to restore.",
         404
       );
     }
 
-    return this.restoreHistoryRevision(orgId, history[1]!.id, actorUserId);
+    return this.restoreHistoryRevision(orgId, previous.id, actorUserId);
   }
 
   /**

--- a/apps/server/src/services/skills-service.ts
+++ b/apps/server/src/services/skills-service.ts
@@ -182,18 +182,20 @@ export class SkillsService {
     const skillFilePath = path.join(record.sourcePath, SKILL_FILE_NAME);
     const existing = await readFile(skillFilePath, "utf8");
     const parsed = parseSkillMarkdown(existing, skillFilePath);
-    const description = hasDescription
-      ? request.description!.trim()
-      : parsed.frontmatter.description;
+    const description =
+      request.description === undefined
+        ? parsed.frontmatter.description
+        : request.description.trim();
 
     if (!description) {
       throw new Error("Skill description is required.");
     }
 
-    const body = hasBody ? request.body! : parsed.body;
-    const disableModelInvocation = hasDisableModelInvocation
-      ? request.disableModelInvocation!
-      : parsed.frontmatter.disableModelInvocation;
+    const body = request.body === undefined ? parsed.body : request.body;
+    const disableModelInvocation =
+      request.disableModelInvocation === undefined
+        ? parsed.frontmatter.disableModelInvocation
+        : request.disableModelInvocation;
 
     const content = composeSkillMarkdown({
       body,

--- a/apps/server/src/tools/bash.ts
+++ b/apps/server/src/tools/bash.ts
@@ -343,6 +343,11 @@ function keepTail(value: string, maxChars: number): string {
 }
 
 async function resolveWorkspaceRoot(rawWorkspaceRoot: string): Promise<string> {
+  if (!path.isAbsolute(rawWorkspaceRoot)) {
+    throw new Error(
+      "workspaceRoot must be an absolute path; relative roots resolve against process.cwd() and break profile isolation."
+    );
+  }
   try {
     return await realpath(rawWorkspaceRoot);
   } catch {

--- a/apps/server/src/tools/generate-image-tool.ts
+++ b/apps/server/src/tools/generate-image-tool.ts
@@ -164,6 +164,11 @@ export async function runGenerateImageTool(
 
   const workspaceRoot =
     context.workspaceRoot?.trim() || getProfileSoulDir(orgId, profileId);
+  if (!path.isAbsolute(workspaceRoot)) {
+    throw new Error(
+      "workspaceRoot must be an absolute path; relative roots resolve against process.cwd() and break profile isolation."
+    );
+  }
   const artifactsDir = path.join(workspaceRoot, "artifacts");
   const outputName = resolveOutputFilename(filenameHint, result.mediaType);
   const targetPath = await uniqueArtifactPath(

--- a/apps/server/src/tools/skill-manage-tool.ts
+++ b/apps/server/src/tools/skill-manage-tool.ts
@@ -208,14 +208,10 @@ export function createSkillManageTools(
         const { orgId, profileId } = requireSkillManageAccess(context);
         const action = readAction(input);
 
-        const gateOn =
+        if (
           skillProposalService !== null &&
-          (await skillProposalService.isWriteApprovalRequired(
-            orgId,
-            profileId
-          ));
-
-        if (gateOn) {
+          (await skillProposalService.isWriteApprovalRequired(orgId, profileId))
+        ) {
           if (action === "create") {
             const content = readRawString(input, "content");
             if (!content?.trim()) {
@@ -224,7 +220,7 @@ export function createSkillManageTools(
               );
             }
 
-            const staged = await skillProposalService!.stageProposal({
+            const staged = await skillProposalService.stageProposal({
               action: "create",
               content,
               orgId,
@@ -263,7 +259,7 @@ export function createSkillManageTools(
               throw new Error("new_string is required for patch.");
             }
 
-            const staged = await skillProposalService!.stageProposal({
+            const staged = await skillProposalService.stageProposal({
               action: "patch",
               newString,
               oldString,
@@ -295,7 +291,7 @@ export function createSkillManageTools(
               );
             }
 
-            const staged = await skillProposalService!.stageProposal({
+            const staged = await skillProposalService.stageProposal({
               action: "edit",
               content,
               orgId,
@@ -328,7 +324,7 @@ export function createSkillManageTools(
               throw new Error("content is required for write_file.");
             }
 
-            const staged = await skillProposalService!.stageProposal({
+            const staged = await skillProposalService.stageProposal({
               action: "write_file",
               content,
               orgId,
@@ -361,7 +357,7 @@ export function createSkillManageTools(
               throw new Error("path is required for remove_file.");
             }
 
-            const staged = await skillProposalService!.stageProposal({
+            const staged = await skillProposalService.stageProposal({
               action: "remove_file",
               orgId,
               profileId,
@@ -388,7 +384,7 @@ export function createSkillManageTools(
             throw new Error("name is required for delete.");
           }
 
-          const staged = await skillProposalService!.stageProposal({
+          const staged = await skillProposalService.stageProposal({
             action: "delete",
             orgId,
             profileId,

--- a/packages/core/src/profiles.ts
+++ b/packages/core/src/profiles.ts
@@ -212,12 +212,13 @@ export function resolveProfileInScopes(
     }
   }
 
-  if (matches.length === 0) {
+  const [onlyMatch] = matches;
+  if (!onlyMatch) {
     return null;
   }
 
   if (matches.length === 1) {
-    return { profile: matches[0]!.profile, scope: matches[0]!.scope };
+    return { profile: onlyMatch.profile, scope: onlyMatch.scope };
   }
 
   return {

--- a/packages/core/src/tools/builtin.ts
+++ b/packages/core/src/tools/builtin.ts
@@ -736,14 +736,12 @@ function removeTrailingWhitespaceTokens(
 }
 
 function assertNoOverlappingEdits(plans: PlannedEdit[]): void {
+  // Caller sorts by start before invoking; only overlap is still possible.
   for (let index = 1; index < plans.length; index += 1) {
-    const previous = plans[index - 1]!;
-    const current = plans[index]!;
-
-    if (current.start < previous.start) {
-      throw new Error(
-        "Edit plans must be sorted by start offset before applying."
-      );
+    const previous = plans[index - 1];
+    const current = plans[index];
+    if (previous === undefined || current === undefined) {
+      throw new Error("Edit plans must be a contiguous list.");
     }
 
     if (current.start < previous.end) {

--- a/packages/core/src/tools/context.ts
+++ b/packages/core/src/tools/context.ts
@@ -16,6 +16,12 @@ export function buildToolExecutionContext(context: ToolContext): ToolContext {
   const orgId = context.orgId?.trim();
   const profileId = context.profileId?.trim();
 
+  if (Boolean(orgId) !== Boolean(profileId)) {
+    throw new Error(
+      "orgId and profileId must both be set to derive workspaceRoot, or neither."
+    );
+  }
+
   if (!(orgId && profileId)) {
     return context;
   }

--- a/packages/core/src/tools/paths.ts
+++ b/packages/core/src/tools/paths.ts
@@ -62,7 +62,13 @@ export async function guardFilePath(
   const allowedDirs = await resolveAllowedDirs(rawAllowedDirs);
   const maxBytes = options.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES;
   // rawAllowedDirs is non-empty: either allowedOption or [cwdOption] from above.
-  const defaultCwd = await resolveDirectoryPath(cwdOption ?? rawAllowedDirs[0]);
+  const fallbackAllowedDir = rawAllowedDirs[0];
+  if (!fallbackAllowedDir) {
+    throw new PathGuardError(WORKSPACE_REQUIRED_MESSAGE, "TRAVERSAL");
+  }
+  const defaultCwd = await resolveDirectoryPath(
+    cwdOption ?? fallbackAllowedDir
+  );
 
   if (rawPath.includes("\0")) {
     throw new PathGuardError("Path contains null byte", "NULL_BYTE");

--- a/packages/core/src/user-config.ts
+++ b/packages/core/src/user-config.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import {
   isValidBaseUrl,
   normalizeBaseUrl,
@@ -214,6 +214,11 @@ export function getUserConfigDir(): string {
   const override = process.env.NAKAMA_CONFIG_DIR?.trim();
 
   if (override) {
+    if (!isAbsolute(override)) {
+      throw new Error(
+        "NAKAMA_CONFIG_DIR must be an absolute path; relative paths resolve against process.cwd() and break profile isolation."
+      );
+    }
     return override;
   }
 


### PR DESCRIPTION
## What changed

Removed/fixed five meaningless or tautological assert-shaped checks and added five contract asserts making implicit rules explicit.

### Removed / fixed (meaningless)
1. `assertNoOverlappingEdits` sort check in `packages/core/src/tools/builtin.ts` — caller sorts by start offset immediately before, so the "must be sorted" branch was dead. Kept the overlap check.
2. Six `skillProposalService!` non-null assertions in `apps/server/src/tools/skill-manage-tool.ts` — the gate already proved non-null, but a `boolean` couldn't narrow TypeScript. Inlined the null check so narrowing works and dropped `!`.
3. `request.description!` / `body!` / `disableModelInvocation!` in `apps/server/src/services/skills-service.ts` — values already gated by `has*` booleans. Switched to `=== undefined` ternaries (no `!`).
4. `matches[0]!` in `packages/core/src/profiles.ts` — length already checked. Destructured with early return.
5. `history[1]!` in `apps/server/src/services/org-memory-service.ts` — `length < 2` already checked. Bound `previous` and asserted once.
6. Bonus: `delivery.to!` in `apps/server/src/services/automation-delivery-service.ts` — replaced assumed validation with a real runtime assert for email `to`.

### Added (contract asserts)
1. `getUserConfigDir` — `NAKAMA_CONFIG_DIR` must be absolute (profile isolation root).
2. `buildToolExecutionContext` — `orgId`/`profileId` both set or neither.
3. `guardFilePath` — explicit assert that allowed-dirs fallback exists (was comment-only).
4. `bash.resolveWorkspaceRoot` — absolute workspace root (parity with search/kb tools).
5. `generate_image` — absolute workspace before writing artifacts.

## What was verified

- `bun test` on 11 affected files — 135 pass, 0 fail.
- `bun x ultracite check` on all 11 modified files — clean after one auto-fix.
- `bun test` on 6 further files — 104 pass, 0 fail.
- Independently re-ran 7 affected test files — 108 pass, 0 fail.

Full monorepo suite was **not** run.

## Remaining risks

- Full monorepo test suite not run; changes touch shared core path/tool code so regressions outside the tested subsets are possible.
- Added asserts are runtime throws; they could surface pre-existing call sites passing relative paths where none existed before. No such call sites found in the reviewed scope.