### PR TITLE
Review asserts: remove meaningless, add meaningful

### DIFF
--- a/apps/server/src/services/org-service.ts
+++ b/apps/server/src/services/org-service.ts
@@ -155,7 +155,7 @@ export class OrgService {
       ? memberships.find((membership) => membership.organization.id === trimmed)
       : undefined;
     const activeOrgId =
-      matched?.organization.id ?? memberships[0]!.organization.id;
+      matched?.organization.id ?? memberships[0].organization.id;
 
     if (sessionId && activeOrgId !== (trimmed ?? null)) {
       await this.databaseAdapter.updateBrowserSessionActiveOrgId(

--- a/apps/server/src/tools/sub-agent-tool.ts
+++ b/apps/server/src/tools/sub-agent-tool.ts
@@ -56,6 +56,10 @@ export async function runSubAgentTool(
 ): Promise<SubAgentToolOutput> {
   const depth = context.agentDepth ?? 0;
 
+  if (!Number.isInteger(depth) || depth < 0) {
+    return failSubAgentResult("agentDepth must be a non-negative integer.");
+  }
+
   if (depth >= 1) {
     return failSubAgentResult("Nested sub-agent execution is not allowed.");
   }

--- a/packages/core/src/artifact-shares.ts
+++ b/packages/core/src/artifact-shares.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { pathExists } from "./fs";
-import { getArtifactSharesDir } from "./soul/resolve";
+import { assertConfigPathSegment, getArtifactSharesDir } from "./soul/resolve";
 
 export function generateArtifactShareToken(): string {
   // No underscores: plain-text markdown strippers treat `_word_` as italic and can
@@ -21,7 +21,10 @@ export async function writeArtifactShareSnapshot(input: {
   bytes: Buffer;
 }): Promise<string> {
   const sharesDir = getArtifactSharesDir(input.orgId);
-  const shareDir = path.join(sharesDir, input.shareId);
+  const shareDir = path.join(
+    sharesDir,
+    assertConfigPathSegment(input.shareId, "shareId")
+  );
   await mkdir(shareDir, { recursive: true });
 
   const safeName =

--- a/packages/core/src/channel-org.ts
+++ b/packages/core/src/channel-org.ts
@@ -155,7 +155,7 @@ export async function prepareChannelOrgContext(options: {
   }
 
   if (orgs.length === 1) {
-    const org = orgs[0]!;
+    const org = orgs[0];
     if (options.getSelectedOrgId() !== org.id) {
       await options.saveSelectedOrgId(org.id);
     }

--- a/packages/core/src/knowledge-base/paths.ts
+++ b/packages/core/src/knowledge-base/paths.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import { getProfileSoulDir } from "../soul/resolve";
+import { assertConfigPathSegment, getProfileSoulDir } from "../soul/resolve";
 
 export const KNOWLEDGE_BASE_RELATIVE_DIR = "knowledge-base";
 export const KNOWLEDGE_BASE_MANIFEST_FILE = "manifest.json";
@@ -29,7 +29,7 @@ export function getKnowledgeBaseStoredDocumentPath(
   const sanitized = base.replace(/[^\w.\-() ]+/g, "_") || "document";
   return join(
     getKnowledgeBaseDir(orgId, profileId),
-    `${documentId}--${sanitized}`
+    `${assertConfigPathSegment(documentId, "documentId")}--${sanitized}`
   );
 }
 
@@ -40,6 +40,6 @@ export function getKnowledgeBaseExtractedPath(
 ): string {
   return join(
     getKnowledgeBaseDir(orgId, profileId),
-    `${documentId}${KNOWLEDGE_BASE_EXTRACTED_SUFFIX}`
+    `${assertConfigPathSegment(documentId, "documentId")}${KNOWLEDGE_BASE_EXTRACTED_SUFFIX}`
   );
 }

--- a/packages/core/src/profiles.ts
+++ b/packages/core/src/profiles.ts
@@ -274,9 +274,10 @@ export function pickProfileForOrg(
     return defaultProfile;
   }
 
-  if (profiles.length === 0) {
+  const [firstProfile] = profiles;
+  if (!firstProfile) {
     throw new Error("No profiles are available.");
   }
 
-  return profiles[0]!;
+  return firstProfile;
 }

--- a/packages/core/src/skills/github-skill-url.ts
+++ b/packages/core/src/skills/github-skill-url.ts
@@ -44,9 +44,9 @@ function normalizeRawUrl(parsed: URL): string {
     );
   }
 
-  const owner = segments[0]!;
-  const repo = segments[1]!;
-  const ref = segments[2]!;
+  const owner = segments[0];
+  const repo = segments[1];
+  const ref = segments[2];
   const filePath = ensureSkillFilePath(segments.slice(3).join("/"), "file");
 
   return buildRawUrl(owner, repo, ref, filePath);
@@ -60,9 +60,9 @@ function githubHtmlUrlToRaw(parsed: URL): string {
     );
   }
 
-  const owner = segments[0]!;
-  const repo = segments[1]!;
-  const kind = segments[2]!;
+  const owner = segments[0];
+  const repo = segments[1];
+  const kind = segments[2];
 
   if (kind !== "blob" && kind !== "tree" && kind !== "raw") {
     throw new Error(
@@ -76,7 +76,7 @@ function githubHtmlUrlToRaw(parsed: URL): string {
     );
   }
 
-  const ref = segments[3]!;
+  const ref = segments[3];
   const rest = segments.slice(4).join("/");
   const mode = kind === "tree" ? "tree" : "file";
   const filePath = ensureSkillFilePath(rest, mode);
@@ -90,16 +90,13 @@ function buildRawUrl(
   ref: string,
   filePath: string
 ): string {
+  // Segments are validated in splitPath / ensureSkillFilePath before this runs.
   const pathSegments = [
     owner,
     repo,
     ref,
     ...filePath.split("/").filter((segment) => segment.length > 0),
   ];
-
-  for (const segment of pathSegments) {
-    assertSafePathSegment(segment);
-  }
 
   return `https://${RAW_HOST}/${pathSegments.map(encodeURIComponent).join("/")}`;
 }
@@ -117,10 +114,8 @@ function ensureSkillFilePath(pathPart: string, mode: "file" | "tree"): string {
     );
   }
 
+  // pathPart is built from splitPath segments (already assertSafePathSegment).
   const parts = normalized.split("/").filter((segment) => segment.length > 0);
-  for (const part of parts) {
-    assertSafePathSegment(part);
-  }
 
   const base = parts.at(-1) ?? "";
   if (base === SKILL_FILE_NAME) {

--- a/packages/core/src/soul/org-memory-history.ts
+++ b/packages/core/src/soul/org-memory-history.ts
@@ -6,7 +6,7 @@ import {
   readText,
   writePrivateTextFile,
 } from "../fs";
-import { getOrgMemoryHistoryDir } from "./resolve";
+import { assertConfigPathSegment, getOrgMemoryHistoryDir } from "./resolve";
 
 export const ORG_MEMORY_HISTORY_MAX_ENTRIES = 50;
 
@@ -19,7 +19,10 @@ function historyMetaPath(
   id: string,
   configDir?: string
 ): string {
-  return join(getOrgMemoryHistoryDir(orgId, configDir), `${id}.json`);
+  return join(
+    getOrgMemoryHistoryDir(orgId, configDir),
+    `${assertConfigPathSegment(id, "revisionId")}.json`
+  );
 }
 
 function historyContentPath(
@@ -27,7 +30,10 @@ function historyContentPath(
   id: string,
   configDir?: string
 ): string {
-  return join(getOrgMemoryHistoryDir(orgId, configDir), `${id}.md`);
+  return join(
+    getOrgMemoryHistoryDir(orgId, configDir),
+    `${assertConfigPathSegment(id, "revisionId")}.md`
+  );
 }
 
 let orgMemoryChangeSequence = 0;

--- a/packages/core/src/tools/builtin.ts
+++ b/packages/core/src/tools/builtin.ts
@@ -538,22 +538,18 @@ function planEdit(
     );
   }
 
-  if (exactMatches.length === 1) {
-    const start = exactMatches[0]!;
+  const [exactStart] = exactMatches;
+  if (exactStart !== undefined) {
     return {
-      end: start + edit.oldText.length,
+      end: exactStart + edit.oldText.length,
       fuzzy: false,
       index,
       newText: normalizeReplacementLineEndings(edit.newText, lineEnding),
-      start,
+      start: exactStart,
     };
   }
 
   const fuzzyMatches = findNormalizedMatches(content, edit.oldText);
-
-  if (fuzzyMatches.length === 0) {
-    throw new Error(`Edit ${index + 1} oldText not found in file.`);
-  }
 
   if (fuzzyMatches.length > 1) {
     throw new Error(
@@ -561,7 +557,10 @@ function planEdit(
     );
   }
 
-  const match = fuzzyMatches[0]!;
+  const [match] = fuzzyMatches;
+  if (!match) {
+    throw new Error(`Edit ${index + 1} oldText not found in file.`);
+  }
 
   return {
     end: match.end,
@@ -737,18 +736,14 @@ function removeTrailingWhitespaceTokens(
 
 function assertNoOverlappingEdits(plans: PlannedEdit[]): void {
   // Caller sorts by start before invoking; only overlap is still possible.
-  for (let index = 1; index < plans.length; index += 1) {
-    const previous = plans[index - 1];
-    const current = plans[index];
-    if (previous === undefined || current === undefined) {
-      throw new Error("Edit plans must be a contiguous list.");
-    }
-
-    if (current.start < previous.end) {
+  let previous: PlannedEdit | undefined;
+  for (const current of plans) {
+    if (previous !== undefined && current.start < previous.end) {
       throw new Error(
         `Edit ${current.index + 1} overlaps with edit ${previous.index + 1}.`
       );
     }
+    previous = current;
   }
 }
 

--- a/packages/core/src/tools/paths.ts
+++ b/packages/core/src/tools/paths.ts
@@ -62,13 +62,7 @@ export async function guardFilePath(
   const allowedDirs = await resolveAllowedDirs(rawAllowedDirs);
   const maxBytes = options.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES;
   // rawAllowedDirs is non-empty: either allowedOption or [cwdOption] from above.
-  const fallbackAllowedDir = rawAllowedDirs[0];
-  if (!fallbackAllowedDir) {
-    throw new PathGuardError(WORKSPACE_REQUIRED_MESSAGE, "TRAVERSAL");
-  }
-  const defaultCwd = await resolveDirectoryPath(
-    cwdOption ?? fallbackAllowedDir
-  );
+  const defaultCwd = await resolveDirectoryPath(cwdOption ?? rawAllowedDirs[0]);
 
   if (rawPath.includes("\0")) {
     throw new PathGuardError("Path contains null byte", "NULL_BYTE");

--- a/packages/core/src/tools/ripgrep.ts
+++ b/packages/core/src/tools/ripgrep.ts
@@ -56,6 +56,17 @@ export async function runRipgrep(
   args: string[],
   options: { workspaceRoot: string; searchRoot: string; maxResults: number }
 ): Promise<RipgrepSearchResult> {
+  if (!path.isAbsolute(options.workspaceRoot)) {
+    throw new Error(
+      "workspaceRoot must be an absolute path; relative roots resolve against process.cwd() and break profile isolation."
+    );
+  }
+  if (!path.isAbsolute(options.searchRoot)) {
+    throw new Error(
+      "searchRoot must be an absolute path; relative roots resolve against process.cwd() and break profile isolation."
+    );
+  }
+
   const command = await resolveRipgrepCommand();
 
   return await new Promise((resolve, reject) => {


### PR DESCRIPTION
## What changed

Removed five meaningless asserts/checks (no-op, tautological, or already guaranteed):

1. `guardFilePath` (`packages/core/src/tools/paths.ts`) — dropped the `fallbackAllowedDir` guard; `rawAllowedDirs` is non-empty by construction (either `allowedOption`, `[cwdOption]`, or it throws).
2. `assertNoOverlappingEdits` (`packages/core/src/tools/builtin.ts`) — dropped the impossible "contiguous list" throw; a dense array from `.map().sort()` has no holes.
3. `buildRawUrl` (`packages/core/src/skills/github-skill-url.ts`) — removed duplicate `assertSafePathSegment` loop; `splitPath` already validates every segment.
4. `ensureSkillFilePath` (same file) — removed the second re-assert on already-validated segments.
5. Replaced post-guard non-null `!` with real bindings/destructuring: `memberships[0]`, `orgs[0]`, `segments[n]`, `exactMatches[0]`/`fuzzyMatches[0]`, `profiles[0]`.

Added five negative-space contract asserts:

1. `org-memory-history` — `assertConfigPathSegment(revisionId)` before path join.
2. `knowledge-base/paths` — `assertConfigPathSegment(documentId)` in stored/extracted paths.
3. `artifact-shares` — `assertConfigPathSegment(shareId)` before writing under shares dir.
4. `runRipgrep` — `workspaceRoot`/`searchRoot` must be absolute.
5. `sub_agent` — `agentDepth` must be a non-negative integer.

## Verification

- `bun run check` (ultracite, 1125 files, clean)
- `bun test` on 15 affected files — 137 pass, 0 fail

## Remaining risks

- Full monorepo suite was not run; only the affected subset. Other packages (web, telegram, whatsapp, discord, automation, cli) were not exercised.
- `sub_agent` agentDepth guard is a runtime fail (not a thrown assert), chosen to match the existing `failSubAgentResult` pattern for the nest check.