### PR TITLE
perf(web): lazy-load Mermaid renderer

### DIFF
--- a/apps/web/src/components/ai-elements/lazy-mermaid-plugin.test.ts
+++ b/apps/web/src/components/ai-elements/lazy-mermaid-plugin.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import type { DiagramPlugin } from "streamdown";
+import { createLazyMermaidPlugin } from "./lazy-mermaid-plugin";
+
+const createDelegate = (
+  render: (id: string, chart: string) => Promise<{ svg: string }>,
+  onConfig?: DiagramPlugin["getMermaid"]
+): DiagramPlugin => ({
+  getMermaid: onConfig ?? (() => ({ initialize: () => undefined, render })),
+  language: "mermaid",
+  name: "mermaid",
+  type: "diagram",
+});
+
+describe("createLazyMermaidPlugin", () => {
+  test("does not load Mermaid for an empty streamed chart", async () => {
+    let loadCount = 0;
+    const plugin = createLazyMermaidPlugin(async () => {
+      loadCount += 1;
+      return {
+        mermaid: createDelegate(async () => ({ svg: "unused" })),
+      };
+    });
+
+    const result = await plugin.getMermaid().render("diagram", " \n\t");
+
+    expect(result).toEqual({ svg: "" });
+    expect(loadCount).toBe(0);
+  });
+
+  test("preserves config and render arguments when delegating", async () => {
+    const received: {
+      chart?: string;
+      config?: Parameters<DiagramPlugin["getMermaid"]>[0];
+      id?: string;
+    } = {};
+    const delegate = createDelegate(
+      async (id, chart) => {
+        received.id = id;
+        received.chart = chart;
+        return { svg: "<svg />" };
+      },
+      (config) => {
+        received.config = config;
+        return {
+          initialize: () => undefined,
+          render: async (id, chart) => {
+            received.id = id;
+            received.chart = chart;
+            return { svg: "<svg />" };
+          },
+        };
+      }
+    );
+    const plugin = createLazyMermaidPlugin(async () => ({ mermaid: delegate }));
+    const config = { theme: "dark" } as const;
+    const chart = " \n graph TD\n ";
+
+    const result = await plugin.getMermaid(config).render("diagram-1", chart);
+
+    expect(received).toEqual({
+      chart,
+      config,
+      id: "diagram-1",
+    });
+    expect(result).toEqual({ svg: "<svg />" });
+  });
+
+  test("propagates loader rejection to Streamdown", async () => {
+    const loadError = new Error("loader rejected");
+    const plugin = createLazyMermaidPlugin(async () => {
+      throw loadError;
+    });
+
+    await expect(
+      plugin.getMermaid().render("diagram", "graph TD")
+    ).rejects.toBe(loadError);
+  });
+});

--- a/apps/web/src/components/ai-elements/lazy-mermaid-plugin.ts
+++ b/apps/web/src/components/ai-elements/lazy-mermaid-plugin.ts
@@ -1,0 +1,24 @@
+import type { DiagramPlugin } from "streamdown";
+
+type MermaidPluginLoader = () => Promise<{ mermaid: DiagramPlugin }>;
+
+export function createLazyMermaidPlugin(
+  loadPlugin: MermaidPluginLoader
+): DiagramPlugin {
+  return {
+    getMermaid: (config) => ({
+      initialize: () => undefined,
+      render: async (id, chart) => {
+        if (!chart.trim()) {
+          return { svg: "" };
+        }
+
+        const { mermaid } = await loadPlugin();
+        return mermaid.getMermaid(config).render(id, chart);
+      },
+    }),
+    language: "mermaid",
+    name: "mermaid",
+    type: "diagram",
+  };
+}

--- a/apps/web/src/components/ai-elements/message.tsx
+++ b/apps/web/src/components/ai-elements/message.tsx
@@ -3,7 +3,6 @@
 import { cjk } from "@streamdown/cjk";
 import { code } from "@streamdown/code";
 import { math } from "@streamdown/math";
