### PR TITLE
fix(server): require orgId on by-id session operations

### DIFF
--- a/apps/server/src/services/agent-service.test.ts
+++ b/apps/server/src/services/agent-service.test.ts
@@ -84,28 +84,36 @@ describe("AgentService branching", () => {
       title: "Need input",
     });
 
-    const result = await service.branchSession(sourceSessionId, 1);
+    const result = await service.branchSession(sourceSessionId, 1, ORG_ID);
 
     expect(result).not.toBeNull();
     const branchSessionId = result!.sessionId;
 
-    const branchMessages = await service.getSessionMessages(branchSessionId);
+    const branchMessages = await service.getSessionMessages(
+      branchSessionId,
+      ORG_ID
+    );
     expect(branchMessages?.messages).toEqual([
       { content: "Hello", role: "user" },
       { content: "Hi there", role: "assistant" },
     ]);
     expect(branchMessages?.messageMeta).toHaveLength(2);
 
-    const branchTodos = await service.getSessionTodos(branchSessionId);
+    const branchTodos = await service.getSessionTodos(branchSessionId, ORG_ID);
     expect(branchTodos).toEqual([]);
-    expect(await service.getSessionQuestionnaire(branchSessionId)).toBeNull();
+    expect(
+      await service.getSessionQuestionnaire(branchSessionId, ORG_ID)
+    ).toBeNull();
 
     const branchRecord = await db.getSession(branchSessionId);
     expect(branchRecord?.profileId).toBe("profile_default");
     expect(branchRecord?.channel).toBe("web");
     expect(branchRecord?.title).toBe("Original chat (Branch)");
 
-    const sourceMessages = await service.getSessionMessages(sourceSessionId);
+    const sourceMessages = await service.getSessionMessages(
+      sourceSessionId,
+      ORG_ID
+    );
     expect(sourceMessages?.messages).toHaveLength(3);
   });
 
@@ -129,9 +137,9 @@ describe("AgentService branching", () => {
       },
     ]);
 
-    await expect(service.branchSession(sourceSessionId, 3)).rejects.toThrow(
-      "messageIndex is out of bounds."
-    );
+    await expect(
+      service.branchSession(sourceSessionId, 3, ORG_ID)
+    ).rejects.toThrow("messageIndex is out of bounds.");
   });
 
   test("falls back to org default when the requested profile is missing", async () => {
@@ -172,6 +180,31 @@ describe("AgentService branching", () => {
     } finally {
       database.close();
     }
+  });
+});
+
+describe("AgentService session org scope", () => {
+  test("by-id reads return null for a session in another org", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    await db.upsertProfile(createDefaultProfile());
+    await db.upsertProfile({
+      ...createDefaultProfile(),
+      id: "profile_other",
+      isDefault: false,
+      name: "Other",
+      orgId: "org_other",
+    });
+    const service = new AgentService(null, null, db);
+    const sessionId = await service.createSession(
+      ORG_ID,
+      "web",
+      "profile_default"
+    );
+
+    expect(await service.getSessionMessages(sessionId, "org_other")).toBeNull();
+    expect(await service.resolveSession(sessionId, "org_other")).toBeNull();
+    expect(await service.purgeSession(sessionId, "org_other")).toBe(false);
+    expect(await db.getSession(sessionId)).not.toBeNull();
   });
 });
 
