### PR TITLE
fix(openai): replay assistant text once when the turn also calls a tool

### DIFF
--- a/apps/server/src/providers/openai-responses-replay.test.ts
+++ b/apps/server/src/providers/openai-responses-replay.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import type { ChatMessage } from "@nakama/core";
+import { generateOpenAIResponsesChat, toResponsesInput } from "./openai";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+const ASSISTANT_TEXT = "Let me look up the invoices from last quarter.";
+
+// The shape the Responses API returns for a turn that says something and then
+// calls a tool: one message item, one function_call item.
+const RESPONSE_PAYLOAD = {
+  output: [
+    {
+      content: [{ text: ASSISTANT_TEXT, type: "output_text" }],
+      id: "msg_1",
+      role: "assistant",
+      status: "completed",
+      type: "message",
+    },
+    {
+      arguments: '{"query":"invoice"}',
+      call_id: "call_1",
+      id: "fc_1",
+      name: "search_invoices",
+      status: "completed",
+      type: "function_call",
+    },
+  ],
+  usage: { input_tokens: 10, output_tokens: 5 },
+};
+
+function itemsCarrying(items: unknown[], text: string): unknown[] {
+  return items.filter((item) => JSON.stringify(item).includes(text));
+}
+
+describe("OpenAI Responses assistant replay", () => {
+  test("sends the assistant text once", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response(JSON.stringify(RESPONSE_PAYLOAD), {
+          headers: { "Content-Type": "application/json" },
+          status: 200,
+        })
+    ) as unknown as typeof fetch;
+
+    const result = await generateOpenAIResponsesChat({
+      apiKey: "sk-test",
+      input: { messages: [{ content: "invoices", role: "user" }], system: "s" },
+      model: "gpt-5.4",
+      stream: false,
+    });
+
+    const replay = await toResponsesInput([
+      { content: "invoices", role: "user" },
+      result.assistantMessage,
+    ]);
+
+    expect(itemsCarrying(replay, ASSISTANT_TEXT)).toHaveLength(1);
+  });
+
+  test("still sends the text when there is no providerContent", async () => {
+    const history: ChatMessage[] = [
+      { content: "invoices", role: "user" },
+      {
+        content: ASSISTANT_TEXT,
+        role: "assistant",
+        toolCalls: [
+          {
+            arguments: { query: "invoice" },
+            id: "call_1",
+            name: "search_invoices",
+          },
+        ],
+      },
+    ];
+
+    const replay = await toResponsesInput(history);
+    const carrying = itemsCarrying(replay, ASSISTANT_TEXT);
+
+    expect(carrying).toHaveLength(1);
+    expect(carrying[0]).toEqual({
+      content: [{ text: ASSISTANT_TEXT, type: "output_text" }],
+      role: "assistant",
+      type: "message",
+    });
+  });
+});

--- a/apps/server/src/providers/openai/responses.ts
+++ b/apps/server/src/providers/openai/responses.ts
@@ -185,14 +185,14 @@ function toResponsesAssistantInput(
   const input: unknown[] = [];
 
   if (message.toolCalls?.length) {
-    if (message.content.trim()) {
-      input.push(toResponsesAssistantTextMessage(message.content));
-    }
-
     if (message.providerContent?.length) {
+      // providerContent already carries the assistant message item; pushing
+      // message.content as well would replay the same text twice.
       input.push(
         ...message.providerContent.filter(isNonFunctionCallProviderItem)
       );
+    } else if (message.content.trim()) {
+      input.push(toResponsesAssistantTextMessage(message.content));
     }
 
     input.push(


### PR DESCRIPTION
Fixes #341.

## What changed

`toResponsesAssistantInput` pushed a rebuilt content item and then the raw `providerContent` items. `isNonFunctionCallProviderItem` drops `function_call` items, so the assistant `message` item survived next to the rebuilt one, and the same text reached the Responses API twice on every later request in the thread.

`providerContent` already carries that item, so it now takes precedence and `message.content` is used only when `providerContent` is absent. The `function_call` mapping below it is untouched, so tool-id alignment behaves exactly as before.

Four lines added and four removed in `apps/server/src/providers/openai/responses.ts`, two of the added lines being a comment, plus a new test file carrying the test from the issue and one regression guard.

## Scope

OpenAI Responses only, and only assistant turns that carry both text and a tool call. `toResponsesInput` has a single call site, `apps/server/src/providers/openai/responses.ts:95`, inside the request builder that takes `stream`, so the streaming and non-streaming paths share this code. That matches the two live reproductions in the issue thread.

## What I verified

Measured on `3338536a`. Running the new test file against `main`'s `responses.ts` and then against this branch:

before
```
Expected length: 1
Received length: 2
(fail) OpenAI Responses assistant replay > sends the assistant text once
 1 pass
 1 fail
```

after
```
 2 pass
 0 fail
```

- The test from the issue is landed as `apps/server/src/providers/openai-responses-replay.test.ts`, with its assertion pulled into a small helper the second test also uses. It builds the assistant message through the provider's own parser from a realistic Responses payload rather than by hand.
- A second test in the same file covers the branch this change introduces: an assistant turn with tool calls and no `providerContent` still sends its text once. It passes before and after, so it is a regression guard rather than evidence of the fix. It also asserts the shape of the surviving item, not just that the text appears once. To check that it guards anything, I deleted the new `else` branch and it failed with `Received length: 0`.
- `bun run test`, the command the Unit Tests workflow runs: exit 0 on both sides, 2283 pass and 0 fail on `main`, 2285 pass and 0 fail here. Each side was run twice and gave identical numbers. One new file, two new tests, nothing else moved.
- `bun install --frozen-lockfile` leaves `bun.lock` untouched.
- `bun run knip -- --cache --reporter github-actions`, the command the Knip workflow runs: exit 0 on both sides, and the output is identical apart from a Node deprecation warning. The one configuration hint it prints is already on `main`.
- `bun x ultracite check` reports no findings on either changed file.

## Remaining risks

The change decides which source wins when both are present, so a caller that populates `providerContent` without an assistant message item would now replay no text at all. I did not find such a path here: `providerContent` is the raw `output` array (`apps/server/src/providers/openai/responses.ts:302`), the same array the text is read from, so a response with text always has the item. It is worth remembering if another Responses-shaped provider is added later.

One further case is worth naming because this change touches it. A session keeps its history when a profile's model moves to another provider, since the harness resolves the provider from `profile.model` each time it is built (`apps/server/src/services/agent-service.ts:3506`), and nothing strips `providerContent` written by the previous provider. Such a turn used to send the foreign items plus a rebuilt text item and now sends the foreign items alone. Neither is right, and the Anthropic path trusts `providerContent` the same way (`apps/server/src/providers/anthropic/web-search.ts:73`), so this is not something the change introduces. I did not exercise it against a live API.

No cassette was recorded or changed, and these tests make no live provider call.
