### PR TITLE
feat(agent): wait out repeated in-flight tool polls in the tool loop

### DIFF
--- a/packages/agent/src/chat-tool-loop.test.ts
+++ b/packages/agent/src/chat-tool-loop.test.ts
@@ -443,4 +443,87 @@ describe("agent chat tool loop", () => {
 
     expect(systems[0]).toContain("[pending] Ship");
   });
+
+  test("collapses repeated in-flight status polls after the third call", async () => {
+    let runs = 0;
+    const statusTool: ToolDefinition = {
+      description: "Poll a job",
+      name: "job_status",
+      parameters: {
+        properties: { job_id: { type: "number" } },
+        required: ["job_id"],
+        type: "object",
+      },
+      run() {
+        runs += 1;
+        if (runs < 4) {
+          return Promise.resolve({
+            progress: { percent: 5 },
+            status: "running",
+          });
+        }
+        return Promise.resolve({
+          progress: { percent: 20 },
+          status: "running",
+        });
+      },
+    };
+
+    const statusCall = (id: string) => ({
+      arguments: { job_id: 17 },
+      id,
+      name: "job_status",
+    });
+
+    const provider = createMockProvider([
+      {
+        assistantMessage: {
+          content: "",
+          role: "assistant",
+          toolCalls: [statusCall("call_1")],
+        },
+        content: "",
+        toolCalls: [statusCall("call_1")],
+      },
+      {
+        assistantMessage: {
+          content: "",
+          role: "assistant",
+          toolCalls: [statusCall("call_2")],
+        },
+        content: "",
+        toolCalls: [statusCall("call_2")],
+      },
+      {
+        assistantMessage: {
+          content: "",
+          role: "assistant",
+          toolCalls: [statusCall("call_3")],
+        },
+        content: "",
+        toolCalls: [statusCall("call_3")],
+      },
+      {
+        assistantMessage: { content: "Done", role: "assistant" },
+        content: "Done",
+        toolCalls: [],
+      },
+    ]);
+
+    const harness = createAgentHarness({ provider, tools: [statusTool] });
+    const session = harness.createChatSession({ tools: [statusTool] });
+    const reply = await session.send("check job");
+
+    expect(reply).toBe("Done");
+    expect(runs).toBe(4);
+
+    const history = session.getHistory() as ChatMessage[];
+    const toolMessages = history.filter((message) => message.role === "tool");
+    expect(toolMessages).toHaveLength(3);
+    expect(toolMessages[2]).toMatchObject({
+      content: '{"progress":{"percent":20},"status":"running"}',
+      name: "job_status",
+      role: "tool",
+    });
+  });
 });

--- a/packages/agent/src/chat.ts
+++ b/packages/agent/src/chat.ts
@@ -49,6 +49,11 @@ import {
   executeToolCall,
   serializeToolResult,
 } from "./tool-loop";
+import {
+  createToolPollWaitState,
+  executeToolCallWithPollWait,
+  type ToolPollWaitState,
+} from "./tool-poll-wait";
 
 const MAX_TOOL_ITERATIONS = 100;
 