-import { mermaid } from "@streamdown/mermaid";
 import type { UIMessage } from "ai";
 import { type ComponentProps, type HTMLAttributes, memo } from "react";
 import {
@@ -12,6 +11,7 @@ import {
   Streamdown,
 } from "streamdown";
 import { ExternalLinkSafetyModal } from "@/components/ai-elements/external-link-safety-modal";
+import { createLazyMermaidPlugin } from "@/components/ai-elements/lazy-mermaid-plugin";
 import { MarkdownA } from "@/components/ai-elements/markdown-a";
 import { useTheme } from "@/context/use-theme";
 import { cn } from "@/lib/utils";
@@ -55,7 +55,10 @@ export const MessageContent = ({
 
 export type MessageResponseProps = ComponentProps<typeof Streamdown>;
 
-const streamdownPlugins = { cjk, code, math, mermaid };
+const lazyMermaidPlugin = createLazyMermaidPlugin(
+  () => import("@streamdown/mermaid")
+);
+const streamdownPlugins = { cjk, code, math, mermaid: lazyMermaidPlugin };
 
 function renderExternalLinkSafetyModal(props: LinkSafetyModalProps) {
   return <ExternalLinkSafetyModal {...props} />;
@@ -81,6 +84,7 @@ const MessageResponseBody = memo(
     shikiTheme,
     linkSafety: linkSafetyOverride,
     components: userComponents,
+    plugins: pluginsOverride,
     ...props
   }: MessageResponseProps) => (
     <Streamdown
@@ -92,7 +96,7 @@ const MessageResponseBody = memo(
       controls={controls}
       lineNumbers={lineNumbers}
       linkSafety={linkSafetyOverride ?? linkSafety}
-      plugins={streamdownPlugins}
+      plugins={pluginsOverride ?? streamdownPlugins}
       shikiTheme={shikiTheme}
       {...props}
     />


### PR DESCRIPTION
## Summary

Fixes #346.

Chat currently statically imports `@streamdown/mermaid`, so every conversation downloads the renderer even when it contains no Mermaid diagram. This change keeps Streamdown's Mermaid plugin contract available synchronously but loads the renderer with `import("@streamdown/mermaid")` only when Streamdown supplies a non-empty chart.

The lazy delegate preserves Mermaid configuration and render arguments. `MessageResponse` also continues to honor a caller-provided `plugins` override.

## Measured impact

Measured from Vite's `--manifest` output on `ecf998a0` and this branch. Static closures recursively include each entry's static JavaScript imports.

| Production JavaScript | `main` | This PR | Change |
| --- | ---: | ---: | ---: |
| Chat static closure, raw | 2,611,495 B | 1,990,497 B | -620,998 B (-23.8%) |
| Chat static closure, gzip | 771,095 B | 622,770 B | -148,325 B (-19.2%) |
| Application entry, gzip | 238,293 B | 238,282 B | -11 B |
| All emitted JS, gzip | 3,384,315 B | 3,383,534 B | -781 B |

The deferred renderer is emitted as a separate 618.69 kB raw / 148.24 kB gzip dynamic chunk. This defers work from first Chat load; it does not claim to remove the renderer for users who display Mermaid.

## Verification

- `bun test src/components/ai-elements/lazy-mermaid-plugin.test.ts`: 3 passed, 0 failed
- `bun x tsc --noEmit` from `apps/web`: passed
- `bun x vite build --manifest` from `apps/web`: passed; 8,300 modules transformed
- Browser proof: 9 impacted scenarios passed: plain Markdown, partial and newline-only streaming fences, streaming source, literal outer fence, nested list/blockquote, caller plugin override, two mounts, and blocked renderer chunk
- `bun run knip`: passed with the existing `packages/core` configuration hint
- Targeted Ultracite check for the three changed files: passed
- `git diff --check origin/main...HEAD`: passed

The repository-wide Ultracite check on the Windows checkout reports CRLF formatting diagnostics across 1,171 files, including unchanged files. The committed versions of all three changed files use LF and pass the targeted check.

## Remaining risks

- The first real Mermaid diagram waits for one additional chunk request before rendering.
- An open tab can request an old hashed renderer chunk after deployment. The blocked-chunk browser scenario verifies that Streamdown displays its error and source fallback rather than blank content.
