### PR TITLE
test: remove low-value tests

### DIFF
--- a/apps/cli/src/rotate-token.test.ts
+++ b/apps/cli/src/rotate-token.test.ts
@@ -7,19 +7,9 @@ import {
   loadLocalAuthToken,
   verifyLocalAuthToken,
 } from "@nakama/core/local-auth";
-import {
-  formatRotateTokenError,
-  isRotateTokenCommand,
-  runRotateToken,
-} from "./rotate-token";
+import { formatRotateTokenError, runRotateToken } from "./rotate-token";
 
 describe("rotate-token command", () => {
-  test("isRotateTokenCommand matches the rotate-token subcommand", () => {
-    expect(isRotateTokenCommand(["rotate-token"])).toBe(true);
-    expect(isRotateTokenCommand(["chat"])).toBe(false);
-    expect(isRotateTokenCommand([])).toBe(false);
-  });
-
   test("runRotateToken rotates the on-disk token", async () => {
     const configDir = await mkdtemp(join(tmpdir(), "nakama-cli-rotate-"));
     process.env.NAKAMA_CONFIG_DIR = configDir;

--- a/apps/cli/src/terminal-screen.test.ts
+++ b/apps/cli/src/terminal-screen.test.ts
@@ -31,10 +31,6 @@ describe("consumeTerminalInput", () => {
     expect(consumed.events).toEqual(["\x1b[200~hello\x1b[201~"]);
   });
 
-  test("isTerminalResponse identifies cursor reports", () => {
-    expect(isTerminalResponse("\x1b[12;1R")).toBe(true);
-  });
-
   test("emits mouse tracking events", () => {
     const consumed = consumeTerminalInput("a\x1b[<64;12;8Mb");
 

--- a/apps/server/src/tools/generate-image-tool.test.ts
+++ b/apps/server/src/tools/generate-image-tool.test.ts
@@ -14,7 +14,6 @@ import { GENERATE_IMAGE_TOOL_ID } from "@nakama/core/tools/protected";
 import {
   createInMemoryDatabaseAdapter,
   ensureGenerateImageToolDefinition,
-  removeUnsupportedTools,
   seedDatabase,
   seedOrgSuperBotProfile,
 } from "@nakama/db";
@@ -67,15 +66,6 @@ describe("generate_image tool seed and resolver (U3)", () => {
     expect(tool).not.toBeNull();
     expect(tool?.name).toBe(GENERATE_IMAGE_TOOL_NAME);
     expect(tool?.handlerType).toBe("generate_image");
-  });
-
-  test("unsupported-handler cleanup retains generate_image after seed", async () => {
-    const db = createInMemoryDatabaseAdapter();
-
-    await ensureGenerateImageToolDefinition(db);
-    await removeUnsupportedTools(db);
-
-    expect(await db.getTool(GENERATE_IMAGE_TOOL_ID)).not.toBeNull();
   });
 
   test("seedDatabase includes generate_image and Super Bot is not auto-assigned", async () => {

--- a/apps/web/src/hooks/use-data-portability.test.ts
+++ b/apps/web/src/hooks/use-data-portability.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
 import {
-  canRestoreDataImport,
   formatDataPortabilityBytes,
   shouldStartInitialFilePreview,
 } from "./use-data-portability";
@@ -10,41 +9,6 @@ describe("formatDataPortabilityBytes", () => {
     expect(formatDataPortabilityBytes(42)).toBe("42 B");
     expect(formatDataPortabilityBytes(1536)).toBe("1.5 KB");
     expect(formatDataPortabilityBytes(12 * 1024 * 1024)).toBe("12 MB");
-  });
-});
-
-describe("canRestoreDataImport", () => {
-  const file = new File(["zip"], "nakama.zip", { type: "application/zip" });
-
-  test("requires a selected file, successful preview, and idle restore state", () => {
-    expect(
-      canRestoreDataImport({
-        pending: false,
-        previewReady: true,
-        selectedFile: file,
-      })
-    ).toBe(true);
-    expect(
-      canRestoreDataImport({
-        pending: false,
-        previewReady: true,
-        selectedFile: null,
-      })
-    ).toBe(false);
-    expect(
-      canRestoreDataImport({
-        pending: false,
-        previewReady: false,
-        selectedFile: file,
-      })
-    ).toBe(false);
-    expect(
-      canRestoreDataImport({
-        pending: true,
-        previewReady: true,
-        selectedFile: file,
-      })
-    ).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/chat-list-stickiness.test.ts
+++ b/apps/web/src/lib/chat-list-stickiness.test.ts
@@ -1,18 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import {
-  followOutputBehavior,
-  listOverflowsViewport,
-} from "./chat-list-stickiness";
-
-describe("followOutputBehavior", () => {
-  test("follows with auto when at bottom", () => {
-    expect(followOutputBehavior(true)).toBe("auto");
-  });
-
-  test("does not follow when not at bottom", () => {
-    expect(followOutputBehavior(false)).toBe(false);
-  });
-});
+import { listOverflowsViewport } from "./chat-list-stickiness";
 
 describe("listOverflowsViewport", () => {
   test("detects when content is taller than the viewport", () => {

--- a/apps/web/src/lib/thinking-settings.test.ts
+++ b/apps/web/src/lib/thinking-settings.test.ts
@@ -1,28 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import {
-  buildAutoEnableThinkingPayload,
-  shouldAutoEnableThinking,
-  shouldShowThinkingEffort,
-} from "./thinking-settings";
+import { shouldAutoEnableThinking } from "./thinking-settings";
 
 describe("thinking-settings helpers", () => {
-  test("shouldShowThinkingEffort is true only when model explicitly supports thinking", () => {
-    expect(shouldShowThinkingEffort(true)).toBe(true);
-    expect(shouldShowThinkingEffort(false)).toBe(false);
-    expect(shouldShowThinkingEffort(undefined)).toBe(false);
-  });
-
-  test("buildAutoEnableThinkingPayload always enables thinking", () => {
-    expect(buildAutoEnableThinkingPayload({ effort: "high" })).toEqual({
-      effort: "high",
-      enabled: true,
-    });
-    expect(buildAutoEnableThinkingPayload({ effort: "medium" })).toEqual({
-      effort: "medium",
-      enabled: true,
-    });
-  });
-
   test("shouldAutoEnableThinking respects guards", () => {
     const disabled = { effort: "low" as const, enabled: false };
 

--- a/packages/agent/src/task-prompt.test.ts
+++ b/packages/agent/src/task-prompt.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
 import type { ProviderClient } from "@nakama/core";
-import { normalizeTaskPrompt } from "@nakama/core";
 import {
   buildTaskPromptUserPrompt,
   draftTaskPromptFromFields,
@@ -18,12 +17,6 @@ describe("task prompt drafting", () => {
     await expect(
       draftTaskPromptFromFields({ title: "   " }, {})
     ).rejects.toThrow("Task title is required.");
-  });
-
-  test("normalizeTaskPrompt unwraps JSON for provider mocks", () => {
-    expect(
-      normalizeTaskPrompt('{"prompt":"Summarize competitor positioning."}')
-    ).toBe("Summarize competitor positioning.");
   });
 
   test("draftTaskPromptFromFields unwraps JSON-like provider output", async () => {


### PR DESCRIPTION
## Summary
Removes 7 low-value unit tests (tautological wrappers, a duplicate assertion, and coverage already provided by sibling tests). No production code changes.

### Removed tests
1. `isRotateTokenCommand matches the rotate-token subcommand` (`apps/cli/src/rotate-token.test.ts`) — tautological: source is `argv[0] === "rotate-token"`.
2. `isTerminalResponse identifies cursor reports` (`apps/cli/src/terminal-screen.test.ts`) — duplicate of the existing `isTerminalResponse > detects cursor position reports` cases in the same file.
3. `unsupported-handler cleanup retains generate_image after seed` (`apps/server/src/tools/generate-image-tool.test.ts`) — redundant with the remaining seed/resolver tests that already assert the tool survives seed.
4. `requires a selected file, successful preview, and idle restore state` (`apps/web/src/hooks/use-data-portability.test.ts`) — tautological: source is `Boolean(file) && previewReady && !pending`.
5. `follows with auto when at bottom` / `does not follow when not at bottom` (`apps/web/src/lib/chat-list-stickiness.test.ts`) — tautological: source is `atBottom ? "auto" : false`.
6. `shouldShowThinkingEffort…` / `buildAutoEnableThinkingPayload always enables thinking` (`apps/web/src/lib/thinking-settings.test.ts`) — tautological wrappers (`=== true` and `{ effort, enabled: true }`); guard logic remains covered by `shouldAutoEnableThinking`.
7. `normalizeTaskPrompt unwraps JSON for provider mocks` (`packages/agent/src/task-prompt.test.ts`) — redundant with `draftTaskPromptFromFields unwraps JSON-like provider output`.

## Test plan
- [x] `bun test` on the 7 affected files — **30 pass, 0 fail**
- [x] `bun test` at repo root — **2284 pass, 0 fail**
