### PR TITLE
fix(providers): persist Cloudflare account ID in config.ini

### DIFF
--- a/apps/server/src/providers/cloudflare/index.test.ts
+++ b/apps/server/src/providers/cloudflare/index.test.ts
@@ -106,7 +106,7 @@ describe("Cloudflare provider", () => {
         baseUrl: `${CLOUDFLARE_API_ROOT}/from-config/ai/v1`,
         createdAt: new Date(0).toISOString(),
         id: "cf-1",
-        label: "Cloudflare",
+        label: "Cloudflare Worker AI",
         type: "cloudflare",
       })
     ).toBe(`${CLOUDFLARE_API_ROOT}/from-config/ai/v1`);

--- a/apps/server/src/providers/cloudflare/index.test.ts
+++ b/apps/server/src/providers/cloudflare/index.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { createCloudflareProvider } from "./index";
+import {
+  CLOUDFLARE_API_ROOT,
+  createCloudflareProvider,
+  resolveCloudflareBaseUrl,
+} from "./index";
 
 const originalFetch = globalThis.fetch;
 
@@ -93,5 +97,28 @@ describe("Cloudflare provider", () => {
     await expect(
       provider.generateText({ prompt: "Hi", system: "Be helpful." })
     ).rejects.toThrow(/Cloudflare/);
+  });
+
+  test("prefers the instance base URL over the env account ID", () => {
+    expect(
+      resolveCloudflareBaseUrl("env-account", {
+        apiKey: "key",
+        baseUrl: `${CLOUDFLARE_API_ROOT}/from-config/ai/v1`,
+        createdAt: new Date(0).toISOString(),
+        id: "cf-1",
+        label: "Cloudflare",
+        type: "cloudflare",
+      })
+    ).toBe(`${CLOUDFLARE_API_ROOT}/from-config/ai/v1`);
+  });
+
+  test("falls back to CLOUDFLARE_ACCOUNT_ID when the instance has no base URL", () => {
+    expect(resolveCloudflareBaseUrl("env-account")).toBe(
+      `${CLOUDFLARE_API_ROOT}/env-account/ai/v1`
+    );
+  });
+
+  test("throws when neither instance base URL nor account ID is set", () => {
+    expect(() => resolveCloudflareBaseUrl("")).toThrow(/base_url/);
   });
 });