@@ -617,13 +650,13 @@ describe("AgentService skill_manage injection", () => {
       null,
       { orgRole: "admin" }
     );
-    const session = await service.resolveSession(sessionId);
+    const session = await service.resolveSession(sessionId, ORG_ID);
     expect(session).not.toBeNull();
 
     const typed = "/learn filing an expense: open portal, submit receipt";
     await session!.send({ message: typed });
 
-    const stored = await service.getSessionMessages(sessionId);
+    const stored = await service.getSessionMessages(sessionId, ORG_ID);
     const userMessage = stored?.messages.find(
       (message) => message.role === "user"
     );
@@ -652,14 +685,14 @@ describe("AgentService skill_manage injection", () => {
       null,
       { orgRole: "admin" }
     );
-    const session = await service.resolveSession(sessionId);
+    const session = await service.resolveSession(sessionId, ORG_ID);
     expect(session).not.toBeNull();
 
     await session!.send({
       message: "/learn filing an expense",
     });
 
-    const stored = await service.getSessionMessages(sessionId);
+    const stored = await service.getSessionMessages(sessionId, ORG_ID);
     const userMessage = stored?.messages.find(
       (message) => message.role === "user"
     );
@@ -688,12 +721,12 @@ describe("AgentService skill_manage injection", () => {
       null,
       { orgRole: "admin" }
     );
-    const session = await service.resolveSession(sessionId);
+    const session = await service.resolveSession(sessionId, ORG_ID);
     expect(session).not.toBeNull();
 
     await session!.send({ message: "/learn" });
 
-    const stored = await service.getSessionMessages(sessionId);
+    const stored = await service.getSessionMessages(sessionId, ORG_ID);
     const userMessage = stored?.messages.find(
       (message) => message.role === "user"
     );

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -1381,7 +1381,7 @@ export class AgentService {
       profileId,
       task.orgId
     );
-    const session = await this.resolveSession(sessionId);
+    const session = await this.resolveSession(sessionId, task.orgId);
 
     if (!session) {
       throw new Error("Session not found.");
@@ -1575,7 +1575,7 @@ export class AgentService {
 
   async getSessionTodos(
     sessionId: string,
-    orgId?: string
+    orgId: string
   ): Promise<AgentTodo[] | null> {
     const record = await this.getSessionRecordForOrg(sessionId, orgId);
 
@@ -1588,7 +1588,7 @@ export class AgentService {
 
   async getSessionQuestionnaire(
     sessionId: string,
-    orgId?: string
+    orgId: string
   ): Promise<AgentQuestionnaire | null> {
     const record = await this.getSessionRecordForOrg(sessionId, orgId);
 
@@ -1601,7 +1601,7 @@ export class AgentService {
 
   async getSessionMessages(
     sessionId: string,
-    orgId?: string
+    orgId: string
   ): Promise<{
     channel: AgentChannel;
     messages: ChatMessage[];
@@ -1664,7 +1664,7 @@ export class AgentService {
   async branchSession(
     sessionId: string,
     messageIndex: number,
-    orgId?: string
+    orgId: string
   ): Promise<BranchSessionResponse | null> {
     const record = await this.getSessionRecordForOrg(sessionId, orgId);
 
@@ -1772,7 +1772,7 @@ export class AgentService {
     return this.skillPostTurnReviewService;
   }
 
-  async purgeSession(sessionId: string, orgId?: string): Promise<boolean> {
+  async purgeSession(sessionId: string, orgId: string): Promise<boolean> {
     const record = await this.getSessionRecordForOrg(sessionId, orgId);
 
     if (!record) {
@@ -1789,7 +1789,7 @@ export class AgentService {
 
   async resolveSession(
     sessionId: string,
-    orgId?: string
+    orgId: string
   ): Promise<AgentChatSession | null> {
     const record = await this.getSessionRecordForOrg(sessionId, orgId);
 
@@ -1835,7 +1835,7 @@ export class AgentService {
     return session;
   }
 
-  async clearSession(sessionId: string, orgId?: string): Promise<boolean> {
+  async clearSession(sessionId: string, orgId: string): Promise<boolean> {
     const record = await this.getSessionRecordForOrg(sessionId, orgId);
 
     if (!record) {
@@ -1856,7 +1856,7 @@ export class AgentService {
   async compactSession(
     sessionId: string,
     options: { force?: boolean } = {},
-    orgId?: string
+    orgId: string
   ): Promise<CompactionResponse | null> {
     const session = await this.resolveSession(sessionId, orgId);
 
@@ -1865,18 +1865,6 @@ export class AgentService {
     }
 
     return session.compact(options);
-  }
-
-  async deleteSession(sessionId: string): Promise<boolean> {
-    const deleted = this.sessions.delete(sessionId);
-
-    if (deleted) {
-      this.agentTodoState.clearSession(sessionId);
-      this.agentQuestionnaireState.clearSession(sessionId);
-      await this.db.deleteSession(sessionId);
-    }
-
-    return deleted;
   }
 
   async draftAutomation(prompt: string, channel: AgentChannel) {
@@ -2943,9 +2931,14 @@ export class AgentService {
     };
   }
 
+  /**
+   * Sessions carry no org column; the org is only reachable through their
+   * profile. Every by-id session operation resolves scope here so a caller in
+   * one org cannot name a session id belonging to another.
+   */
   private async getSessionRecordForOrg(
     sessionId: string,
-    orgId?: string
+    orgId: string
   ): Promise<StoredSessionRecord | null> {
     const record = await this.db.getSession(sessionId);
 
@@ -2953,17 +2946,9 @@ export class AgentService {
       return null;
     }
 
-    if (!orgId) {
-      return record;
-    }
-
     const profile = await this.db.getProfileForOrg(record.profileId, orgId);
 
-    if (!profile) {
-      return null;
-    }
-
-    return record;
+    return profile ? record : null;
   }
 
   private async requireProfile(


### PR DESCRIPTION
A new `AgentService` call site can no longer look up, mutate, or delete a session without naming the caller's org. HTTP by-id routes were already passing `orgId`; the optional argument still let an internal caller skip `profiles.org_id` and resolve another org's session.

`runTaskPrompt` now passes `task.orgId` into `resolveSession`. Unused cache-only `deleteSession` is gone — it never checked org and had no callers.

## Validation

`bun test apps/server/src/services/agent-service.test.ts apps/server/src/http/routes/sessions.org-scope.test.ts` — 25 pass, including a new service-level cross-org reject and the existing HTTP 404 suite.

## Related

Related: #304
