### PR TITLE
fix(server): kill a SIGTERM-proof harness after the version probe times out

### DIFF
--- a/apps/server/src/services/coding-agent-harness-service.test.ts
+++ b/apps/server/src/services/coding-agent-harness-service.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { createInMemoryDatabaseAdapter } from "@nakama/db";
@@ -221,6 +221,61 @@ describe("coding-agent harness resolution", () => {
     }
   }, 45_000);
 
+  test("a harness that traps SIGTERM is killed once the version probe times out", async () => {
+    const dir = await mkdtemp(
+      path.join(tmpdir(), "nakama-sigterm-proof-harness-")
+    );
+    const command = path.join(dir, "stubborn-version");
+    const pidFile = path.join(dir, "pid");
+    // Hangs on --version and swallows SIGTERM, so only the SIGKILL escalation
+    // ends it. It records its own pid because the probe never exposes the child.
+    await writeFile(
+      command,
+      [
+        `#!${process.execPath}`,
+        `require("node:fs").writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));`,
+        'process.on("SIGTERM", () => {});',
+        "setInterval(() => {}, 1000);",
+        "",
+      ].join("\n"),
+      { mode: 0o755 }
+    );
+
+    try {
+      const db = createInMemoryDatabaseAdapter();
+      await db.upsertWorkspaceSettings({
+        codingAgentHarnesses: [
+          {
+            args: [],
+            command,
+            enabled: true,
+            id: "coding-harness-claude-code",
+            kind: "claude_code",
+            name: "Claude Code",
+          },
+        ],
+        id: "workspace-settings",
+        imageModel: null,
+        selectedCodingAgentHarness: "coding-harness-claude-code",
+        transcriptionModel: null,
+        updatedAt: new Date().toISOString(),
+        visionModel: null,
+      });
+
+      const statuses = await listCodingAgentHarnessStatuses(db);
+      expect(
+        statuses.find((harness) => harness.id === "coding-harness-claude-code")
+          ?.installed
+      ).toBe(false);
+
+      const pid = Number.parseInt(await readFile(pidFile, "utf8"), 10);
+      expect(Number.isInteger(pid)).toBe(true);
+      expect(await waitForExit(pid, 15_000)).toBe(true);
+    } finally {
+      await rm(dir, { force: true, recursive: true });
+    }
+  }, 45_000);
+
   test("a harness that hangs on --version resolves as not installed", async () => {
     const dir = await mkdtemp(path.join(tmpdir(), "nakama-hanging-harness-"));
     // exec, so SIGTERM reaches sleep itself rather than orphaning it under sh.
@@ -260,3 +315,19 @@ describe("coding-agent harness resolution", () => {
     }
   }, 20_000);
 });
+
+async function waitForExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return true;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  return false;
+}

--- a/apps/server/src/services/coding-agent-harness-service.ts
+++ b/apps/server/src/services/coding-agent-harness-service.ts
@@ -732,6 +732,7 @@ async function probeHarnessVersion(command: string): Promise<{
 
     let stdout = "";
     let stderr = "";
+    let killTimeoutId: ReturnType<typeof setTimeout> | undefined;
 
     // The bash tool awaits this probe, so a CLI that never answers --version
     // would otherwise hold the turn open forever. Resolve on the timer instead
@@ -740,6 +741,10 @@ async function probeHarnessVersion(command: string): Promise<{
     // timeout a second time on its PATH retry.
     const timeoutId = setTimeout(() => {
       child.kill("SIGTERM");
+      // A harness that traps SIGTERM outlives the probe, and its open stdio
+      // pipes then keep this process alive too. Same escalation as the probe
+      // run and the install (#275); this site was missed.
+      killTimeoutId = setTimeout(() => child.kill("SIGKILL"), SIGTERM_GRACE_MS);
       resolve({ installed: false, missing: false, version: null });
     }, timeoutMs);
 
@@ -751,6 +756,7 @@ async function probeHarnessVersion(command: string): Promise<{
     });
     child.once("error", (error) => {
       clearTimeout(timeoutId);
+      clearTimeout(killTimeoutId);
       resolve({
         installed: false,
         missing: (error as NodeJS.ErrnoException).code === "ENOENT",
@@ -759,6 +765,7 @@ async function probeHarnessVersion(command: string): Promise<{
     });
     child.once("close", (code) => {
       clearTimeout(timeoutId);
+      clearTimeout(killTimeoutId);
       resolve({
         installed: code === 0,
         missing: false,


### PR DESCRIPTION
`probeHarnessVersion` sends SIGTERM when the 5s bound fires and returns. A harness that traps SIGTERM keeps running, and its open stdio pipes keep the parent process alive with it. #275 added the SIGKILL escalation to the probe run and the install and missed this third site.

Same repro as the issue: a stub `claude` that traps SIGTERM and never answers `--version`, driven through `listCodingAgentHarnessStatuses`, then `ps` 12 seconds later.

before
```
probe returned in 5007ms, claude installed=false
70586    00:12 bun run orphan-repro.ts
70593    00:11 .../stub-harness/claude --version
```

after
```
probe returned in 5012ms, claude installed=false
(nothing left in ps, and the script exits on its own)
```

The new test writes the stub's pid to a file, because the probe never exposes the child, then waits for that pid to disappear. With the service change stashed it fails:

```
(fail) a harness that traps SIGTERM is killed once the version probe times out [20121.02ms]
```

`bun run test` on this branch: 883 server tests, 0 fail, and web, cli and the platform workspaces green.

`probeAgentBrowserVersion` in #330 is a copy of this function, so it inherits the same gap. I have not touched that branch; @rioaguspermana, the three lines here drop straight in if you want them, otherwise it is a follow-up once yours lands.

Fixes #338
