### PR TITLE
docs: point local dev dashboard URL to port 3003

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ bun run dev:web      # web dashboard (starts the server if needed)
 bun run dev:cli      # terminal client
 ```
 
-- Local Bun web dashboard: http://localhost:3000
+- Local Bun web dashboard: http://localhost:3003
 - Docker single-container dashboard (API + web + workers): http://localhost:4310
 
 See [AGENTS.md](./AGENTS.md) for Docker run/build scripts and deeper layout notes.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ bun install
 bun run dev:web
 ```
 
-Open the web dashboard: http://localhost:3000
+Open the web dashboard: http://localhost:3003
 
 Or start the server alone:
 


### PR DESCRIPTION
## Summary

`bun run dev:web` serves the dashboard on port 3003, but `README.md` and
`CONTRIBUTING.md` still send you to http://localhost:3000.

The docs site was already corrected in 041942ad ("docs: point local web
dashboard URL to port 3003"); these two files were missed.

Where 3003 comes from:

- `apps/web/vite.config.ts` sets `server.port: 3003`
- `apps/web/scripts/dev.ts` spawns `bun run vite` with no port argument, so
  nothing overrides it

`README.md` gets a one-line URL correction, not a rewrite.

## Test plan

- [x] `bun install && bun run dev:web` on Bun 1.3.14: vite listens on 3003 and
      the API on 4310. `curl http://localhost:3003/` returns 200; nothing
      listens on 3000 and `curl http://localhost:3000/` gets no answer.
- [x] `grep -rn "localhost:3000" --exclude-dir=node_modules .` returns nothing
- [x] `bun install --frozen-lockfile`, `bun run check`, and `bun run test`
      (the commands CI runs) all pass on `67542c4a`: 1169 files checked with no
      fixes, 2280 tests across 326 files, 0 fail

## Risks

None. Documentation only, no runtime change.
