### PR TITLE
Review asserts: remove meaningless, add meaningful

### DIFF
--- a/apps/server/src/services/artifact-share-service.ts
+++ b/apps/server/src/services/artifact-share-service.ts
@@ -157,7 +157,7 @@ export class ArtifactShareService {
       orgId: string;
     }
   ): Promise<StoredArtifactShareRecord> {
-    await deleteArtifactShareSnapshot(existing.storagePath);
+    await deleteArtifactShareSnapshot(input.orgId, existing.storagePath);
 
     const storagePath = await writeArtifactShareSnapshot({
       bytes: input.bytes,
@@ -285,7 +285,7 @@ export class ArtifactShareService {
       new Date().toISOString()
     );
     if (revoked) {
-      await deleteArtifactShareSnapshot(share.storagePath);
+      await deleteArtifactShareSnapshot(input.orgId, share.storagePath);
     }
 
     return { id: share.id, revoked };
@@ -308,7 +308,10 @@ export class ArtifactShareService {
       throw new NakamaApiError("Not found", 404);
     }
 
-    const bytes = await readArtifactShareSnapshot(share.storagePath);
+    const bytes = await readArtifactShareSnapshot(
+      share.orgId,
+      share.storagePath
+    );
     // Sidecars sometimes store application/octet-stream; resolve from the filename
     // so <video>/<img> can play with X-Content-Type-Options: nosniff.
     const mimeType = resolveArtifactMimeType(share.mimeType, share.filename);

--- a/apps/server/src/services/data-portability.ts
+++ b/apps/server/src/services/data-portability.ts
@@ -70,10 +70,20 @@ interface InventoryItem {
 const RESTORE_PREFIX = ".nakama-restore-";
 const BACKUP_PREFIX = ".nakama-backup-";
 
+function resolveNakamaRootDir(rootDir?: string): string {
+  const raw = rootDir ?? getUserConfigDir();
+  if (!isAbsolute(raw)) {
+    throw new Error(
+      "rootDir must be an absolute path; relative paths resolve against process.cwd() and break config isolation."
+    );
+  }
+  return resolve(raw);
+}
+
 export async function createNakamaDataExport(
   options: CreateDataExportOptions = {}
 ): Promise<CreateDataExportResult> {
-  const rootDir = resolve(options.rootDir ?? getUserConfigDir());
+  const rootDir = resolveNakamaRootDir(options.rootDir);
   const createdAt = (options.now ?? new Date()).toISOString();
   const { files, skipped } = await inventoryConfigRoot(rootDir);
   const topLevelPaths = Array.from(
@@ -132,7 +142,7 @@ export async function previewNakamaDataImport(
   archive: Buffer | Uint8Array | ArrayBuffer,
   options: PreviewDataImportOptions = {}
 ): Promise<DataImportPreviewResponse> {
-  const rootDir = resolve(options.rootDir ?? getUserConfigDir());
+  const rootDir = resolveNakamaRootDir(options.rootDir);
   const entries = readZip(toBuffer(archive));
   const manifest = readManifest(entries);
   const restorableEntries = entries.filter(
@@ -174,7 +184,7 @@ export async function restoreNakamaDataImport(
     throw new Error("Restore confirmation is required.");
   }
 
-  const rootDir = resolve(options.rootDir ?? getUserConfigDir());
+  const rootDir = resolveNakamaRootDir(options.rootDir);
   const entries = readZip(toBuffer(archive));
   const manifest = readManifest(entries);
 

--- a/apps/server/src/services/org-memory-service.ts
+++ b/apps/server/src/services/org-memory-service.ts
@@ -6,6 +6,7 @@ import {
   createOrgMemoryChangeId,
   detectOrgMemoryInjectionWarnings,
   getOrgMemoryArchiveDir,
+  getOrgMemoryArchiveFilePath,
   getOrgMemoryDir,
   getOrgMemoryFilePath,
   getOrgMemoryHistoryEntry,
@@ -365,7 +366,11 @@ export class OrgMemoryService {
     const archivedAt = options.archivedAt ?? new Date();
     const yearMonth = `${archivedAt.getFullYear()}-${String(archivedAt.getMonth() + 1).padStart(2, "0")}`;
     const archiveDir = getOrgMemoryArchiveDir(orgId, this.options.configDir);
-    const archivePath = join(archiveDir, `${yearMonth}.md`);
+    const archivePath = getOrgMemoryArchiveFilePath(
+      orgId,
+      yearMonth,
+      this.options.configDir
+    );
     const appendLines = [`<!-- archived: ${archivedAt.toISOString()} -->`];
     if (options.reason?.trim()) {
       appendLines.push(

--- a/apps/server/src/services/skills-service.ts
+++ b/apps/server/src/services/skills-service.ts
@@ -349,18 +349,14 @@ export class SkillsService {
       profileId,
     });
 
+    // written.directory came from resolveProfileSkillDirectory (containment already
+    // enforced); syncSkillRecordFromDirectory keys off that same path.
     const record = await this.syncSkillRecordFromDirectory(
       written.directory,
       written.name,
       "written",
       createdBy
     );
-
-    if (!isPathWithinProfileSkillsDir(orgId, profileId, record.sourcePath)) {
-      throw new Error(
-        `Skill "${written.name}" resolved outside this profile skills directory.`
-      );
-    }
 
     await this.db.assignSkillToProfile(profileId, record.id);
     const response = await this.getSkill(record.id);

--- a/packages/core/src/artifact-shares.test.ts
+++ b/packages/core/src/artifact-shares.test.ts
@@ -49,7 +49,7 @@ describe("artifact shares", () => {
     });
 
     expect(storagePath.startsWith(getArtifactSharesDir(orgId))).toBe(true);
-    expect(await readArtifactShareSnapshot(storagePath)).toEqual(bytes);
-    await deleteArtifactShareSnapshot(storagePath);
+    expect(await readArtifactShareSnapshot(orgId, storagePath)).toEqual(bytes);
+    await deleteArtifactShareSnapshot(orgId, storagePath);
   });
 });

--- a/packages/core/src/artifact-shares.ts
+++ b/packages/core/src/artifact-shares.ts
@@ -34,9 +34,31 @@ export async function writeArtifactShareSnapshot(input: {
   return storagePath;
 }
 
+function assertArtifactShareStoragePath(
+  orgId: string,
+  storagePath: string
+): void {
+  if (!path.isAbsolute(storagePath)) {
+    throw new Error(
+      "Artifact share storage path must be absolute; relative paths resolve against process.cwd()."
+    );
+  }
+
+  const root = path.resolve(getArtifactSharesDir(orgId));
+  const resolved = path.resolve(storagePath);
+  if (resolved !== root && !resolved.startsWith(`${root}${path.sep}`)) {
+    throw new Error(
+      "Artifact share storage path escapes the org artifact-shares directory."
+    );
+  }
+}
+
 export async function readArtifactShareSnapshot(
+  orgId: string,
   storagePath: string
 ): Promise<Buffer> {
+  assertArtifactShareStoragePath(orgId, storagePath);
+
   if (!(await pathExists(storagePath))) {
     throw new Error(`Artifact share snapshot not found: ${storagePath}`);
   }
@@ -45,8 +67,11 @@ export async function readArtifactShareSnapshot(
 }
 
 export async function deleteArtifactShareSnapshot(
+  orgId: string,
   storagePath: string
 ): Promise<void> {
+  assertArtifactShareStoragePath(orgId, storagePath);
+
   try {
     await unlink(storagePath);
   } catch (error) {

--- a/packages/core/src/message-content.ts
+++ b/packages/core/src/message-content.ts
@@ -75,12 +75,12 @@ export function normalizeUserContent(
     return message;
   }
 
-  if (hasImages) {
-    validateImageAttachments(images!);
+  if (images?.length) {
+    validateImageAttachments(images);
   }
 
-  if (hasDocuments) {
-    validateDocumentAttachments(documents!);
+  if (documents?.length) {
+    validateDocumentAttachments(documents);
   }
 
   validateCombinedAttachmentCount(images?.length ?? 0, documents?.length ?? 0);

--- a/packages/core/src/skills/archive.ts
+++ b/packages/core/src/skills/archive.ts
@@ -1,11 +1,7 @@
 import { mkdir, rename } from "node:fs/promises";
 import path from "node:path";
 import { pathExists } from "../fs";
-import {
-  getProfileSkillsArchiveDir,
-  getProfileSkillsDir,
-  SKILL_ARCHIVE_DIR_NAME,
-} from "./paths";
+import { getProfileSkillsArchiveDir, getProfileSkillsDir } from "./paths";
 import {
   assertNotBundledSkillName,
   assertValidSkillName,
@@ -56,19 +52,12 @@ export async function archiveSkillDirectory(options: {
   );
   await mkdir(archiveRoot, { recursive: true });
 
-  // skillName is a single validated segment from resolveProfileSkillDirectory.
+  // skillName is a single validated segment from resolveProfileSkillDirectory;
+  // archiveRoot is getProfileSkillsArchiveDir, so the join stays under .archive.
   let archivedDirectory = path.join(archiveRoot, skillName);
   if (await pathExists(archivedDirectory)) {
     const stamp = (options.now ?? new Date()).getTime();
     archivedDirectory = path.join(archiveRoot, `${skillName}-${stamp}`);
-  }
-
-  if (
-    !archivedDirectory.includes(
-      `${path.sep}${SKILL_ARCHIVE_DIR_NAME}${path.sep}`
-    )
-  ) {
-    throw new Error("Archive path must stay under skills/.archive.");
   }
 
   await rename(liveDirectory, archivedDirectory);

--- a/packages/core/src/skills/write.ts
+++ b/packages/core/src/skills/write.ts
@@ -327,6 +327,7 @@ export async function createSkillFile(
   options: CreateSkillFileOptions
 ): Promise<string> {
   const name = assertValidSkillName(options.name);
+  assertNotBundledSkillName(name);
   const description = options.description.trim();
   const orgId = options.orgId?.trim();
   const profileId = options.profileId?.trim();

--- a/packages/core/src/soul/memory-archive.ts
+++ b/packages/core/src/soul/memory-archive.ts
@@ -10,7 +10,7 @@ import {
   formatMemoryArchiveYearMonth,
   getMemoryArchiveDir,
 } from "./memory-paths";
-import { assertYearMonth, getProfileSoulDir } from "./resolve";
+import { getProfileSoulDir } from "./resolve";
 
 export const MEMORY_ARCHIVE_TEMPLATE = `# Archived Memory
 
@@ -220,7 +220,9 @@ export async function archiveMemoryBullets(
   }
 
   const archivedAt = options.archivedAt ?? new Date();
-  const yearMonth = assertYearMonth(formatMemoryArchiveYearMonth(archivedAt));
+  // formatMemoryArchiveYearMonth always yields YYYY-MM; assertYearMonth stays on
+  // untrusted inputs (getMemoryArchiveFilePath / getOrgMemoryArchiveFilePath).
+  const yearMonth = formatMemoryArchiveYearMonth(archivedAt);
   const archivePath = join(archiveDir, `${yearMonth}.md`);
   const archiveAppend = formatArchiveAppend(
     archivedAt,

--- a/packages/core/src/soul/resolve.ts
+++ b/packages/core/src/soul/resolve.ts
@@ -1,4 +1,4 @@
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { getUserConfigDir } from "../user-config";
 import { getSoulStatus, loadSoulStack } from "./load";
 import type { LoadedSoulStack, SoulStatus } from "./types";
@@ -65,6 +65,11 @@ export function getOrgMemoryDir(
   orgId: string,
   configDir = getUserConfigDir()
 ): string {
+  if (!isAbsolute(configDir)) {
+    throw new Error(
+      "configDir must be an absolute path; relative paths resolve against process.cwd() and break org isolation."
+    );
+  }
   return join(configDir, "orgs", assertConfigPathSegment(orgId, "orgId"));
 }
 


### PR DESCRIPTION
## What changed

Removed five meaningless asserts (tautological / no-op / already-guaranteed) and added five contract asserts to make implicit rules explicit.

**Removed (meaningless):**
1. `skills/archive.ts` — dropped `includes(SKILL_ARCHIVE_DIR_NAME)` check. `archivedDirectory` is `path.join(archiveRoot, ...)` where `archiveRoot` comes from `getProfileSkillsArchiveDir`, so the containment check was true by construction.
2. `soul/memory-archive.ts` — dropped `assertYearMonth(formatMemoryArchiveYearMonth(...))`. The formatter always yields `YYYY-MM`; the assert now stays only on untrusted inputs.
3. `services/skills-service.ts` — dropped post-write `isPathWithinProfileSkillsDir` check. `record.sourcePath` already derives from `resolveProfileSkillDirectory`, which enforces containment.
4. `message-content.ts` — narrowed `images!` / `documents!` after `hasImages`/`hasDocuments` to real `images?.length` / `documents?.length` guards.

**Added (contracts):**
1. `artifact-shares.ts` — new `assertArtifactShareStoragePath` enforces absolute path + containment under the org shares dir; `readArtifactShareSnapshot` / `deleteArtifactShareSnapshot` now take `orgId`.
2. `services/org-memory-service.ts` — archive path now via `getOrgMemoryArchiveFilePath`, which asserts `YYYY-MM` on input.
3. `soul/resolve.ts` — `getOrgMemoryDir` rejects relative `configDir`.
4. `services/data-portability.ts` — `resolveNakamaRootDir` rejects relative `rootDir`.
5. `skills/write.ts` — `createSkillFile` now asserts `assertNotBundledSkillName`.

## Verified

```
bun install
bun test <affected core + server suites>
# 107 pass, 0 fail
bun x ultracite check <changed source files>
# clean
```

Affected suites covered archive, memory-archive, resolve, artifact-shares, write, message-content, skills-service, org-memory-service, data-portability, and artifact-share routes/services.

## Remaining risks

- `readArtifactShareSnapshot` / `deleteArtifactShareSnapshot` signatures changed (added `orgId`); call sites in `artifact-share-service.ts` and `artifact-shares.test.ts` were updated. Any external callers outside this repo would need the new arg.
- Removed a defensive containment check in `skills-service.ts` on the reasoning that the source path is already contained; that holds only if `syncSkillRecordFromDirectory` never rewrites `sourcePath` independently.