### PR TITLE
fix(web): keep chat mounted when the session URL updates

### DIFF
--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -166,7 +166,7 @@ export function Layout() {
                   : null
               )}
             >
-              <RouteBoundary key={location.pathname}>
+              <RouteBoundary resetKey={location.pathname}>
                 <Outlet />
               </RouteBoundary>
             </main>

--- a/apps/web/src/components/RouteBoundary.test.ts
+++ b/apps/web/src/components/RouteBoundary.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { routeErrorStateFromResetKey } from "@/components/route-error-state";
+
+describe("routeErrorStateFromResetKey", () => {
+  test("clears a failed load when the route key changes", () => {
+    expect(
+      routeErrorStateFromResetKey("/chat/p1/s1", {
+        failed: true,
+        resetKey: "/chat",
+      })
+    ).toEqual({ failed: false, resetKey: "/chat/p1/s1" });
+  });
+
+  test("keeps a failed load when the route key is unchanged", () => {
+    expect(
+      routeErrorStateFromResetKey("/chat", {
+        failed: true,
+        resetKey: "/chat",
+      })
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/components/RouteBoundary.tsx
+++ b/apps/web/src/components/RouteBoundary.tsx
@@ -1,4 +1,8 @@
 import { Component, type ReactNode, Suspense } from "react";
+import {
+  type RouteErrorState,
+  routeErrorStateFromResetKey,
+} from "@/components/route-error-state";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
@@ -6,21 +10,25 @@ import { cn } from "@/lib/utils";
 interface RouteBoundaryProps {
   children: ReactNode;
   fullScreen?: boolean;
-}
-
-interface RouteErrorBoundaryState {
-  failed: boolean;
+  resetKey?: string;
 }
 
 // biome-ignore lint/style/useReactFunctionComponents: React error boundaries require a class component.
 class RouteErrorBoundary extends Component<
   RouteBoundaryProps,
-  RouteErrorBoundaryState
+  RouteErrorState
 > {
-  state: RouteErrorBoundaryState = { failed: false };
+  state: RouteErrorState = { failed: false };
 
-  static getDerivedStateFromError(): RouteErrorBoundaryState {
+  static getDerivedStateFromError(): Pick<RouteErrorState, "failed"> {
     return { failed: true };
+  }
+
+  static getDerivedStateFromProps(
+    props: RouteBoundaryProps,
+    state: RouteErrorState
+  ): Partial<RouteErrorState> | null {
+    return routeErrorStateFromResetKey(props.resetKey, state);
   }
 
   render() {
@@ -64,9 +72,13 @@ function RouteLoadError({ fullScreen }: { fullScreen?: boolean }) {
   );
 }
 
-export function RouteBoundary({ children, fullScreen }: RouteBoundaryProps) {
+export function RouteBoundary({
+  children,
+  fullScreen,
+  resetKey,
+}: RouteBoundaryProps) {
   return (
-    <RouteErrorBoundary fullScreen={fullScreen}>
+    <RouteErrorBoundary fullScreen={fullScreen} resetKey={resetKey}>
       <Suspense fallback={<RouteLoading fullScreen={fullScreen} />}>
         {children}
       </Suspense>

--- a/apps/web/src/components/route-error-state.ts
+++ b/apps/web/src/components/route-error-state.ts
@@ -1,0 +1,15 @@
+export interface RouteErrorState {
+  failed: boolean;
+  resetKey?: string;
+}
+
+export function routeErrorStateFromResetKey(
+  resetKey: string | undefined,
+  state: RouteErrorState
+): Partial<RouteErrorState> | null {
+  if (resetKey === state.resetKey) {
+    return null;
+  }
+
+  return { failed: false, resetKey };
+}


### PR DESCRIPTION
## Summary

Sending the first chat message used to remount the page the moment the URL became `/chat/<profile>/<session>`, so the in-flight reply and local chat state disappeared. Chat now stays mounted through that URL write. Navigating after a failed chunk load still clears the reload prompt.

Related: #310

## Bundle results

Re-measured on this branch (`a21e21e2`) with the workspace Vite 6.4.2: `vite build --manifest` from `apps/web`. Before column is the #310 baseline at `041942ad`.

| Payload | Before | After |
| --- | ---: | ---: |
| Initial entry, minified | 3,166.09 kB | 768.89 kB |
| Initial entry, gzip | 904.71 kB | 240.51 kB |
| Login route total, gzip | ~899 kB | 241.68 kB |
| Setup route total, gzip | ~899 kB | 277.24 kB |
| Profiles route total, gzip | ~899 kB | 289.45 kB |
| Chat route total, gzip | ~899 kB | 778.85 kB |

The initial entry is 75.7% smaller minified and 73.4% smaller gzip. Route totals are entry JS plus that page's static import graph (Vite-reported gzip).

`bun test apps/web/src/components/RouteBoundary.test.ts` — 2 passed. Did not re-run a first-send browser smoke in this change.

## New concepts

**Reset an error boundary without remounting.** A React `key` change destroys the subtree. That is the usual way to clear a class error boundary, and it is the wrong tool when the child holds session state that must survive a URL update.

This PR compares a `resetKey` in `getDerivedStateFromProps` and only flips `failed` back to false. Same instance, same ChatPage, same stream.

Do not use this when you *want* a fresh mount (leaving a page entirely is already enough — React Router replaces the outlet child).

```ts
// Why: clear the failed-load prompt on navigation without unmounting Chat.
if (resetKey === state.resetKey) {
  return null;
}
return { failed: false, resetKey };
```

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Cursor_Grok_4.6](https://img.shields.io/badge/Cursor_Grok_4.6-000000)
