### PR TITLE
Review asserts: remove meaningless, add meaningful

### DIFF
--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -1142,7 +1142,7 @@ export class AgentService {
       throw new Error("Recipient email is required.");
     }
 
-    const sender = createSmtpSender(emailConfigToMailboxConfig(config!));
+    const sender = createSmtpSender(emailConfigToMailboxConfig(config));
     const result = await sender.send({
       subject: "Nakama test email",
       text: "This is a test email from your Nakama deployment.",

--- a/apps/server/src/services/attachment-service.ts
+++ b/apps/server/src/services/attachment-service.ts
@@ -60,7 +60,11 @@ export function createAttachmentLoader(
   return async (attachmentId) => {
     const record = await db.getAttachment(attachmentId);
 
-    if (!record || record.profileId !== context.profileId) {
+    if (
+      !record ||
+      record.orgId !== context.orgId ||
+      record.profileId !== context.profileId
+    ) {
       return null;
     }
 

--- a/apps/server/src/tools/bash.ts
+++ b/apps/server/src/tools/bash.ts
@@ -259,6 +259,11 @@ async function writeCodingAgentLog(
   stdout: string,
   stderr: string
 ): Promise<string | null> {
+  if (!path.isAbsolute(workspaceRoot)) {
+    throw new Error(
+      "workspaceRoot must be an absolute path; relative roots resolve against process.cwd() and break profile isolation."
+    );
+  }
   try {
     const dir = path.join(workspaceRoot, "artifacts", "coding-agent-runs");
     await mkdir(dir, { recursive: true });

--- a/packages/core/src/agent-questionnaire.ts
+++ b/packages/core/src/agent-questionnaire.ts
@@ -59,7 +59,10 @@ export function tryParseChannelQuestionnaireAnswers(
   }
 
   if (questionnaire.questions.length === 1) {
-    const question = questionnaire.questions[0]!;
+    const [question] = questionnaire.questions;
+    if (!question) {
+      return null;
+    }
     const answer = resolveQuestionAnswer(question, trimmed);
 
     if (!answer) {

--- a/packages/core/src/artifact-shares.ts
+++ b/packages/core/src/artifact-shares.ts
@@ -11,7 +11,7 @@ export function generateArtifactShareToken(): string {
 }
 
 export function buildArtifactSharePath(token: string): string {
-  return `/s/${token}`;
+  return `/s/${assertConfigPathSegment(token, "shareToken")}`;
 }
 
 export async function writeArtifactShareSnapshot(input: {

--- a/packages/core/src/attachments/store.ts
+++ b/packages/core/src/attachments/store.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 import { ensureDir, readBytes, removeFile, writePrivateBytesFile } from "../fs";
-import { getProfileSoulDir } from "../soul/resolve";
+import { assertConfigPathSegment, getProfileSoulDir } from "../soul/resolve";
 
 const ATTACHMENTS_DIR = "attachments";
 
@@ -13,7 +13,10 @@ export function getAttachmentFilePath(
   profileId: string,
   attachmentId: string
 ): string {
-  return join(getAttachmentDir(orgId, profileId), attachmentId);
+  return join(
+    getAttachmentDir(orgId, profileId),
+    assertConfigPathSegment(attachmentId, "attachmentId")
+  );
 }
 
 export async function saveAttachmentBytes(

--- a/packages/core/src/channels/email-outbound.ts
+++ b/packages/core/src/channels/email-outbound.ts
@@ -16,7 +16,7 @@ export function createEmailOutboundAdapter(): EmailOutboundAdapter {
           return { error: "Email is not configured.", ok: false };
         }
 
-        const sender = createSmtpSender(emailConfigToMailboxConfig(config!));
+        const sender = createSmtpSender(emailConfigToMailboxConfig(config));
         await sender.send({
           subject: input.subject,
           text: input.text,

--- a/packages/core/src/email-config.ts
+++ b/packages/core/src/email-config.ts
@@ -147,7 +147,9 @@ export function resolveFromHeader(
   return `"${escaped}" <${address}>`;
 }
 
-export function isEmailConfigComplete(config: EmailConfigFile | null): boolean {
+export function isEmailConfigComplete(
+  config: EmailConfigFile | null
+): config is EmailConfigFile {
   if (!config) {
     return false;
   }

--- a/packages/core/src/normalize-task-prompt.ts
+++ b/packages/core/src/normalize-task-prompt.ts
@@ -93,8 +93,9 @@ function unwrapPayload(payload: unknown): string | null {
       typeof value === "string" && value.trim().length > 0
   );
 
-  if (stringValues.length === 1) {
-    return stringValues[0]!.trim();
+  const [onlyValue] = stringValues;
+  if (stringValues.length === 1 && onlyValue) {
+    return onlyValue.trim();
   }
 
   return null;

--- a/packages/core/src/provider-resolution.ts
+++ b/packages/core/src/provider-resolution.ts
@@ -102,8 +102,9 @@ export function resolveProvider(
     return envVar && readEnvValue(env, envVar);
   });
 
-  if (providersWithEnvKeys.length === 1) {
-    return providersWithEnvKeys[0]!;
+  const [onlyProvider] = providersWithEnvKeys;
+  if (providersWithEnvKeys.length === 1 && onlyProvider) {
+    return onlyProvider;
   }
 
   return null;

--- a/packages/core/src/skills/archive.ts
+++ b/packages/core/src/skills/archive.ts
@@ -33,27 +33,17 @@ export async function archiveSkillDirectory(options: {
   skillName: string;
   now?: Date;
 }): Promise<{ archivedDirectory: string; skillName: string }> {
-  const skillName = assertValidSkillName(options.skillName);
-  assertNotBundledSkillName(skillName);
-
   const liveDirectory = resolveProfileSkillDirectory(
     options.orgId,
     options.profileId,
-    skillName
+    options.skillName
   );
+  // resolveProfileSkillDirectory already assertValidSkillName + assertNotBundledSkillName
+  // and keeps liveDirectory inside the profile skills root.
+  const skillName = path.basename(liveDirectory);
 
   if (isUnderArchiveDir(options.orgId, options.profileId, liveDirectory)) {
     throw new Error("Skill is already archived.");
-  }
-
-  if (
-    !isPathWithinProfileSkillsDir(
-      options.orgId,
-      options.profileId,
-      liveDirectory
-    )
-  ) {
-    throw new Error("Path is outside the profile skills directory.");
   }
 
   if (!(await pathExists(liveDirectory))) {
@@ -66,20 +56,11 @@ export async function archiveSkillDirectory(options: {
   );
   await mkdir(archiveRoot, { recursive: true });
 
+  // skillName is a single validated segment from resolveProfileSkillDirectory.
   let archivedDirectory = path.join(archiveRoot, skillName);
   if (await pathExists(archivedDirectory)) {
     const stamp = (options.now ?? new Date()).getTime();
     archivedDirectory = path.join(archiveRoot, `${skillName}-${stamp}`);
-  }
-
-  if (
-    !isPathWithinProfileSkillsDir(
-      options.orgId,
-      options.profileId,
-      archivedDirectory
-    )
-  ) {
-    throw new Error("Archive path is outside the profile skills directory.");
   }
 
   if (

--- a/packages/core/src/soul/memory-archive.ts
+++ b/packages/core/src/soul/memory-archive.ts
@@ -10,7 +10,7 @@ import {
   formatMemoryArchiveYearMonth,
   getMemoryArchiveDir,
 } from "./memory-paths";
-import { getProfileSoulDir } from "./resolve";
+import { assertYearMonth, getProfileSoulDir } from "./resolve";
 
 export const MEMORY_ARCHIVE_TEMPLATE = `# Archived Memory
 
@@ -220,7 +220,7 @@ export async function archiveMemoryBullets(
   }
 
   const archivedAt = options.archivedAt ?? new Date();
-  const yearMonth = formatMemoryArchiveYearMonth(archivedAt);
+  const yearMonth = assertYearMonth(formatMemoryArchiveYearMonth(archivedAt));
   const archivePath = join(archiveDir, `${yearMonth}.md`);
   const archiveAppend = formatArchiveAppend(
     archivedAt,

--- a/packages/core/src/tools/email.ts
+++ b/packages/core/src/tools/email.ts
@@ -197,7 +197,7 @@ export async function runEmailTool(
   }
 
   const parsed = parseEmailToolInput(input);
-  const mailboxConfig = emailConfigToMailboxConfig(config!);
+  const mailboxConfig = emailConfigToMailboxConfig(config);
 
   if (parsed.action === "send") {
     return sendEmail(parsed, mailboxConfig, dependencies.createSender);

--- a/packages/core/src/tools/extract-document-text.ts
+++ b/packages/core/src/tools/extract-document-text.ts
@@ -119,7 +119,7 @@ export async function runExtractDocumentText(
         };
       }
 
-      const mailboxConfig = emailConfigToMailboxConfig(config!);
+      const mailboxConfig = emailConfigToMailboxConfig(config);
       let reference;
       try {
         reference = verifyAttachmentReference(


### PR DESCRIPTION
## What changed

Removed/fixed five meaningless asserts:

1. `archiveSkillDirectory` — dropped duplicate `assertValidSkillName` / `assertNotBundledSkillName` (already enforced by `resolveProfileSkillDirectory`).
2. `archiveSkillDirectory` — dropped `isPathWithinProfileSkillsDir(liveDirectory)` (same containment check already done).
3. `archiveSkillDirectory` — dropped `isPathWithinProfileSkillsDir(archivedDirectory)` (validated single-segment join under `.archive`).
4. `provider-resolution`, `normalize-task-prompt`, `agent-questionnaire` — replaced `[0]!` non-null bangs after `length === 1` with real narrowing.
5. `isEmailConfigComplete` — became a type predicate; removed four `config!` bangs at call sites.

Added five negative-space contracts:

1. `getAttachmentFilePath` — `assertConfigPathSegment(attachmentId)` (blocks `../` traversal).
2. `createAttachmentLoader` — require `record.orgId === context.orgId`.
3. `writeCodingAgentLog` — absolute `workspaceRoot` required.
4. `buildArtifactSharePath` — `assertConfigPathSegment(token)`.
5. memory archive write — `assertYearMonth(...)` before joining archive filename.

## Verified

`bun test` over the 12 affected test files: **75 pass, 0 fail**. Did not run the full monorepo suite.

## Remaining risks

- Not the full monorepo suite, only the affected subset.
- `archiveSkillDirectory` now derives `skillName` via `path.basename(liveDirectory)`; behavior-preserving but worth a glance.
- Root `tsc -p tsconfig.json` is not a clean gate in this repo (pre-existing unrelated errors); the changed lines introduce none.