@@ -501,6 +506,8 @@ async function runConversation(
   ) => void,
   signal?: AbortSignal
 ): Promise<string> {
+  const pollWaitState = createToolPollWaitState();
+
   for (let iteration = 0; iteration < MAX_TOOL_ITERATIONS; iteration += 1) {
     signal?.throwIfAborted();
 
@@ -561,7 +568,8 @@ async function runConversation(
       result.toolCalls,
       history,
       handlers,
-      toolContext
+      toolContext,
+      pollWaitState
     );
   }
 
@@ -580,7 +588,8 @@ async function executeToolCalls(
   toolCalls: ToolCall[],
   history: ChatMessage[],
   handlers?: StreamHandlers,
-  toolContext: ToolContext = {}
+  toolContext: ToolContext = {},
+  pollWaitState: ToolPollWaitState = createToolPollWaitState()
 ): Promise<void> {
   const contextForCall = (call: ToolCall): ToolContext => {
     if (!handlers?.onSubAgentActivity || call.name !== "sub_agent") {
@@ -641,7 +650,12 @@ async function executeToolCalls(
       toolCallId: call.id,
     });
 
-    const result = await executeToolCall(tools, call, contextForCall(call));
+    const result = await executeToolCallWithPollWait({
+      call,
+      context: contextForCall(call),
+      state: pollWaitState,
+      tools,
+    });
 
     handlers?.onToolEnd?.({
       result,

--- a/packages/agent/src/tool-poll-wait.test.ts
+++ b/packages/agent/src/tool-poll-wait.test.ts
@@ -1,0 +1,476 @@
+import { describe, expect, test } from "bun:test";
+import type { ToolDefinition } from "@nakama/core";
+import {
+  canPollWaitOnResult,
+  createToolPollWaitState,
+  executeToolCallWithPollWait,
+  isTerminalSnapshot,
+  isToolErrorResult,
+  payloadsEqual,
+  TOOL_POLL_WAIT_TIMEOUT_MS,
+  unwrapToolPayload,
+  withPollTimeout,
+} from "./tool-poll-wait";
+
+function createFakeClock(): {
+  clock: {
+    now: () => number;
+    sleep: (ms: number, signal?: AbortSignal) => Promise<void>;
+  };
+} {
+  let now = 0;
+
+  return {
+    clock: {
+      now: () => now,
+      async sleep(ms: number, signal?: AbortSignal) {
+        signal?.throwIfAborted();
+        now += ms;
+      },
+    },
+  };
+}
+
+function statusTool(
+  run: ToolDefinition["run"],
+  name = "job_status"
+): ToolDefinition {
+  return {
+    description: "Poll a job",
+    name,
+    parameters: {
+      properties: { job_id: { type: "number" } },
+      required: ["job_id"],
+      type: "object",
+    },
+    run,
+  };
+}
+
+function call(id: string, jobId = 17) {
+  return {
+    arguments: { job_id: jobId },
+    id,
+    name: "job_status",
+  };
+}
+
+describe("tool poll wait detection", () => {
+  test("unwraps MCP text envelopes", () => {
+    const wrapped = {
+      content: [
+        {
+          text: '{\n  "job_id": 17,\n  "status": "running"\n}',
+          type: "text",
+        },
+      ],
+      text: '{\n  "job_id": 17,\n  "status": "running"\n}',
+    };
+
+    expect(unwrapToolPayload(wrapped)).toEqual({
+      job_id: 17,
+      status: "running",
+    });
+  });
+
+  test("treats running status and progress as pollable, not terminal", () => {
+    const running = {
+      job_id: 17,
+      progress: { percent: 5 },
+      status: "running",
+    };
+
+    expect(canPollWaitOnResult(running)).toBe(true);
+    expect(isTerminalSnapshot(running)).toBe(false);
+  });
+
+  test("does not poll-wait a create ack that only has job_id", () => {
+    expect(canPollWaitOnResult({ job_id: 17 })).toBe(false);
+  });
+
+  test("does not poll-wait mutating acks or errors", () => {
+    expect(canPollWaitOnResult({ ok: true })).toBe(false);
+    expect(canPollWaitOnResult({ error: "boom" })).toBe(false);
+    expect(isToolErrorResult({ error: "boom" })).toBe(true);
+    expect(isTerminalSnapshot({ post_id: 13, status: "succeeded" })).toBe(true);
+  });
+
+  test("compares MCP envelopes by unwrapped payload", () => {
+    expect(
+      payloadsEqual(
+        { text: '{"status":"running","progress":{"percent":5}}' },
+        {
+          content: [
+            {
+              text: '{"progress":{"percent":5},"status":"running"}',
+              type: "text",
+            },
+          ],
+        }
+      )
+    ).toBe(true);
+  });
+});
+
+describe("executeToolCallWithPollWait", () => {
+  test("returns the first two in-flight polls immediately", async () => {
+    let runs = 0;
+    const tool = statusTool(() => {
+      runs += 1;
+      return Promise.resolve({ progress: { percent: 5 }, status: "running" });
+    });
+    const { clock } = createFakeClock();
+    const state = createToolPollWaitState();
+
+    const first = await executeToolCallWithPollWait({
+      call: call("1"),
+      clock,
+      state,
+      tools: [tool],
+    });
+    const second = await executeToolCallWithPollWait({
+      call: call("2"),
+      clock,
+      state,
+      tools: [tool],
+    });
+
+    expect(runs).toBe(2);
+    expect(first).toEqual({ progress: { percent: 5 }, status: "running" });
+    expect(second).toEqual({ progress: { percent: 5 }, status: "running" });
+  });
+
+  test("on the third same call, waits until the payload changes", async () => {
+    let runs = 0;
+    const tool = statusTool(() => {
+      runs += 1;
+      if (runs < 5) {
+        return Promise.resolve({
+          progress: { percent: 5 },
+          status: "running",
+        });
+      }
+      return Promise.resolve({ progress: { percent: 20 }, status: "running" });
+    });
+    const { clock } = createFakeClock();
+    const state = createToolPollWaitState();
+
+    await executeToolCallWithPollWait({
+      call: call("1"),
+      clock,
+      state,
+      tools: [tool],
+    });
+    await executeToolCallWithPollWait({
+      call: call("2"),
+      clock,
+      state,
+      tools: [tool],
+    });
+    const third = await executeToolCallWithPollWait({
+      call: call("3"),
+      clock,
+      state,
+      tools: [tool],
+    });
+
+    expect(runs).toBe(5);
+    expect(third).toEqual({ progress: { percent: 20 }, status: "running" });
+  });
+
+  test("stays latched for later calls with the same name and args", async () => {
+    let runs = 0;
+    const percents = [5, 5, 5, 20, 20, 27];
+    const tool = statusTool(() => {
+      runs += 1;
+      const percent = percents[runs - 1] ?? 27;
+      return Promise.resolve({ progress: { percent }, status: "running" });
+    });
+    const { clock } = createFakeClock();
+    const state = createToolPollWaitState();
+
+    await executeToolCallWithPollWait({
+      call: call("1"),
+      clock,
+      state,
+      tools: [tool],
+    });
+    await executeToolCallWithPollWait({
+      call: call("2"),
+      clock,
+      state,
+      tools: [tool],
+    });
+    await executeToolCallWithPollWait({
+      call: call("3"),
+      clock,
+      state,
+      tools: [tool],
+    });
+    const fourth = await executeToolCallWithPollWait({
+      call: call("4"),
+      clock,
+      state,
+      tools: [tool],
+    });
+
+    expect(runs).toBeGreaterThan(4);
+    expect(fourth).toEqual({ progress: { percent: 27 }, status: "running" });
+  });
+
+  test("does not share latch across different args or tool names", async () => {
+    let statusRuns = 0;
+    let otherRuns = 0;
+    const status = statusTool(() => {
+      statusRuns += 1;
+      return Promise.resolve({ status: "running" });
+    });
+    const other = statusTool(() => {
+      otherRuns += 1;
+      return Promise.resolve({ status: "running" });
+    }, "other_status");
+    const { clock } = createFakeClock();
+    const state = createToolPollWaitState();
+
+    await executeToolCallWithPollWait({
+      call: call("1"),
+      clock,
+      state,
+      tools: [status, other],
+    });
+    await executeToolCallWithPollWait({
+      call: { arguments: { job_id: 99 }, id: "2", name: "job_status" },
+      clock,
+      state,
+      tools: [status, other],
+    });
+    await executeToolCallWithPollWait({
+      call: { arguments: {}, id: "3", name: "other_status" },
+      clock,
+      state,
+      tools: [status, other],
+    });
+
+    expect(statusRuns).toBe(2);
+    expect(otherRuns).toBe(1);
+  });
+
+  test("never retries a mutating ack even on the third identical call", async () => {
+    let runs = 0;
+    const send: ToolDefinition = {
+      description: "Send mail",
+      name: "email_send",
+      run() {
+        runs += 1;
+        return Promise.resolve({ message_id: "m1", ok: true });
+      },
+    };
+    const { clock } = createFakeClock();
+    const state = createToolPollWaitState();
+    const sendCall = {
+      arguments: { to: "a@b.com" },
+      id: "1",
+      name: "email_send",
+    };
+
+    await executeToolCallWithPollWait({
+      call: { ...sendCall, id: "1" },
+      clock,
+      state,
+      tools: [send],
+    });
+    await executeToolCallWithPollWait({
+      call: { ...sendCall, id: "2" },
+      clock,
+      state,
+      tools: [send],
+    });
+    await executeToolCallWithPollWait({
+      call: { ...sendCall, id: "3" },
+      clock,
+      state,
+      tools: [send],
+    });
+
+    expect(runs).toBe(3);
+  });
+
+  test("returns errors immediately without waiting", async () => {
+    let runs = 0;
+    const tool = statusTool(() => {
+      runs += 1;
+      return Promise.resolve({ error: "MCP server is not connected." });
+    });
+    const { clock } = createFakeClock();
+    const state = createToolPollWaitState();
+
+    for (const id of ["1", "2", "3"]) {
+      const result = await executeToolCallWithPollWait({
+        call: call(id),
+        clock,
+        state,
+        tools: [tool],
+      });
+      expect(result).toEqual({ error: "MCP server is not connected." });
+    }
+
+    expect(runs).toBe(3);
+  });
+
+  test("returns a terminal snapshot without extra polls", async () => {
+    let runs = 0;
+    const tool = statusTool(() => {
+      runs += 1;
+      return Promise.resolve({ post_id: 13, status: "succeeded" });
+    });
+    const { clock } = createFakeClock();
+    const state = createToolPollWaitState();
+
+    await executeToolCallWithPollWait({
+      call: call("1"),
+      clock,
+      state,
+      tools: [tool],
+    });
+    await executeToolCallWithPollWait({
+      call: call("2"),
+      clock,
+      state,
+      tools: [tool],
+    });
+    const third = await executeToolCallWithPollWait({
+      call: call("3"),
+      clock,
+      state,
+      tools: [tool],
+    });
+
+    expect(runs).toBe(3);
+    expect(third).toEqual({ post_id: 13, status: "succeeded" });
+  });
+
+  test("times out with the last payload when the snapshot never changes", async () => {
+    const tool = statusTool(() =>
+      Promise.resolve({ progress: { percent: 5 }, status: "running" })
+    );
+    const { clock } = createFakeClock();
+    const state = createToolPollWaitState();
+
+    await executeToolCallWithPollWait({
+      call: call("1"),
+      clock,
+      state,
+      tools: [tool],
+    });
+    await executeToolCallWithPollWait({
+      call: call("2"),
+      clock,
+      state,
+      tools: [tool],
+    });
+    const timedOut = await executeToolCallWithPollWait({
+      call: call("3"),
+      clock,
+      state,
+      timeoutMs: TOOL_POLL_WAIT_TIMEOUT_MS,
+      tools: [tool],
+    });
+
+    expect(timedOut).toEqual({
+      poll_timeout: true,
+      progress: { percent: 5 },
+      status: "running",
+      waited_ms: TOOL_POLL_WAIT_TIMEOUT_MS,
+    });
+  });
+
+  test("stops waiting when the turn is aborted", async () => {
+    const controller = new AbortController();
+    let sleeps = 0;
+    const tool = statusTool(() => Promise.resolve({ status: "running" }));
+    const clock = {
+      now: () => sleeps * 500,
+      async sleep(_ms: number, signal?: AbortSignal) {
+        sleeps += 1;
+        controller.abort();
+        signal?.throwIfAborted();
+      },
+    };
+    const state = createToolPollWaitState();
+
+    await executeToolCallWithPollWait({
+      call: call("1"),
+      clock,
+      state,
+      tools: [tool],
+    });
+    await executeToolCallWithPollWait({
+      call: call("2"),
+      clock,
+      state,
+      tools: [tool],
+    });
+
+    await expect(
+      executeToolCallWithPollWait({
+        call: call("3"),
+        clock,
+        context: { signal: controller.signal },
+        state,
+        tools: [tool],
+      })
+    ).rejects.toThrow();
+  });
+
+  test("waits on MCP-wrapped running payloads", async () => {
+    let runs = 0;
+    const tool = statusTool(() => {
+      runs += 1;
+      const payload =
+        runs < 4
+          ? { progress: { percent: 5 }, status: "running" }
+          : { progress: { percent: 20 }, status: "running" };
+      return Promise.resolve({
+        content: [{ text: JSON.stringify(payload), type: "text" }],
+        text: JSON.stringify(payload),
+      });
+    });
+    const { clock } = createFakeClock();
+    const state = createToolPollWaitState();
+
+    await executeToolCallWithPollWait({
+      call: call("1"),
+      clock,
+      state,
+      tools: [tool],
+    });
+    await executeToolCallWithPollWait({
+      call: call("2"),
+      clock,
+      state,
+      tools: [tool],
+    });
+    const third = await executeToolCallWithPollWait({
+      call: call("3"),
+      clock,
+      state,
+      tools: [tool],
+    });
+
+    expect(runs).toBe(4);
+    expect(unwrapToolPayload(third)).toEqual({
+      progress: { percent: 20 },
+      status: "running",
+    });
+  });
+});
+
+describe("withPollTimeout", () => {
+  test("wraps non-objects", () => {
+    expect(withPollTimeout("still going", 1200)).toEqual({
+      poll_timeout: true,
+      result: "still going",
+      waited_ms: 1200,
+    });
+  });
+});

--- a/packages/agent/src/tool-poll-wait.ts
+++ b/packages/agent/src/tool-poll-wait.ts
@@ -1,0 +1,371 @@
+import type { ToolCall, ToolContext, ToolDefinition } from "@nakama/core";
+import { executeToolCall } from "./tool-loop";
+
+export const TOOL_POLL_WAIT_AFTER_CALLS = 3;
+export const TOOL_POLL_WAIT_TIMEOUT_MS = 120_000;
+export const TOOL_POLL_WAIT_INITIAL_DELAY_MS = 500;
+export const TOOL_POLL_WAIT_MAX_DELAY_MS = 5000;
+
+const TERMINAL_STATUSES = new Set([
+  "cancelled",
+  "canceled",
+  "complete",
+  "completed",
+  "done",
+  "error",
+  "failed",
+  "failure",
+  "ok",
+  "success",
+  "succeeded",
+  "timed_out",
+  "timeout",
+]);
+
+export interface ToolPollWaitClock {
+  now: () => number;
+  sleep: (ms: number, signal?: AbortSignal) => Promise<void>;
+}
+
+export interface ToolPollWaitState {
+  counts: Map<string, number>;
+  lastReturned: Map<string, string>;
+  latched: Set<string>;
+}
+
+export interface ExecuteToolCallWithPollWaitInput {
+  call: ToolCall;
+  clock?: ToolPollWaitClock;
+  context?: ToolContext;
+  state: ToolPollWaitState;
+  timeoutMs?: number;
+  tools: ToolDefinition[];
+}
+
+export function createToolPollWaitState(): ToolPollWaitState {
+  return {
+    counts: new Map(),
+    lastReturned: new Map(),
+    latched: new Set(),
+  };
+}
+
+export const defaultToolPollWaitClock: ToolPollWaitClock = {
+  now: () => Date.now(),
+  sleep: sleepUntilAbort,
+};
+
+export function toolPollWaitKey(name: string, args: unknown): string {
+  return `${name}:${stableSerialize(args)}`;
+}
+
+export function unwrapToolPayload(result: unknown): unknown {
+  if (!isRecord(result)) {
+    return result;
+  }
+
+  if (typeof result.text === "string") {
+    const parsed = tryParseJson(result.text);
+    if (parsed !== undefined) {
+      return parsed;
+    }
+  }
+
+  if (Array.isArray(result.content)) {
+    const chunks: string[] = [];
+
+    for (const part of result.content) {
+      if (
+        isRecord(part) &&
+        part.type === "text" &&
+        typeof part.text === "string"
+      ) {
+        chunks.push(part.text);
+      }
+    }
+
+    if (chunks.length > 0) {
+      const parsed = tryParseJson(chunks.join("\n"));
+      if (parsed !== undefined) {
+        return parsed;
+      }
+    }
+  }
+
+  return result;
+}
+
+export function isToolErrorResult(result: unknown): boolean {
+  return isRecord(result) && typeof result.error === "string";
+}
+
+export function isTerminalSnapshot(result: unknown): boolean {
+  if (isToolErrorResult(result)) {
+    return true;
+  }
+
+  const payload = unwrapToolPayload(result);
+  if (!isRecord(payload)) {
+    return false;
+  }
+
+  if (
+    payload.done === true ||
+    payload.complete === true ||
+    payload.finished === true
+  ) {
+    return true;
+  }
+
+  const status = snapshotStatus(payload);
+  return status !== null && TERMINAL_STATUSES.has(status);
+}
+
+export function canPollWaitOnResult(result: unknown): boolean {
+  if (isToolErrorResult(result) || isTerminalSnapshot(result)) {
+    return false;
+  }
+
+  const payload = unwrapToolPayload(result);
+  if (!isRecord(payload)) {
+    return false;
+  }
+
+  const status = snapshotStatus(payload);
+  if (status !== null) {
+    return !TERMINAL_STATUSES.has(status);
+  }
+
+  const percent = progressPercent(payload);
+  return percent !== null && percent < 100;
+}
+
+export function payloadsEqual(left: unknown, right: unknown): boolean {
+  return (
+    stableSerialize(unwrapToolPayload(left)) ===
+    stableSerialize(unwrapToolPayload(right))
+  );
+}
+
+export function withPollTimeout(result: unknown, waitedMs: number): unknown {
+  if (isRecord(result)) {
+    return {
+      ...result,
+      poll_timeout: true,
+      waited_ms: waitedMs,
+    };
+  }
+
+  return {
+    poll_timeout: true,
+    result,
+    waited_ms: waitedMs,
+  };
+}
+
+export async function executeToolCallWithPollWait(
+  input: ExecuteToolCallWithPollWaitInput
+): Promise<unknown> {
+  const clock = input.clock ?? defaultToolPollWaitClock;
+  const context = input.context ?? {};
+  const timeoutMs = input.timeoutMs ?? TOOL_POLL_WAIT_TIMEOUT_MS;
+  const key = toolPollWaitKey(input.call.name, input.call.arguments);
+  const count = (input.state.counts.get(key) ?? 0) + 1;
+  input.state.counts.set(key, count);
+
+  const first = await executeToolCall(input.tools, input.call, context);
+  return finishOrWait({
+    call: input.call,
+    clock,
+    context,
+    count,
+    first,
+    key,
+    state: input.state,
+    timeoutMs,
+    tools: input.tools,
+  });
+}
+
+async function finishOrWait(input: {
+  call: ToolCall;
+  clock: ToolPollWaitClock;
+  context: ToolContext;
+  count: number;
+  first: unknown;
+  key: string;
+  state: ToolPollWaitState;
+  timeoutMs: number;
+  tools: ToolDefinition[];
+}): Promise<unknown> {
+  if (!canPollWaitOnResult(input.first)) {
+    return rememberReturned(input.state, input.key, input.first);
+  }
+
+  if (input.count >= TOOL_POLL_WAIT_AFTER_CALLS) {
+    input.state.latched.add(input.key);
+  }
+
+  if (!input.state.latched.has(input.key)) {
+    return rememberReturned(input.state, input.key, input.first);
+  }
+
+  const previous = input.state.lastReturned.get(input.key);
+  if (
+    previous !== undefined &&
+    stableSerialize(unwrapToolPayload(input.first)) !== previous
+  ) {
+    return rememberReturned(input.state, input.key, input.first);
+  }
+
+  return waitUntilPayloadChanges(input);
+}
+
+async function waitUntilPayloadChanges(input: {
+  call: ToolCall;
+  clock: ToolPollWaitClock;
+  context: ToolContext;
+  first: unknown;
+  key: string;
+  state: ToolPollWaitState;
+  timeoutMs: number;
+  tools: ToolDefinition[];
+}): Promise<unknown> {
+  const startedAt = input.clock.now();
+  let delayMs = TOOL_POLL_WAIT_INITIAL_DELAY_MS;
+  let last = input.first;
+
+  while (true) {
+    input.context.signal?.throwIfAborted();
+    const waitedMs = input.clock.now() - startedAt;
+    if (waitedMs >= input.timeoutMs) {
+      return rememberReturned(
+        input.state,
+        input.key,
+        withPollTimeout(last, waitedMs)
+      );
+    }
+
+    await input.clock.sleep(
+      Math.min(delayMs, input.timeoutMs - waitedMs),
+      input.context.signal
+    );
+    input.context.signal?.throwIfAborted();
+
+    last = await executeToolCall(input.tools, input.call, input.context);
+
+    if (!(canPollWaitOnResult(last) && payloadsEqual(last, input.first))) {
+      return rememberReturned(input.state, input.key, last);
+    }
+
+    delayMs = Math.min(delayMs * 2, TOOL_POLL_WAIT_MAX_DELAY_MS);
+  }
+}
+
+function rememberReturned(
+  state: ToolPollWaitState,
+  key: string,
+  result: unknown
+): unknown {
+  state.lastReturned.set(key, stableSerialize(unwrapToolPayload(result)));
+  return result;
+}
+
+function snapshotStatus(payload: Record<string, unknown>): string | null {
+  for (const field of [
+    "status",
+    "state",
+    "job_status",
+    "task_status",
+  ] as const) {
+    const value = payload[field];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim().toLowerCase().replaceAll(" ", "_");
+    }
+  }
+
+  return null;
+}
+
+function progressPercent(payload: Record<string, unknown>): number | null {
+  if (!isRecord(payload.progress)) {
+    return null;
+  }
+
+  const percent = payload.progress.percent;
+  return typeof percent === "number" && Number.isFinite(percent)
+    ? percent
+    : null;
+}
+
+function tryParseJson(text: string): unknown {
+  const trimmed = text.trim();
+  if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) {
+    return;
+  }
+
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {}
+}
+
+function stableSerialize(value: unknown): string {
+  return JSON.stringify(sortJson(value));
+}
+
+function sortJson(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortJson);
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  const sorted: Record<string, unknown> = {};
+  const keys = Object.keys(value).sort();
+  for (const key of keys) {
+    sorted[key] = sortJson(value[key]);
+  }
+  return sorted;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function sleepUntilAbort(
+  ms: number,
+  signal?: AbortSignal
+): Promise<void> {
+  if (ms <= 0) {
+    signal?.throwIfAborted();
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(abortReason(signal));
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+
+    function onAbort(): void {
+      clearTimeout(timer);
+      reject(abortReason(signal));
+    }
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function abortReason(signal?: AbortSignal): unknown {
+  return (
+    signal?.reason ??
+    new DOMException("This operation was aborted", "AbortError")
+  );
+}


### PR DESCRIPTION
## Summary

An in-flight MCP job (Digest Instagram ingest in session `webKKzAzLjA8gSwm9QsCf`) used to cost a full LLM turn per `job_status` poll — 41 rounds for 13 progress states. After the **third** same `name`+args call in a turn, the tool loop now retries that tool with backoff until the payload **changes**, the snapshot is terminal, the turn is aborted, or 2 minutes elapse.

This is not Digest-specific. Any sequential tool (MCP, builtin, custom JS) that returns an in-flight `status`/`state`/`progress` snapshot can latch. Create/send acks (`{ok: true}`, `{job_id}` only) and `{error}` results are never retried, so a repeated `email_send` cannot loop-send.

The model still sees each changed snapshot (OCR 5% → 20% → 27%…), not a single wait-until-succeeded result. Kickoff tools are unchanged.

## Test plan

- [x] `bun test packages/agent` — 102 pass, including poll-wait unit tests and a chat-loop integration that collapses the third status poll
- [ ] Re-run a Digest `instagram_save_url` flow and confirm the UI shows a handful of status cards, not dozens, while OCR is running
