### PR TITLE
docs: point local web dashboard URL to port 3003

### DIFF
--- a/docs/website/content/docs/contributing.mdx
+++ b/docs/website/content/docs/contributing.mdx
@@ -16,7 +16,7 @@ bun install
 bun run dev:web
 ```
 
-Open the web dashboard at http://localhost:3000. `dev:web` starts the API if needed.
+Open the web dashboard at http://localhost:3003. `dev:web` starts the API if needed.
 
 Other entry points:
 


### PR DESCRIPTION
## Summary
- Update the Run locally dashboard link in contributing docs from `http://localhost:3000` to `http://localhost:3003`
- Leave the Docker dashboard URL (`http://localhost:4310`) unchanged

## Test plan
- [x] Confirm `docs/website/content/docs/contributing.mdx` contains `localhost:3003`
- [x] Confirm the same file no longer contains `localhost:3000`
- [ ] Spot-check the contributing page renders the updated URL


Made with [Cursor](https://cursor.com)