### PR TITLE
feat(composio): connect, auto-assign and a shorter app list on Integrations

### DIFF
--- a/apps/server/src/services/composio-service.test.ts
+++ b/apps/server/src/services/composio-service.test.ts
@@ -154,6 +154,78 @@ describe("ComposioService", () => {
     }
   });
 
+  test("enableToolkit assigns the toolkit to the org default profile", async () => {
+    const { db, service, restore } = await createConfiguredService();
+
+    try {
+      await db.upsertProfile({
+        createdAt: new Date().toISOString(),
+        id: "profile_default",
+        isDefault: true,
+        isSuper: false,
+        model: null,
+        name: "Default",
+        orgId: ORG_ID,
+        systemPrompt: "",
+      });
+      await db.upsertProfile({
+        createdAt: new Date().toISOString(),
+        id: "profile_super",
+        isDefault: false,
+        isSuper: true,
+        model: null,
+        name: "Super Bot",
+        orgId: ORG_ID,
+        systemPrompt: "",
+      });
+
+      const toolkit = await service.enableToolkit(ORG_ID, {
+        toolkitSlug: "gmail",
+      });
+
+      const assigned = await db.listProfileComposioToolkits("profile_default");
+      expect(assigned.map((entry) => entry.toolkitId)).toEqual([toolkit.id]);
+
+      // Super Bot and channel-facing profiles stay an explicit choice.
+      expect(await db.listProfileComposioToolkits("profile_super")).toEqual([]);
+    } finally {
+      restore();
+    }
+  });
+
+  test("disableToolkit removes the toolkit from every profile in the org", async () => {
+    const { db, service, restore } = await createConfiguredService();
+
+    try {
+      await db.upsertProfile({
+        createdAt: new Date().toISOString(),
+        id: "profile_default",
+        isDefault: true,
+        isSuper: false,
+        model: null,
+        name: "Default",
+        orgId: ORG_ID,
+        systemPrompt: "",
+      });
+
+      const toolkit = await service.enableToolkit(ORG_ID, {
+        toolkitSlug: "gmail",
+      });
+      expect(
+        await db.listProfileComposioToolkits("profile_default")
+      ).toHaveLength(1);
+
+      await service.disableToolkit(ORG_ID, "gmail");
+
+      expect(await db.listProfileComposioToolkits("profile_default")).toEqual(
+        []
+      );
+      expect(toolkit.status).toBe("enabled");
+    } finally {
+      restore();
+    }
+  });
+
   test("connectToolkit stores oauth state on user connection and returns redirect URL", async () => {
     const { service, restore } = await createConfiguredService();
 

--- a/apps/server/src/services/composio-service.ts
+++ b/apps/server/src/services/composio-service.ts
@@ -341,6 +341,7 @@ export class ComposioService {
         updatedAt: now,
       };
       await this.databaseAdapter.upsertComposioToolkit(updated);
+      await this.assignToDefaultProfile(orgId, updated.id);
       return toOrgToolkitSummary(updated);
     }
 
@@ -357,6 +358,7 @@ export class ComposioService {
     };
 
     await this.databaseAdapter.upsertComposioToolkit(record);
+    await this.assignToDefaultProfile(orgId, record.id);
     return toOrgToolkitSummary(record);
   }
 
@@ -371,7 +373,69 @@ export class ComposioService {
       updatedAt: new Date().toISOString(),
     };
     await this.databaseAdapter.upsertComposioToolkit(updated);
+    await this.unassignFromAllProfiles(orgId, updated.id);
     return toOrgToolkitSummary(updated);
