### PR TITLE
fix(anthropic): replay the streamed tool input instead of an empty object

### DIFF
--- a/apps/server/src/providers/anthropic/tool-input-replay.test.ts
+++ b/apps/server/src/providers/anthropic/tool-input-replay.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, mock, test } from "bun:test";
+import { createAnthropicProvider } from "./index";
+
+const START =
+  'event: message_start\r\ndata:{"type":"message_start","message":{"usage":{"input_tokens":10}}}\r\n\r\n';
+
+const TOOL_USE = [
+  START,
+  'event: content_block_start\r\ndata:{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01","name":"search_invoices","input":{}}}\r\n\r\n',
+  'event: content_block_delta\r\ndata:{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"query\\":"}}\r\n\r\n',
+  'event: content_block_delta\r\ndata:{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\\"invoice\\"}"}}\r\n\r\n',
+  'event: content_block_stop\r\ndata:{"type":"content_block_stop","index":0}\r\n\r\n',
+  'event: message_delta\r\ndata:{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":5}}\r\n\r\n',
+];
+
+const PAUSE_TURN = [
+  START,
+  'event: content_block_start\r\ndata:{"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"srvtoolu_01","name":"web_search","input":{}}}\r\n\r\n',
+  'event: content_block_delta\r\ndata:{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"query\\":\\"nakama\\"}"}}\r\n\r\n',
+  'event: content_block_stop\r\ndata:{"type":"content_block_stop","index":0}\r\n\r\n',
+  'event: message_delta\r\ndata:{"type":"message_delta","delta":{"stop_reason":"pause_turn"},"usage":{"output_tokens":5}}\r\n\r\n',
+];
+
+const PAUSE_TURN_NO_INPUT = [
+  START,
+  'event: content_block_start\r\ndata:{"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"srvtoolu_02","name":"web_search","input":{}}}\r\n\r\n',
+  'event: content_block_stop\r\ndata:{"type":"content_block_stop","index":0}\r\n\r\n',
+  'event: message_delta\r\ndata:{"type":"message_delta","delta":{"stop_reason":"pause_turn"},"usage":{"output_tokens":5}}\r\n\r\n',
+];
+
+const DONE = [
+  START,
+  'event: content_block_start\r\ndata:{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\r\n\r\n',
+  'event: content_block_delta\r\ndata:{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}\r\n\r\n',
+  'event: message_delta\r\ndata:{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}\r\n\r\n',
+];
+
+type CapturedBody = { messages: { content: unknown }[] };
+
+function eventStream(chunks: string[]): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+
+  return new Response(body, {
+    headers: { "Content-Type": "text/event-stream" },
+    status: 200,
+  });
+}
+
+function providerCapturingBodies(streams: string[][]) {
+  const responses = streams.map(eventStream);
+  const bodies: CapturedBody[] = [];
+  let call = 0;
+
+  const fetchMock = mock(
+    async (_input: RequestInfo | URL, init?: RequestInit) => {
+      bodies.push(JSON.parse(String(init?.body)));
+      const response = responses[call];
+      call += 1;
+      return response;
+    }
+  );
+
+  const provider = createAnthropicProvider({
+    apiKey: "sk-ant-test",
+    fetch: fetchMock as unknown as typeof fetch,
+    model: "claude-sonnet-4-6",
+  });
+
+  return { bodies, provider };
+}
+
+function replayedBlocks(body: CapturedBody | undefined) {
+  const assistant = body?.messages.find((message) =>
+    Array.isArray(message.content)
+  );
+
+  return (assistant?.content ?? []) as { type: string; input?: unknown }[];
+}
+
+describe("Anthropic tool input replay", () => {
+  test("replays streamed tool input on the next request", async () => {
+    const { bodies, provider } = providerCapturingBodies([TOOL_USE, DONE]);
+
+    const first = await provider.streamChat(
+      { messages: [{ content: "find invoices", role: "user" }], system: "s" },
+      { onChunk: () => undefined }
+    );
+
+    expect(first.toolCalls[0]?.arguments).toEqual({ query: "invoice" });
+
+    await provider.streamChat(
+      {
+        messages: [
+          { content: "find invoices", role: "user" },
+          first.assistantMessage,
+          {
+            content: "[]",
+            name: "search_invoices",
+            role: "tool",
+            toolCallId: "toolu_01",
+          },
+        ],
+        system: "s",
+      },
+      { onChunk: () => undefined }
+    );
+
+    const toolUse = replayedBlocks(bodies[1]).find(
+      (block) => block.type === "tool_use"
+    );
+
+    expect(toolUse?.input).toEqual({ query: "invoice" });
+  });
+
+  test("replays streamed server tool input on a pause_turn continuation", async () => {
+    const { bodies, provider } = providerCapturingBodies([PAUSE_TURN, DONE]);
+
+    await provider.streamChat(
+      { messages: [{ content: "search the web", role: "user" }], system: "s" },
+      { onChunk: () => undefined }
+    );
+
+    const serverToolUse = replayedBlocks(bodies[1]).find(
+      (block) => block.type === "server_tool_use"
+    );
+
+    expect(serverToolUse?.input).toEqual({ query: "nakama" });
+  });
+
+  test("leaves a tool block alone when no input was streamed", async () => {
+    const { bodies, provider } = providerCapturingBodies([
+      PAUSE_TURN_NO_INPUT,
+      DONE,
+    ]);
+
+    await provider.streamChat(
+      { messages: [{ content: "search the web", role: "user" }], system: "s" },
+      { onChunk: () => undefined }
+    );
+
+    const serverToolUse = replayedBlocks(bodies[1]).find(
+      (block) => block.type === "server_tool_use"
+    );
+
+    expect(serverToolUse).toEqual({
+      id: "srvtoolu_02",
+      input: {},
+      name: "web_search",
+      type: "server_tool_use",
+    });
+  });
+});

