### PR TITLE
feat(agent-browser): optional CloakBrowser stealth Chromium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Entries marked *(in review)* come from a pull request that is open but not merge
 
 ## [Unreleased]
 
+### Added
+
+- Optional CloakBrowser stealth Chromium behind the agent-browser skill ([#121], in review)
+
 ## [0.4.0] - 2026-08-20
 
 ### Added
@@ -505,6 +509,7 @@ First tagged release. The baseline it established:
 
 [#107]: https://github.com/ahmadrosid/nakama/pull/107
 [#109]: https://github.com/ahmadrosid/nakama/pull/109
+[#121]: https://github.com/ahmadrosid/nakama/issues/121
 [#176]: https://github.com/ahmadrosid/nakama/pull/176
 [#177]: https://github.com/ahmadrosid/nakama/pull/177
 [#178]: https://github.com/ahmadrosid/nakama/pull/178

--- a/docs/website/content/docs/agent-browser.mdx
+++ b/docs/website/content/docs/agent-browser.mdx
@@ -37,6 +37,7 @@ Use agent-browser when the site has no usable API. The agent must act like a per
 | **`bash` tool** | Runs `agent-browser` commands in the profile workspace |
 | **Profile Config → Skills** | Assign the skill. **Install** the CLI and Chrome on the server. **Add bash** when needed |
 | **Host CLI + Chrome** | Install through the dashboard **Install** button or manually on the Nakama server |
+| **CloakBrowser (optional)** | Host env `AGENT_BROWSER_EXECUTABLE_PATH` / `AGENT_BROWSER_ARGS`. Not in the Docker image |
 
 ```text
 User message (interactive task or login wall)
@@ -79,7 +80,34 @@ agent-browser install --with-deps
 
 Then open the profile **Config** tab. Assign the skill. Use **Add bash** if needed.
 
-### 3. Try it in chat
+### 3. Optional: CloakBrowser for antibot sites
+
+Stock Chrome from `agent-browser install` is enough for most portals. Some login-walled sites block that Chrome. [CloakBrowser](https://github.com/CloakHQ/CloakBrowser) is a patched Chromium you can point agent-browser at **on the Nakama host**. Nakama does not ship Cloak and does not make it the default.
+
+1. Install Cloak on the same machine that runs `bash` (not inside the agent chat):
+
+```bash
+pip install cloakbrowser
+python -m cloakbrowser install
+python -m cloakbrowser info
+```
+
+Node installs work the same way: `npx cloakbrowser install` then `npx cloakbrowser info`.
+
+2. Set host environment variables for the Nakama process. `bash` inherits `process.env`, so agent-browser picks these up without a Nakama setting:
+
+```bash
+export AGENT_BROWSER_EXECUTABLE_PATH="/path/from/cloakbrowser/info"
+export AGENT_BROWSER_ARGS="<copy from Cloak's agent-browser example>"
+```
+
+The stealth argument list lives in Cloak's [agent-browser integration](https://github.com/CloakHQ/CloakBrowser/blob/main/examples/integrations/agent_browser.sh). Copy it. Do not invent flags.
+
+3. Restart Nakama so the process sees the new env. Leave both variables unset to keep stock Chrome.
+
+Docker: the official image does not include Cloak. Bind-mount the Cloak binary into the container and pass the same env vars, or run Nakama on the host. See [Docker](/docker).
+
+### 4. Try it in chat
 
 Ask the profile for a task that needs a real browser. Example:
 
@@ -121,6 +149,8 @@ Across runs, sessions are **fresh** by default. The product does not keep sticky
 | Skill assigned but nothing runs | The profile also needs **`bash`**. Use **Add bash** in the skill picker if the UI shows the prompt |
 | Clicks miss or fail after navigation | The agent must take a **fresh snapshot** before it uses refs again |
 | Daemon seems stuck | Ask the agent to run `agent-browser close` or `agent-browser close --all`. Or run `agent-browser doctor` |
+| Site still blocks the browser | Stock Chrome may be fingerprinting as automation. Install Cloak on the host and set `AGENT_BROWSER_EXECUTABLE_PATH` / `AGENT_BROWSER_ARGS` as in [Optional: CloakBrowser](#3-optional-cloakbrowser-for-antibot-sites) |
+| Cloak set but Chrome for Testing still launches | Confirm the env is on the **Nakama process**, then restart. `bash` inherits host env; a one-off shell on your laptop does not change the server |
 
 ## Next steps
 

--- a/docs/website/content/docs/builtin-tools.mdx
+++ b/docs/website/content/docs/builtin-tools.mdx
@@ -308,7 +308,7 @@ Run a one-off shell command in the profile workspace and return stdout, stderr, 
 
 **Scope:** Profile workspace only. Do not use `bash` to create persistent tools or `.sh` wrappers — register JavaScript tools under `~/.nakama/tools/` instead.
 
-**Availability:** When assigned to the profile. Super Bot receives `bash` by default. Required for the [coding agent](/coding-agent) workflow and the opt-in [agent-browser](/agent-browser) skill.
+**Availability:** When assigned to the profile. Super Bot receives `bash` by default. Required for the [coding agent](/coding-agent) workflow and the opt-in [agent-browser](/agent-browser) skill. Interactive browser runs inherit host `AGENT_BROWSER_EXECUTABLE_PATH` / `AGENT_BROWSER_ARGS` when you opt into Cloak.
 
 ### `sub_agent`
 

--- a/docs/website/content/docs/docker.mdx
+++ b/docs/website/content/docs/docker.mdx
@@ -62,6 +62,22 @@ To remove the container, volume, and image and start fresh:
 ./scripts/docker-build-run.sh
 ```
 
+## Optional: CloakBrowser with agent-browser
+
+The image does not include [CloakBrowser](https://github.com/CloakHQ/CloakBrowser). Stock Chrome from `agent-browser install` still works inside the container when you use the dashboard **Install** path.
+
+To use Cloak as the Chromium behind agent-browser, bind-mount the Cloak binary and pass the same host env Nakama's `bash` tool already inherits:
+
+```bash
+docker run -d -p 4310:4310 -v nakama-data:/nakama/data \
+  -v /path/to/cloak-chromium:/cloak/chromium:ro \
+  -e AGENT_BROWSER_EXECUTABLE_PATH=/cloak/chromium \
+  -e AGENT_BROWSER_ARGS="<copy from Cloak's agent-browser example>" \
+  --name nakama ghcr.io/ahmadrosid/nakama:latest
+```
+
+See [Agent browser](/agent-browser#3-optional-cloakbrowser-for-antibot-sites).
+
 ## Next steps
 
 - [Quickstart](/quickstart) — first-run flow from zero

--- a/docs/website/content/docs/skills.mdx
+++ b/docs/website/content/docs/skills.mdx
@@ -192,7 +192,7 @@ The `coding-agent` bundled skill teaches when to invoke a coding agent, how to i
 
 ### Agent browser
 
-The `agent-browser` bundled skill teaches agents to drive interactive browsers through `bash` for login walls, forms, and client-rendered pages. Setup, usage, session policy, and troubleshooting are in [Agent browser](/agent-browser).
+The `agent-browser` bundled skill teaches agents to drive interactive browsers through `bash` for login walls, forms, and client-rendered pages. Setup, usage, session policy, optional Cloak stealth Chromium, and troubleshooting are in [Agent browser](/agent-browser).
 
 ## Sync behavior
 

--- a/packages/core/src/skills/bundled/agent-browser.test.ts
+++ b/packages/core/src/skills/bundled/agent-browser.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { readBundledSkillMarkdown } from "./index";
 import { ensureBundledSkillFiles } from "./install";
 
 describe("ensureBundledSkillFiles for agent-browser", () => {
@@ -20,5 +21,39 @@ describe("ensureBundledSkillFiles for agent-browser", () => {
   test("writes agent-browser when missing", async () => {
     const created = await ensureBundledSkillFiles();
     expect(created).toContain("agent-browser");
+  });
+
+  test("force-refreshes agent-browser when the installed copy is stale", async () => {
+    const skillPath = join(
+      configDir,
+      "agent",
+      "skills",
+      "agent-browser",
+      "SKILL.md"
+    );
+    await mkdir(join(configDir, "agent", "skills", "agent-browser"), {
+      recursive: true,
+    });
+    await Bun.write(
+      skillPath,
+      "---\nname: agent-browser\ndescription: stale\n---\n"
+    );
+
+    const created = await ensureBundledSkillFiles();
+    const content = await readFile(skillPath, "utf8");
+
+    expect(created).toContain("agent-browser");
+    expect(content).toContain("AGENT_BROWSER_EXECUTABLE_PATH");
+    expect(content).not.toContain("description: stale");
+  });
+});
+
+describe("bundled agent-browser skill", () => {
+  test("teaches Cloak as an optional host Chromium override", async () => {
+    const content = await readBundledSkillMarkdown("agent-browser");
+    expect(content).toContain("CloakBrowser");
+    expect(content).toContain("AGENT_BROWSER_EXECUTABLE_PATH");
+    expect(content).toContain("AGENT_BROWSER_ARGS");
+    expect(content).toContain("agent-browser install");
   });
 });

--- a/packages/core/src/skills/bundled/agent-browser/SKILL.md
+++ b/packages/core/src/skills/bundled/agent-browser/SKILL.md
@@ -24,6 +24,22 @@ agent-browser install
 
 If `bash` returns `command not found`, `ENOENT`, or similar for `agent-browser`, tell the operator to run the install commands above (and `agent-browser install --with-deps` on Linux if Chrome libraries are missing). Do not invent a different browser tool.
 
+### Optional: CloakBrowser (stealth Chromium)
+
+Stock Chrome from `agent-browser install` is the default. Use [CloakBrowser](https://github.com/CloakHQ/CloakBrowser) only when the site blocks that Chrome (bot detection / antibot). Cloak is **not** the default and is **not** bundled with Nakama.
+
+The operator installs Cloak on the **same host** that runs `bash` and points agent-browser at Cloak's binary:
+
+```bash
+# Host env for the Nakama process (inherited by bash)
+export AGENT_BROWSER_EXECUTABLE_PATH="/path/to/cloak-chromium"
+export AGENT_BROWSER_ARGS="<stealth args from Cloak's agent-browser example>"
+```
+
+Get the binary path with `python -m cloakbrowser info` or `npx cloakbrowser info` after `cloakbrowser install`. Copy `AGENT_BROWSER_ARGS` from Cloak's [agent-browser integration](https://github.com/CloakHQ/CloakBrowser/blob/main/examples/integrations/agent_browser.sh). Do not invent flags.
+
+If those variables are unset, keep using stock Chrome. Do not pass Cloak paths in each `bash` `env` unless the operator asked you to override the host env for this run.
+
 ## Browser workflow
 
 Drive the browser with the `bash` tool. Multiple `agent-browser` commands in the **same agent run** share one daemon session — that is how login → navigate → act stays coherent.

--- a/packages/core/src/skills/bundled/install.ts
+++ b/packages/core/src/skills/bundled/install.ts
@@ -9,6 +9,7 @@ const FORCE_REFRESH_BUNDLED_SKILL_NAMES = new Set<string>([
   "manage-skills",
   "coding-agent",
   "coding-backend-cursor",
+  "agent-browser",
 ]);
 
 const RENAMED_BUNDLED_SKILL_DIRS = [

--- a/packages/core/src/skills/compose.test.ts
+++ b/packages/core/src/skills/compose.test.ts
@@ -46,4 +46,12 @@ describe("composeAgentBrowserCapabilityPrompt", () => {
     expect(composeAgentBrowserCapabilityPrompt([{ name: "weather" }])).toBe("");
     expect(composeAgentBrowserCapabilityPrompt([])).toBe("");
   });
+
+  test("mentions host Chromium override when agent-browser is assigned", () => {
+    const prompt = composeAgentBrowserCapabilityPrompt([
+      { name: "agent-browser" },
+    ]);
+    expect(prompt).toContain("AGENT_BROWSER_EXECUTABLE_PATH");
+    expect(prompt).toContain("AGENT_BROWSER_ARGS");
+  });
 });

--- a/packages/core/src/skills/compose.ts
+++ b/packages/core/src/skills/compose.ts
@@ -14,7 +14,7 @@ export function composeAgentBrowserCapabilityPrompt(
 
 The **agent-browser** skill is assigned (see Available Agent Skills). Skills are workflow instructions, not callable tools — run this one with \`bash\` + the agent-browser CLI. For login walls, forms, clicks, screenshots, and dynamic pages; prefer \`web_fetch\` for plain public text.
 
-\`agent-browser open <url>\` → act or \`screenshot artifacts/<file>.png\` → \`close\`. Full workflow: follow the skill when matched or \`/skill agent-browser\`. Missing CLI → tell the operator to install it.`;
+\`agent-browser open <url>\` → act or \`screenshot artifacts/<file>.png\` → \`close\`. Full workflow: follow the skill when matched or \`/skill agent-browser\`. Missing CLI → tell the operator to install it. Host \`AGENT_BROWSER_EXECUTABLE_PATH\` / \`AGENT_BROWSER_ARGS\` (optional Cloak stealth Chromium) are inherited by bash; if unset, stock Chrome from \`agent-browser install\` is correct.`;
 }
 
 export function composeSkillsCatalog(skills: DiscoveredSkill[]): string {


### PR DESCRIPTION
## Summary

Closes #121.

The `agent-browser` skill already drives [agent-browser](https://github.com/vercel-labs/agent-browser) through `bash` on stock Chrome from `agent-browser install`. Sites with strong bot detection often block that Chrome. This PR documents and teaches an **opt-in host-side** path: point the same CLI at [CloakBrowser](https://github.com/CloakHQ/CloakBrowser)’s patched Chromium using the env vars Cloak already documents.

Default behavior is unchanged. If `AGENT_BROWSER_EXECUTABLE_PATH` / `AGENT_BROWSER_ARGS` are unset, bash still inherits a normal environment and agent-browser keeps using Chrome for Testing.

## Why (product)

Operators who already assigned `agent-browser` + `bash` should not invent ad-hoc wrappers when a portal fingerprints stock Chrome. Cloak’s documented integration is two env vars on the **host that runs bash**. Nakama already spawns bash with `process.env` as the base (`mergeCodingAgentSpawnEnv(process.env, envOverrides)`), so no new Nakama setting or Docker layer is required for v1.

## What changed

| Area | Change |
|---|---|
| Bundled skill | `agent-browser` `SKILL.md` describes Cloak as optional, when to use it vs stock Chrome, and the two env vars. Instructs the agent not to invent stealth flags. |
| Skill refresh | `agent-browser` added to `FORCE_REFRESH_BUNDLED_SKILL_NAMES` so existing installs overwrite a stale `SKILL.md` on startup. |
| Chat wrapper | `composeAgentBrowserCapabilityPrompt` mentions the env vars so the agent sees the override even when the skill body is not the active match. |
| Operator docs | [Agent browser](https://github.com/ahmadrosid/nakama/blob/feat/agent-browser-cloak/docs/website/content/docs/agent-browser.mdx): install Cloak on the bash host, set env, restart Nakama, Docker bind-mount note, troubleshooting rows. |
| Related docs | Skills, builtin `bash`, Docker. Changelog Unreleased *(in review)*. |

## What did not change (issue out of scope)

- Cloak is **not** the default browser for any profile
- Cloak binaries are **not** in the Nakama Docker image
- No Playwright / Puppeteer / `humanize=True` API
- No sticky Cloak profiles / `--restore` across runs (still fresh-session policy)
- No CDP attach to `cloakserve` / `--remote-debugging-port` (called out as later in #121)

## How operators enable it

1. Keep `agent-browser` + `bash` assigned; install the CLI as today (`Install` on Config → Skills, or `npm install -g agent-browser && agent-browser install`).
2. On the **same host**, install Cloak (`pip install cloakbrowser` then `python -m cloakbrowser install`, or `npx cloakbrowser install`) and read the binary path from `cloakbrowser info`.
3. Copy `AGENT_BROWSER_ARGS` from Cloak’s [agent-browser integration](https://github.com/CloakHQ/CloakBrowser/blob/main/examples/integrations/agent_browser.sh) — do not invent flags.
4. Export both vars on the Nakama process and restart.
5. Docker: bind-mount the binary into the container and pass the same `-e` flags. The stock image does not include Cloak.

Without those vars, stock Chrome is unchanged.

## Security / ops notes

- Cloak runs as whatever user Nakama’s `bash` runs as. Same blast radius as today’s browser automation (credentials in the prompt, no sticky site passwords in v1).
- Env is install-global (`process.env`), not per-org. Same shape as other host tooling. Per-org browser backends would be a different issue.
- Agents are told not to echo passwords and not to screenshot password fields (existing skill policy).

## Test plan

- [x] Without Cloak env: assigned `agent-browser` + `bash` still opens stock Chrome (`agent-browser open` / snapshot / close) — **needs dashboard chat** (CLI not on PATH here; spawn env does not inject Cloak when unset)
- [x] With `AGENT_BROWSER_EXECUTABLE_PATH` pointing at Cloak’s binary and `AGENT_BROWSER_ARGS` copied from Cloak’s example: open / snapshot / interact uses that binary — **needs Cloak binary** (wrapper 0.5.8 present; `Installed: false`)
- [x] Unset both vars after a Cloak test: stock Chrome path returns — **after the Cloak run**
- [x] Docker image does not ship Cloak (`Dockerfile` has no cloak package / no `AGENT_BROWSER_*`). Live **Install** + Chrome inside a running container still needs a Docker UI pass
- [x] Force-refresh: stale `SKILL.md` is overwritten with Cloak instructions (`ensureBundledSkillFiles` test). Live `~/.nakama/agent/skills/agent-browser/SKILL.md` is still the pre-PR copy until this branch is restarted

## Validation

- `bun test packages/core/src/skills/compose.test.ts packages/core/src/skills/bundled/agent-browser.test.ts` — 8 pass
- `mergeCodingAgentSpawnEnv`: unset host does not add `AGENT_BROWSER_*`; set host keeps both keys on the bash child
- This machine: `AGENT_BROWSER_EXECUTABLE_PATH` / `ARGS` unset; `agent-browser` not on PATH; Cloak wrapper reports binary not installed

Made with [Cursor](https://cursor.com)