### PR TITLE
feat(coding-agent): optional harness-native vendor login

### DIFF
--- a/apps/server/src/http/app.ts
+++ b/apps/server/src/http/app.ts
@@ -8,6 +8,7 @@ import { createOrgContextMiddleware } from "./org-middleware";
 import { registerArtifactShareRoutes } from "./routes/artifact-shares";
 import { registerAuthRoutes } from "./routes/auth";
 import { registerAutomationRoutes } from "./routes/automations";
+import { registerCodingHarnessSettingsRoutes } from "./routes/coding-harnesses";
 import {
   registerComposioOAuthRoutes,
   registerComposioRoutes,
@@ -117,6 +118,7 @@ export function createHonoApp(options: ServerOptions) {
   registerAutomationRoutes(app, options);
   registerNotificationDestinationRoutes(app, options);
   registerTokenOptimizationRoutes(app, options);
+  registerCodingHarnessSettingsRoutes(app, options);
   registerComposioRoutes(app, options);
   registerTaskRoutes(app, options);
   registerPlatformOrgRoutes(app, options);

--- a/apps/server/src/http/coding-harnesses.test.ts
+++ b/apps/server/src/http/coding-harnesses.test.ts
@@ -8,9 +8,29 @@ import { AuthService } from "../services/auth-service";
 import { OrgService } from "../services/org-service";
 import { createHonoApp } from "./app";
 import {
+  loginPlatformAdminSession,
   loginUserSession,
   setupFreshInstallSession,
 } from "./test-session-helpers";
+
+function createHarnessApp() {
+  const databaseAdapter = createInMemoryDatabaseAdapter();
+  const authService = new AuthService();
+  const app = createHonoApp({
+    agent: new AgentService(null, null, databaseAdapter),
+    authService,
+    automationService: {} as never,
+    databaseAdapter,
+    mcpService: {} as never,
+    orgService: new OrgService(databaseAdapter, authService),
+    systemStatus: { getStatus: async () => ({ ok: true }) } as never,
+    taskService: {} as never,
+    webDistDir: null,
+    workerManager: {} as never,
+  });
+
+  return { app, authService, databaseAdapter };
+}
 
 describe("coding harness settings routes", () => {
   let configDir = "";
@@ -28,20 +48,7 @@ describe("coding harness settings routes", () => {
     configDir = await mkdtemp(join(tmpdir(), "nakama-coding-harness-route-"));
     process.env.NAKAMA_CONFIG_DIR = configDir;
 
-    const databaseAdapter = createInMemoryDatabaseAdapter();
-    const authService = new AuthService();
-    const app = createHonoApp({
-      agent: new AgentService(null, null, databaseAdapter),
-      authService,
-      automationService: {} as never,
-      databaseAdapter,
-      mcpService: {} as never,
-      orgService: new OrgService(databaseAdapter, authService),
-      systemStatus: { getStatus: async () => ({ ok: true }) } as never,
-      taskService: {} as never,
-      webDistDir: null,
-      workerManager: {} as never,
-    });
+    const { app, databaseAdapter } = createHarnessApp();
 
     const session = await setupFreshInstallSession(app, databaseAdapter);
 
@@ -94,21 +101,7 @@ describe("coding harness settings routes", () => {
     configDir = await mkdtemp(join(tmpdir(), "nakama-coding-harness-member-"));
     process.env.NAKAMA_CONFIG_DIR = configDir;
 
-    const databaseAdapter = createInMemoryDatabaseAdapter();
-    const authService = new AuthService();
-    const app = createHonoApp({
-      agent: new AgentService(null, null, databaseAdapter),
-      authService,
-      automationService: {} as never,
-      databaseAdapter,
-      mcpService: {} as never,
-      orgService: new OrgService(databaseAdapter, authService),
-      systemStatus: { getStatus: async () => ({ ok: true }) } as never,
-      taskService: {} as never,
-      webDistDir: null,
-      workerManager: {} as never,
-    });
-
+    const { app, databaseAdapter } = createHarnessApp();
     const adminSession = await setupFreshInstallSession(app, databaseAdapter);
     const orgId = adminSession.orgId!;
 
@@ -168,6 +161,55 @@ describe("coding harness settings routes", () => {
     );
     expect(adminPut.status).toBe(200);
     const saved = (await adminPut.json()) as {
+      providerPassthroughEnabled: boolean;
+    };
+    expect(saved.providerPassthroughEnabled).toBe(false);
+  });
+
+  test("a platform admin who is only an org member can write the setting", async () => {
+    configDir = await mkdtemp(
+      join(tmpdir(), "nakama-coding-harness-platform-")
+    );
+    process.env.NAKAMA_CONFIG_DIR = configDir;
+
+    const { app, authService, databaseAdapter } = createHarnessApp();
+    const adminSession = await setupFreshInstallSession(app, databaseAdapter);
+    const orgId = adminSession.orgId!;
+
+    await loginPlatformAdminSession(app, authService, databaseAdapter);
+    const platformUser = await databaseAdapter.getUserByEmail(
+      "platform@example.com"
+    );
+    if (!platformUser) {
+      throw new Error("platform admin user missing");
+    }
+
+    await databaseAdapter.upsertOrgMember({
+      createdAt: new Date().toISOString(),
+      orgId,
+      role: "member",
+      userId: platformUser.id,
+    });
+
+    const platformSession = await loginUserSession(
+      app,
+      "platform@example.com",
+      "password123",
+      orgId
+    );
+
+    const putResponse = await app.fetch(
+      new Request("http://localhost:4310/v1/settings/coding-harnesses", {
+        body: JSON.stringify({ providerPassthroughEnabled: false }),
+        headers: platformSession.headers({
+          "Content-Type": "application/json",
+          "X-CSRF-Token": platformSession.csrfToken,
+        }),
+        method: "PUT",
+      })
+    );
+    expect(putResponse.status).toBe(200);
+    const saved = (await putResponse.json()) as {
       providerPassthroughEnabled: boolean;
     };
     expect(saved.providerPassthroughEnabled).toBe(false);

--- a/apps/server/src/http/coding-harnesses.test.ts
+++ b/apps/server/src/http/coding-harnesses.test.ts
@@ -7,7 +7,10 @@ import { AgentService } from "../services/agent-service";
 import { AuthService } from "../services/auth-service";
 import { OrgService } from "../services/org-service";
 import { createHonoApp } from "./app";
-import { setupFreshInstallSession } from "./test-session-helpers";
+import {
+  loginUserSession,
+  setupFreshInstallSession,
+} from "./test-session-helpers";
 
 describe("coding harness settings routes", () => {
   let configDir = "";
@@ -85,5 +88,88 @@ describe("coding harness settings routes", () => {
       providerPassthroughEnabled: boolean;
     };
     expect(savedBody.providerPassthroughEnabled).toBe(false);
+  });
+
+  test("org members can read coding harness settings but cannot write them", async () => {
+    configDir = await mkdtemp(join(tmpdir(), "nakama-coding-harness-member-"));
+    process.env.NAKAMA_CONFIG_DIR = configDir;
+
+    const databaseAdapter = createInMemoryDatabaseAdapter();
+    const authService = new AuthService();
+    const app = createHonoApp({
+      agent: new AgentService(null, null, databaseAdapter),
+      authService,
+      automationService: {} as never,
+      databaseAdapter,
+      mcpService: {} as never,
+      orgService: new OrgService(databaseAdapter, authService),
+      systemStatus: { getStatus: async () => ({ ok: true }) } as never,
+      taskService: {} as never,
+      webDistDir: null,
+      workerManager: {} as never,
+    });
+
+    const adminSession = await setupFreshInstallSession(app, databaseAdapter);
+    const orgId = adminSession.orgId!;
+
+    const memberResp = await app.fetch(
+      new Request(`http://localhost:4310/v1/orgs/${orgId}/members`, {
+        body: JSON.stringify({
+          email: "member@example.com",
+          name: "Member",
+          role: "member",
+        }),
+        headers: adminSession.headers({
+          "Content-Type": "application/json",
+          "X-CSRF-Token": adminSession.csrfToken,
+        }),
+        method: "POST",
+      })
+    );
+    expect(memberResp.status).toBe(201);
+    const memberProvisioned = (await memberResp.json()) as {
+      temporaryPassword: string;
+    };
+    const memberSession = await loginUserSession(
+      app,
+      "member@example.com",
+      memberProvisioned.temporaryPassword,
+      orgId
+    );
+
+    const memberGet = await app.fetch(
+      new Request("http://localhost:4310/v1/settings/coding-harnesses", {
+        headers: memberSession.headers(),
+      })
+    );
+    expect(memberGet.status).toBe(200);
+
+    const memberPut = await app.fetch(
+      new Request("http://localhost:4310/v1/settings/coding-harnesses", {
+        body: JSON.stringify({ providerPassthroughEnabled: false }),
+        headers: memberSession.headers({
+          "Content-Type": "application/json",
+          "X-CSRF-Token": memberSession.csrfToken,
+        }),
+        method: "PUT",
+      })
+    );
+    expect(memberPut.status).toBe(403);
+
+    const adminPut = await app.fetch(
+      new Request("http://localhost:4310/v1/settings/coding-harnesses", {
+        body: JSON.stringify({ providerPassthroughEnabled: false }),
+        headers: adminSession.headers({
+          "Content-Type": "application/json",
+          "X-CSRF-Token": adminSession.csrfToken,
+        }),
+        method: "PUT",
+      })
+    );
+    expect(adminPut.status).toBe(200);
+    const saved = (await adminPut.json()) as {
+      providerPassthroughEnabled: boolean;
+    };
+    expect(saved.providerPassthroughEnabled).toBe(false);
   });
 });

--- a/apps/server/src/http/coding-harnesses.test.ts
+++ b/apps/server/src/http/coding-harnesses.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createInMemoryDatabaseAdapter } from "@nakama/db";
+import { AgentService } from "../services/agent-service";
+import { AuthService } from "../services/auth-service";
+import { OrgService } from "../services/org-service";
+import { createHonoApp } from "./app";
+import { setupFreshInstallSession } from "./test-session-helpers";
+
+describe("coding harness settings routes", () => {
+  let configDir = "";
+
+  afterEach(async () => {
+    if (configDir) {
+      await rm(configDir, { force: true, recursive: true });
+      configDir = "";
+    }
+
+    delete process.env.NAKAMA_CONFIG_DIR;
+  });
+
+  test("defaults to Nakama provider passthrough and can switch to harness login", async () => {
+    configDir = await mkdtemp(join(tmpdir(), "nakama-coding-harness-route-"));
+    process.env.NAKAMA_CONFIG_DIR = configDir;
+
+    const databaseAdapter = createInMemoryDatabaseAdapter();
+    const authService = new AuthService();
+    const app = createHonoApp({
+      agent: new AgentService(null, null, databaseAdapter),
+      authService,
+      automationService: {} as never,
+      databaseAdapter,
+      mcpService: {} as never,
+      orgService: new OrgService(databaseAdapter, authService),
+      systemStatus: { getStatus: async () => ({ ok: true }) } as never,
+      taskService: {} as never,
+      webDistDir: null,
+      workerManager: {} as never,
+    });
+
+    const session = await setupFreshInstallSession(app, databaseAdapter);
+
+    const getDefault = await app.fetch(
+      new Request("http://localhost:4310/v1/settings/coding-harnesses", {
+        headers: session.headers(),
+      })
+    );
+    expect(getDefault.status).toBe(200);
+    const defaultBody = (await getDefault.json()) as {
+      providerPassthroughEnabled: boolean;
+      loginCommands: Array<{ command: string; name: string }>;
+    };
+    expect(defaultBody.providerPassthroughEnabled).toBe(true);
+    expect(defaultBody.loginCommands.map((item) => item.command)).toEqual([
+      "codex login",
+      "claude auth login",
+      "opencode auth login",
+      "pi login",
+    ]);
+
+    const putResponse = await app.fetch(
+      new Request("http://localhost:4310/v1/settings/coding-harnesses", {
+        body: JSON.stringify({ providerPassthroughEnabled: false }),
+        headers: session.headers({
+          "Content-Type": "application/json",
+          "X-CSRF-Token": session.csrfToken,
+        }),
+        method: "PUT",
+      })
+    );
+    expect(putResponse.status).toBe(200);
+    const saved = (await putResponse.json()) as {
+      providerPassthroughEnabled: boolean;
+    };
+    expect(saved.providerPassthroughEnabled).toBe(false);
+
+    const getSaved = await app.fetch(
+      new Request("http://localhost:4310/v1/settings/coding-harnesses", {
+        headers: session.headers(),
+      })
+    );
+    const savedBody = (await getSaved.json()) as {
+      providerPassthroughEnabled: boolean;
+    };
+    expect(savedBody.providerPassthroughEnabled).toBe(false);
+  });
+});

--- a/apps/server/src/http/routes/coding-harnesses.ts
+++ b/apps/server/src/http/routes/coding-harnesses.ts
@@ -1,0 +1,68 @@
+import { NakamaApiError } from "@nakama/core";
+import {
+  getCodingHarnessLoginCommand,
+  loadCodingAgentWorkspaceSettings,
+  saveCodingAgentWorkspaceSettings,
+} from "../../services/coding-agent-harness-service";
+import type { ServerOptions } from "../context";
+import {
+  requireActiveOrgIdFromContext,
+  requireOrgAdminFromContext,
+} from "../org-guards";
+import { json, readJson } from "../shared";
+import type { HonoApp } from "../types";
+
+const HARNESS_LOGIN_ORDER = [
+  { kind: "codex" as const, name: "Codex" },
+  { kind: "claude_code" as const, name: "Claude Code" },
+  { kind: "opencode" as const, name: "OpenCode" },
+  { kind: "pi" as const, name: "pi" },
+];
+
+function loginCommands() {
+  return HARNESS_LOGIN_ORDER.flatMap((harness) => {
+    const command = getCodingHarnessLoginCommand(harness.kind);
+    return command ? [{ command, name: harness.name }] : [];
+  });
+}
+
+export function registerCodingHarnessSettingsRoutes(
+  app: HonoApp,
+  options: ServerOptions
+): void {
+  app.get("/v1/settings/coding-harnesses", async (c) => {
+    requireActiveOrgIdFromContext(c);
+    const settings = await loadCodingAgentWorkspaceSettings(
+      options.databaseAdapter
+    );
+
+    return json({
+      loginCommands: loginCommands(),
+      providerPassthroughEnabled: settings.providerPassthroughEnabled,
+    });
+  });
+
+  app.put("/v1/settings/coding-harnesses", async (c) => {
+    requireOrgAdminFromContext(c);
+    const body = await readJson<{ providerPassthroughEnabled?: boolean }>(
+      c.req.raw
+    );
+
+    if (typeof body.providerPassthroughEnabled !== "boolean") {
+      throw new NakamaApiError(
+        "providerPassthroughEnabled must be a boolean.",
+        400
+      );
+    }
+
+    const settings = await saveCodingAgentWorkspaceSettings(
+      options.databaseAdapter,
+      { providerPassthroughEnabled: body.providerPassthroughEnabled }
+    );
+
+    return json({
+      loginCommands: loginCommands(),
+      providerPassthroughEnabled: settings.providerPassthroughEnabled,
+    });
+  });
+}

--- a/apps/server/src/http/routes/coding-harnesses.ts
+++ b/apps/server/src/http/routes/coding-harnesses.ts
@@ -1,30 +1,16 @@
 import { NakamaApiError } from "@nakama/core";
 import {
-  getCodingHarnessLoginCommand,
+  listCodingHarnessLoginCommands,
   loadCodingAgentWorkspaceSettings,
   saveCodingAgentWorkspaceSettings,
 } from "../../services/coding-agent-harness-service";
 import type { ServerOptions } from "../context";
 import {
   requireActiveOrgIdFromContext,
-  requireOrgAdminFromContext,
+  requireOrgAdminOrPlatformAdminFromContext,
 } from "../org-guards";
 import { json, readJson } from "../shared";
 import type { HonoApp } from "../types";
-
-const HARNESS_LOGIN_ORDER = [
-  { kind: "codex" as const, name: "Codex" },
-  { kind: "claude_code" as const, name: "Claude Code" },
-  { kind: "opencode" as const, name: "OpenCode" },
-  { kind: "pi" as const, name: "pi" },
-];
-
-function loginCommands() {
-  return HARNESS_LOGIN_ORDER.flatMap((harness) => {
-    const command = getCodingHarnessLoginCommand(harness.kind);
-    return command ? [{ command, name: harness.name }] : [];
-  });
-}
 
 export function registerCodingHarnessSettingsRoutes(
   app: HonoApp,
@@ -37,13 +23,15 @@ export function registerCodingHarnessSettingsRoutes(
     );
 
     return json({
-      loginCommands: loginCommands(),
+      loginCommands: listCodingHarnessLoginCommands(),
       providerPassthroughEnabled: settings.providerPassthroughEnabled,
     });
   });
 
   app.put("/v1/settings/coding-harnesses", async (c) => {
-    requireOrgAdminFromContext(c);
+    // Workspace-global, same bar as other install-wide settings (#305).
+    // Per-org isolation of this flag is #307.
+    requireOrgAdminOrPlatformAdminFromContext(c);
     const body = await readJson<{ providerPassthroughEnabled?: boolean }>(
       c.req.raw
     );
@@ -61,7 +49,7 @@ export function registerCodingHarnessSettingsRoutes(
     );
 
     return json({
-      loginCommands: loginCommands(),
+      loginCommands: listCodingHarnessLoginCommands(),
       providerPassthroughEnabled: settings.providerPassthroughEnabled,
     });
   });

--- a/apps/server/src/http/routes/token-optimization.ts
+++ b/apps/server/src/http/routes/token-optimization.ts
@@ -6,6 +6,7 @@ import {
   type OmniInstallResult,
   OPTIMIZER_ID,
 } from "@nakama/core";
+import { mergeWorkspaceSettings } from "@nakama/db";
 import type { ServerOptions } from "../context";
 import {
   requireActiveOrgIdFromContext,
@@ -155,16 +156,12 @@ export function registerTokenOptimizationRoutes(
     const enabled = Boolean(body.enabled);
     const existing = await options.databaseAdapter.getWorkspaceSettings();
 
-    await options.databaseAdapter.upsertWorkspaceSettings({
-      codingAgentHarnesses: existing?.codingAgentHarnesses ?? [],
-      id: existing?.id ?? "default",
-      imageModel: existing?.imageModel ?? null,
-      selectedCodingAgentHarness: existing?.selectedCodingAgentHarness ?? null,
-      tokenOptimizerEnabled: enabled,
-      transcriptionModel: existing?.transcriptionModel ?? null,
-      updatedAt: new Date().toISOString(),
-      visionModel: existing?.visionModel ?? null,
-    });
+    await options.databaseAdapter.upsertWorkspaceSettings(
+      mergeWorkspaceSettings(existing, {
+        tokenOptimizerEnabled: enabled,
+        updatedAt: new Date().toISOString(),
+      })
+    );
 
     // Switching it on when the binary is absent used to save a setting that did
     // nothing. Fetch it instead, and report the failure to the operator who

--- a/apps/server/src/services/agent-service.test.ts
+++ b/apps/server/src/services/agent-service.test.ts
@@ -267,6 +267,43 @@ describe("AgentService vision settings", () => {
       vision: { model: "p-openai-1::gpt-4o-mini" },
     });
   });
+
+  test("does not reset coding-agent passthrough when vision is saved", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    await db.upsertWorkspaceSettings({
+      codingAgentHarnesses: [],
+      codingAgentProviderPassthrough: false,
+      id: "workspace-settings",
+      imageModel: null,
+      selectedCodingAgentHarness: null,
+      transcriptionModel: null,
+      updatedAt: new Date().toISOString(),
+      visionModel: null,
+    });
+    const service = new AgentService(
+      {
+        defaultProviderId: "p-openai-1",
+        providers: [
+          {
+            apiKey: "test-key",
+            createdAt: new Date().toISOString(),
+            id: "p-openai-1",
+            label: "OpenAI",
+            type: "openai",
+          },
+        ],
+      },
+      null,
+      db
+    );
+
+    await service.setVisionSettings({ model: "p-openai-1::gpt-4o-mini" });
+
+    expect(await db.getWorkspaceSettings()).toMatchObject({
+      codingAgentProviderPassthrough: false,
+      visionModel: "p-openai-1::gpt-4o-mini",
+    });
+  });
 });
 
 describe("AgentService transcription settings", () => {
@@ -301,6 +338,45 @@ describe("AgentService transcription settings", () => {
     });
     expect(await service.getTranscriptionSettings()).toEqual({
       transcription: { model: "p-openai-1::whisper-1" },
+    });
+  });
+
+  test("does not reset coding-agent passthrough when transcription is saved", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    await db.upsertWorkspaceSettings({
+      codingAgentHarnesses: [],
+      codingAgentProviderPassthrough: false,
+      id: "workspace-settings",
+      imageModel: null,
+      selectedCodingAgentHarness: null,
+      transcriptionModel: null,
+      updatedAt: new Date().toISOString(),
+      visionModel: null,
+    });
+    const service = new AgentService(
+      {
+        defaultProviderId: "p-openai-1",
+        providers: [
+          {
+            apiKey: "test-key",
+            createdAt: new Date().toISOString(),
+            id: "p-openai-1",
+            label: "OpenAI",
+            type: "openai",
+          },
+        ],
+      },
+      null,
+      db
+    );
+
+    await service.setTranscriptionSettings({
+      model: "p-openai-1::whisper-1",
+    });
+
+    expect(await db.getWorkspaceSettings()).toMatchObject({
+      codingAgentProviderPassthrough: false,
+      transcriptionModel: "p-openai-1::whisper-1",
     });
   });
 });

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -164,10 +164,10 @@ import {
 import { canAccessSuperBotProfile } from "@nakama/core/profiles";
 import {
   type DatabaseAdapter,
+  mergeWorkspaceSettings,
   type StoredProfileRecord,
   type StoredTaskRunRecord,
   SUPER_BOT_TOOL_AUTHORING_RULES,
-  WORKSPACE_SETTINGS_ID,
 } from "@nakama/db";
 import {
   AVAILABLE_MODELS,
@@ -633,18 +633,17 @@ export class AgentService {
 
     const vision: VisionSettings = { model };
     const existing = await this.db.getWorkspaceSettings();
-    await this.db.upsertWorkspaceSettings({
-      codingAgentHarnesses: existing?.codingAgentHarnesses ?? [],
-      id: WORKSPACE_SETTINGS_ID,
-      imageModel: existing?.imageModel ?? this.userConfig?.imageModel ?? null,
-      selectedCodingAgentHarness: existing?.selectedCodingAgentHarness ?? null,
-      transcriptionModel:
-        existing?.transcriptionModel ??
-        this.userConfig?.transcriptionModel ??
-        null,
-      updatedAt: new Date().toISOString(),
-      visionModel: model,
-    });
+    await this.db.upsertWorkspaceSettings(
+      mergeWorkspaceSettings(existing, {
+        imageModel: existing?.imageModel ?? this.userConfig?.imageModel ?? null,
+        transcriptionModel:
+          existing?.transcriptionModel ??
+          this.userConfig?.transcriptionModel ??
+          null,
+        updatedAt: new Date().toISOString(),
+        visionModel: model,
+      })
+    );
 
     if (this.userConfig) {
       this.userConfig = {
@@ -688,16 +687,15 @@ export class AgentService {
 
     const transcription: TranscriptionSettings = { model };
     const existing = await this.db.getWorkspaceSettings();
-    await this.db.upsertWorkspaceSettings({
-      codingAgentHarnesses: existing?.codingAgentHarnesses ?? [],
-      id: WORKSPACE_SETTINGS_ID,
-      imageModel: existing?.imageModel ?? this.userConfig?.imageModel ?? null,
-      selectedCodingAgentHarness: existing?.selectedCodingAgentHarness ?? null,
-      transcriptionModel: model,
-      updatedAt: new Date().toISOString(),
-      visionModel:
-        existing?.visionModel ?? this.userConfig?.visionModel ?? null,
-    });
+    await this.db.upsertWorkspaceSettings(
+      mergeWorkspaceSettings(existing, {
+        imageModel: existing?.imageModel ?? this.userConfig?.imageModel ?? null,
+        transcriptionModel: model,
+        updatedAt: new Date().toISOString(),
+        visionModel:
+          existing?.visionModel ?? this.userConfig?.visionModel ?? null,
+      })
+    );
 
     if (this.userConfig) {
       this.userConfig = {
@@ -782,15 +780,14 @@ export class AgentService {
       (await loadUserTranscriptionSettings()).model ??
       null;
 
-    await this.db.upsertWorkspaceSettings({
-      codingAgentHarnesses: stored?.codingAgentHarnesses ?? [],
-      id: WORKSPACE_SETTINGS_ID,
-      imageModel: this.userConfig?.imageModel ?? null,
-      selectedCodingAgentHarness: stored?.selectedCodingAgentHarness ?? null,
-      transcriptionModel: legacyModel,
-      updatedAt: new Date().toISOString(),
-      visionModel: this.userConfig?.visionModel ?? null,
-    });
+    await this.db.upsertWorkspaceSettings(
+      mergeWorkspaceSettings(stored, {
+        imageModel: this.userConfig?.imageModel ?? null,
+        transcriptionModel: legacyModel,
+        updatedAt: new Date().toISOString(),
+        visionModel: this.userConfig?.visionModel ?? null,
+      })
+    );
 
     if (this.userConfig) {
       this.userConfig = { ...this.userConfig, transcriptionModel: legacyModel };
@@ -822,19 +819,18 @@ export class AgentService {
 
     const imageGeneration: ImageGenerationSettings = { model };
     const existing = await this.db.getWorkspaceSettings();
-    await this.db.upsertWorkspaceSettings({
-      codingAgentHarnesses: existing?.codingAgentHarnesses ?? [],
-      id: WORKSPACE_SETTINGS_ID,
-      imageModel: model,
-      selectedCodingAgentHarness: existing?.selectedCodingAgentHarness ?? null,
-      transcriptionModel:
-        existing?.transcriptionModel ??
-        this.userConfig?.transcriptionModel ??
-        null,
-      updatedAt: new Date().toISOString(),
-      visionModel:
-        existing?.visionModel ?? this.userConfig?.visionModel ?? null,
-    });
+    await this.db.upsertWorkspaceSettings(
+      mergeWorkspaceSettings(existing, {
+        imageModel: model,
+        transcriptionModel:
+          existing?.transcriptionModel ??
+          this.userConfig?.transcriptionModel ??
+          null,
+        updatedAt: new Date().toISOString(),
+        visionModel:
+          existing?.visionModel ?? this.userConfig?.visionModel ?? null,
+      })
+    );
 
     if (this.userConfig) {
       this.userConfig = {
@@ -916,15 +912,14 @@ export class AgentService {
 
     const legacyModel = this.userConfig?.imageModel ?? null;
 
-    await this.db.upsertWorkspaceSettings({
-      codingAgentHarnesses: [],
-      id: WORKSPACE_SETTINGS_ID,
-      imageModel: legacyModel,
-      selectedCodingAgentHarness: null,
-      transcriptionModel: this.userConfig?.transcriptionModel ?? null,
-      updatedAt: new Date().toISOString(),
-      visionModel: this.userConfig?.visionModel ?? null,
-    });
+    await this.db.upsertWorkspaceSettings(
+      mergeWorkspaceSettings(null, {
+        imageModel: legacyModel,
+        transcriptionModel: this.userConfig?.transcriptionModel ?? null,
+        updatedAt: new Date().toISOString(),
+        visionModel: this.userConfig?.visionModel ?? null,
+      })
+    );
 
     if (this.userConfig) {
       this.userConfig = { ...this.userConfig, imageModel: legacyModel };
@@ -968,15 +963,14 @@ export class AgentService {
       null;
     const legacyImageModel = this.userConfig?.imageModel ?? null;
 
-    await this.db.upsertWorkspaceSettings({
-      codingAgentHarnesses: stored?.codingAgentHarnesses ?? [],
-      id: WORKSPACE_SETTINGS_ID,
-      imageModel: legacyImageModel,
-      selectedCodingAgentHarness: stored?.selectedCodingAgentHarness ?? null,
-      transcriptionModel: legacyTranscriptionModel,
-      updatedAt: new Date().toISOString(),
-      visionModel: legacyVisionModel,
-    });
+    await this.db.upsertWorkspaceSettings(
+      mergeWorkspaceSettings(stored, {
+        imageModel: legacyImageModel,
+        transcriptionModel: legacyTranscriptionModel,
+        updatedAt: new Date().toISOString(),
+        visionModel: legacyVisionModel,
+      })
+    );
 
     if (this.userConfig) {
       this.userConfig = {

--- a/apps/server/src/services/coding-agent-bash-env.test.ts
+++ b/apps/server/src/services/coding-agent-bash-env.test.ts
@@ -203,4 +203,51 @@ describe("enrichCodingAgentBashInput", () => {
     expect(enriched.env?.ANTHROPIC_API_KEY).toBeUndefined();
     expect(enriched.env?.OPENAI_API_KEY).toBeUndefined();
   });
+
+  test("does not merge provider credentials when harness-native login is enabled", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    await db.upsertWorkspaceSettings({
+      codingAgentHarnesses: [
+        {
+          args: [],
+          command: "echo",
+          enabled: true,
+          id: "coding-harness-claude-code",
+          kind: "claude_code",
+          name: "Claude Code",
+        },
+      ],
+      codingAgentProviderPassthrough: false,
+      id: "workspace-settings",
+      imageModel: null,
+      selectedCodingAgentHarness: null,
+      transcriptionModel: null,
+      updatedAt: new Date().toISOString(),
+      visionModel: null,
+    });
+    await db.upsertProfile({
+      createdAt: new Date().toISOString(),
+      id: "profile_test",
+      isDefault: true,
+      isSuper: false,
+      model: "anthropic:claude-sonnet-4-6",
+      name: "Test",
+      orgId: "org_test",
+      systemPrompt: "test",
+      updatedAt: new Date().toISOString(),
+    });
+
+    const enriched = (await enrichCodingAgentBashInput(
+      db,
+      { command: "echo hello" },
+      { orgId: "org_test", profileId: "profile_test" },
+      {
+        defaultProviderId: anthropicProvider.id,
+        providers: [anthropicProvider],
+      }
+    )) as { env?: Record<string, string>; codingAgent?: boolean };
+
+    expect(enriched.codingAgent).toBe(true);
+    expect(enriched.env?.ANTHROPIC_API_KEY).toBeUndefined();
+  });
 });

--- a/apps/server/src/services/coding-agent-bash-env.ts
+++ b/apps/server/src/services/coding-agent-bash-env.ts
@@ -62,8 +62,20 @@ export async function enrichCodingAgentBashInput(
       : null;
   const harness = await resolveCodingAgentHarness(db, inferredKind, {
     profileModel,
+    providerPassthroughEnabled: workspace.providerPassthroughEnabled,
     userConfig,
   });
+
+  if (
+    !workspace.providerPassthroughEnabled ||
+    harness.kind === "cursor_agent"
+  ) {
+    return {
+      ...record,
+      codingAgent: true,
+    };
+  }
+
   const { spawn } = await resolveCodingAgentSpawnBundle({
     harnessKind: harness.kind,
     profileModel,

--- a/apps/server/src/services/coding-agent-harness-service.test.ts
+++ b/apps/server/src/services/coding-agent-harness-service.test.ts
@@ -8,10 +8,20 @@ import {
   inferCodingAgentHarnessKind,
   isCodingAgentCommand,
   listCodingAgentHarnessStatuses,
+  listCodingHarnessLoginCommands,
   refreshCodingAgentHarnessProbe,
 } from "./coding-agent-harness-service";
 
 describe("coding-agent harness resolution", () => {
+  test("login commands follow default harnesses that support vendor login", () => {
+    expect(listCodingHarnessLoginCommands()).toEqual([
+      { command: "codex login", name: "Codex" },
+      { command: "claude auth login", name: "Claude Code" },
+      { command: "opencode auth login", name: "OpenCode" },
+      { command: "pi login", name: "pi.dev" },
+    ]);
+  });
+
   test("detects harness-shaped bash commands", () => {
     const harnesses = [
       { command: "claude", enabled: true },

--- a/apps/server/src/services/coding-agent-harness-service.test.ts
+++ b/apps/server/src/services/coding-agent-harness-service.test.ts
@@ -91,6 +91,38 @@ describe("coding-agent harness resolution", () => {
     expect(cursor?.statusMessage).toMatch(/host Cursor auth/i);
   });
 
+  test("marks a harness ready without Nakama provider when passthrough is off", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    await db.upsertWorkspaceSettings({
+      codingAgentHarnesses: [
+        {
+          args: [],
+          command: "echo",
+          enabled: true,
+          id: "coding-harness-codex",
+          kind: "codex",
+          name: "Codex",
+        },
+      ],
+      codingAgentProviderPassthrough: false,
+      id: "workspace-settings",
+      imageModel: null,
+      selectedCodingAgentHarness: null,
+      transcriptionModel: null,
+      updatedAt: new Date().toISOString(),
+      visionModel: null,
+    });
+
+    const statuses = await listCodingAgentHarnessStatuses(db);
+    const codex = statuses.find(
+      (harness) => harness.id === "coding-harness-codex"
+    );
+    expect(codex?.installed).toBe(true);
+    expect(codex?.ready).toBe(true);
+    expect(codex?.statusMessage).toMatch(/codex login/i);
+    expect(codex?.statusMessage).not.toMatch(/Settings → Provider/);
+  });
+
   test("refreshCodingAgentHarnessProbe persists cached readiness", async () => {
     const db = createInMemoryDatabaseAdapter();
     await db.upsertWorkspaceSettings({

--- a/apps/server/src/services/coding-agent-harness-service.ts
+++ b/apps/server/src/services/coding-agent-harness-service.ts
@@ -8,7 +8,10 @@ import type {
   StoredCodingAgentHarnessProbeCache,
   StoredCodingAgentHarnessRecord,
 } from "@nakama/db";
-import { WORKSPACE_SETTINGS_ID } from "@nakama/db";
+import {
+  isCodingAgentProviderPassthroughEnabled,
+  mergeWorkspaceSettings,
+} from "@nakama/db";
 import {
   ensureBunGlobalInstallDirs,
   ensureProcessPath,
@@ -92,6 +95,7 @@ export function buildCodingHarnessInstallPlan(
 
 export interface CodingAgentWorkspaceSettings {
   harnesses: StoredCodingAgentHarnessRecord[];
+  providerPassthroughEnabled: boolean;
   selectedHarnessId: string | null;
 }
 
@@ -99,6 +103,7 @@ const PROBE_CACHE_TTL_MS = 5 * 60 * 1000;
 
 export interface CodingAgentHarnessProbeContext {
   profileModel?: string | null;
+  providerPassthroughEnabled?: boolean;
   userConfig?: UserConfig | null;
 }
 
@@ -166,6 +171,9 @@ export async function loadCodingAgentWorkspaceSettings(
 
   return {
     harnesses: mergeHarnesses(stored?.codingAgentHarnesses ?? []),
+    providerPassthroughEnabled: isCodingAgentProviderPassthroughEnabled(
+      stored ?? null
+    ),
     selectedHarnessId: stored?.selectedCodingAgentHarness ?? null,
   };
 }
@@ -193,6 +201,11 @@ export async function listCodingAgentHarnessStatuses(
         };
       }
 
+      const probeContext = withPassthroughProbeContext(
+        options.probeContext,
+        settings.providerPassthroughEnabled
+      );
+
       const shouldProbe =
         probe && (probeHarnessId === null || probeHarnessId === harness.id);
 
@@ -201,7 +214,7 @@ export async function listCodingAgentHarnessStatuses(
           return buildHarnessStatusFromCache(harness, runtime);
         }
 
-        const light = await probeHarnessLight(harness, options.probeContext);
+        const light = await probeHarnessLight(harness, probeContext);
 
         return {
           ...harness,
@@ -222,7 +235,7 @@ export async function listCodingAgentHarnessStatuses(
           ready: false,
           statusMessage: null,
         },
-        options.probeContext
+        probeContext
       );
 
       return {
@@ -273,7 +286,10 @@ export async function refreshCodingAgentHarnessProbe(
       ready: false,
       statusMessage: null,
     },
-    probeContext
+    withPassthroughProbeContext(
+      probeContext,
+      settings.providerPassthroughEnabled
+    )
   );
 
   const checkedAt = new Date().toISOString();
@@ -302,6 +318,7 @@ export async function saveCodingAgentWorkspaceSettings(
   db: DatabaseAdapter,
   input: {
     selectedHarnessId?: string | null;
+    providerPassthroughEnabled?: boolean;
     harnesses?: Array<{
       id: string;
       command?: string;
@@ -337,19 +354,21 @@ export async function saveCodingAgentWorkspaceSettings(
       : input.selectedHarnessId && byId.has(input.selectedHarnessId)
         ? input.selectedHarnessId
         : null;
+  const providerPassthroughEnabled =
+    input.providerPassthroughEnabled ?? settings.providerPassthroughEnabled;
 
-  await db.upsertWorkspaceSettings({
-    codingAgentHarnesses: nextHarnesses,
-    id: stored?.id ?? WORKSPACE_SETTINGS_ID,
-    imageModel: stored?.imageModel ?? null,
-    selectedCodingAgentHarness: selectedHarnessId,
-    transcriptionModel: stored?.transcriptionModel ?? null,
-    updatedAt: new Date().toISOString(),
-    visionModel: stored?.visionModel ?? null,
-  });
+  await db.upsertWorkspaceSettings(
+    mergeWorkspaceSettings(stored, {
+      codingAgentHarnesses: nextHarnesses,
+      codingAgentProviderPassthrough: providerPassthroughEnabled,
+      selectedCodingAgentHarness: selectedHarnessId,
+      updatedAt: new Date().toISOString(),
+    })
+  );
 
   return {
     harnesses: nextHarnesses,
+    providerPassthroughEnabled,
     selectedHarnessId,
   };
 }
@@ -637,15 +656,13 @@ async function saveHarnessProbeCache(
     harness.id === harnessId ? { ...harness, probeCache } : harness
   );
 
-  await db.upsertWorkspaceSettings({
-    codingAgentHarnesses: nextHarnesses,
-    id: stored?.id ?? WORKSPACE_SETTINGS_ID,
-    imageModel: stored?.imageModel ?? null,
-    selectedCodingAgentHarness: settings.selectedHarnessId,
-    transcriptionModel: stored?.transcriptionModel ?? null,
-    updatedAt: new Date().toISOString(),
-    visionModel: stored?.visionModel ?? null,
-  });
+  await db.upsertWorkspaceSettings(
+    mergeWorkspaceSettings(stored, {
+      codingAgentHarnesses: nextHarnesses,
+      selectedCodingAgentHarness: settings.selectedHarnessId,
+      updatedAt: new Date().toISOString(),
+    })
+  );
 }
 
 async function clearHarnessProbeCache(
@@ -658,15 +675,13 @@ async function clearHarnessProbeCache(
     harness.id === harnessId ? { ...harness, probeCache: null } : harness
   );
 
-  await db.upsertWorkspaceSettings({
-    codingAgentHarnesses: nextHarnesses,
-    id: stored?.id ?? WORKSPACE_SETTINGS_ID,
-    imageModel: stored?.imageModel ?? null,
-    selectedCodingAgentHarness: settings.selectedHarnessId,
-    transcriptionModel: stored?.transcriptionModel ?? null,
-    updatedAt: new Date().toISOString(),
-    visionModel: stored?.visionModel ?? null,
-  });
+  await db.upsertWorkspaceSettings(
+    mergeWorkspaceSettings(stored, {
+      codingAgentHarnesses: nextHarnesses,
+      selectedCodingAgentHarness: settings.selectedHarnessId,
+      updatedAt: new Date().toISOString(),
+    })
+  );
 }
 
 async function getHarnessRuntimeStatus(
@@ -699,10 +714,22 @@ async function probeHarnessVersion(command: string): Promise<{
   const timeoutMs = 5000;
 
   return new Promise((resolve) => {
-    const child = spawn(command, ["--version"], {
-      env: getToolExecutionEnv(),
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    let child: ReturnType<typeof spawn>;
+
+    try {
+      child = spawn(command, ["--version"], {
+        env: getToolExecutionEnv(),
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch {
+      resolve({
+        installed: false,
+        missing: true,
+        version: null,
+      });
+      return;
+    }
+
     let stdout = "";
     let stderr = "";
 
@@ -748,6 +775,51 @@ function extractVersion(stdout: string, stderr: string): string | null {
   }
 
   return output.split(/\r?\n/, 1)[0]?.trim() || null;
+}
+
+export function getCodingHarnessLoginCommand(
+  kind: StoredCodingAgentHarnessKind
+): string | null {
+  if (kind === "codex") {
+    return "codex login";
+  }
+
+  if (kind === "claude_code") {
+    return "claude auth login";
+  }
+
+  if (kind === "opencode") {
+    return "opencode auth login";
+  }
+
+  if (kind === "pi") {
+    return "pi login";
+  }
+
+  return null;
+}
+
+function withPassthroughProbeContext(
+  probeContext: CodingAgentHarnessProbeContext | undefined,
+  providerPassthroughEnabled: boolean
+): CodingAgentHarnessProbeContext {
+  return {
+    ...probeContext,
+    providerPassthroughEnabled:
+      probeContext?.providerPassthroughEnabled ?? providerPassthroughEnabled,
+  };
+}
+
+function harnessNativeLoginMessage(
+  harness: Pick<CodingAgentHarnessStatus, "kind" | "name">
+): string {
+  const login = getCodingHarnessLoginCommand(harness.kind);
+
+  if (login) {
+    return `${harness.name} is installed. Uses harness login on this server (\`${login}\`).`;
+  }
+
+  return `${harness.name} is installed. Uses host Cursor auth (no Nakama provider passthrough).`;
 }
 
 export function getCodingHarnessInstallCommand(
@@ -839,12 +911,15 @@ async function probeHarnessLight(
   nextStep: "retry" | null;
   statusMessage: string | null;
 }> {
-  if (harness.kind === "cursor_agent") {
+  if (
+    harness.kind === "cursor_agent" ||
+    probeContext?.providerPassthroughEnabled === false
+  ) {
     return {
       authenticated: null,
       nextStep: null,
       ready: true,
-      statusMessage: `${harness.name} is installed. Uses host Cursor auth (no Nakama provider passthrough).`,
+      statusMessage: harnessNativeLoginMessage(harness),
     };
   }
 
@@ -887,15 +962,31 @@ async function probeHarnessExec(
       authenticated: null,
       nextStep: null,
       ready: true,
-      statusMessage: `${harness.name} is installed. Uses host Cursor auth (no Nakama provider passthrough).`,
+      statusMessage: harnessNativeLoginMessage(harness),
     };
   }
 
-  const { spawn, routing } = await resolveCodingAgentSpawnBundle({
-    harnessKind: harness.kind,
-    profileModel: probeContext?.profileModel ?? null,
-    userConfig: probeContext?.userConfig,
-  });
+  const passthrough = probeContext?.providerPassthroughEnabled !== false;
+  const { spawn, routing } = passthrough
+    ? await resolveCodingAgentSpawnBundle({
+        harnessKind: harness.kind,
+        profileModel: probeContext?.profileModel ?? null,
+        userConfig: probeContext?.userConfig,
+      })
+    : {
+        routing: {
+          active: false,
+          apiKey: null,
+          baseUrl: null,
+          compatible: false,
+          configured: false,
+          error: null,
+          model: null,
+          providerLabel: null,
+          providerType: null,
+        },
+        spawn: { env: {} as Record<string, string> },
+      };
   const tempDir = await mkdtemp(
     path.join(tmpdir(), "nakama-coding-agent-probe-")
   );
@@ -934,20 +1025,30 @@ async function probeHarnessExec(
         authenticated: true,
         nextStep: null,
         ready: true,
-        statusMessage: `${harness.name} is installed and ready via Nakama provider passthrough.`,
+        statusMessage: passthrough
+          ? `${harness.name} is installed and ready via Nakama provider passthrough.`
+          : harnessNativeLoginMessage(harness),
       };
     }
 
     if (looksLikeAuthenticationFailure(combinedOutput)) {
+      const login = getCodingHarnessLoginCommand(harness.kind);
+      const nativeHint = login
+        ? `Run \`${login}\` on this server.`
+        : "Authenticate the CLI on this server.";
+
       return {
         authenticated: false,
         nextStep: "retry",
         ready: false,
-        statusMessage:
-          routing.error ??
-          (combinedOutput
-            ? `${harness.name} could not authenticate with the configured Nakama provider. ${summarizeProbeOutput(combinedOutput)} Check Settings → Provider.`
-            : `${harness.name} could not authenticate with the configured Nakama provider. Check Settings → Provider.`),
+        statusMessage: passthrough
+          ? (routing.error ??
+            (combinedOutput
+              ? `${harness.name} could not authenticate with the configured Nakama provider. ${summarizeProbeOutput(combinedOutput)} Check Settings → Provider.`
+              : `${harness.name} could not authenticate with the configured Nakama provider. Check Settings → Provider.`))
+          : combinedOutput
+            ? `${harness.name} could not authenticate with harness login. ${summarizeProbeOutput(combinedOutput)} ${nativeHint}`
+            : `${harness.name} could not authenticate with harness login. ${nativeHint}`,
       };
     }
 

--- a/apps/server/src/services/coding-agent-harness-service.ts
+++ b/apps/server/src/services/coding-agent-harness-service.ts
@@ -799,6 +799,16 @@ export function getCodingHarnessLoginCommand(
   return null;
 }
 
+export function listCodingHarnessLoginCommands(): Array<{
+  command: string;
+  name: string;
+}> {
+  return DEFAULT_HARNESSES.flatMap((harness) => {
+    const command = getCodingHarnessLoginCommand(harness.kind);
+    return command ? [{ command, name: harness.name }] : [];
+  });
+}
+
 function withPassthroughProbeContext(
   probeContext: CodingAgentHarnessProbeContext | undefined,
   providerPassthroughEnabled: boolean

--- a/apps/web/src/components/CodingAgentsSettingsCard.tsx
+++ b/apps/web/src/components/CodingAgentsSettingsCard.tsx
@@ -1,0 +1,86 @@
+import type { CodingHarnessSettingsResponse } from "@nakama/core/contract";
+import { useEffect, useState } from "react";
+import { Spinner } from "@/components/ui/spinner";
+import { Switch } from "@/components/ui/switch";
+import { client, formatError } from "@/lib/client";
+
+export function CodingAgentsSettingsCard() {
+  const [settings, setSettings] =
+    useState<CodingHarnessSettingsResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void client
+      .getCodingHarnessSettings()
+      .then((response) => {
+        if (!cancelled) {
+          setSettings(response);
+        }
+      })
+      .catch((cause: unknown) => {
+        if (!cancelled) {
+          setError(formatError(cause));
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function toggle(providerPassthroughEnabled: boolean) {
+    setSaving(true);
+    setError(null);
+
+    try {
+      const response = await client.setCodingHarnessSettings(
+        providerPassthroughEnabled
+      );
+      setSettings(response);
+    } catch (cause) {
+      setError(formatError(cause));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!(settings || error)) {
+    return (
+      <div className="flex min-h-32 items-center justify-center text-muted-foreground">
+        <Spinner className="size-5" />
+      </div>
+    );
+  }
+
+  const passthrough = settings?.providerPassthroughEnabled !== false;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start justify-between gap-4">
+        <p className="font-medium text-sm">Use Nakama provider</p>
+        <Switch
+          aria-label="Use Nakama provider"
+          checked={passthrough}
+          className="mt-0.5"
+          disabled={saving || !settings}
+          onCheckedChange={toggle}
+        />
+      </div>
+
+      {error ? <p className="text-destructive text-xs">{error}</p> : null}
+
+      {passthrough ? null : (
+        <ul className="space-y-1 font-mono text-muted-foreground text-xs">
+          {settings?.loginCommands.map((item) => (
+            <li key={item.command}>
+              {item.name}: {item.command}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/IntegrationsPage.tsx
+++ b/apps/web/src/pages/IntegrationsPage.tsx
@@ -1,4 +1,5 @@
 import {
+  CodeIcon,
   CpuChargeIcon,
   HashtagIcon,
   Key01Icon,
@@ -8,6 +9,7 @@ import {
   WhatsappIcon,
 } from "hugeicons-react";
 import { Navigate, useSearchParams } from "react-router-dom";
+import { CodingAgentsSettingsCard } from "@/components/CodingAgentsSettingsCard";
 import { ComposioConnectionsCard } from "@/components/ComposioConnectionsCard";
 import { ComposioSettingsCard } from "@/components/ComposioSettingsCard";
 import { DiscordSettingsCard } from "@/components/DiscordSettingsCard";
@@ -54,6 +56,11 @@ const INTEGRATION_SECTIONS = [
     label: "Local token",
   },
   {
+    icon: CodeIcon,
+    id: "coding-agents",
+    label: "Coding agents",
+  },
+  {
     icon: CpuChargeIcon,
     id: "optimization",
     label: "Context savings",
@@ -69,7 +76,8 @@ function resolveSection(value: string | null): IntegrationSectionId {
     value === "whatsapp" ||
     value === "discord" ||
     value === "composio" ||
-    value === "optimization"
+    value === "optimization" ||
+    value === "coding-agents"
   ) {
     return value;
   }
@@ -145,6 +153,8 @@ export function IntegrationsPage() {
           {section === "token" ? <LocalAuthTokenCard /> : null}
 
           {section === "optimization" ? <TokenOptimizationCard /> : null}
+
+          {section === "coding-agents" ? <CodingAgentsSettingsCard /> : null}
 
           {section === "composio" ? (
             <div className={cn(isOrgAdmin && "space-y-4")}>

--- a/docs/website/content/docs/coding-agent.mdx
+++ b/docs/website/content/docs/coding-agent.mdx
@@ -99,7 +99,17 @@ Nakama injects your configured LLM provider credentials at coding-agent spawn ti
 - A compatible provider configured in Nakama (Settings → Provider)
 - Claude Code requires an **Anthropic** provider; Codex and OpenCode support OpenAI-compatible providers (OpenAI, OpenRouter, DeepSeek, etc.)
 
-The `bash` tool merges spawn env when:
+This is the default. Org admins can switch to **harness login on this server** under **Integrations → Coding agents** when coding CLIs should use their own vendor accounts instead of the Nakama-configured provider.
+
+When harness login is on:
+
+- Nakama does **not** inject provider API keys into the subprocess
+- Readiness treats vendor login as success (not a Settings → Provider error)
+- Log in on the host with `codex login`, `claude auth login`, `opencode auth login`, or `pi login` as needed
+
+Cursor Agent always uses host Cursor auth, regardless of this toggle.
+
+The `bash` tool merges spawn env when passthrough is on and:
 
 - the command starts with a known harness binary (`codex`, `claude`, `opencode`, `pi`, or `agent`), or
 - `codingAgent: true` is set **and** the command starts with a known harness binary
@@ -108,7 +118,7 @@ If `codingAgent: true` is set but the command does not start with a known binary
 
 Passthrough follows the **binary in the command**, not a dashboard selection.
 
-**Security:** Passthrough injects the real org provider API key into subprocess env on the host. Use on trusted machines only.
+**Security:** Passthrough injects the real org provider API key into subprocess env on the host. Use on trusted machines only. Harness login keeps those keys out of the coding CLI process, but the vendor account on the host can still reach whatever that CLI is allowed to do.
 
 ## When to use a coding agent vs Nakama alone
 
@@ -172,8 +182,8 @@ Tool and skill assignment remain per profile.
 | Cursor Agent missing / auth fails | Install and authenticate Cursor Agent CLI on the server host; verify with `agent --version` |
 | Nakama asks which coding agent to use | Multiple CLIs are installed; answer for this conversation |
 | Nakama explains instead of coding | Message may not match the skill; ask for an explicit repo change |
-| Claude Code asks for `/login` | Provider passthrough not applied — ensure Settings → Provider is compatible and the bash command starts with `claude` |
-| Provider passthrough inactive / no provider | Configure a compatible model provider in Nakama Settings for the profile |
+| Claude Code asks for `/login` | Provider passthrough not applied — ensure Settings → Provider is compatible and the bash command starts with `claude`. If **Integrations → Coding agents** uses harness login, run `claude auth login` on the server |
+| Provider passthrough inactive / no provider | Configure a compatible model provider in Nakama Settings, or turn off **Use Nakama provider** on **Integrations → Coding agents** and log the CLI in on the host |
 | Run times out | Increase `bash` `timeoutMs`; split the task into smaller coding-agent runs |
 | Changes land outside the workspace | Command `cwd` or backend `--dir` may point outside the profile tree |
 

--- a/docs/website/content/docs/integrations.mdx
+++ b/docs/website/content/docs/integrations.mdx
@@ -12,8 +12,7 @@ Use **Integrations** in the Nakama dashboard to connect channels, bridge workers
 - [Discord](/discord): save the bot token, invite the bot, pair users, and run the Discord worker
 - [Composio](/composio): connect SaaS toolkits with per-user OAuth and assign them to profiles
 - [MCP Servers](/mcp): connect external MCP servers and expose their tools to profiles
-
-Coding agents are set up in chat via the [`coding-agent` skill](/coding-agent), not as an Integrations section.
+- **Coding agents**: choose Nakama provider passthrough (default) or harness login on this server — see [Coding agent](/coding-agent#provider-passthrough)
 
 ## What lives in Integrations
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -22,6 +22,7 @@ import type {
   BranchSessionResponse,
   ChangePasswordRequest,
   CloneProfileRequest,
+  CodingHarnessSettingsResponse,
   CompactionResponse,
   ComposioConnectRequest,
   ComposioConnectResponse,
@@ -256,6 +257,24 @@ export class NakamaClient {
       "/v1/token-optimization",
       {
         body: JSON.stringify({ enabled }),
+        method: "PUT",
+      }
+    );
+  }
+
+  async getCodingHarnessSettings(): Promise<CodingHarnessSettingsResponse> {
+    return this.request<CodingHarnessSettingsResponse>(
+      "/v1/settings/coding-harnesses"
+    );
+  }
+
+  async setCodingHarnessSettings(
+    providerPassthroughEnabled: boolean
+  ): Promise<CodingHarnessSettingsResponse> {
+    return this.request<CodingHarnessSettingsResponse>(
+      "/v1/settings/coding-harnesses",
+      {
+        body: JSON.stringify({ providerPassthroughEnabled }),
         method: "PUT",
       }
     );

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -260,6 +260,20 @@ export interface TokenOptimizationUpdateResponse {
   installed: boolean;
 }
 
+export interface CodingHarnessLoginCommand {
+  command: string;
+  name: string;
+}
+
+export interface CodingHarnessSettingsResponse {
+  loginCommands: CodingHarnessLoginCommand[];
+  providerPassthroughEnabled: boolean;
+}
+
+export interface UpdateCodingHarnessSettingsRequest {
+  providerPassthroughEnabled: boolean;
+}
+
 export interface TokenOptimizationTurnArm {
   arm: string;
   /** Turns whose token count came from an estimate, not the provider. */

--- a/packages/db/sql/schema.sql
+++ b/packages/db/sql/schema.sql
@@ -406,6 +406,7 @@ CREATE TABLE IF NOT EXISTS workspace_settings (
   image_model TEXT,
   coding_agent_harnesses TEXT NOT NULL DEFAULT '[]',
   selected_coding_agent_harness TEXT,
+  coding_agent_provider_passthrough INTEGER NOT NULL DEFAULT 1,
   updated_at TEXT NOT NULL
 );
 

--- a/packages/db/src/adapters/in-memory.ts
+++ b/packages/db/src/adapters/in-memory.ts
@@ -1469,6 +1469,8 @@ export function createInMemoryDatabaseAdapter(): DatabaseAdapter {
           ...harness,
           args: [...harness.args],
         })),
+        codingAgentProviderPassthrough:
+          record.codingAgentProviderPassthrough !== false,
       };
     },
   };

--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -186,6 +186,7 @@ interface LlmUsageModelStatsRow {
 
 interface WorkspaceSettingsRow {
   coding_agent_harnesses: string;
+  coding_agent_provider_passthrough: number | null;
   id: string;
   image_model: string | null;
   selected_coding_agent_harness: string | null;
@@ -921,9 +922,10 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
       coding_agent_harnesses,
       selected_coding_agent_harness,
       token_optimizer_enabled,
+      coding_agent_provider_passthrough,
       updated_at
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(id) DO UPDATE SET
       vision_model = excluded.vision_model,
       transcription_model = excluded.transcription_model,
@@ -931,6 +933,7 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
       coding_agent_harnesses = excluded.coding_agent_harnesses,
       selected_coding_agent_harness = excluded.selected_coding_agent_harness,
       token_optimizer_enabled = excluded.token_optimizer_enabled,
+      coding_agent_provider_passthrough = excluded.coding_agent_provider_passthrough,
       updated_at = excluded.updated_at
   `);
   const listNotificationDestinationsForOrgStmt = db.prepare(`
@@ -2902,6 +2905,7 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
           record.tokenOptimizerEnabled === undefined
           ? null
           : Number(record.tokenOptimizerEnabled),
+        record.codingAgentProviderPassthrough === false ? 0 : 1,
         record.updatedAt
       );
     },
@@ -3259,6 +3263,7 @@ function toWorkspaceSettingsRecord(
 ): StoredWorkspaceSettingsRecord {
   return {
     codingAgentHarnesses: parseCodingAgentHarnesses(row.coding_agent_harnesses),
+    codingAgentProviderPassthrough: row.coding_agent_provider_passthrough !== 0,
     id: row.id,
     imageModel: row.image_model?.trim() || null,
     selectedCodingAgentHarness:

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -15,6 +15,7 @@ export * from "./local-client";
 export * from "./org-profiles";
 export * from "./seed";
 export * from "./types";
+export * from "./workspace-settings";
 
 export interface Database {
   adapter: DatabaseAdapter;

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1109,6 +1109,12 @@ function migrateWorkspaceSettingsTable(db: Database): void {
       ALTER TABLE workspace_settings ADD COLUMN token_optimizer_enabled INTEGER;
     `);
   }
+
+  if (!columnNames.has("coding_agent_provider_passthrough")) {
+    db.exec(`
+      ALTER TABLE workspace_settings ADD COLUMN coding_agent_provider_passthrough INTEGER NOT NULL DEFAULT 1;
+    `);
+  }
 }
 
 function migrateAutomationRunsTable(db: Database): void {

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -166,6 +166,11 @@ export interface StoredLlmUsageModelStatsRecord {
 
 export interface StoredWorkspaceSettingsRecord {
   codingAgentHarnesses: StoredCodingAgentHarnessRecord[];
+  /**
+   * When true (default), coding CLIs get Nakama provider credentials at spawn.
+   * When false, harness-native vendor login on the host is used instead.
+   */
+  codingAgentProviderPassthrough: boolean;
   id: string;
   imageModel: string | null;
   orgId?: string | null;

--- a/packages/db/src/workspace-settings.test.ts
+++ b/packages/db/src/workspace-settings.test.ts
@@ -40,4 +40,30 @@ describe("workspace settings merge", () => {
     expect(merged.codingAgentProviderPassthrough).toBe(false);
     expect(merged.visionModel).toBe("other");
   });
+
+  test("merge can clear nullable fields to null", () => {
+    const merged = mergeWorkspaceSettings(
+      {
+        codingAgentHarnesses: [],
+        codingAgentProviderPassthrough: true,
+        id: "default",
+        imageModel: "openai::gpt-image-2",
+        selectedCodingAgentHarness: "coding-harness-codex",
+        transcriptionModel: "whisper",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        visionModel: "vision",
+      },
+      {
+        imageModel: null,
+        selectedCodingAgentHarness: null,
+        transcriptionModel: null,
+        visionModel: null,
+      }
+    );
+
+    expect(merged.imageModel).toBeNull();
+    expect(merged.selectedCodingAgentHarness).toBeNull();
+    expect(merged.transcriptionModel).toBeNull();
+    expect(merged.visionModel).toBeNull();
+  });
 });

--- a/packages/db/src/workspace-settings.test.ts
+++ b/packages/db/src/workspace-settings.test.ts
@@ -41,6 +41,28 @@ describe("workspace settings merge", () => {
     expect(merged.visionModel).toBe("other");
   });
 
+  test("merge keeps passthrough when token optimizer is patched", () => {
+    const merged = mergeWorkspaceSettings(
+      {
+        codingAgentHarnesses: [],
+        codingAgentProviderPassthrough: false,
+        id: "default",
+        imageModel: null,
+        selectedCodingAgentHarness: null,
+        transcriptionModel: null,
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        visionModel: null,
+      },
+      {
+        tokenOptimizerEnabled: true,
+        updatedAt: "2026-01-02T00:00:00.000Z",
+      }
+    );
+
+    expect(merged.codingAgentProviderPassthrough).toBe(false);
+    expect(merged.tokenOptimizerEnabled).toBe(true);
+  });
+
   test("merge can clear nullable fields to null", () => {
     const merged = mergeWorkspaceSettings(
       {

--- a/packages/db/src/workspace-settings.test.ts
+++ b/packages/db/src/workspace-settings.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isCodingAgentProviderPassthroughEnabled,
+  mergeWorkspaceSettings,
+} from "./workspace-settings";
+
+describe("workspace settings merge", () => {
+  test("passthrough defaults on when unset", () => {
+    expect(isCodingAgentProviderPassthroughEnabled(null)).toBe(true);
+    expect(
+      isCodingAgentProviderPassthroughEnabled({
+        codingAgentProviderPassthrough: true,
+      })
+    ).toBe(true);
+    expect(
+      isCodingAgentProviderPassthroughEnabled({
+        codingAgentProviderPassthrough: false,
+      })
+    ).toBe(false);
+  });
+
+  test("merge keeps passthrough when another field is patched", () => {
+    const merged = mergeWorkspaceSettings(
+      {
+        codingAgentHarnesses: [],
+        codingAgentProviderPassthrough: false,
+        id: "default",
+        imageModel: null,
+        selectedCodingAgentHarness: null,
+        transcriptionModel: null,
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        visionModel: "vision",
+      },
+      {
+        updatedAt: "2026-01-02T00:00:00.000Z",
+        visionModel: "other",
+      }
+    );
+
+    expect(merged.codingAgentProviderPassthrough).toBe(false);
+    expect(merged.visionModel).toBe("other");
+  });
+});

--- a/packages/db/src/workspace-settings.ts
+++ b/packages/db/src/workspace-settings.ts
@@ -11,32 +11,42 @@ export function isCodingAgentProviderPassthroughEnabled(
   return settings?.codingAgentProviderPassthrough !== false;
 }
 
+function pickDefined<T>(patch: T | undefined, fallback: T): T {
+  return patch === undefined ? fallback : patch;
+}
+
 export function mergeWorkspaceSettings(
   existing: StoredWorkspaceSettingsRecord | null | undefined,
   patch: Partial<StoredWorkspaceSettingsRecord> = {}
 ): StoredWorkspaceSettingsRecord {
   return {
-    codingAgentHarnesses:
-      patch.codingAgentHarnesses ?? existing?.codingAgentHarnesses ?? [],
-    codingAgentProviderPassthrough:
-      patch.codingAgentProviderPassthrough ??
-      existing?.codingAgentProviderPassthrough ??
-      true,
-    id: patch.id ?? existing?.id ?? WORKSPACE_SETTINGS_ID,
-    imageModel: patch.imageModel ?? existing?.imageModel ?? null,
-    orgId: patch.orgId ?? existing?.orgId,
-    selectedCodingAgentHarness:
-      patch.selectedCodingAgentHarness === undefined
-        ? (existing?.selectedCodingAgentHarness ?? null)
-        : patch.selectedCodingAgentHarness,
+    codingAgentHarnesses: pickDefined(
+      patch.codingAgentHarnesses,
+      existing?.codingAgentHarnesses ?? []
+    ),
+    codingAgentProviderPassthrough: pickDefined(
+      patch.codingAgentProviderPassthrough,
+      existing?.codingAgentProviderPassthrough ?? true
+    ),
+    id: pickDefined(patch.id, existing?.id ?? WORKSPACE_SETTINGS_ID),
+    imageModel: pickDefined(patch.imageModel, existing?.imageModel ?? null),
+    orgId: "orgId" in patch ? patch.orgId : existing?.orgId,
+    selectedCodingAgentHarness: pickDefined(
+      patch.selectedCodingAgentHarness,
+      existing?.selectedCodingAgentHarness ?? null
+    ),
     tokenOptimizerEnabled:
       patch.tokenOptimizerEnabled === undefined
         ? existing?.tokenOptimizerEnabled
         : patch.tokenOptimizerEnabled,
-    transcriptionModel:
-      patch.transcriptionModel ?? existing?.transcriptionModel ?? null,
-    updatedAt:
-      patch.updatedAt ?? existing?.updatedAt ?? new Date().toISOString(),
-    visionModel: patch.visionModel ?? existing?.visionModel ?? null,
+    transcriptionModel: pickDefined(
+      patch.transcriptionModel,
+      existing?.transcriptionModel ?? null
+    ),
+    updatedAt: pickDefined(
+      patch.updatedAt,
+      existing?.updatedAt ?? new Date().toISOString()
+    ),
+    visionModel: pickDefined(patch.visionModel, existing?.visionModel ?? null),
   };
 }

--- a/packages/db/src/workspace-settings.ts
+++ b/packages/db/src/workspace-settings.ts
@@ -1,0 +1,42 @@
+import { WORKSPACE_SETTINGS_ID } from "./constants";
+import type { StoredWorkspaceSettingsRecord } from "./types";
+
+/** Missing / unset means passthrough (the v1 default). */
+export function isCodingAgentProviderPassthroughEnabled(
+  settings: Pick<
+    StoredWorkspaceSettingsRecord,
+    "codingAgentProviderPassthrough"
+  > | null
+): boolean {
+  return settings?.codingAgentProviderPassthrough !== false;
+}
+
+export function mergeWorkspaceSettings(
+  existing: StoredWorkspaceSettingsRecord | null | undefined,
+  patch: Partial<StoredWorkspaceSettingsRecord> = {}
+): StoredWorkspaceSettingsRecord {
+  return {
+    codingAgentHarnesses:
+      patch.codingAgentHarnesses ?? existing?.codingAgentHarnesses ?? [],
+    codingAgentProviderPassthrough:
+      patch.codingAgentProviderPassthrough ??
+      existing?.codingAgentProviderPassthrough ??
+      true,
+    id: patch.id ?? existing?.id ?? WORKSPACE_SETTINGS_ID,
+    imageModel: patch.imageModel ?? existing?.imageModel ?? null,
+    orgId: patch.orgId ?? existing?.orgId,
+    selectedCodingAgentHarness:
+      patch.selectedCodingAgentHarness === undefined
+        ? (existing?.selectedCodingAgentHarness ?? null)
+        : patch.selectedCodingAgentHarness,
+    tokenOptimizerEnabled:
+      patch.tokenOptimizerEnabled === undefined
+        ? existing?.tokenOptimizerEnabled
+        : patch.tokenOptimizerEnabled,
+    transcriptionModel:
+      patch.transcriptionModel ?? existing?.transcriptionModel ?? null,
+    updatedAt:
+      patch.updatedAt ?? existing?.updatedAt ?? new Date().toISOString(),
+    visionModel: patch.visionModel ?? existing?.visionModel ?? null,
+  };
+}


### PR DESCRIPTION
## Summary

Closes #143.

Coding agents currently always inject Nakama provider credentials at spawn. This PR restores an opt-in path for operators who want Codex / Claude Code / OpenCode / pi to use **harness-native vendor login on the host** instead.

Default remains **Use Nakama provider** (passthrough on). Turning it off:

- does not merge `ANTHROPIC_*` / `OPENAI_*` / temp harness config env into `bash` coding-agent runs
- treats an installed CLI as ready without requiring Settings → Provider
- on a failed auth probe, points at `codex login` / `claude auth login` / `opencode auth login` / `pi login` instead of Settings → Provider
- shows those login commands on **Integrations → Coding agents**

Cursor Agent is unchanged: it already uses host Cursor auth and never gets Nakama keys.

## Why

Some installs want separate billing for coding CLIs vs chat, or do not want org API keys in subprocess env on a shared host. That toggle existed in an earlier sketch (`coding_agent_provider_passthrough`) and was removed to keep v1 passthrough-only.

## Changes

- Workspace setting `coding_agent_provider_passthrough` (SQLite default `1`)
- `GET`/`PUT /v1/settings/coding-harnesses` with `providerPassthroughEnabled` (org-admin write)
- Integrations card with a single switch; login commands only when passthrough is off
- Spawn/probe/bash enrichment honor the flag
- `mergeWorkspaceSettings` so unrelated settings writes cannot drop the flag
- Docs: [Coding agent](https://github.com/ahmadrosid/nakama/blob/feat/coding-agent-harness-login/docs/website/content/docs/coding-agent.mdx) and Integrations

## Security tradeoff

| Mode | Credential blast radius |
|---|---|
| Nakama provider (default) | Org provider API key is injected into the coding CLI process on the host |
| Harness login | Nakama keys stay out of that process; the vendor account already logged in on the host is used instead |

## Test plan

- [x] Integrations → Coding agents: toggle defaults on; turn off and confirm login commands (`codex login`, `claude auth login`, `opencode auth login`, `pi login`)
- [x] Passthrough on: coding `bash` run still gets provider env (Claude Code / Codex)
- [x] Passthrough off: coding `bash` run has no `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`
- [x] Passthrough off, no Nakama provider configured: installed harness still reports ready
- [x] Cursor Agent: still no Nakama env either way
- [x] Org member cannot PUT the setting; org admin can
- [x] Vision/transcription/token-optimizer saves do not reset the toggle

## Validation

- UI: Integrations toggle + login commands (admin vs member screenshots); Cursor Agent still has no Nakama env
- `bun test packages/db/src/workspace-settings.test.ts apps/server/src/services/coding-agent-bash-env.test.ts apps/server/src/services/coding-agent-harness-service.test.ts apps/server/src/http/coding-harnesses.test.ts` — 20 pass
- Extra: `AgentService` vision/transcription saves keep `codingAgentProviderPassthrough: false`

Made with [Cursor](https://cursor.com)