--- a/apps/server/src/providers/anthropic/web-search.ts
+++ b/apps/server/src/providers/anthropic/web-search.ts
@@ -395,6 +395,17 @@ async function readAnthropicStream(
       const index = event.index;
       const block = providerContent[index];
 
+      const streamedInput = pending.get(index)?.inputJson;
+      if (
+        streamedInput &&
+        (block?.type === "tool_use" || block?.type === "server_tool_use")
+      ) {
+        providerContent[index] = {
+          ...block,
+          input: parseJsonRecord(streamedInput),
+        };
+      }
+
       if (block?.type === "web_search_tool_result") {
         handlers?.onToolEnd?.({
           result: block.content ?? block,


### PR DESCRIPTION
## Summary

Fixes #333.

`readAnthropicStream` keeps two records of every streamed block. `thinking_delta`, `signature_delta` and `text_delta` each end by writing their updated block back into `providerContent`; `input_json_delta` only accumulates into `pending`. So `providerContent` keeps the block exactly as `content_block_start` delivered it, without the arguments that arrive as deltas.

`toAnthropicMessages` returns `providerContent` for an assistant message and never reaches the `toolCalls` branch below it, so every later request in the thread replays the tool call with an empty input, and a `pause_turn` continuation echoes the same empty `server_tool_use`. The first hop is fine, because tool execution reads `toolCalls`, which is built from `pending`.

## Before and after

The second outgoing request body, captured through the provider's own `fetch` hook, on `3338536a` and on this branch:

```
before  {"type":"tool_use","id":"toolu_01","name":"search_invoices","input":{}}
after   {"type":"tool_use","id":"toolu_01","name":"search_invoices","input":{"query":"invoice"}}

before  {"type":"server_tool_use","id":"srvtoolu_01","name":"web_search","input":{}}
after   {"type":"server_tool_use","id":"srvtoolu_01","name":"web_search","input":{"query":"nakama"}}
```

`toolCalls` prints the same on both sides, `[{"arguments":{"query":"invoice"},"id":"toolu_01","name":"search_invoices"}]`, which is the acceptance criterion that it stays untouched.

## The change

Eleven added lines, none removed, at `content_block_stop`, after the last delta for that block has arrived. It reuses `parseJsonRecord`, which the file already applies to `toolCalls`, so both records are parsed the same way.

The `streamedInput &&` guard is load-bearing rather than defensive: `pending` is seeded only for `tool_use`, so a `server_tool_use` block that streams no input has no entry at all, and `parseJsonRecord` throws when handed the resulting `undefined`.

## Test plan

`apps/server/src/providers/anthropic/tool-input-replay.test.ts` is new. The first two tests are the ones in the issue, taken back out of the issue body rather than retyped, with only the `describe` label changed so it does not collide with the one in `stream.test.ts`: a two-turn exchange asserting the replayed `tool_use` input, and a `pause_turn` continuation asserting the replayed `server_tool_use` input. Both fail on `main`, each printing an empty object where the arguments should be, and pass here. The third test covers the guard above.

Each of the three tests was checked against a mutation of the change, and each one catches a different mutation: dropping `streamedInput &&` raises a `TypeError` in the third test, dropping `server_tool_use` from the type check fails the second, dropping `tool_use` fails the first.

Every number below was measured twice on each side, and the two runs agreed:

- `bun run test`, the command the Unit Tests workflow runs: exit 0 on both sides, 2283 pass and 0 fail on `main`, 2286 pass and 0 fail here, 326 files against 327. The difference is the new file and its three tests, and all eleven workspaces report 0 fail on both sides.
- `bun run knip -- --cache --reporter github-actions`, the command the Knip workflow runs: exit 0, and the output is byte-identical to `main`, so nothing new is reported. The one configuration hint it prints is already there.
- `bun install --frozen-lockfile` leaves `bun.lock` untouched.
- `bun run check` reports no fixes on either side, across 1170 files on `main` and 1171 here.

## Remaining risks

- Not verified against the live Anthropic API. Every measurement here is taken from the outgoing request body through the provider's test hook, so how the API responds to an empty `input` is not established, and neither is how the model behaves when its own call is replayed without arguments.
- Sessions already on disk are not repaired. Assistant messages are stored as JSON and read back verbatim, so a thread that already recorded an empty `input` keeps it. Only new turns are affected.
- If a stream is cut off mid-arguments, `parseJsonRecord` returns `{}` for malformed JSON, so that case lands exactly where it lands today rather than anywhere worse.
- The context estimate for an Anthropic tool turn goes up. `estimateMessageTokens` sums `toolCalls` and `providerContent` separately (`packages/agent/src/history-compaction.ts:100-109`), and `stripThinkingFromProviderContent` removes only `thinking` and `reasoning` blocks, so arguments that used to be counted once are now counted twice and `estimateHistoryTokens` can reach the compaction threshold marginally sooner. The double count is not new, and it already covered each call's id and name; what changes is that the arguments join it.