+  }
+
+  /**
+   * Enabling a toolkit assigns it to the org's default profile, so a fresh
+   * setup is usable without a second trip to Profiles. Other profiles stay an
+   * explicit choice: Super Bot and channel-facing profiles should not gain a
+   * member's Gmail because an admin enabled it for the org.
+   */
+  private async assignToDefaultProfile(
+    orgId: string,
+    toolkitId: string
+  ): Promise<void> {
+    const profiles = await this.databaseAdapter.listProfiles();
+    const target = profiles.find(
+      (profile) => profile.orgId === orgId && profile.isDefault === true
+    );
+    if (!target) {
+      return;
+    }
+
+    const assignments = await this.databaseAdapter.listProfileComposioToolkits(
+      target.id
+    );
+    if (assignments.some((entry) => entry.toolkitId === toolkitId)) {
+      return;
+    }
+
+    await this.databaseAdapter.replaceProfileComposioToolkits(target.id, [
+      ...assignments,
+      { allowedActions: null, profileId: target.id, toolkitId },
+    ]);
+  }
+
+  /**
+   * Disabling for the org removes the toolkit from every profile. The tool
+   * bridge already skips disabled toolkits, so this is about the Profiles page
+   * not listing a toolkit that does nothing.
+   */
+  private async unassignFromAllProfiles(
+    orgId: string,
+    toolkitId: string
+  ): Promise<void> {
+    const profiles = await this.databaseAdapter.listProfiles();
+
+    for (const profile of profiles) {
+      if (profile.orgId !== orgId) {
+        continue;
+      }
+
+      const assignments =
+        await this.databaseAdapter.listProfileComposioToolkits(profile.id);
+      const kept = assignments.filter((entry) => entry.toolkitId !== toolkitId);
+      if (kept.length === assignments.length) {
+        continue;
+      }
+
+      await this.databaseAdapter.replaceProfileComposioToolkits(
+        profile.id,
+        kept
+      );
+    }
   }
 
   async connectToolkit(

--- a/apps/web/src/components/ComposioConnectionsCard.tsx
+++ b/apps/web/src/components/ComposioConnectionsCard.tsx
@@ -176,7 +176,8 @@ function ComposioToolkitRow({
         </div>
         {orgEnabled && userStatus === "connected" ? (
           <p className="mt-1 text-muted-foreground text-xs">
-            Agents can use this once the toolkit is assigned to a profile.
+            Assigned to the default profile. Other profiles are assigned on the
+            Profiles page.
           </p>
         ) : null}
         {lastError ? (

--- a/apps/web/src/components/ComposioConnectionsCard.tsx
+++ b/apps/web/src/components/ComposioConnectionsCard.tsx
@@ -38,6 +38,41 @@ import { cn } from "@/lib/utils";
 
 const CATALOG_PAGE_SIZE = 15;
 
+/**
+ * The catalog is 200 apps, which buries the ones a team actually asks for. The
+ * list opens on these plus whatever the org already enabled; everything else is
+ * one click away behind "all apps", and search always covers the full catalog.
+ */
+const FEATURED_TOOLKIT_SLUGS = new Set([
+  "airtable",
+  "asana",
+  "clickup",
+  "discord",
+  "dropbox",
+  "facebook",
+  "github",
+  "gmail",
+  "googlecalendar",
+  "googledocs",
+  "googledrive",
+  "googlemeet",
+  "googlesheets",
+  "googletasks",
+  "jira",
+  "linear",
+  "linkedin",
+  "notion",
+  "one_drive",
+  "outlook",
+  "reddit",
+  "slack",
+  "trello",
+  "twitter",
+  "whatsapp",
+  "youtube",
+  "zoom",
+]);
+
 function compareToolkitRows(a: ToolkitRowModel, b: ToolkitRowModel): number {
   const aActive = isActiveToolkit(a) ? 0 : 1;
   const bActive = isActiveToolkit(b) ? 0 : 1;
@@ -317,6 +352,7 @@ function ComposioToolkitList({
 }: ComposioToolkitListProps) {
   const [search, setSearch] = useState("");
   const [visibleCount, setVisibleCount] = useState(CATALOG_PAGE_SIZE);
+  const [showAllApps, setShowAllApps] = useState(false);
   const deferredSearch = useDeferredValue(search);
 
   const query = deferredSearch.trim().toLowerCase();
@@ -368,8 +404,15 @@ function ComposioToolkitList({
       return activeRows.filter((row) => row.orgToolkit?.status === "enabled");
     }
 
-    return rows.toSorted(compareToolkitRows);
-  }, [activeRows, isOrgAdmin, isSearching, query, rows]);
+    const base = showAllApps
+      ? rows
+      : rows.filter(
+          (row) =>
+            FEATURED_TOOLKIT_SLUGS.has(row.catalog.slug) || isActiveToolkit(row)
+        );
+
+    return base.toSorted(compareToolkitRows);
+  }, [activeRows, isOrgAdmin, isSearching, query, rows, showAllApps]);
 
   const displayedRows = filteredRows.slice(0, visibleCount);
   const remainingCount = Math.max(
@@ -409,22 +452,41 @@ function ComposioToolkitList({
           />
         </div>
 
-        <p className="text-muted-foreground text-xs tabular-nums">
-          {isSearching ? (
-            <>
-              {filteredRows.length} match{filteredRows.length === 1 ? "" : "es"}
-            </>
-          ) : isOrgAdmin ? (
-            <>
-              {enabledCount} enabled · {connectedCount} connected by you ·{" "}
-              {data.catalog.length} available
-            </>
-          ) : (
-            <>
-              {enabledCount} enabled · {connectedCount} connected by you
-            </>
-          )}
-        </p>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <p className="text-muted-foreground text-xs tabular-nums">
+            {isSearching ? (
+              <>
+                {filteredRows.length} match
+                {filteredRows.length === 1 ? "" : "es"}
+              </>
+            ) : isOrgAdmin ? (
+              <>
+                {enabledCount} enabled · {connectedCount} connected by you ·{" "}
+                {showAllApps ? data.catalog.length : filteredRows.length} shown
+              </>
+            ) : (
+              <>
+                {enabledCount} enabled · {connectedCount} connected by you
+              </>
+            )}
+          </p>
+
+          {isOrgAdmin && !isSearching ? (
+            <Button
+              className="h-auto p-0 text-xs"
+              onClick={() => {
+                setShowAllApps((current) => !current);
+                setVisibleCount(CATALOG_PAGE_SIZE);
+              }}
+              type="button"
+              variant="link"
+            >
+              {showAllApps
+                ? "Show popular apps"
+                : `Show all ${data.catalog.length} apps`}
+            </Button>
+          ) : null}
+        </div>
       </div>
 
       {data.catalog.length === 0 ? (

--- a/apps/web/src/components/ComposioConnectionsCard.tsx
+++ b/apps/web/src/components/ComposioConnectionsCard.tsx
@@ -21,6 +21,7 @@ import { useAuth } from "@/context/use-auth";
 import {
   useComposioSettings,
   useComposioToolkits,
+  useConnectComposioToolkit,
   useDisableComposioToolkit,
   useDisconnectComposioToolkit,
   useEnableComposioToolkit,
@@ -123,6 +124,7 @@ function StatusPill({
 interface ComposioToolkitRowProps {
   busy: boolean;
   isOrgAdmin: boolean;
+  onConnect: (slug: string) => void;
   onDisable: (slug: string) => void;
   onDisconnect: (slug: string) => void;
   onEnable: (slug: string) => void;
@@ -134,6 +136,7 @@ function ComposioToolkitRow({
   row,
   isOrgAdmin,
   busy,
+  onConnect,
   onEnable,
   onDisable,
   onSync,
@@ -171,6 +174,11 @@ function ComposioToolkitRow({
             />
           ) : null}
         </div>
+        {orgEnabled && userStatus === "connected" ? (
+          <p className="mt-1 text-muted-foreground text-xs">
+            Agents can use this once the toolkit is assigned to a profile.
+          </p>
+        ) : null}
         {lastError ? (
           <p className="mt-1 truncate text-destructive text-xs">{lastError}</p>
         ) : null}
@@ -219,6 +227,19 @@ function ComposioToolkitRow({
           </DropdownMenu>
         ) : null}
 
+        {orgEnabled && userStatus !== "connected" ? (
+          <Button
+            disabled={busy}
+            onClick={() => onConnect(catalog.slug)}
+            size="sm"
+            type="button"
+          >
+            {userStatus === "oauth_in_progress"
+              ? "Finish connecting"
+              : "Connect"}
+          </Button>
+        ) : null}
+
         {isOrgAdmin && orgEnabled && userStatus !== "connected" ? (
           <Button
             disabled={busy}
@@ -239,6 +260,7 @@ interface ComposioToolkitListProps {
   busy: boolean;
   data: ListComposioToolkitsResponse;
   isOrgAdmin: boolean;
+  onConnect: (slug: string) => void;
   onDisable: (slug: string) => void;
   onDisconnect: (slug: string) => void;
   onEnable: (slug: string) => void;
@@ -249,6 +271,7 @@ function ComposioToolkitList({
   data,
   isOrgAdmin,
   busy,
+  onConnect,
   onEnable,
   onDisable,
   onSync,
@@ -395,6 +418,7 @@ function ComposioToolkitList({
                   busy={busy}
                   isOrgAdmin={isOrgAdmin}
                   key={row.catalog.slug}
+                  onConnect={onConnect}
                   onDisable={onDisable}
                   onDisconnect={onDisconnect}
                   onEnable={onEnable}
@@ -478,12 +502,14 @@ export function ComposioConnectionsCard({
   const isOrgAdmin = activeOrg?.role === "admin";
   const { data: settings } = useComposioSettings();
   const toolkitsQuery = useComposioToolkits();
+  const connectMutation = useConnectComposioToolkit();
   const enableMutation = useEnableComposioToolkit();
   const disableMutation = useDisableComposioToolkit();
   const disconnectMutation = useDisconnectComposioToolkit();
   const syncMutation = useSyncComposioToolkit();
 
   const busy =
+    connectMutation.isPending ||
     enableMutation.isPending ||
     disableMutation.isPending ||
     disconnectMutation.isPending ||
@@ -556,6 +582,7 @@ export function ComposioConnectionsCard({
         busy={busy}
         data={data}
         isOrgAdmin={isOrgAdmin}
+        onConnect={(slug) => connectMutation.mutate(slug)}
         onDisable={(slug) => disableMutation.mutate(slug)}
         onDisconnect={(slug) => disconnectMutation.mutate(slug)}
         onEnable={(slug) => enableMutation.mutate(slug)}

--- a/apps/web/src/components/ComposioConnectionsCard.tsx
+++ b/apps/web/src/components/ComposioConnectionsCard.tsx
@@ -4,9 +4,12 @@ import type {
   ComposioUserConnectionStatus,
   ComposioUserConnectionSummary,
   ListComposioToolkitsResponse,
+  ProfileSummary,
 } from "@nakama/core/contract";
+import { useQueries } from "@tanstack/react-query";
 import { MoreHorizontalIcon, Search01Icon } from "hugeicons-react";
 import { useDeferredValue, useMemo, useState } from "react";
+import { ComposioProfileAssignPicker } from "@/components/ComposioProfileAssignPicker";
 import { ComposioToolkitLogo } from "@/components/ComposioToolkitLogo";
 import { IntegrationCardShell } from "@/components/integration-settings.shared";
 import { Button } from "@/components/ui/button";
@@ -18,7 +21,9 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { useAuth } from "@/context/use-auth";
+import { useProfilesQuery } from "@/hooks/use-app-queries";
 import {
+  profileComposioToolkitsQueryOptions,
   useComposioSettings,
   useComposioToolkits,
   useConnectComposioToolkit,
@@ -26,6 +31,7 @@ import {
   useDisconnectComposioToolkit,
   useEnableComposioToolkit,
   useSyncComposioToolkit,
+  useUpdateProfileComposioToolkitsMutation,
 } from "@/hooks/use-composio";
 import { formatError } from "@/lib/client";
 import { cn } from "@/lib/utils";
@@ -122,6 +128,7 @@ function StatusPill({
 }
 
 interface ComposioToolkitRowProps {
+  assignedProfileIds: string[];
   busy: boolean;
   isOrgAdmin: boolean;
   onConnect: (slug: string) => void;
@@ -129,6 +136,12 @@ interface ComposioToolkitRowProps {
   onDisconnect: (slug: string) => void;
   onEnable: (slug: string) => void;
   onSync: (slug: string) => void;
+  onToggleProfile: (
+    profileId: string,
+    toolkitId: string,
+    assigned: boolean
+  ) => void;
+  profiles: ProfileSummary[];
   row: ToolkitRowModel;
 }
 
@@ -136,6 +149,9 @@ function ComposioToolkitRow({
   row,
   isOrgAdmin,
   busy,
+  assignedProfileIds,
+  profiles,
+  onToggleProfile,
   onConnect,
   onEnable,
   onDisable,
@@ -176,8 +192,7 @@ function ComposioToolkitRow({
         </div>
         {orgEnabled && userStatus === "connected" ? (
           <p className="mt-1 text-muted-foreground text-xs">
-            Assigned to the default profile. Other profiles are assigned on the
-            Profiles page.
+            Assigned to the default profile when it was enabled.
           </p>
         ) : null}
         {lastError ? (
@@ -228,6 +243,18 @@ function ComposioToolkitRow({
           </DropdownMenu>
         ) : null}
 
+        {isOrgAdmin && orgEnabled && orgToolkit ? (
+          <ComposioProfileAssignPicker
+            assignedProfileIds={assignedProfileIds}
+            busy={busy}
+            onToggle={(profileId, assigned) =>
+              onToggleProfile(profileId, orgToolkit.id, assigned)
+            }
+            profiles={profiles}
+            toolkitName={catalog.name}
+          />
+        ) : null}
+
         {orgEnabled && userStatus !== "connected" ? (
           <Button
             disabled={busy}
@@ -258,6 +285,7 @@ function ComposioToolkitRow({
 }
 
 interface ComposioToolkitListProps {
+  assignedProfileIdsByToolkit: Map<string, string[]>;
   busy: boolean;
   data: ListComposioToolkitsResponse;
   isOrgAdmin: boolean;
@@ -266,12 +294,21 @@ interface ComposioToolkitListProps {
   onDisconnect: (slug: string) => void;
   onEnable: (slug: string) => void;
   onSync: (slug: string) => void;
+  onToggleProfile: (
+    profileId: string,
+    toolkitId: string,
+    assigned: boolean
+  ) => void;
+  profiles: ProfileSummary[];
 }
 
 function ComposioToolkitList({
   data,
   isOrgAdmin,
   busy,
+  assignedProfileIdsByToolkit,
+  profiles,
+  onToggleProfile,
   onConnect,
   onEnable,
   onDisable,
@@ -416,6 +453,10 @@ function ComposioToolkitList({
             <div className="divide-y divide-border">
               {displayedRows.map((row) => (
                 <ComposioToolkitRow
+                  assignedProfileIds={
+                    assignedProfileIdsByToolkit.get(row.orgToolkit?.id ?? "") ??
+                    []
+                  }
                   busy={busy}
                   isOrgAdmin={isOrgAdmin}
                   key={row.catalog.slug}
@@ -424,6 +465,8 @@ function ComposioToolkitList({
                   onDisconnect={onDisconnect}
                   onEnable={onEnable}
                   onSync={onSync}
+                  onToggleProfile={onToggleProfile}
+                  profiles={profiles}
                   row={row}
                 />
               ))}
@@ -505,11 +548,65 @@ export function ComposioConnectionsCard({
   const toolkitsQuery = useComposioToolkits();
   const connectMutation = useConnectComposioToolkit();
   const enableMutation = useEnableComposioToolkit();
+  const assignMutation = useUpdateProfileComposioToolkitsMutation();
+  const profilesQuery = useProfilesQuery();
+  const profiles = isOrgAdmin ? (profilesQuery.data ?? []) : [];
+
+  // Assignments live per profile, so the reverse map is built here rather than
+  // asking the toolkits endpoint for it. Only org admins may read them, and the
+  // profile count is small, so one query per profile is cheap enough.
+  const assignmentQueries = useQueries({
+    queries: profiles.map((profile) =>
+      profileComposioToolkitsQueryOptions(profile.id)
+    ),
+  });
+
+  const assignedProfileIdsByToolkit = useMemo(() => {
+    const map = new Map<string, string[]>();
+
+    profiles.forEach((profile, index) => {
+      for (const assignment of assignmentQueries[index]?.data?.assignments ??
+        []) {
+        map.set(assignment.toolkitId, [
+          ...(map.get(assignment.toolkitId) ?? []),
+          profile.id,
+        ]);
+      }
+    });
+
+    return map;
+  }, [profiles, assignmentQueries]);
+
+  const toggleProfileAssignment = (
+    profileId: string,
+    toolkitId: string,
+    assigned: boolean
+  ) => {
+    const index = profiles.findIndex((profile) => profile.id === profileId);
+    const current = assignmentQueries[index]?.data?.assignments ?? [];
+    const next = assigned
+      ? [
+          ...current.map((entry) => ({
+            allowedActions: entry.allowedActions,
+            toolkitId: entry.toolkitId,
+          })),
+          { allowedActions: null, toolkitId },
+        ]
+      : current
+          .filter((entry) => entry.toolkitId !== toolkitId)
+          .map((entry) => ({
+            allowedActions: entry.allowedActions,
+            toolkitId: entry.toolkitId,
+          }));
+
+    assignMutation.mutate({ assignments: next, profileId });
+  };
   const disableMutation = useDisableComposioToolkit();
   const disconnectMutation = useDisconnectComposioToolkit();
   const syncMutation = useSyncComposioToolkit();
 
   const busy =
+    assignMutation.isPending ||
     connectMutation.isPending ||
     enableMutation.isPending ||
     disableMutation.isPending ||
@@ -580,6 +677,7 @@ export function ComposioConnectionsCard({
   return (
     <IntegrationCardShell {...shellProps}>
       <ComposioToolkitList
+        assignedProfileIdsByToolkit={assignedProfileIdsByToolkit}
         busy={busy}
         data={data}
         isOrgAdmin={isOrgAdmin}
@@ -588,6 +686,8 @@ export function ComposioConnectionsCard({
         onDisconnect={(slug) => disconnectMutation.mutate(slug)}
         onEnable={(slug) => enableMutation.mutate(slug)}
         onSync={(slug) => syncMutation.mutate(slug)}
+        onToggleProfile={toggleProfileAssignment}
+        profiles={profiles}
       />
     </IntegrationCardShell>
   );

--- a/apps/web/src/components/ComposioProfileAssignPicker.tsx
+++ b/apps/web/src/components/ComposioProfileAssignPicker.tsx
@@ -1,0 +1,112 @@
+import type { ProfileSummary } from "@nakama/core/contract";
+import { CheckmarkCircle02Icon, UserGroupIcon } from "hugeicons-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+
+interface ComposioProfileAssignPickerProps {
+  assignedProfileIds: string[];
+  busy: boolean;
+  onToggle: (profileId: string, assigned: boolean) => void;
+  profiles: ProfileSummary[];
+  toolkitName: string;
+}
+
+export function ComposioProfileAssignPicker({
+  assignedProfileIds,
+  busy,
+  onToggle,
+  profiles,
+  toolkitName,
+}: ComposioProfileAssignPickerProps) {
+  const [open, setOpen] = useState(false);
+
+  if (profiles.length === 0) {
+    return null;
+  }
+
+  const assigned = new Set(assignedProfileIds);
+
+  return (
+    <>
+      <Button
+        disabled={busy}
+        onClick={() => setOpen(true)}
+        size="sm"
+        type="button"
+        variant="outline"
+      >
+        <UserGroupIcon aria-hidden className="size-4" />
+        {assigned.size === 1 ? "1 profile" : `${assigned.size} profiles`}
+      </Button>
+
+      <Dialog onOpenChange={setOpen} open={open}>
+        <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-md">
+          <DialogHeader className="gap-1 border-border border-b px-6 py-4 text-left">
+            <DialogTitle>Profiles for {toolkitName}</DialogTitle>
+            <DialogDescription>
+              Pick which agents can use it. Changes save as you click, so the
+              dialog stays open.
+            </DialogDescription>
+          </DialogHeader>
+
+          <Command className="rounded-none bg-transparent">
+            <div className="border-border/60 border-b px-2 py-2 [&_[data-slot=command-input-wrapper]]:p-0">
+              <CommandInput placeholder="Search profiles…" />
+            </div>
+            <CommandList className="max-h-72 p-1">
+              <CommandEmpty>No profiles found.</CommandEmpty>
+              <CommandGroup>
+                {profiles.map((profile) => {
+                  const isAssigned = assigned.has(profile.id);
+
+                  return (
+                    <CommandItem
+                      key={profile.id}
+                      onSelect={() => onToggle(profile.id, !isAssigned)}
+                      value={profile.name}
+                    >
+                      <CheckmarkCircle02Icon
+                        aria-hidden
+                        className={cn(
+                          "size-4 shrink-0",
+                          isAssigned
+                            ? "text-primary"
+                            : "text-muted-foreground/40"
+                        )}
+                      />
+                      <div className="min-w-0">
+                        <p className="truncate font-medium text-foreground text-sm leading-tight">
+                          {profile.name}
+                        </p>
+                        <p className="mt-0.5 text-muted-foreground text-xs leading-snug">
+                          {isAssigned ? "Can use this toolkit" : "Not assigned"}
+                          {profile.isSuper ? " · runs bash" : ""}
+                        </p>
+                      </div>
+                    </CommandItem>
+                  );
+                })}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/components/ComposioSettingsCard.tsx
+++ b/apps/web/src/components/ComposioSettingsCard.tsx
@@ -174,7 +174,7 @@ export function ComposioSettingsCard({
               Project API key
             </p>
             <p className="text-muted-foreground text-sm [text-wrap:pretty]">
-              Paste a Composio project API key — not the MCP consumer key.
+              Paste a Composio project API key, not the MCP consumer key.
             </p>
           </div>
           {embedded ? (
@@ -251,7 +251,7 @@ export function ComposioSettingsCard({
       <div className={cn(footerPadding)}>
         <a
           className="inline-flex items-center gap-2 text-muted-foreground text-sm transition-colors hover:text-foreground"
-          href="https://docs.composio.dev/reference/authentication"
+          href="https://dashboard.composio.dev"
           rel="noreferrer"
           target="_blank"
         >

--- a/apps/web/src/hooks/use-composio.ts
+++ b/apps/web/src/hooks/use-composio.ts
@@ -71,6 +71,18 @@ export function useDisableComposioToolkit() {
   });
 }
 
+export function useConnectComposioToolkit() {
+  return useMutation({
+    mutationFn: (toolkitSlug: string) =>
+      client.connectComposioToolkit(toolkitSlug),
+    onSuccess: (response) => {
+      // Composio hosts the account picker and consent, then redirects back to
+      // /integrations through our OAuth callback.
+      window.location.href = response.redirectUrl;
+    },
+  });
+}
+
 export function useDisconnectComposioToolkit() {
   const queryClient = useQueryClient();
 


### PR DESCRIPTION
Enabling a Composio toolkit used to leave it usable by nobody, and for most org admins there was no way out of that.

There was no Connect button anywhere in `apps/web` (nothing called `client.connectComposioToolkit`), and the chat fallback only offers `composio__connect_account` for toolkits already assigned to a profile (`composio-tool-bridge.ts:185`), so a freshly enabled toolkit had no path to a connection at all. `composio.mdx` pointed at a button that did not exist. Assignment was worse: `PUT /v1/profiles/:profileId/composio-toolkits` allows an org admin, but its only UI lives on `/profiles`, which `PlatformAdminGuard` restricts to platform admins.

Four changes, all on the Integrations page.

**Connect.**

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/fajarhide/tinyclaw/44867144447f4d05bf684b8e26cb9a06302feb1b/composio-before.png) | ![after](https://raw.githubusercontent.com/fajarhide/tinyclaw/44867144447f4d05bf684b8e26cb9a06302feb1b/composio-after.png) |

**Enabling assigns the toolkit to the org's default profile**, and disabling removes it from every profile in the org. The Profiles page then already reads 1 assigned without anyone going there:

![assigned](https://raw.githubusercontent.com/fajarhide/tinyclaw/44867144447f4d05bf684b8e26cb9a06302feb1b/composio-assigned.png)

**The list opens on popular apps** instead of all 200, with a toggle for the full catalog. Search always covers everything, so a niche app stays one query away.

![list](https://raw.githubusercontent.com/fajarhide/tinyclaw/a8075f5eed5b1bade6faf5e534287be73e7add37/composio-toolkit-list.png)

**A profiles button on each enabled row** for everything beyond the default, so an org admin never needs the platform admin page:

![row](https://raw.githubusercontent.com/fajarhide/tinyclaw/44867144447f4d05bf684b8e26cb9a06302feb1b/composio-row-picker.png)

![dialog](https://raw.githubusercontent.com/fajarhide/tinyclaw/44867144447f4d05bf684b8e26cb9a06302feb1b/composio-profile-dialog.png)

Super profiles are labelled as running bash, because that is the assignment worth a second thought. Assignment deliberately does not follow a disconnect: connections are per member, so dropping it when one member disconnects would take the toolkit from everyone else. The bridge already filters on the chatting user's connection.

Verified against a live instance, reading the server rather than the UI. Clicking Connect through Google consent left one connected row and gmail with 61 cached tools, both empty beforehand, with no Sync click. On a fresh org, enable moved assignments 0 to 1 (default profile only, not Super Bot), disable moved it back to 0, and re-enable restored it. Toggling Super Bot in the new dialog wrote the second row:

```
profile      toolkit_slug
Default Bot  gmail
Super Bot    gmail
```

The two new service tests fail without the change (10 pass 2 fail, then 12 pass).

`bun run test`: 2284 tests across 11 workspaces, 0 fail. `bun run check`: clean.

Refs #329
