### PR TITLE
fix(agent): scale pruneToolOutputs thresholds off the model context window (#342)

### DIFF
--- a/packages/agent/src/history-compaction.test.ts
+++ b/packages/agent/src/history-compaction.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type {
   ChatCompletionResult,
   ChatMessage,
+  CompactionConfig,
   ProviderClient,
 } from "@nakama/core";
 import {
@@ -14,8 +15,18 @@ import {
   usableContextTokens,
 } from "./history-compaction";
 
-const compaction = {
+const compaction: CompactionConfig = {
   contextWindow: 100_000,
+  maxOutputTokens: 8192,
+};
+
+const largeWindow: CompactionConfig = {
+  contextWindow: 1_000_000,
+  maxOutputTokens: 8192,
+};
+
+const smallWindow: CompactionConfig = {
+  contextWindow: 128_000,
   maxOutputTokens: 8192,
 };
 
@@ -30,6 +41,26 @@ function createToolMessage(content: string): ChatMessage {
     role: "tool",
     toolCallId: "call_1",
   };
+}
+
+// Builds the 14-message transcript used by the prune tests: three turns
+// each carrying one tool result, followed by a tail turn with no tool call.
+// The last two user turns are protected, so only the older tool messages
+// are pruning candidates.
+function seedHistory(toolChars: number): ChatMessage[] {
+  return [
+    { content: "turn 1", role: "user" },
+    createToolMessage(repeat("a", toolChars)),
+    { content: "done 1", role: "assistant" },
+    { content: "turn 2", role: "user" },
+    createToolMessage(repeat("b", toolChars)),
+    { content: "done 2", role: "assistant" },
+    { content: "turn 3", role: "user" },
+    createToolMessage(repeat("c", toolChars)),
+    { content: "done 3", role: "assistant" },
+    { content: "turn 4", role: "user" },
+    { content: "done 4", role: "assistant" },
+  ];
 }
 
 describe("history compaction", () => {
@@ -55,7 +86,7 @@ describe("history compaction", () => {
       { content: "done 4", role: "assistant" },
     ];
 
-    const result = pruneToolOutputs(messages);
+    const result = pruneToolOutputs(messages, compaction);
 
     expect(result.prunedTokens).toBeGreaterThan(0);
     expect(messages[1]?.role === "tool" && messages[1].content).toContain(
@@ -63,6 +94,56 @@ describe("history compaction", () => {
     );
     expect(messages[10]?.role === "assistant" && messages[10].content).toBe(
       "done 4"
+    );
+  });
+
+  test("does not prune when tool output is well below the model's usable window (#342)", () => {
+    // Three 30k-token tool results; the last 2 turns are protected, so two
+    // candidates (60k tokens) are considered. On a 1M window the protect
+    // fraction is ~496k, so the loop must leave the stored transcript intact.
+    const messages = seedHistory(120_000);
+    const result = pruneToolOutputs(messages, largeWindow);
+
+    expect(result.prunedTokens).toBe(0);
+    expect(messages[1]?.role === "tool" && messages[1].content).toBe(
+      repeat("a", 120_000)
+    );
+    expect(messages[4]?.role === "tool" && messages[4].content).toBe(
+      repeat("b", 120_000)
+    );
+    expect(messages[7]?.role === "tool" && messages[7].content).toBe(
+      repeat("c", 120_000)
+    );
+  });
+
+  test("still prunes when accumulated tool output crosses the protect fraction", () => {
+    // Same three 30k-token tool results against a 128k window. The protect
+    // fraction is ~60k, so the older candidate crosses the threshold and the
+    // function must truncate it.
+    const messages = seedHistory(120_000);
+    const result = pruneToolOutputs(messages, smallWindow);
+
+    expect(result.prunedTokens).toBeGreaterThan(0);
+    expect(messages[1]?.role === "tool" && messages[1].content).toContain(
+      "truncated"
+    );
+    expect(messages[4]?.role === "tool" && messages[4].content).toBe(
+      repeat("b", 120_000)
+    );
+  });
+
+  test("does not prune when usable tokens are non-positive", () => {
+    const degenerate: CompactionConfig = {
+      contextWindow: 4096,
+      maxOutputTokens: 8192,
+    };
+
+    const messages = seedHistory(200_000);
+    const result = pruneToolOutputs(messages, degenerate);
+
+    expect(result.prunedTokens).toBe(0);
+    expect(messages[1]?.role === "tool" && messages[1].content).toBe(
+      repeat("a", 200_000)
     );
   });
 

--- a/packages/agent/src/history-compaction.test.ts
+++ b/packages/agent/src/history-compaction.test.ts
@@ -132,6 +132,39 @@ describe("history compaction", () => {
     );
   });
 
+  test("does not truncate when reclaimed tokens do not clear the minimum fraction", () => {
+    // usable = 200k (protect = 100k, minimum = 20k). Walking newest→oldest,
+    // the 95k-token result stays under protect and the 20k-token one crosses
+    // it, but the reclaim equals the minimum, so nothing may be rewritten.
+    const messages: ChatMessage[] = [
+      { content: "turn 1", role: "user" },
+      createToolMessage(repeat("a", 80_000)),
+      { content: "done 1", role: "assistant" },
+      { content: "turn 2", role: "user" },
+      createToolMessage(repeat("b", 380_000)),
+      { content: "done 2", role: "assistant" },
+      { content: "turn 3", role: "user" },
+      createToolMessage(repeat("c", 4000)),
+      { content: "done 3", role: "assistant" },
+      { content: "turn 4", role: "user" },
+      { content: "done 4", role: "assistant" },
+    ];
+    const window: CompactionConfig = {
+      contextWindow: 208_192,
+      maxOutputTokens: 8192,
+    };
+
+    const result = pruneToolOutputs(messages, window);
+
+    expect(result.prunedTokens).toBe(0);
+    expect(messages[1]?.role === "tool" && messages[1].content).toBe(
+      repeat("a", 80_000)
+    );
+    expect(messages[4]?.role === "tool" && messages[4].content).toBe(
+      repeat("b", 380_000)
+    );
+  });
+
   test("does not prune when usable tokens are non-positive", () => {
     const degenerate: CompactionConfig = {
       contextWindow: 4096,

--- a/packages/agent/src/history-compaction.test.ts
+++ b/packages/agent/src/history-compaction.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, test } from "bun:test";
 import type {
   ChatCompletionResult,
   ChatMessage,
-  CompactionConfig,
   ProviderClient,
 } from "@nakama/core";
 import {
   buildCompactionPrompt,
+  type CompactionConfig,
   compactHistory,
   estimateHistoryTokens,
   isOverflow,

--- a/packages/agent/src/history-compaction.ts
+++ b/packages/agent/src/history-compaction.ts
@@ -10,8 +10,12 @@ import {
 } from "@nakama/core";
 
 const COMPACTION_BUFFER = 20_000;
-const PRUNE_MINIMUM = 20_000;
-const PRUNE_PROTECT = 40_000;
+// Pruning thresholds are fractions of the model's usable context so that
+// large-window models keep their history intact when tool output is small
+// relative to the window, while small-window models still reclaim tokens
+// before overflow. See #342.
+const PRUNE_PROTECT_FRACTION = 0.5;
+const PRUNE_MINIMUM_FRACTION = 0.1;
 const TAIL_TURNS = 2;
 const TOKEN_ESTIMATE_RATIO = 4;
 const PRUNE_TRUNCATION = "[output truncated by compaction]";
@@ -218,9 +222,20 @@ export function selectCompactionRange(
   };
 }
 
-export function pruneToolOutputs(messages: ChatMessage[]): {
-  prunedTokens: number;
-} {
+export function pruneToolOutputs(
+  messages: ChatMessage[],
+  compaction: CompactionConfig
+): { prunedTokens: number } {
+  const usable = usableContextTokens(compaction);
+  const protect = Math.floor(usable * PRUNE_PROTECT_FRACTION);
+  const minimum = Math.floor(usable * PRUNE_MINIMUM_FRACTION);
+
+  // Degenerate configs (small contextWindow vs. maxOutputTokens) yield a
+  // non-positive usable budget; pruning would have nothing to protect.
+  if (usable <= 0) {
+    return { prunedTokens: 0 };
+  }
+
   let total = 0;
   let pruned = 0;
   const toPrune: Extract<ChatMessage, { role: "tool" }>[] = [];
@@ -260,7 +275,7 @@ export function pruneToolOutputs(messages: ChatMessage[]): {
     const estimate = estimateTokens(message.content);
     total += estimate;
 
-    if (total <= PRUNE_PROTECT) {
+    if (total <= protect) {
       continue;
     }
 
@@ -268,7 +283,7 @@ export function pruneToolOutputs(messages: ChatMessage[]): {
     toPrune.push(message);
   }
 
-  if (pruned <= PRUNE_MINIMUM) {
+  if (pruned <= minimum) {
     return { prunedTokens: 0 };
   }
 
@@ -283,7 +298,7 @@ export async function compactHistory(
   input: CompactHistoryInput
 ): Promise<CompactionResponse> {
   const messagesBefore = input.history.length;
-  const { prunedTokens } = pruneToolOutputs(input.history);
+  const { prunedTokens } = pruneToolOutputs(input.history, input.compaction);
   const usedTokens = estimateHistoryTokens(
     input.history,
     input.systemPrompt,


### PR DESCRIPTION
## Summary

`pruneToolOutputs` rewrote stored tool output using module-level constants (`PRUNE_PROTECT = 40_000`, `PRUNE_MINIMUM = 20_000`) regardless of the model's context window. On a 1M-token model a session with three 30k-token tool results lost **240 kB of stored tool output on a single ordinary turn** while the context was at 9% of its usable window. The truncation is written back to `session_messages`, so the same rows `GET /v1/sessions/:id/messages`, `branchSession`, and the web transcript all read are the rows that got rewritten. `branchSession` cannot recover the text because it copies the stored rows.

This PR scales the thresholds off `usableContextTokens(compaction)` (direction 1 of the two options the issue lays out). `compactHistory` already received the session's `CompactionConfig`, so no changes were needed in `chat.ts`; the PR teaches `pruneToolOutputs` to read that config, which is what lets the per-turn `runCompaction(false)` path prune against the real window size.

## What the code did before

| | File | Line |
|---|---|---|
| Module constants | `packages/agent/src/history-compaction.ts` | 13–14 |
| `pruneToolOutputs` (no `compaction` arg) | `packages/agent/src/history-compaction.ts` | 221 |
| Call from `compactHistory` (drops `compaction`) | `packages/agent/src/history-compaction.ts` | 286 |
| Per-turn compaction driver | `packages/agent/src/chat.ts` | 410 |
| Config built from model catalog | `apps/server/src/services/agent-service.ts` | 3569–3588 |

`pruneToolOutputs` took only `messages: ChatMessage[]`. `contextWindow` was never on the call path.

## What it does now

```ts
const PRUNE_PROTECT_FRACTION = 0.5; // protect tool output up to 50% of usable
const PRUNE_MINIMUM_FRACTION = 0.1; // only act when pruning >= 10% of usable

export function pruneToolOutputs(
  messages: ChatMessage[],
  compaction: CompactionConfig
): { prunedTokens: number } {
  const usable = usableContextTokens(compaction);
  if (usable <= 0) return { prunedTokens: 0 }; // degenerate configs: no-op
  const protect = Math.floor(usable * PRUNE_PROTECT_FRACTION);
  const minimum = Math.floor(usable * PRUNE_MINIMUM_FRACTION);
  // ...same loop, using `protect`/`minimum` instead of the module constants
}
```

`compactHistory` now passes `input.compaction` through. `usableContextTokens` is the same helper the existing overflow check (`isOverflow`) uses, so the two are consistent.

## Behavior change

A note on call shapes first, because it changes the numbers. `seedHistory`
returns 11 messages and the unit tests call `pruneToolOutputs` on that array
directly. On the per-turn path `compactHistory` sees the array after the new
turn has been appended, so the two-turn tail slides forward and all three tool
results become candidates instead of two. The per-turn path is the one that
writes back to `session_messages`, so the table below uses that shape
throughout. Every cell was measured by running both implementations over the
same seeds, not derived by hand.

Before/after on the issue's seed (three 30k-token tool results, one ordinary turn sent on top):

| Window | Usable | Old result | New result |
|---|---:|---|---|
| 1,000,000 | 991,808 | **2 of 3 truncated, 240 kB deleted** | no prune ✓ |
| 200,000 | 191,808 | 2 of 3 truncated | no prune ✓ |
| 128,000 | 119,808 | 2 of 3 truncated | 2 of 3 truncated |

Called directly on the 11-message array, as the unit tests do, the old code
truncates 1 of 3 at every window (its constants are window-blind) and the new
code truncates 1 of 3 at 128k and 100k and 0 elsewhere. Both "no prune" cells
hold under either shape.

Two rows from the test suite, each its own seed, called directly:

| Seed | Old | New |
|---|---|---|
| existing test's transcript (one 50,000-token result, 100k window) | 50k truncated | 50k truncated (test unchanged) |
| degenerate guard test (`seedHistory(200_000)`, 4,096 window) | 2 of 3 truncated (100k tokens) | no prune (usable ≤ 0 guard) |

The 200k row is a deliberate behavior change: under 50% of usable, the history
is left alone. The bug report's intent is that pruning is reserved for actual
overflow pressure, not as a flat cost optimisation.

Two things worth knowing about the 128k row: it is also where
`resolveCompactionConfig` lands for any model the catalog does not carry
(`contextWindow: model?.contextWindow ?? 128_000`), so uncataloged models keep
today's behavior; and on the smallest catalog entry (7968) the old code's
stored-byte counter reads 0 only because overflow summarization drops the
whole head afterwards — the text was lost either way, so the small model
pruning earlier is intended behavior, not a safety baseline.

## Tests

`packages/agent/src/history-compaction.test.ts` (11/11 pass, 28 expects):

- **existing** `prunes old tool outputs while protecting recent turns` — still passes (100k window, 50k tool result)
- **new** `does not prune when tool output is well below the model's usable window (#342)` — pins the bug fix (1M window, 60k tool output → no prune)
- **new** `still prunes when accumulated tool output crosses the protect fraction` — pins preserved overflow behavior (128k window)
- **new** `does not truncate when reclaimed tokens do not clear the minimum fraction` — pins the below-minimum no-op branch (200k window; the reclaim equals the minimum, so nothing is rewritten)
- **new** `does not prune when usable tokens are non-positive` — pins the degenerate guard (4k window, 8k maxOutput → no prune)

Wider sweep:

```
bun test packages/                 # 808 pass, 0 fail, 1696 expects
bun test apps/server/src/services  # 409 pass, 0 fail, 1010 expects
bun x ultracite check              # 1175 files clean
```

## Out of scope (deliberately)

- **Direction 2** from the issue — separate prompt-time prune (`rehydrateMessagesForProvider`) from stored-transcript edits. That also fixes `branchSession` losing text, but it touches `rehydrateMessagesForProvider`, `session-persistence`, and the SQLite adapter. Worth a follow-up.
- The follow-up timeout bug in `omni-install.ts:204` from #326 — separate issue.
- Adding a kill-switch / config knob to disable pruning. With the new fractions, the worst-case deletion is bounded by usable context, so a knob is no longer required for correctness. If product wants it later, add it on top.

## Reproduction (from the issue)

```bash
git clone https://github.com/ahmadrosid/nakama.git nakama-prune
cd nakama-prune
git checkout f1be072b
bun install
# paste the prune-window-probe.test.ts block from the issue body
bun test apps/server/src/services/prune-window-probe.test.ts
# 1M window: 240 kB removed from session_messages while context was 9% full
```

After this PR, on the same seed and a 1M window the probe shows `prunedTokens: 0` and no tool output is touched; the stored payload ends up 69 bytes larger, which is the two rows the turn itself writes (`turn 5` / `ok`).

Closes #342

