### PR TITLE
test: remove low-value tests

### DIFF
--- a/apps/web/src/lib/chat-list-stickiness.test.ts
+++ b/apps/web/src/lib/chat-list-stickiness.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test";
 import {
   followOutputBehavior,
   listOverflowsViewport,
-  shouldAutoscrollOnHeightGrowth,
 } from "./chat-list-stickiness";
 
 describe("followOutputBehavior", () => {
@@ -12,13 +11,6 @@ describe("followOutputBehavior", () => {
 
   test("does not follow when not at bottom", () => {
     expect(followOutputBehavior(false)).toBe(false);
-  });
-});
-
-describe("shouldAutoscrollOnHeightGrowth", () => {
-  test("autoscrolls only when at bottom", () => {
-    expect(shouldAutoscrollOnHeightGrowth(true)).toBe(true);
-    expect(shouldAutoscrollOnHeightGrowth(false)).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/chat-stream-image-generation.test.ts
+++ b/apps/web/src/lib/chat-stream-image-generation.test.ts
@@ -4,7 +4,6 @@ import {
   buildGenerateImageToolState,
   formatImageGenerationResolution,
   imageGenerationAspectFromSize,
-  isGenerateImageTool,
   parseGenerateImagePrompt,
   parseGenerateImageSize,
   shouldRenderGenerateImageToolRow,
@@ -26,12 +25,6 @@ function toolMessage(
 }
 
 describe("chat-stream-image-generation", () => {
-  test("isGenerateImageTool matches name", () => {
-    expect(isGenerateImageTool("generate_image")).toBe(true);
-    expect(isGenerateImageTool("web_search")).toBe(false);
-    expect(isGenerateImageTool(undefined)).toBe(false);
-  });
-
   test("parseGenerateImagePrompt and size", () => {
     expect(parseGenerateImagePrompt({ prompt: "  lake  " })).toBe("lake");
     expect(parseGenerateImagePrompt({})).toBeNull();

--- a/apps/web/src/lib/thinking-settings.test.ts
+++ b/apps/web/src/lib/thinking-settings.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test";
 import {
   buildAutoEnableThinkingPayload,
   shouldAutoEnableThinking,
-  shouldBlockThinkingEffortChange,
   shouldShowThinkingEffort,
 } from "./thinking-settings";
 
@@ -54,10 +53,5 @@ describe("thinking-settings helpers", () => {
         hasProfileId: false,
       })
     ).toBe(false);
-  });
-
-  test("shouldBlockThinkingEffortChange blocks while busy", () => {
-    expect(shouldBlockThinkingEffortChange(true)).toBe(true);
-    expect(shouldBlockThinkingEffortChange(false)).toBe(false);
   });
 });

--- a/apps/web/src/lib/timezones.test.ts
+++ b/apps/web/src/lib/timezones.test.ts
@@ -31,11 +31,4 @@ describe("searchTimezoneEntries", () => {
     expect(matches).toHaveLength(1);
     expect(matches[0]?.id).toBe("America/Los_Angeles");
   });
-
-  test("matches when query tokens appear in different fields", () => {
-    const matches = searchTimezoneEntries("san francisco", sampleCatalog);
-
-    expect(matches).toHaveLength(1);
-    expect(matches[0]?.id).toBe("America/Los_Angeles");
-  });
 });

--- a/packages/core/src/cloudflare-provider-config.test.ts
+++ b/packages/core/src/cloudflare-provider-config.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
   CLOUDFLARE_API_ROOT,
-  cloudflareBaseUrlFromAccountId,
   resolveCloudflareAccountInput,
 } from "./cloudflare-provider-config";
 
@@ -24,13 +23,5 @@ describe("resolveCloudflareAccountInput", () => {
     expect(resolveCloudflareAccountInput("")).toBeNull();
     expect(resolveCloudflareAccountInput("not a url")).toBeNull();
     expect(resolveCloudflareAccountInput("https://")).toBeNull();
-  });
-});
-
-describe("cloudflareBaseUrlFromAccountId", () => {
-  test("builds the OpenAI-compatible Workers AI path", () => {
-    expect(cloudflareBaseUrlFromAccountId("acct")).toBe(
-      `${CLOUDFLARE_API_ROOT}/acct/ai/v1`
-    );
   });
 });


### PR DESCRIPTION
## Summary
- Removed 5 clearly low-value unit tests (identity wrappers, a redundant duplicate, a constant-name assert, and coverage already provided elsewhere).
- No production code changes.

### Removed tests
1. `shouldBlockThinkingEffortChange blocks while busy` (`apps/web/src/lib/thinking-settings.test.ts`) — tautological: source is `return busy`.
2. `autoscrolls only when at bottom` (`apps/web/src/lib/chat-list-stickiness.test.ts`) — tautological: source is `return atBottom`.
3. `matches when query tokens appear in different fields` (`apps/web/src/lib/timezones.test.ts`) — redundant duplicate of the San Francisco alias case (same match path; does not exercise different fields).
4. `isGenerateImageTool matches name` (`apps/web/src/lib/chat-stream-image-generation.test.ts`) — tautological constant equality (`tool === "generate_image"`); real parsing/render behavior remains covered by sibling tests.
5. `builds the OpenAI-compatible Workers AI path` (`packages/core/src/cloudflare-provider-config.test.ts`) — redundant with `resolveCloudflareAccountInput` account-ID coverage, which already calls `cloudflareBaseUrlFromAccountId`.

## Test plan
- [x] `bun test` on each affected file (18 pass, 0 fail)
- [x] `bun test` at repo root (2279 pass, 0 fail)
- [x] Pre-commit ultracite check clean

## Remaining risks
- Identity helpers (`shouldBlockThinkingEffortChange`, `shouldAutoscrollOnHeightGrowth`) no longer have direct unit coverage; regressions would only show up if callers start treating them as real logic rather than aliases.
- Case-insensitive timezone search is still exercised via the remaining alias test, but a dedicated multi-field token case is gone (keep an eye out if search scoring changes).

Made with [Cursor](https://cursor.com)