### PR TITLE
fix(server): bound the agent-browser version probe with a timeout

### DIFF
--- a/apps/server/src/services/agent-browser-service.test.ts
+++ b/apps/server/src/services/agent-browser-service.test.ts
@@ -57,6 +57,29 @@ describe("agent-browser service", () => {
     expect(status.ready).toBe(true);
     expect(status.nextStep).toBeNull();
   });
+
+  test("a CLI that hangs on --version resolves as not installed", async () => {
+    await installFakeBinary(tempBinDir, "agent-browser", "hangs");
+
+    const started = Date.now();
+    const status = await getAgentBrowserStatus();
+
+    expect(status.installed).toBe(false);
+    expect(status.ready).toBe(false);
+    expect(status.nextStep).toBe("install");
+    expect(Date.now() - started).toBeLessThan(15_000);
+  }, 20_000);
+
+  test("a CLI that ignores SIGTERM still resolves the readiness probe", async () => {
+    await installFakeBinary(tempBinDir, "agent-browser", "stubborn");
+
+    const started = Date.now();
+    const status = await getAgentBrowserStatus();
+
+    expect(status.installed).toBe(false);
+    expect(status.ready).toBe(false);
+    expect(Date.now() - started).toBeLessThan(15_000);
+  }, 20_000);
 });
 
 describe("agent-browser settings routes", () => {
@@ -133,6 +156,43 @@ describe("agent-browser settings routes", () => {
     expect(body.version).toBe("agent-browser 1.0.0");
   });
 
+  test("org admin status request returns when agent-browser hangs", async () => {
+    await installFakeBinary(tempBinDir, "agent-browser", "hangs");
+
+    const databaseAdapter = createInMemoryDatabaseAdapter();
+    const authService = new AuthService();
+    const app = createHonoApp({
+      agent: new AgentService(null, null, databaseAdapter),
+      authService,
+      automationService: {} as any,
+      databaseAdapter,
+      mcpService: {} as any,
+      orgService: new OrgService(databaseAdapter, authService),
+      systemStatus: { getStatus: async () => ({ ok: true }) } as any,
+      taskService: {} as any,
+      webDistDir: null,
+      workerManager: {} as any,
+    });
+
+    const session = await setupFreshInstallSession(app, databaseAdapter);
+    const started = Date.now();
+
+    const response = await app.fetch(
+      new Request("http://localhost:4310/v1/settings/agent-browser", {
+        headers: session.headers(),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      installed: boolean;
+      ready: boolean;
+    };
+    expect(body.installed).toBe(false);
+    expect(body.ready).toBe(false);
+    expect(Date.now() - started).toBeLessThan(15_000);
+  }, 20_000);
+
   test("install stream emits progress events", async () => {
     await installFakeBinary(tempBinDir, "npm", "noop");
     await installFakeBinary(tempBinDir, "agent-browser", "installable");
@@ -174,7 +234,13 @@ describe("agent-browser settings routes", () => {
 async function installFakeBinary(
   binDir: string,
   name: string,
-  mode: "ready" | "login-required" | "noop" | "installable"
+  mode:
+    | "ready"
+    | "login-required"
+    | "noop"
+    | "installable"
+    | "hangs"
+    | "stubborn"
 ): Promise<void> {
   const scriptPath = join(binDir, name);
   let script = "";
@@ -211,6 +277,18 @@ if [ "$1" = "install" ]; then
   exit 0
 fi
 exit 0
+`;
+  } else if (mode === "hangs") {
+    // Direct Node process so SIGTERM hits this PID. A shell wrapper would
+    // leave `sleep` running after kill(), and PATH in these tests is only
+    // the stub dir so `sleep` would not be found anyway.
+    script = `#!${process.execPath}
+setInterval(() => {}, 1000);
+`;
+  } else if (mode === "stubborn") {
+    script = `#!${process.execPath}
+process.on("SIGTERM", () => {});
+setInterval(() => {}, 1000);
 `;
   }
 

--- a/apps/server/src/services/agent-browser-service.ts
+++ b/apps/server/src/services/agent-browser-service.ts
@@ -64,14 +64,38 @@ async function probeAgentBrowserVersion(): Promise<{
   missing: boolean;
 }> {
   const { spawn } = await import("node:child_process");
+  const timeoutMs = 5000;
 
   return new Promise((resolve) => {
-    const child = spawn(AGENT_BROWSER_COMMAND, ["--version"], {
-      env: getToolExecutionEnv(),
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    let child: ReturnType<typeof spawn>;
+
+    try {
+      child = spawn(AGENT_BROWSER_COMMAND, ["--version"], {
+        env: getToolExecutionEnv(),
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch {
+      resolve({
+        installed: false,
+        missing: true,
+        version: null,
+      });
+      return;
+    }
+
     let stdout = "";
     let stderr = "";
+
+    // Settings awaits this probe, so a CLI that never answers --version
+    // would otherwise hold GET /v1/settings/agent-browser open forever.
+    // Resolve on the timer instead of waiting for close, because a child
+    // that ignores SIGTERM never emits one. `missing: false` keeps
+    // getAgentBrowserRuntimeStatus from paying the timeout a second time
+    // on its PATH retry.
+    const timeoutId = setTimeout(() => {
+      child.kill("SIGTERM");
+      resolve({ installed: false, missing: false, version: null });
+    }, timeoutMs);
 
     child.stdout?.on("data", (chunk) => {
       stdout += chunk.toString();
@@ -79,20 +103,22 @@ async function probeAgentBrowserVersion(): Promise<{
     child.stderr?.on("data", (chunk) => {
       stderr += chunk.toString();
     });
-    child.once("error", (error) =>
+    child.once("error", (error) => {
+      clearTimeout(timeoutId);
       resolve({
         installed: false,
         missing: (error as NodeJS.ErrnoException).code === "ENOENT",
         version: null,
-      })
-    );
-    child.once("close", (code) =>
+      });
+    });
+    child.once("close", (code) => {
+      clearTimeout(timeoutId);
       resolve({
         installed: code === 0,
         missing: false,
         version: code === 0 ? extractVersion(stdout, stderr) : null,
-      })
-    );
+      });
+    });
   });
 }
 


### PR DESCRIPTION
`GET /v1/settings/agent-browser` waits on `probeAgentBrowserVersion()`. That spawn only resolved on `close` or `error`, so a CLI that hung on `--version` left Settings open.

This copies the coding-agent harness bound: 5s then SIGTERM, resolve as not installed. Timeout sets `missing: false` so `getAgentBrowserRuntimeStatus` does not pay the 5s again on the PATH retry.

Tests use `NAKAMA_DISABLE_FIX_PATH=1` so `fixPath()` cannot hide the stub (the trap from the issue). Hang and SIGTERM-ignoring stubs are Node processes, not `sh`+`sleep`, so the signal hits the PID we spawn.

`omni-install` `tar` spawn is still unbounded; left for a follow-up as agreed on the issue.

## Validation

Added hang / stubborn / Settings GET coverage in `apps/server/src/services/agent-browser-service.test.ts`. I could not run `bun test` to completion on this Windows machine: the local `openai` install is missing files (`version.mjs`, then `resources/videos.mjs`). CI on Linux should be the check.

## Related

Fixes #326