--- a/apps/server/src/providers/cloudflare/index.ts
+++ b/apps/server/src/providers/cloudflare/index.ts
@@ -39,7 +39,7 @@ export function createCloudflareProvider(options: {
   return createOpenAICompatibleProvider({
     apiKey: options.apiKey,
     baseUrl: resolveCloudflareBaseUrl(options.accountId, options.instance),
-    displayName: "Cloudflare",
+    displayName: "Cloudflare Worker AI",
     model: options.model,
     providerName: "cloudflare",
     supportsThinking: false,

--- a/apps/server/src/providers/cloudflare/index.ts
+++ b/apps/server/src/providers/cloudflare/index.ts
@@ -1,12 +1,12 @@
 import {
+  cloudflareBaseUrlFromAccountId,
   normalizeBaseUrl,
   type ProviderClient,
   type ProviderInstance,
 } from "@nakama/core";
 import { createOpenAICompatibleProvider } from "../openai-compatible";
 
-export const CLOUDFLARE_API_ROOT =
-  "https://api.cloudflare.com/client/v4/accounts";
+export { CLOUDFLARE_API_ROOT } from "@nakama/core";
 
 export function resolveCloudflareBaseUrl(
   accountId: string,
@@ -19,11 +19,11 @@ export function resolveCloudflareBaseUrl(
 
   if (!accountId) {
     throw new Error(
-      "Cloudflare provider requires CLOUDFLARE_ACCOUNT_ID env var, or paste the full Workers AI endpoint (https://api.cloudflare.com/client/v4/accounts/<id>/ai/v1) into the provider base URL."
+      "Cloudflare provider requires an account ID on the provider instance (saved as base_url), or CLOUDFLARE_ACCOUNT_ID as a fallback."
     );
   }
 
-  return `${CLOUDFLARE_API_ROOT}/${accountId}/ai/v1`;
+  return cloudflareBaseUrlFromAccountId(accountId);
 }
 
 export function createCloudflareProvider(options: {

--- a/apps/server/src/services/provider-instance-helpers.test.ts
+++ b/apps/server/src/services/provider-instance-helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { ProviderInstance } from "@nakama/core";
 import {
   applyProviderInstanceUpdate,
+  buildProviderInstanceFromCreateRequest,
   modelExistsOnInstance,
   resolveProfileProviderSelection,
 } from "./provider-instance-helpers";
@@ -239,5 +240,23 @@ describe("applyProviderInstanceUpdate", () => {
     expect(
       modelExistsOnInstance(withoutShortlist, "accounts/unknown/models/foo")
     ).toBe(false);
+  });
+});
+
+describe("buildProviderInstanceFromCreateRequest", () => {
+  test("persists a Cloudflare Workers AI base URL on the instance", () => {
+    const instance = buildProviderInstanceFromCreateRequest(
+      {
+        apiKey: "cf-key",
+        baseUrl: "https://api.cloudflare.com/client/v4/accounts/abc123/ai/v1",
+        type: "cloudflare",
+      },
+      []
+    );
+
+    expect(instance.type).toBe("cloudflare");
+    expect(instance.baseUrl).toBe(
+      "https://api.cloudflare.com/client/v4/accounts/abc123/ai/v1"
+    );
   });
 });

--- a/apps/web/src/components/ProviderSetupForm.tsx
+++ b/apps/web/src/components/ProviderSetupForm.tsx
@@ -13,6 +13,7 @@ import { ShortlistBrowseProviderModelFields } from "@/components/ShortlistBrowse
 import { isShortlistBrowseProvider } from "@/components/shortlist-browse-providers.shared";
 import { Button } from "@/components/ui/button";
 import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
 import {
   InputGroup,
   InputGroupAddon,
@@ -161,6 +162,34 @@ export function ProviderSetupForm({
               </InputGroupAddon>
             </InputGroup>
           </FormField>
+
+          {form.selectedProvider === "cloudflare" ? (
+            <FormField
+              density={density}
+              footer={
+                form.baseUrlError ? (
+                  <p
+                    className="text-destructive text-sm"
+                    id="cloudflare-account-id-error"
+                    role="alert"
+                  >
+                    {form.baseUrlError}
+                  </p>
+                ) : null
+              }
+              id="cloudflare-account-id"
+              label="Account ID"
+            >
+              <Input
+                aria-invalid={form.baseUrlError != null}
+                autoComplete="off"
+                disabled={form.busy}
+                id="cloudflare-account-id"
+                onChange={(event) => form.setBaseUrl(event.target.value)}
+                value={form.baseUrl}
+              />
+            </FormField>
+          ) : null}
 
           {form.selectedProvider === "openai_compatible" ? (
             <CustomProviderFields

--- a/apps/web/src/hooks/use-provider-setup-form.ts
+++ b/apps/web/src/hooks/use-provider-setup-form.ts
@@ -1,3 +1,4 @@
+import { resolveCloudflareAccountInput } from "@nakama/core/cloudflare-provider-config";
 import type {
   CreateProviderResponse,
   OllamaHostMode,
@@ -395,7 +396,11 @@ export function useProviderSetupForm(
         selectedProvider === "openai_compatible" ||
         selectedProvider === "ollama"
           ? validateBaseUrlInput(baseUrl)
-          : null;
+          : selectedProvider === "cloudflare"
+            ? resolveCloudflareAccountInput(baseUrl)
+              ? null
+              : "Enter a Cloudflare account ID or Workers AI URL."
+            : null;
       const nextModelsError =
         selectedProvider === "openai_compatible" ||
         selectedProvider === "ollama"
@@ -433,7 +438,9 @@ export function useProviderSetupForm(
           .getElementById(
             selectedProvider === "ollama"
               ? "ollama-base-url"
-              : "provider-base-url"
+              : selectedProvider === "cloudflare"
+                ? "cloudflare-account-id"
+                : "provider-base-url"
           )
           ?.focus();
         return;
@@ -461,10 +468,14 @@ export function useProviderSetupForm(
       setFormError(null);
 
       try {
+        const resolvedCloudflareBaseUrl =
+          selectedProvider === "cloudflare"
+            ? resolveCloudflareAccountInput(baseUrl)
+            : null;
         const result = await createProvider(
           buildCreateProviderRequest({
             apiKey: trimmedKey,
-            baseUrl,
+            baseUrl: resolvedCloudflareBaseUrl ?? baseUrl,
             customModels:
               selectedProvider === "openai_compatible" ||
               selectedProvider === "ollama"

--- a/apps/web/src/lib/models.test.ts
+++ b/apps/web/src/lib/models.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { USER_PROVIDER_NAMES } from "@nakama/core/provider-resolution";
 import {
   encodeModelSelection,
   filterVisionCapableProviderGroups,
@@ -6,6 +7,7 @@ import {
   hasOpenCodeZenProvider,
   isOpenCodeZenBaseUrl,
   isProviderTypeAlreadyConfigured,
+  PROVIDER_OPTIONS,
   resolveModelThinkingSupport,
   resolveModelVisionSupport,
 } from "./models";
@@ -278,6 +280,14 @@ describe("isProviderTypeAlreadyConfigured", () => {
   });
 });
 
+describe("PROVIDER_OPTIONS", () => {
+  test("lists every registered provider type", () => {
+    expect(PROVIDER_OPTIONS.map((option) => option.id).toSorted()).toEqual(
+      [...USER_PROVIDER_NAMES].toSorted()
+    );
+  });
+});
+
 describe("firstAvailableProviderOption", () => {
   test("keeps preferred provider when it is still free", () => {
     expect(firstAvailableProviderOption(new Set(["anthropic"]), "openai")).toBe(
@@ -298,6 +308,7 @@ describe("firstAvailableProviderOption", () => {
           "gemini",
           "deepseek",
           "cerebras",
+          "cloudflare",
           "fireworks",
           "opencode_go",
         ]),

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -74,7 +74,7 @@ export const PROVIDER_OPTIONS: Array<{ id: SelectedProvider; label: string }> =
     { id: "gemini", label: "Gemini" },
     { id: "deepseek", label: "DeepSeek" },
     { id: "cerebras", label: "Cerebras" },
-    { id: "cloudflare", label: "Cloudflare" },
+    { id: "cloudflare", label: "Cloudflare Worker AI" },
     { id: "fireworks", label: "Fireworks" },
     { id: "ollama", label: "Ollama" },
     { id: "opencode_go", label: "OpenCode Go" },

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -54,6 +54,7 @@ export function formatProviderLabel(
     provider === "gemini" ||
     provider === "deepseek" ||
     provider === "cerebras" ||
+    provider === "cloudflare" ||
     provider === "fireworks" ||
     provider === "ollama" ||
     provider === "openai_compatible" ||
@@ -73,6 +74,7 @@ export const PROVIDER_OPTIONS: Array<{ id: SelectedProvider; label: string }> =
     { id: "gemini", label: "Gemini" },
     { id: "deepseek", label: "DeepSeek" },
     { id: "cerebras", label: "Cerebras" },
+    { id: "cloudflare", label: "Cloudflare" },
     { id: "fireworks", label: "Fireworks" },
     { id: "ollama", label: "Ollama" },
     { id: "opencode_go", label: "OpenCode Go" },

--- a/docs/website/content/docs/providers.mdx
+++ b/docs/website/content/docs/providers.mdx
@@ -31,7 +31,7 @@ Nakama supports these built-in provider types:
 | Gemini | Google Gemini models |
 | DeepSeek | DeepSeek models |
 | Cerebras | Cerebras models |
-| Cloudflare | Workers AI models; add an API key and account ID in Settings (saved to `config.ini`). `CLOUDFLARE_ACCOUNT_ID` is a fallback only |
+| Cloudflare Worker AI | Workers AI models; add an API key and account ID in Settings (saved to `config.ini`). `CLOUDFLARE_ACCOUNT_ID` is a fallback only |
 | Fireworks | Fireworks AI models |
 | Ollama | Local or Ollama Cloud; multiple instances allowed |
 | OpenCode Go | OpenCode Go endpoint |

--- a/docs/website/content/docs/providers.mdx
+++ b/docs/website/content/docs/providers.mdx
@@ -31,7 +31,7 @@ Nakama supports these built-in provider types:
 | Gemini | Google Gemini models |
 | DeepSeek | DeepSeek models |
 | Cerebras | Cerebras models |
-| Cloudflare | Workers AI models via Cloudflare's OpenAI-compatible endpoint; requires `CLOUDFLARE_ACCOUNT_ID` env var (set on the server) |
+| Cloudflare | Workers AI models; add an API key and account ID in Settings (saved to `config.ini`). `CLOUDFLARE_ACCOUNT_ID` is a fallback only |
 | Fireworks | Fireworks AI models |
 | Ollama | Local or Ollama Cloud; multiple instances allowed |
 | OpenCode Go | OpenCode Go endpoint |

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,7 @@
     "./attachments/content": "./src/attachments/content.ts",
     "./image-content": "./src/image-content.ts",
     "./normalize-task-prompt": "./src/normalize-task-prompt.ts",
+    "./cloudflare-provider-config": "./src/cloudflare-provider-config.ts",
     "./ollama-provider-config": "./src/ollama-provider-config.ts",
     "./provider-inference": "./src/provider-inference.ts",
     "./provider-label": "./src/provider-label.ts",

--- a/packages/core/src/cloudflare-provider-config.test.ts
+++ b/packages/core/src/cloudflare-provider-config.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CLOUDFLARE_API_ROOT,
+  cloudflareBaseUrlFromAccountId,
+  resolveCloudflareAccountInput,
+} from "./cloudflare-provider-config";
+
+describe("resolveCloudflareAccountInput", () => {
+  test("turns an account ID into the Workers AI base URL", () => {
+    expect(resolveCloudflareAccountInput("abc123")).toBe(
+      `${CLOUDFLARE_API_ROOT}/abc123/ai/v1`
+    );
+  });
+
+  test("accepts a full Workers AI URL", () => {
+    expect(
+      resolveCloudflareAccountInput(
+        "https://api.cloudflare.com/client/v4/accounts/abc123/ai/v1/"
+      )
+    ).toBe(`${CLOUDFLARE_API_ROOT}/abc123/ai/v1`);
+  });
+
+  test("rejects empty or invalid input", () => {
+    expect(resolveCloudflareAccountInput("")).toBeNull();
+    expect(resolveCloudflareAccountInput("not a url")).toBeNull();
+    expect(resolveCloudflareAccountInput("https://")).toBeNull();
+  });
+});
+
+describe("cloudflareBaseUrlFromAccountId", () => {
+  test("builds the OpenAI-compatible Workers AI path", () => {
+    expect(cloudflareBaseUrlFromAccountId("acct")).toBe(
+      `${CLOUDFLARE_API_ROOT}/acct/ai/v1`
+    );
+  });
+});

--- a/packages/core/src/cloudflare-provider-config.ts
+++ b/packages/core/src/cloudflare-provider-config.ts
@@ -1,0 +1,32 @@
+import { isValidBaseUrl, normalizeBaseUrl } from "./compatible-provider-config";
+
+export const CLOUDFLARE_API_ROOT =
+  "https://api.cloudflare.com/client/v4/accounts";
+
+const ACCOUNT_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+export function cloudflareBaseUrlFromAccountId(accountId: string): string {
+  return `${CLOUDFLARE_API_ROOT}/${accountId}/ai/v1`;
+}
+
+export function resolveCloudflareAccountInput(input: string): string | null {
+  const trimmed = input.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+    if (!isValidBaseUrl(trimmed)) {
+      return null;
+    }
+
+    return normalizeBaseUrl(trimmed);
+  }
+
+  if (!ACCOUNT_ID_PATTERN.test(trimmed)) {
+    return null;
+  }
+
+  return cloudflareBaseUrlFromAccountId(trimmed);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,7 @@ export * from "./channel-artifact-delivery";
 export * from "./channel-artifacts";
 export * from "./channel-org";
 export * from "./channels";
+export * from "./cloudflare-provider-config";
 export * from "./compatible-provider-config";
 export * from "./composio";
 export * from "./composio-config";

--- a/packages/core/src/provider-label.ts
+++ b/packages/core/src/provider-label.ts
@@ -6,7 +6,7 @@ const BUILTIN_LABELS: Record<
 > = {
   anthropic: "Anthropic",
   cerebras: "Cerebras",
-  cloudflare: "Cloudflare",
+  cloudflare: "Cloudflare Worker AI",
   deepseek: "DeepSeek",
   fireworks: "Fireworks",
   gemini: "Gemini",

--- a/packages/core/src/provider-setup-prompt.test.ts
+++ b/packages/core/src/provider-setup-prompt.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { CLOUDFLARE_API_ROOT } from "./cloudflare-provider-config";
+import { promptForProviderConfig } from "./provider-setup-prompt";
+
+function scriptedPrompt(answers: string[]) {
+  const remaining = [...answers];
+
+  return {
+    getDefaultModel: () => "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+    getModelById: () => undefined,
+    getModelsForProvider: () => [],
+    question: async () => remaining.shift() ?? "",
+    writeLine: () => {},
+  };
+}
+
+describe("promptForProviderConfig", () => {
+  test("saves a Cloudflare account ID as the instance base URL", async () => {
+    const config = await promptForProviderConfig(
+      scriptedPrompt(["cloudflare", "test-key", "abc123", ""])
+    );
+
+    expect(config.providers[0]?.type).toBe("cloudflare");
+    expect(config.providers[0]?.apiKey).toBe("test-key");
+    expect(config.providers[0]?.baseUrl).toBe(
+      `${CLOUDFLARE_API_ROOT}/abc123/ai/v1`
+    );
+  });
+
+  test("accepts a pasted Workers AI URL for Cloudflare", async () => {
+    const config = await promptForProviderConfig(
+      scriptedPrompt([
+        "cloudflare",
+        "test-key",
+        "https://api.cloudflare.com/client/v4/accounts/acct/ai/v1",
+        "",
+      ])
+    );
+
+    expect(config.providers[0]?.baseUrl).toBe(
+      `${CLOUDFLARE_API_ROOT}/acct/ai/v1`
+    );
+  });
+});

--- a/packages/core/src/provider-setup-prompt.ts
+++ b/packages/core/src/provider-setup-prompt.ts
@@ -1,3 +1,4 @@
+import { resolveCloudflareAccountInput } from "./cloudflare-provider-config";
 import {
   isValidBaseUrl,
   normalizeBaseUrl,
@@ -89,6 +90,21 @@ export async function promptForProviderConfig(
       continue;
     }
 
+    let cloudflareBaseUrl: string | undefined;
+
+    if (provider === "cloudflare") {
+      const resolved = resolveCloudflareAccountInput(
+        (await question("Account ID: ")).trim()
+      );
+
+      if (!resolved) {
+        writeLine("Enter a Cloudflare account ID or Workers AI URL.\n");
+        continue;
+      }
+
+      cloudflareBaseUrl = resolved;
+    }
+
     const models = getModelsForProvider(provider);
     writeLine(`\nSelected provider: ${provider}`);
     writeLine("\nAvailable models:");
@@ -134,6 +150,7 @@ export async function promptForProviderConfig(
       id: createProviderInstanceId(),
       label: defaultProviderLabel(provider, []),
       type: getModelById(selectedModel)?.provider ?? provider,
+      ...(cloudflareBaseUrl ? { baseUrl: cloudflareBaseUrl } : {}),
       ...(customModels ? { customModels } : {}),
     };
 

--- a/packages/core/src/provider-setup-prompt.ts
+++ b/packages/core/src/provider-setup-prompt.ts
@@ -35,7 +35,7 @@ const PROVIDER_CHOICES: Array<{ id: UserProviderName; label: string }> = [
   { id: "gemini", label: "Gemini" },
   { id: "deepseek", label: "DeepSeek" },
   { id: "cerebras", label: "Cerebras" },
-  { id: "cloudflare", label: "Cloudflare" },
+  { id: "cloudflare", label: "Cloudflare Worker AI" },
   { id: "fireworks", label: "Fireworks" },
   { id: "ollama", label: "Ollama" },
   { id: "opencode_go", label: "OpenCode Go" },

--- a/packages/core/src/user-config.ts
+++ b/packages/core/src/user-config.ts
@@ -70,7 +70,7 @@ const PROVIDER_SECTION_PREFIX = "provider.";
 const PROVIDER_TYPE_LABELS: Record<UserProviderName, string> = {
   anthropic: "Anthropic",
   cerebras: "Cerebras",
-  cloudflare: "Cloudflare",
+  cloudflare: "Cloudflare Worker AI",
   deepseek: "DeepSeek",
   fireworks: "Fireworks",
   gemini: "Gemini",


### PR DESCRIPTION
Operators can now add Cloudflare from Settings or the CLI without setting a server env var. The account ID is stored on the provider instance as `base_url` in `~/.nakama/config.ini`, the same way other providers store `api_key`. `CLOUDFLARE_ACCOUNT_ID` remains a fallback when the instance has no URL.

A pasted Workers AI URL is accepted as well as a raw account ID.

Related: #312

## Validation
- `bun test` on the Cloudflare helper, CLI setup prompt, provider factory, and instance helpers: 21 pass

