### PR TITLE
fix(server): drop the unawaited session delete that can end the process

### DIFF
--- a/apps/server/src/services/session-persistence.test.ts
+++ b/apps/server/src/services/session-persistence.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentChatSession } from "@nakama/agent";
+import type { DatabaseAdapter } from "@nakama/db";
+import { wrapPersistedSession } from "./session-persistence";
+
+describe("wrapPersistedSession", () => {
+  test("clear leaves the delete to clearSession instead of firing it unawaited", () => {
+    let cleared = false;
+    const session = {
+      clear() {
+        cleared = true;
+      },
+      getHistoryRevision: () => 0,
+    } as unknown as AgentChatSession;
+
+    // An unawaited call here rejects with nowhere to report, and Bun ends the
+    // process on an unhandled rejection. AgentService.clearSession awaits the
+    // same delete right after, so this wrapper must not repeat it.
+    const db = {
+      deleteMessagesForSession() {
+        throw new Error("clear() must not delete messages");
+      },
+    } as unknown as DatabaseAdapter;
+
+    wrapPersistedSession("session_1", session, db).clear();
+
+    expect(cleared).toBe(true);
+  });
+});

--- a/apps/server/src/services/session-persistence.ts
+++ b/apps/server/src/services/session-persistence.ts
@@ -15,7 +15,6 @@ export function wrapPersistedSession(
     clear() {
       session.clear();
       lastPersistedRevision = session.getHistoryRevision();
-      void db.deleteMessagesForSession(sessionId);
     },
     async compact(options) {
       const revisionBefore = session.getHistoryRevision();


### PR DESCRIPTION
`wrapPersistedSession.clear()` fired `db.deleteMessagesForSession` without awaiting it, while `AgentService.clearSession` awaits the same delete three lines later. The rows were deleted twice, and the first attempt had nowhere to report a failure. Bun ends the process on an unhandled rejection, so a locked or read only database turned a session clear into a server exit. Reachable from the clear action in the web UI and from the channel `/clear` commands, which all route through `sessions.ts:382`.

Before, driving the real wrapper with a database stub that rejects:

```
error: SQLITE_BUSY: database is locked
      at clear (apps/server/src/services/session-persistence.ts:18:15)
Bun v1.3.14 (macOS arm64)
exit=1
```

After, that path no longer touches the database, and the new test pins it. Putting the one deleted line back turns it red:

```
(fail) wrapPersistedSession > clear leaves the delete to clearSession instead of firing it unawaited
 0 pass  1 fail
```

`bun run test`: 2284 tests across 11 workspaces, 0 fail. `bun run check`: clean, 1169 files.

Closes #327
