### PR TITLE
perf(web): lazy-load route pages

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,80 +1,65 @@
 import { QueryClientProvider } from "@tanstack/react-query";
-import { lazy, Suspense, useEffect } from "react";
+import { type ComponentType, lazy, useEffect } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 import { AuthGuard } from "@/components/AuthGuard";
 import { Layout } from "@/components/Layout";
 import { PlatformAdminGuard } from "@/components/PlatformAdminGuard";
+import { RouteBoundary } from "@/components/RouteBoundary";
 import { SetupGuard } from "@/components/SetupGuard";
-import { Spinner } from "@/components/ui/spinner";
 import { AppProvider } from "@/context/app-context";
 import { AuthProvider } from "@/context/auth-context";
 import { AppQueryPrefetch } from "@/hooks/use-app-queries";
 import { statusTabPath } from "@/lib/navigation";
 import { onGlobalQueryError, queryClient } from "@/lib/query-client";
 
-const AutomationsPage = lazy(() =>
-  import("@/pages/AutomationsPage").then(({ AutomationsPage }) => ({
-    default: AutomationsPage,
-  }))
+const lazyPage = <Name extends string>(
+  load: () => Promise<Record<Name, ComponentType>>,
+  name: Name
+) => lazy(async () => ({ default: (await load())[name] }));
+
+const AutomationsPage = lazyPage(
+  () => import("@/pages/AutomationsPage"),
+  "AutomationsPage"
 );
-const ChatPage = lazy(() =>
-  import("@/pages/ChatPage").then(({ ChatPage }) => ({ default: ChatPage }))
+const ChatPage = lazyPage(() => import("@/pages/ChatPage"), "ChatPage");
+const FilesPage = lazyPage(() => import("@/pages/FilesPage"), "FilesPage");
+const HistoryPage = lazyPage(
+  () => import("@/pages/HistoryPage"),
+  "HistoryPage"
 );
-const FilesPage = lazy(() =>
-  import("@/pages/FilesPage").then(({ FilesPage }) => ({ default: FilesPage }))
+const IntegrationsPage = lazyPage(
+  () => import("@/pages/IntegrationsPage"),
+  "IntegrationsPage"
 );
-const HistoryPage = lazy(() =>
-  import("@/pages/HistoryPage").then(({ HistoryPage }) => ({
-    default: HistoryPage,
-  }))
+const LoginPage = lazyPage(() => import("@/pages/LoginPage"), "LoginPage");
+const NotificationsPage = lazyPage(
+  () => import("@/pages/NotificationsPage"),
+  "NotificationsPage"
 );
-const IntegrationsPage = lazy(() =>
-  import("@/pages/IntegrationsPage").then(({ IntegrationsPage }) => ({
-    default: IntegrationsPage,
-  }))
+const ProfilesPage = lazyPage(
+  () => import("@/pages/ProfilesPage"),
+  "ProfilesPage"
 );
-const LoginPage = lazy(() =>
-  import("@/pages/LoginPage").then(({ LoginPage }) => ({ default: LoginPage }))
+const PublicArtifactSharePage = lazyPage(
+  () => import("@/pages/PublicArtifactSharePage"),
+  "PublicArtifactSharePage"
 );
-const NotificationsPage = lazy(() =>
-  import("@/pages/NotificationsPage").then(({ NotificationsPage }) => ({
-    default: NotificationsPage,
-  }))
+const SettingsPage = lazyPage(
+  () => import("@/pages/SettingsPage"),
+  "SettingsPage"
 );
-const ProfilesPage = lazy(() =>
-  import("@/pages/ProfilesPage").then(({ ProfilesPage }) => ({
-    default: ProfilesPage,
-  }))
+const SetupWizardPage = lazyPage(
+  () => import("@/pages/SetupWizardPage"),
+  "SetupWizardPage"
 );
-const PublicArtifactSharePage = lazy(() =>
-  import("@/pages/PublicArtifactSharePage").then(
-    ({ PublicArtifactSharePage }) => ({ default: PublicArtifactSharePage })
-  )
+const SkillDetailPage = lazyPage(
+  () => import("@/pages/SkillDetailPage"),
+  "SkillDetailPage"
 );
-const SettingsPage = lazy(() =>
-  import("@/pages/SettingsPage").then(({ SettingsPage }) => ({
-    default: SettingsPage,
-  }))
-);
-const SetupWizardPage = lazy(() =>
-  import("@/pages/SetupWizardPage").then(({ SetupWizardPage }) => ({
-    default: SetupWizardPage,
-  }))
-);
-const SkillDetailPage = lazy(() =>
-  import("@/pages/SkillDetailPage").then(({ SkillDetailPage }) => ({
-    default: SkillDetailPage,
-  }))
-);
-const SystemPage = lazy(() =>
-  import("@/pages/SystemPage").then(({ SystemPage }) => ({
-    default: SystemPage,
-  }))
-);
-const ToolPlaygroundPage = lazy(() =>
-  import("@/pages/ToolPlaygroundPage").then(({ ToolPlaygroundPage }) => ({
-    default: ToolPlaygroundPage,
-  }))
+const SystemPage = lazyPage(() => import("@/pages/SystemPage"), "SystemPage");
+const ToolPlaygroundPage = lazyPage(
+  () => import("@/pages/ToolPlaygroundPage"),
+  "ToolPlaygroundPage"
 );
 
 function QueryCacheListener() {
@@ -92,66 +77,76 @@ function AppShell() {
       <AuthProvider>
         <AppQueryPrefetch />
         <AppProvider>
-          <Suspense
-            fallback={
-              <div className="flex h-svh items-center justify-center bg-background">
-                <Spinner className="size-6 text-muted-foreground" />
-              </div>
-            }
-          >
-            <Routes>
-              <Route element={<SetupWizardPage />} path="/setup" />
-              <Route element={<LoginPage />} path="/login" />
-              <Route element={<PublicArtifactSharePage />} path="/s/:token" />
-              <Route element={<AuthGuard />}>
-                <Route element={<SetupGuard />}>
-                  <Route element={<Layout />}>
-                    <Route element={<Navigate replace to="/chat" />} index />
-                    <Route
-                      element={<Navigate replace to={statusTabPath()} />}
-                      path="/status"
-                    />
-                    <Route element={<ChatPage />} path="/chat" />
-                    <Route
-                      element={<ChatPage />}
-                      path="/chat/:profileId/:sessionId"
-                    />
-                    <Route element={<HistoryPage />} path="/history" />
-                    <Route element={<PlatformAdminGuard />}>
-                      <Route element={<FilesPage />} path="/files" />
-                    </Route>
-                    <Route
-                      element={<ToolPlaygroundPage />}
-                      path="/system/playground/:toolId"
-                    />
-                    <Route element={<SystemPage />} path="/system" />
-                    <Route element={<PlatformAdminGuard />}>
-                      <Route element={<ProfilesPage />} path="/profiles" />
-                      <Route
-                        element={<SkillDetailPage />}
-                        path="/profiles/skills/:skillId"
-                      />
-                    </Route>
-                    <Route element={<AutomationsPage />} path="/automations" />
-                    <Route
-                      element={<Navigate replace to="/automations?tab=tasks" />}
-                      path="/tasks"
-                    />
-                    <Route
-                      element={<IntegrationsPage />}
-                      path="/integrations"
-                    />
-                    <Route
-                      element={<NotificationsPage />}
-                      path="/notifications"
-                    />
-                    <Route element={<SettingsPage />} path="/settings" />
-                    <Route element={<Navigate replace to="/chat" />} path="*" />
+          <Routes>
+            <Route
+              element={
+                <RouteBoundary fullScreen>
+                  <SetupWizardPage />
+                </RouteBoundary>
+              }
+              path="/setup"
+            />
+            <Route
+              element={
+                <RouteBoundary fullScreen>
+                  <LoginPage />
+                </RouteBoundary>
+              }
+              path="/login"
+            />
+            <Route
+              element={
+                <RouteBoundary fullScreen>
+                  <PublicArtifactSharePage />
+                </RouteBoundary>
+              }
+              path="/s/:token"
+            />
+            <Route element={<AuthGuard />}>
+              <Route element={<SetupGuard />}>
+                <Route element={<Layout />}>
+                  <Route element={<Navigate replace to="/chat" />} index />
+                  <Route
+                    element={<Navigate replace to={statusTabPath()} />}
+                    path="/status"
+                  />
+                  <Route element={<ChatPage />} path="/chat" />
+                  <Route
+                    element={<ChatPage />}
+                    path="/chat/:profileId/:sessionId"
+                  />
+                  <Route element={<HistoryPage />} path="/history" />
+                  <Route element={<PlatformAdminGuard />}>
+                    <Route element={<FilesPage />} path="/files" />
                   </Route>
+                  <Route
+                    element={<ToolPlaygroundPage />}
+                    path="/system/playground/:toolId"
+                  />
+                  <Route element={<SystemPage />} path="/system" />
+                  <Route element={<PlatformAdminGuard />}>
+                    <Route element={<ProfilesPage />} path="/profiles" />
+                    <Route
+                      element={<SkillDetailPage />}
+                      path="/profiles/skills/:skillId"
+                    />
+                  </Route>
+                  <Route element={<AutomationsPage />} path="/automations" />
+                  <Route
+                    element={<Navigate replace to="/automations?tab=tasks" />}
+                    path="/tasks"
+                  />
+                  <Route element={<IntegrationsPage />} path="/integrations" />
+                  <Route
+                    element={<NotificationsPage />}
+                    path="/notifications"
+                  />
+                  <Route element={<SettingsPage />} path="/settings" />
+                  <Route element={<Navigate replace to="/chat" />} path="*" />
                 </Route>
               </Route>
-            </Routes>
-          </Suspense>
+            </Route>
+          </Routes>
         </AppProvider>
       </AuthProvider>
     </QueryClientProvider>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,29 +1,81 @@
 import { QueryClientProvider } from "@tanstack/react-query";
-import { useEffect } from "react";
+import { lazy, Suspense, useEffect } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 import { AuthGuard } from "@/components/AuthGuard";
 import { Layout } from "@/components/Layout";
 import { PlatformAdminGuard } from "@/components/PlatformAdminGuard";
 import { SetupGuard } from "@/components/SetupGuard";
+import { Spinner } from "@/components/ui/spinner";
 import { AppProvider } from "@/context/app-context";
 import { AuthProvider } from "@/context/auth-context";
 import { AppQueryPrefetch } from "@/hooks/use-app-queries";
 import { statusTabPath } from "@/lib/navigation";
 import { onGlobalQueryError, queryClient } from "@/lib/query-client";
-import { AutomationsPage } from "@/pages/AutomationsPage";
-import { ChatPage } from "@/pages/ChatPage";
-import { FilesPage } from "@/pages/FilesPage";
-import { HistoryPage } from "@/pages/HistoryPage";
-import { IntegrationsPage } from "@/pages/IntegrationsPage";
-import { LoginPage } from "@/pages/LoginPage";
-import { NotificationsPage } from "@/pages/NotificationsPage";
-import { ProfilesPage } from "@/pages/ProfilesPage";
-import { PublicArtifactSharePage } from "@/pages/PublicArtifactSharePage";
-import { SettingsPage } from "@/pages/SettingsPage";
-import { SetupWizardPage } from "@/pages/SetupWizardPage";
-import { SkillDetailPage } from "@/pages/SkillDetailPage";
-import { SystemPage } from "@/pages/SystemPage";
-import { ToolPlaygroundPage } from "@/pages/ToolPlaygroundPage";
+
+const AutomationsPage = lazy(() =>
+  import("@/pages/AutomationsPage").then(({ AutomationsPage }) => ({
+    default: AutomationsPage,
+  }))
+);
+const ChatPage = lazy(() =>
+  import("@/pages/ChatPage").then(({ ChatPage }) => ({ default: ChatPage }))
+);
+const FilesPage = lazy(() =>
+  import("@/pages/FilesPage").then(({ FilesPage }) => ({ default: FilesPage }))
+);
+const HistoryPage = lazy(() =>
+  import("@/pages/HistoryPage").then(({ HistoryPage }) => ({
+    default: HistoryPage,
+  }))
+);
+const IntegrationsPage = lazy(() =>
+  import("@/pages/IntegrationsPage").then(({ IntegrationsPage }) => ({
+    default: IntegrationsPage,
+  }))
+);
+const LoginPage = lazy(() =>
+  import("@/pages/LoginPage").then(({ LoginPage }) => ({ default: LoginPage }))
+);
+const NotificationsPage = lazy(() =>
+  import("@/pages/NotificationsPage").then(({ NotificationsPage }) => ({
+    default: NotificationsPage,
+  }))
+);
+const ProfilesPage = lazy(() =>
+  import("@/pages/ProfilesPage").then(({ ProfilesPage }) => ({
+    default: ProfilesPage,
+  }))
+);
+const PublicArtifactSharePage = lazy(() =>
+  import("@/pages/PublicArtifactSharePage").then(
+    ({ PublicArtifactSharePage }) => ({ default: PublicArtifactSharePage })
+  )
+);
+const SettingsPage = lazy(() =>
+  import("@/pages/SettingsPage").then(({ SettingsPage }) => ({
+    default: SettingsPage,
+  }))
+);
+const SetupWizardPage = lazy(() =>
+  import("@/pages/SetupWizardPage").then(({ SetupWizardPage }) => ({
+    default: SetupWizardPage,
+  }))
+);
+const SkillDetailPage = lazy(() =>
+  import("@/pages/SkillDetailPage").then(({ SkillDetailPage }) => ({
+    default: SkillDetailPage,
+  }))
+);
+const SystemPage = lazy(() =>
+  import("@/pages/SystemPage").then(({ SystemPage }) => ({
+    default: SystemPage,
+  }))
+);
+const ToolPlaygroundPage = lazy(() =>
+  import("@/pages/ToolPlaygroundPage").then(({ ToolPlaygroundPage }) => ({
+    default: ToolPlaygroundPage,
+  }))
+);
 
 function QueryCacheListener() {
   useEffect(() => {
@@ -40,55 +92,66 @@ function AppShell() {
       <AuthProvider>
         <AppQueryPrefetch />
         <AppProvider>
-          <Routes>
-            <Route element={<SetupWizardPage />} path="/setup" />
-            <Route element={<LoginPage />} path="/login" />
-            <Route element={<PublicArtifactSharePage />} path="/s/:token" />
-            <Route element={<AuthGuard />}>
-              <Route element={<SetupGuard />}>
-                <Route element={<Layout />}>
-                  <Route element={<Navigate replace to="/chat" />} index />
-                  <Route
-                    element={<Navigate replace to={statusTabPath()} />}
-                    path="/status"
-                  />
-                  <Route element={<ChatPage />} path="/chat" />
-                  <Route
-                    element={<ChatPage />}
-                    path="/chat/:profileId/:sessionId"
-                  />
-                  <Route element={<HistoryPage />} path="/history" />
-                  <Route element={<PlatformAdminGuard />}>
-                    <Route element={<FilesPage />} path="/files" />
-                  </Route>
-                  <Route
-                    element={<ToolPlaygroundPage />}
-                    path="/system/playground/:toolId"
-                  />
-                  <Route element={<SystemPage />} path="/system" />
-                  <Route element={<PlatformAdminGuard />}>
-                    <Route element={<ProfilesPage />} path="/profiles" />
+          <Suspense
+            fallback={
+              <div className="flex h-svh items-center justify-center bg-background">
+                <Spinner className="size-6 text-muted-foreground" />
+              </div>
+            }
+          >
+            <Routes>
+              <Route element={<SetupWizardPage />} path="/setup" />
+              <Route element={<LoginPage />} path="/login" />
+              <Route element={<PublicArtifactSharePage />} path="/s/:token" />
+              <Route element={<AuthGuard />}>
+                <Route element={<SetupGuard />}>
+                  <Route element={<Layout />}>
+                    <Route element={<Navigate replace to="/chat" />} index />
                     <Route
-                      element={<SkillDetailPage />}
-                      path="/profiles/skills/:skillId"
+                      element={<Navigate replace to={statusTabPath()} />}
+                      path="/status"
                     />
+                    <Route element={<ChatPage />} path="/chat" />
+                    <Route
+                      element={<ChatPage />}
+                      path="/chat/:profileId/:sessionId"
+                    />
+                    <Route element={<HistoryPage />} path="/history" />
+                    <Route element={<PlatformAdminGuard />}>
+                      <Route element={<FilesPage />} path="/files" />
+                    </Route>
+                    <Route
+                      element={<ToolPlaygroundPage />}
+                      path="/system/playground/:toolId"
+                    />
+                    <Route element={<SystemPage />} path="/system" />
+                    <Route element={<PlatformAdminGuard />}>
+                      <Route element={<ProfilesPage />} path="/profiles" />
+                      <Route
+                        element={<SkillDetailPage />}
+                        path="/profiles/skills/:skillId"
+                      />
+                    </Route>
+                    <Route element={<AutomationsPage />} path="/automations" />
+                    <Route
+                      element={<Navigate replace to="/automations?tab=tasks" />}
+                      path="/tasks"
+                    />
+                    <Route
+                      element={<IntegrationsPage />}
+                      path="/integrations"
+                    />
+                    <Route
+                      element={<NotificationsPage />}
+                      path="/notifications"
+                    />
+                    <Route element={<SettingsPage />} path="/settings" />
+                    <Route element={<Navigate replace to="/chat" />} path="*" />
                   </Route>
-                  <Route element={<AutomationsPage />} path="/automations" />
-                  <Route
-                    element={<Navigate replace to="/automations?tab=tasks" />}
-                    path="/tasks"
-                  />
-                  <Route element={<IntegrationsPage />} path="/integrations" />
-                  <Route
-                    element={<NotificationsPage />}
-                    path="/notifications"
-                  />
-                  <Route element={<SettingsPage />} path="/settings" />
-                  <Route element={<Navigate replace to="/chat" />} path="*" />
                 </Route>
               </Route>
-            </Route>
-          </Routes>
+            </Routes>
+          </Suspense>
         </AppProvider>
       </AuthProvider>
     </QueryClientProvider>

--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -5,6 +5,7 @@ import { Link, Outlet, useLocation, useSearchParams } from "react-router-dom";
 import { CommandPalette } from "@/components/CommandPalette";
 import { OrgSwitcher } from "@/components/OrgSwitcher";
 import { ProfileRail } from "@/components/ProfileRail";
+import { RouteBoundary } from "@/components/RouteBoundary";
 import { Button } from "@/components/ui/button";
 import {
   Tooltip,
@@ -165,7 +166,9 @@ export function Layout() {
                   : null
               )}
             >
-              <Outlet />
+              <RouteBoundary key={location.pathname}>
+                <Outlet />
+              </RouteBoundary>
             </main>
           </div>
         </div>

--- a/apps/web/src/components/RouteBoundary.tsx
+++ b/apps/web/src/components/RouteBoundary.tsx
@@ -1,0 +1,75 @@
+import { Component, type ReactNode, Suspense } from "react";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
+
+interface RouteBoundaryProps {
+  children: ReactNode;
+  fullScreen?: boolean;
+}
+
+interface RouteErrorBoundaryState {
+  failed: boolean;
+}
+
+// biome-ignore lint/style/useReactFunctionComponents: React error boundaries require a class component.
+class RouteErrorBoundary extends Component<
+  RouteBoundaryProps,
+  RouteErrorBoundaryState
+> {
+  state: RouteErrorBoundaryState = { failed: false };
+
+  static getDerivedStateFromError(): RouteErrorBoundaryState {
+    return { failed: true };
+  }
+
+  render() {
+    if (this.state.failed) {
+      return <RouteLoadError fullScreen={this.props.fullScreen} />;
+    }
+
+    return this.props.children;
+  }
+}
+
+function RouteLoading({ fullScreen }: { fullScreen?: boolean }) {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-center bg-background",
+        fullScreen ? "h-svh" : "h-full min-h-40"
+      )}
+    >
+      <Spinner className="size-6 text-muted-foreground" />
+    </div>
+  );
+}
+
+function RouteLoadError({ fullScreen }: { fullScreen?: boolean }) {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-center bg-background",
+        fullScreen ? "h-svh" : "h-full min-h-40"
+      )}
+      role="alert"
+    >
+      <div className="flex flex-col items-center gap-3 text-center">
+        <p className="font-medium">This page couldn’t be loaded.</p>
+        <Button onClick={() => window.location.reload()} type="button">
+          Reload
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function RouteBoundary({ children, fullScreen }: RouteBoundaryProps) {
+  return (
+    <RouteErrorBoundary fullScreen={fullScreen}>
+      <Suspense fallback={<RouteLoading fullScreen={fullScreen} />}>
+        {children}
+      </Suspense>
+    </RouteErrorBoundary>
+  );
+}


### PR DESCRIPTION
## Summary

- lazy-load every web page at its existing React Router boundary
- keep the authenticated layout visible while its outlet loads; retain the full-screen fallback for `/login`, `/setup`, and `/s/:token`
- show a reload prompt when a stale deployment chunk cannot be loaded
- keep providers, guards, and the shared layout eager
- use one typed helper for named page exports

Closes #309.

## Bundle results

Measured from production builds at `041942ad` using `bun x vite build --manifest`:

| Payload | Before | After |
| --- | ---: | ---: |
| Initial entry, minified | 3,166.09 kB | 768.21 kB |
| Initial entry, gzip | 904.71 kB | 238.14 kB |
| Login route total, gzip | ~899 kB | 239.31 kB |
| Setup route total, gzip | ~899 kB | 274.70 kB |
| Profiles route total, gzip | ~899 kB | 286.90 kB |
| Chat route total, gzip | ~899 kB | 770.76 kB |

The final initial entry is 75.7% smaller minified and 73.7% smaller gzip.

Deep barrel/icon import rewrites are excluded because isolated production probes produced identical 4,055-byte gzip output for `hugeicons-react` root and deep imports.

### First chat render

I compared the current lazy behavior with a post-mount `import()` warm-up over five cold-profile runs under the same synthetic Chrome profile (1.6 Mbps, 100 ms latency, 4x CPU slowdown):

| Variant | Median first chat render |
| --- | ---: |
| Lazy on navigation | 34.79 s |
| Warm after mount | 34.81 s |

The 0.02 s difference is noise, so the final code keeps Chat lazy rather than downloading its graph for authenticated visits that do not open Chat.

## Verification

- `bun x tsc --noEmit`
- `bun x vite build --manifest`
- `bun run --filter @nakama/web test` - 275 passed
- `bun x ultracite check apps/web/src/App.tsx apps/web/src/components/Layout.tsx apps/web/src/components/RouteBoundary.tsx`
- `bun run doctor` - 90/100, with the same seven existing findings outside the changed files
- production Chrome smoke tests with the built Chat chunk deliberately unavailable: authenticated `/chat` kept the layout and showed the reload prompt; public `/login` showed the full-screen reload prompt
- all 14 dynamic page chunks are present in the final production build

## Local environment notes

The repository-wide Ultracite command reports the Windows checkout's existing CRLF files. The full test command also reaches unrelated Windows path/locking failures in core Telegram fixtures and the SQLite reopen test. The changed files, web test suite, type check, production build, and browser smoke tests pass.
