### PR TITLE
fix(gemini): sanitize tool schemas that reject exclusiveMinimum

### DIFF
--- a/apps/server/src/providers/gemini/config.test.ts
+++ b/apps/server/src/providers/gemini/config.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+import { buildGeminiChatConfig, sanitizeGeminiToolParameters } from "./config";
+
+describe("sanitizeGeminiToolParameters", () => {
+  test("maps integer exclusiveMinimum to inclusive minimum", () => {
+    expect(
+      sanitizeGeminiToolParameters({
+        exclusiveMinimum: 0,
+        maximum: 200,
+        type: "integer",
+      })
+    ).toEqual({
+      maximum: 200,
+      minimum: 1,
+      type: "integer",
+    });
+  });
+
+  test("maps integer exclusiveMaximum to inclusive maximum", () => {
+    expect(
+      sanitizeGeminiToolParameters({
+        exclusiveMaximum: 10,
+        minimum: 0,
+        type: "integer",
+      })
+    ).toEqual({
+      maximum: 9,
+      minimum: 0,
+      type: "integer",
+    });
+  });
+
+  test("keeps an existing inclusive bound instead of overwriting it", () => {
+    expect(
+      sanitizeGeminiToolParameters({
+        exclusiveMinimum: 0,
+        minimum: 5,
+        type: "integer",
+      })
+    ).toEqual({
+      minimum: 5,
+      type: "integer",
+    });
+  });
+
+  test("drops $schema and recurses into properties and items", () => {
+    const sanitized = sanitizeGeminiToolParameters({
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      additionalProperties: false,
+      properties: {
+        limit: {
+          exclusiveMinimum: 0,
+          type: "integer",
+        },
+        offsets: {
+          items: {
+            exclusiveMinimum: 0,
+            type: "integer",
+          },
+          type: "array",
+        },
+        path: { type: "string" },
+      },
+      required: ["path"],
+      type: "object",
+    } as never);
+
+    expect(sanitized).toEqual({
+      additionalProperties: false,
+      properties: {
+        limit: {
+          minimum: 1,
+          type: "integer",
+        },
+        offsets: {
+          items: {
+            minimum: 1,
+            type: "integer",
+          },
+          type: "array",
+        },
+        path: { type: "string" },
+      },
+      required: ["path"],
+      type: "object",
+    });
+    expect(JSON.stringify(sanitized)).not.toContain("exclusiveMinimum");
+    expect(JSON.stringify(sanitized)).not.toContain("$schema");
+  });
+});
+
+describe("buildGeminiChatConfig tool sanitization", () => {
+  test("strips exclusiveMinimum from function declaration parameters", () => {
+    const config = buildGeminiChatConfig(
+      {
+        tools: [
+          {
+            description: "Read a file",
+            name: "read_file",
+            parameters: {
+              properties: {
+                offset: {
+                  exclusiveMinimum: 0,
+                  type: "integer",
+                },
+                path: { type: "string" },
+              },
+              type: "object",
+            } as never,
+          },
+        ],
+      },
+      "system",
+      "gemini-2.5-flash"
+    );
+
+    const tools = config.tools ?? [];
+    const declarations = tools[0]?.functionDeclarations ?? [];
+    const parameters = declarations[0]?.parameters;
+
+    expect(JSON.stringify(parameters)).not.toContain("exclusiveMinimum");
+    expect(parameters).toMatchObject({
+      properties: {
+        offset: {
+          minimum: 1,
+          type: "integer",
+        },
+        path: { type: "string" },
+      },
+      type: "object",
+    });
+  });
+});

--- a/apps/server/src/providers/gemini/config.ts
+++ b/apps/server/src/providers/gemini/config.ts
@@ -37,6 +37,71 @@ export function buildGeminiGenerateConfig(options: {
   };
 }
 
+// Gemini function declarations accept a subset of JSON Schema: exclusive bounds
+// and the $schema marker are rejected with 400 INVALID_ARGUMENT, and Zod emits
+// exclusiveMinimum for .positive(). Translate to the closest supported bound.
+const DROPPED_SCHEMA_KEYS = new Set([
+  "$schema",
+  "exclusiveMaximum",
+  "exclusiveMinimum",
+]);
+
+function inclusiveBoundFor(
+  schema: Record<string, unknown>,
+  exclusiveValue: number,
+  step: number
+): number {
+  return schema.type === "integer" ? exclusiveValue + step : exclusiveValue;
+}
+
+function applyExclusiveBound(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+  exclusiveKey: "exclusiveMaximum" | "exclusiveMinimum",
+  inclusiveKey: "maximum" | "minimum",
+  step: number
+): void {
+  const exclusiveValue = source[exclusiveKey];
+
+  if (typeof exclusiveValue !== "number" || inclusiveKey in target) {
+    return;
+  }
+
+  target[inclusiveKey] = inclusiveBoundFor(source, exclusiveValue, step);
+}
+
+function sanitizeSchemaValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sanitizeSchemaValue);
+  }
+
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  const source = value as Record<string, unknown>;
+  const sanitized: Record<string, unknown> = {};
+
+  for (const [key, entry] of Object.entries(source)) {
+    if (DROPPED_SCHEMA_KEYS.has(key)) {
+      continue;
+    }
+
+    sanitized[key] = sanitizeSchemaValue(entry);
+  }
+
+  applyExclusiveBound(sanitized, source, "exclusiveMinimum", "minimum", 1);
+  applyExclusiveBound(sanitized, source, "exclusiveMaximum", "maximum", -1);
+
+  return sanitized;
+}
+
+export function sanitizeGeminiToolParameters(
+  parameters: LlmToolDefinition["parameters"]
+): LlmToolDefinition["parameters"] {
+  return sanitizeSchemaValue(parameters) as LlmToolDefinition["parameters"];
+}
+
 function buildGeminiTools(
   tools: LlmToolDefinition[] | undefined,
   webSearch: boolean
@@ -52,7 +117,7 @@ function buildGeminiTools(
       functionDeclarations: tools.map((tool) => ({
         description: tool.description,
         name: tool.name,
-        parameters: tool.parameters,
+        parameters: sanitizeGeminiToolParameters(tool.parameters),
       })),
     });
   }


### PR DESCRIPTION
## Summary

- Gemini rejects `exclusiveMinimum` (and related exclusive bounds / `$schema`) in `functionDeclarations` parameters with `400 INVALID_ARGUMENT`.
- Zod 4 emits `exclusiveMinimum: 0` for `z.number().int().positive()` used by builtins such as `read_file`, `search_files`, and `knowledge_base_search`.
- Sanitize tool parameter schemas in the Gemini provider before sending: map exclusive → inclusive bounds and drop `$schema`, recursively.

Closes #292

## Why

Any Gemini chat turn with those tools enabled fails before the model can respond — including `/learn` and normal file/search turns. This is provider-wire handling, not API key scope.

## Test plan

- [x] Unit: `sanitizeGeminiToolParameters` maps integer `exclusiveMinimum: 0` → `minimum: 1`
- [x] Unit: nested `properties` / array `items` sanitized; `$schema` dropped
- [x] Unit: `buildGeminiChatConfig` strips `exclusiveMinimum` from function declarations
- [x] `bun test apps/server/src/providers/gemini/` (13 pass)
- [x] Manual: Gemini profile with file tools — chat / `/learn` no longer 400s on schema


Made with [Cursor](https://cursor.com)