### PR TITLE
feat(tools): add custom Python tool handler (#331)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,22 +129,22 @@ Path bugs (tool resolves under repo instead of `~/.nakama`) → start here. Over
 | Path | Purpose |
 |---|---|
 | `~/.nakama/orgs/{orgId}/profiles/{profileId}/` | Profile workspace — `getProfileSoulDir()` |
-| `~/.nakama/tools/*.js` | Custom JS tools — `getCustomToolsDir()` |
+| `~/.nakama/tools/*.js`, `*.py` | Custom JS / Python tools — `getCustomToolsDir()` |
 
-Always build context with `buildToolExecutionContext()` (`packages/core/src/tools/context.ts`) so `workspaceRoot` = soul dir. Custom JS tools must use `context.workspaceRoot`, **not** `process.cwd()`.
+Always build context with `buildToolExecutionContext()` (`packages/core/src/tools/context.ts`) so `workspaceRoot` = soul dir. Custom JS tools must use `context.workspaceRoot`, **not** `process.cwd()`; custom Python tools receive it as the `NAKAMA_WORKSPACE_ROOT` env var.
 
-| | Built-in | Custom JS |
-|---|---|---|
-| Code | `packages/core/src/tools/`, `apps/server/src/tools/` | `~/.nakama/tools/*.js` |
-| Workspace | `getProfileSoulDir` inside handler | `context.workspaceRoot` |
-| Loader | builtins map | `javascript-tool-loader.ts` |
+| | Built-in | Custom JS | Custom Python |
+|---|---|---|---|
+| Code | `packages/core/src/tools/`, `apps/server/src/tools/` | `~/.nakama/tools/*.js` | `~/.nakama/tools/*.py` |
+| Workspace | `getProfileSoulDir` inside handler | `context.workspaceRoot` | `NAKAMA_WORKSPACE_ROOT` env |
+| Loader | builtins map | `javascript-tool-loader.ts` | `python-tool-loader.ts` |
 
 | Flow | Entry |
 |---|---|
 | Chat | `agent-service` → `buildChatSession()` → `buildToolExecutionContext(...)` |
 | Tool loop | `packages/agent/src/tool-loop.ts` → `executeToolCall()`; parallel batching in `packages/agent/src/chat.ts` when every call in the turn is `parallelSafe` |
 
-**Parallel tool calls:** Built-in read/search/fetch tools (`read_file`, `search_files`, `knowledge_base_search`, `web_search`, `web_fetch`) set `parallelSafe: true` on `ToolDefinition`. Mutating, shell, delegation, and session-state tools stay sequential. Custom JS tools default to sequential; export `parallelSafe: true` from the module to opt in. When a turn mixes parallel-safe and sequential tools, the whole turn runs sequentially.
+**Parallel tool calls:** Built-in read/search/fetch tools (`read_file`, `search_files`, `knowledge_base_search`, `web_search`, `web_fetch`) set `parallelSafe: true` on `ToolDefinition`. Mutating, shell, delegation, and session-state tools stay sequential. Custom JS tools default to sequential; export `parallelSafe: true` from the module to opt in. Custom Python tools cannot opt in — each call spawns a subprocess and stays sequential. When a turn mixes parallel-safe and sequential tools, the whole turn runs sequentially.
 
 | Flow | Entry |
 |---|---|

--- a/apps/server/src/http/routes/tools.ts
+++ b/apps/server/src/http/routes/tools.ts
@@ -202,7 +202,7 @@ export function registerToolRoutes(app: HonoApp, options: ServerOptions): void {
           description: "Error",
         },
       },
-      summary: "Run a custom JavaScript tool in the playground",
+      summary: "Run a custom JavaScript or Python tool in the playground",
       tags: ["Tools"],
     })
   );

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -232,6 +232,10 @@ import {
   buildComposioToolDefinitions,
 } from "./composio-tool-bridge";
 import {
+  customToolTypesLabel,
+  getCustomToolHandler,
+} from "./custom-tool-handlers";
+import {
   generateImageWithOpenAI,
   IMAGE_MODEL_REQUIRED_MESSAGE,
   resolveImageGenerationSelection,
@@ -245,7 +249,6 @@ import {
 } from "./image-vision-fallback";
 import {
   invalidateJavascriptModuleCache,
-  loadJavascriptTool,
   resolveJavascriptModulePath,
 } from "./javascript-tool-loader";
 import type { LlmUsageTracker } from "./llm-usage-tracker";
@@ -2434,10 +2437,11 @@ export class AgentService {
     context: { orgId: string; userId: string }
   ): Promise<RunToolResponse> {
     const { tool } = await this.profileService.getTool(toolId);
+    const handler = getCustomToolHandler(tool.handlerType);
 
-    if (tool.handlerType !== "javascript") {
+    if (!handler) {
       throw new Error(
-        "Only custom JavaScript tools can be run in the playground."
+        `Only custom ${customToolTypesLabel()} tools can be run in the playground.`
       );
     }
 
@@ -2452,22 +2456,25 @@ export class AgentService {
       toolId
     );
 
-    const handlerConfig =
-      typeof record.handlerConfig === "object" && record.handlerConfig !== null
-        ? (record.handlerConfig as { modulePath?: string })
-        : null;
+    if (tool.handlerType === "javascript") {
+      const handlerConfig =
+        typeof record.handlerConfig === "object" &&
+        record.handlerConfig !== null
+          ? (record.handlerConfig as { modulePath?: string })
+          : null;
 
-    if (handlerConfig?.modulePath) {
-      try {
-        invalidateJavascriptModuleCache(
-          resolveJavascriptModulePath(handlerConfig.modulePath)
-        );
-      } catch {
-        // Invalid module paths fail when loading the tool.
+      if (handlerConfig?.modulePath) {
+        try {
+          invalidateJavascriptModuleCache(
+            resolveJavascriptModulePath(handlerConfig.modulePath)
+          );
+        } catch {
+          // Invalid module paths fail when loading the tool.
+        }
       }
     }
 
-    const loaded = await loadJavascriptTool(record);
+    const loaded = await handler.load(record);
 
     if (!loaded) {
       throw new Error(`Failed to load tool "${tool.name}".`);
@@ -2502,10 +2509,11 @@ export class AgentService {
     prompt: string
   ): Promise<SuggestToolParamsResponse> {
     const { tool } = await this.profileService.getTool(toolId);
+    const handler = getCustomToolHandler(tool.handlerType);
 
-    if (tool.handlerType !== "javascript") {
+    if (!handler) {
       throw new Error(
-        "Only custom JavaScript tools support parameter suggestions."
+        `Only custom ${customToolTypesLabel()} tools support parameter suggestions.`
       );
     }
 
@@ -2515,7 +2523,7 @@ export class AgentService {
       throw new Error("Tool not found.");
     }
 
-    const loaded = await loadJavascriptTool(record);
+    const loaded = await handler.load(record);
     const provider = createProviderFromSources(process.env, this.userConfig);
     const parameters = await suggestToolParamsFromPrompt(
       {

--- a/apps/server/src/services/custom-tool-handlers.ts
+++ b/apps/server/src/services/custom-tool-handlers.ts
@@ -1,0 +1,63 @@
+import type { ToolDefinition, ToolSourceResponse } from "@nakama/core";
+import type { StoredToolRecord } from "@nakama/db";
+import {
+  loadJavascriptTool,
+  resolveJavascriptModulePath,
+  validateJavascriptToolModule,
+} from "./javascript-tool-loader";
+import {
+  loadPythonTool,
+  resolvePythonModulePath,
+  validatePythonToolModule,
+} from "./python-tool-loader";
+
+// Registry of custom tool handler types. Adding a new handler type means
+// adding an entry here plus its loader module — no call-site edits.
+export interface CustomToolHandler {
+  /** File extension required in handlerConfig.modulePath, e.g. ".py". */
+  extension: string;
+  /** Language tag returned by tool-source for this handler type. */
+  language: ToolSourceResponse["language"];
+  load(record: StoredToolRecord): Promise<ToolDefinition | null>;
+  resolveModulePath(modulePath: string): string;
+  validateModule(modulePath: string): Promise<void>;
+}
+
+export const CUSTOM_TOOL_HANDLERS = {
+  javascript: {
+    extension: ".js",
+    language: "javascript",
+    load: loadJavascriptTool,
+    resolveModulePath: resolveJavascriptModulePath,
+    validateModule: validateJavascriptToolModule,
+  },
+  python: {
+    extension: ".py",
+    language: "python",
+    load: loadPythonTool,
+    resolveModulePath: resolvePythonModulePath,
+    validateModule: validatePythonToolModule,
+  },
+} satisfies Record<string, CustomToolHandler>;
+
+export type CustomToolType = keyof typeof CUSTOM_TOOL_HANDLERS;
+
+export function getCustomToolHandler(
+  handlerType: string
+): CustomToolHandler | null {
+  return (
+    (CUSTOM_TOOL_HANDLERS as Record<string, CustomToolHandler>)[handlerType] ??
+    null
+  );
+}
+
+export function isCustomToolType(
+  handlerType: string
+): handlerType is CustomToolType {
+  return handlerType in CUSTOM_TOOL_HANDLERS;
+}
+
+/** Human-readable list of supported handler types, e.g. "javascript or python". */
+export function customToolTypesLabel(): string {
+  return Object.keys(CUSTOM_TOOL_HANDLERS).join(" or ");
+}

--- a/apps/server/src/services/custom-tool-shared.ts
+++ b/apps/server/src/services/custom-tool-shared.ts
@@ -1,0 +1,79 @@
+import path from "node:path";
+import type { JsonSchema, ToolDefinition } from "@nakama/core";
+import { permissiveObjectSchema } from "@nakama/core";
+import type { StoredToolRecord } from "@nakama/db";
+
+// Helpers shared by the custom tool loaders (javascript, python, and any
+// future handler type registered in custom-tool-handlers.ts).
+
+export function createErrorTool(
+  record: StoredToolRecord,
+  message: string
+): ToolDefinition {
+  return {
+    description: record.description,
+    name: record.name,
+    parameters: permissiveObjectSchema(),
+    async run() {
+      return { error: message };
+    },
+  };
+}
+
+export function isPathInsideDirectory(
+  targetPath: string,
+  directoryPath: string
+): boolean {
+  const relative = path.relative(directoryPath, targetPath);
+
+  return (
+    relative === "" || !(relative.startsWith("..") || path.isAbsolute(relative))
+  );
+}
+
+export interface CustomToolHandlerConfig {
+  modulePath: string;
+  parameters?: JsonSchema;
+}
+
+export function readHandlerConfig(
+  handlerConfig: unknown
+): CustomToolHandlerConfig | null {
+  if (typeof handlerConfig !== "object" || handlerConfig === null) {
+    return null;
+  }
+
+  const record = handlerConfig as Record<string, unknown>;
+  const modulePath =
+    typeof record.modulePath === "string" && record.modulePath.trim()
+      ? record.modulePath.trim()
+      : null;
+
+  if (!modulePath) {
+    return null;
+  }
+
+  const parameters = isJsonSchema(record.parameters)
+    ? record.parameters
+    : undefined;
+
+  return { modulePath, parameters };
+}
+
+export function readHandlerModulePath(handlerConfig: unknown): string | null {
+  if (typeof handlerConfig !== "object" || handlerConfig === null) {
+    return null;
+  }
+
+  const modulePath = (handlerConfig as Record<string, unknown>).modulePath;
+
+  if (typeof modulePath !== "string" || !modulePath.trim()) {
+    return null;
+  }
+
+  return modulePath.trim();
+}
+
+export function isJsonSchema(value: unknown): value is JsonSchema {
+  return typeof value === "object" && value !== null;
+}

--- a/apps/server/src/services/javascript-tool-loader.ts
+++ b/apps/server/src/services/javascript-tool-loader.ts
@@ -7,13 +7,14 @@ import {
   permissiveObjectSchema,
 } from "@nakama/core";
 import type { StoredToolRecord } from "@nakama/db";
+import {
+  createErrorTool,
+  isJsonSchema,
+  isPathInsideDirectory,
+  readHandlerConfig,
+} from "./custom-tool-shared";
 
 const moduleCache = new Map<string, JavascriptToolModule>();
-
-export interface JavascriptToolHandlerConfig {
-  modulePath: string;
-  parameters?: JsonSchema;
-}
 
 interface JavascriptToolModule {
   parallelSafe?: boolean;
@@ -24,7 +25,7 @@ interface JavascriptToolModule {
 export async function loadJavascriptTool(
   record: StoredToolRecord
 ): Promise<ToolDefinition | null> {
-  const config = readJavascriptHandlerConfig(record.handlerConfig);
+  const config = readHandlerConfig(record.handlerConfig);
 
   if (!config?.modulePath) {
     return createErrorTool(
@@ -98,30 +99,6 @@ export function resolveJavascriptModulePath(modulePath: string): string {
   return resolved;
 }
 
-function readJavascriptHandlerConfig(
-  handlerConfig: unknown
-): JavascriptToolHandlerConfig | null {
-  if (typeof handlerConfig !== "object" || handlerConfig === null) {
-    return null;
-  }
-
-  const record = handlerConfig as Record<string, unknown>;
-  const modulePath =
-    typeof record.modulePath === "string" && record.modulePath.trim()
-      ? record.modulePath.trim()
-      : null;
-
-  if (!modulePath) {
-    return null;
-  }
-
-  const parameters = isJsonSchema(record.parameters)
-    ? record.parameters
-    : undefined;
-
-  return { modulePath, parameters };
-}
-
 async function importJavascriptModule(
   modulePath: string
 ): Promise<JavascriptToolModule> {
@@ -172,33 +149,4 @@ function normalizeJavascriptModule(imported: unknown): JavascriptToolModule {
     ...(parallelSafe ? { parallelSafe: true } : {}),
     run: (input, context) => Promise.resolve(run(input, context)),
   };
-}
-
-function createErrorTool(
-  record: StoredToolRecord,
-  message: string
-): ToolDefinition {
-  return {
-    description: record.description,
-    name: record.name,
-    parameters: permissiveObjectSchema(),
-    async run() {
-      return { error: message };
-    },
-  };
-}
-
-function isPathInsideDirectory(
-  targetPath: string,
-  directoryPath: string
-): boolean {
-  const relative = path.relative(directoryPath, targetPath);
-
-  return (
-    relative === "" || !(relative.startsWith("..") || path.isAbsolute(relative))
-  );
-}
-
-function isJsonSchema(value: unknown): value is JsonSchema {
-  return typeof value === "object" && value !== null;
 }

--- a/apps/server/src/services/profile-service.test.ts
+++ b/apps/server/src/services/profile-service.test.ts
@@ -82,6 +82,86 @@ describe("profile service createTool", () => {
     expect(tool.handlerType).toBe("python");
   });
 
+  test("persists handlerConfig.parameters for python tools", async () => {
+    tempConfigDir = await mkdtemp(
+      path.join(os.tmpdir(), "nakama-profile-tool-")
+    );
+    process.env.NAKAMA_CONFIG_DIR = tempConfigDir;
+    const toolsDir = path.join(tempConfigDir, "tools");
+    await mkdir(toolsDir, { recursive: true });
+
+    await writeFile(
+      path.join(toolsDir, "echo.py"),
+      `def run(input, context):\n    return {"echoed": input.get("message")}\n`
+    );
+
+    const parameters = {
+      properties: { message: { type: "string" } },
+      required: ["message"],
+      type: "object",
+    };
+    const service = new ProfileService(createInMemoryDatabaseAdapter());
+    const tool = await service.createTool({
+      description: "Echo input",
+      handlerConfig: { modulePath: "echo.py", parameters },
+      handlerType: "python",
+      name: "echo_py",
+    });
+
+    expect(tool.handlerConfig).toEqual({ modulePath: "echo.py", parameters });
+    expect(tool.parameters).toEqual(parameters);
+
+    const stored = await service.getTool(tool.id);
+    expect(stored.tool.handlerConfig).toEqual({
+      modulePath: "echo.py",
+      parameters,
+    });
+    expect(stored.tool.parameters).toEqual(parameters);
+  });
+
+  test("creates a python tool without parameters using a permissive schema", async () => {
+    tempConfigDir = await mkdtemp(
+      path.join(os.tmpdir(), "nakama-profile-tool-")
+    );
+    process.env.NAKAMA_CONFIG_DIR = tempConfigDir;
+    const toolsDir = path.join(tempConfigDir, "tools");
+    await mkdir(toolsDir, { recursive: true });
+
+    await writeFile(
+      path.join(toolsDir, "echo.py"),
+      `def run(input, context):\n    return {"echoed": input.get("message")}\n`
+    );
+
+    const service = new ProfileService(createInMemoryDatabaseAdapter());
+    const tool = await service.createTool({
+      description: "Echo input",
+      handlerConfig: { modulePath: "echo.py" },
+      handlerType: "python",
+      name: "echo_py",
+    });
+
+    expect(tool.handlerConfig).toEqual({ modulePath: "echo.py" });
+    expect(tool.parameters).toEqual({
+      additionalProperties: true,
+      type: "object",
+    });
+  });
+
+  test("rejects non-object handlerConfig.parameters", async () => {
+    const service = new ProfileService(createInMemoryDatabaseAdapter());
+
+    for (const parameters of [["message"], "message", null]) {
+      await expect(
+        service.createTool({
+          description: "Bad params",
+          handlerConfig: { modulePath: "echo.py", parameters },
+          handlerType: "python",
+          name: "bad_params",
+        })
+      ).rejects.toThrow();
+    }
+  });
+
   test("rejects unsupported handler types", async () => {
     const service = new ProfileService(createInMemoryDatabaseAdapter());
 

--- a/apps/server/src/services/profile-service.test.ts
+++ b/apps/server/src/services/profile-service.test.ts
@@ -58,7 +58,31 @@ describe("profile service createTool", () => {
     expect(tool.handlerType).toBe("javascript");
   });
 
-  test("rejects non-javascript handler types", async () => {
+  test("creates a python tool when handlerType is python", async () => {
+    tempConfigDir = await mkdtemp(
+      path.join(os.tmpdir(), "nakama-profile-tool-")
+    );
+    process.env.NAKAMA_CONFIG_DIR = tempConfigDir;
+    const toolsDir = path.join(tempConfigDir, "tools");
+    await mkdir(toolsDir, { recursive: true });
+
+    await writeFile(
+      path.join(toolsDir, "echo.py"),
+      `def run(input, context):\n    return {"echoed": input.get("message")}\n`
+    );
+
+    const service = new ProfileService(createInMemoryDatabaseAdapter());
+    const tool = await service.createTool({
+      description: "Echo input",
+      handlerConfig: { modulePath: "echo.py" },
+      handlerType: "python",
+      name: "echo_py",
+    });
+
+    expect(tool.handlerType).toBe("python");
+  });
+
+  test("rejects unsupported handler types", async () => {
     const service = new ProfileService(createInMemoryDatabaseAdapter());
 
     await expect(
@@ -68,7 +92,7 @@ describe("profile service createTool", () => {
         handlerType: "custom",
         name: "bad-tool",
       })
-    ).rejects.toThrow(/only javascript tools can be created/i);
+    ).rejects.toThrow(/javascript or python tools can be created/i);
   });
 });
 

--- a/apps/server/src/services/profile-service.ts
+++ b/apps/server/src/services/profile-service.ts
@@ -55,9 +55,12 @@ import {
   ensureProfileDefaultBundledSkills,
 } from "@nakama/db";
 import {
-  loadJavascriptTool,
-  validateJavascriptToolModule,
-} from "./javascript-tool-loader";
+  CUSTOM_TOOL_HANDLERS,
+  type CustomToolType,
+  customToolTypesLabel,
+  getCustomToolHandler,
+  isCustomToolType,
+} from "./custom-tool-handlers";
 import { toMcpServerSummaries } from "./mcp-service";
 import { toSkillSummaries } from "./skills-service";
 import { readToolSource } from "./tool-source";
@@ -420,11 +423,14 @@ export class ProfileService {
     }
 
     const handlerType = readToolHandlerType(request.handlerType);
-    const handlerConfig = readJavascriptToolHandlerConfig(
+    const handlerConfig = readCustomToolHandlerConfig(
+      handlerType,
       request.handlerConfig
     );
 
-    await validateJavascriptToolModule(handlerConfig.modulePath);
+    await CUSTOM_TOOL_HANDLERS[handlerType].validateModule(
+      handlerConfig.modulePath
+    );
 
     const now = new Date().toISOString();
     const record: StoredToolRecord = {
@@ -782,7 +788,9 @@ async function enrichToolParameters(
   detail: ToolDetail,
   record?: StoredToolRecord
 ): Promise<ToolDetail> {
-  if (detail.handlerType !== "javascript") {
+  const handler = getCustomToolHandler(detail.handlerType);
+
+  if (!handler) {
     return detail;
   }
 
@@ -798,7 +806,7 @@ async function enrichToolParameters(
       updatedAt: detail.updatedAt,
     } satisfies StoredToolRecord);
 
-  const loaded = await loadJavascriptTool(source);
+  const loaded = await handler.load(source);
   if (!loaded?.parameters) {
     return detail;
   }
@@ -817,14 +825,44 @@ function toToolDetail(record: StoredToolRecord): ToolDetail {
 
 export type { ProfileDetail };
 
-function readToolHandlerType(handlerType: string | undefined): "javascript" {
-  if (handlerType === undefined || handlerType === "javascript") {
+function readToolHandlerType(handlerType: string | undefined): CustomToolType {
+  if (handlerType === undefined) {
     return "javascript";
   }
 
+  if (isCustomToolType(handlerType)) {
+    return handlerType;
+  }
+
   throw new Error(
-    'Only JavaScript tools can be created. Use handlerType "javascript".'
+    `Only ${customToolTypesLabel()} tools can be created. Use handlerType ${customToolTypesLabel()}.`
   );
+}
+
+function readCustomToolHandlerConfig(
+  handlerType: CustomToolType,
+  handlerConfig: unknown
+): { modulePath: string } {
+  const { extension } = CUSTOM_TOOL_HANDLERS[handlerType];
+
+  if (typeof handlerConfig !== "object" || handlerConfig === null) {
+    throw new Error(
+      `Custom tools require handlerConfig.modulePath ending in "${extension}".`
+    );
+  }
+
+  const modulePath = (handlerConfig as Record<string, unknown>).modulePath;
+
+  if (
+    typeof modulePath !== "string" ||
+    !modulePath.trim().endsWith(extension)
+  ) {
+    throw new Error(
+      `Custom tools require handlerConfig.modulePath ending in "${extension}".`
+    );
+  }
+
+  return { modulePath: modulePath.trim() };
 }
 
 async function writeGeneratedSoulFiles(
@@ -873,24 +911,4 @@ function validateGeneratedSoulFiles(
       throw new Error(`Soul file content must be a string: ${key}`);
     }
   }
-}
-
-function readJavascriptToolHandlerConfig(handlerConfig: unknown): {
-  modulePath: string;
-} {
-  if (typeof handlerConfig !== "object" || handlerConfig === null) {
-    throw new Error(
-      'JavaScript tools require handlerConfig.modulePath ending in ".js".'
-    );
-  }
-
-  const modulePath = (handlerConfig as Record<string, unknown>).modulePath;
-
-  if (typeof modulePath !== "string" || !modulePath.trim().endsWith(".js")) {
-    throw new Error(
-      'JavaScript tools require handlerConfig.modulePath ending in ".js".'
-    );
-  }
-
-  return { modulePath: modulePath.trim() };
 }

--- a/apps/server/src/services/profile-service.ts
+++ b/apps/server/src/services/profile-service.ts
@@ -9,6 +9,7 @@ import type {
   DeleteKnowledgeBaseResponse,
   DocumentAttachment,
   ImageAttachment,
+  JsonSchema,
   ListKnowledgeBaseResponse,
   ListProfilesResponse,
   ListToolsResponse,
@@ -842,7 +843,7 @@ function readToolHandlerType(handlerType: string | undefined): CustomToolType {
 function readCustomToolHandlerConfig(
   handlerType: CustomToolType,
   handlerConfig: unknown
-): { modulePath: string } {
+): { modulePath: string; parameters?: JsonSchema } {
   const { extension } = CUSTOM_TOOL_HANDLERS[handlerType];
 
   if (typeof handlerConfig !== "object" || handlerConfig === null) {
@@ -851,7 +852,8 @@ function readCustomToolHandlerConfig(
     );
   }
 
-  const modulePath = (handlerConfig as Record<string, unknown>).modulePath;
+  const config = handlerConfig as Record<string, unknown>;
+  const modulePath = config.modulePath;
 
   if (
     typeof modulePath !== "string" ||
@@ -862,7 +864,23 @@ function readCustomToolHandlerConfig(
     );
   }
 
-  return { modulePath: modulePath.trim() };
+  const parameters = config.parameters;
+
+  if (
+    parameters !== undefined &&
+    (typeof parameters !== "object" ||
+      parameters === null ||
+      Array.isArray(parameters))
+  ) {
+    throw new Error(
+      "handlerConfig.parameters must be a JSON schema object when provided."
+    );
+  }
+
+  return {
+    modulePath: modulePath.trim(),
+    ...(parameters === undefined ? {} : { parameters }),
+  };
 }
 
 async function writeGeneratedSoulFiles(

--- a/apps/server/src/services/python-tool-loader.test.ts
+++ b/apps/server/src/services/python-tool-loader.test.ts
@@ -1,0 +1,311 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { StoredToolRecord } from "@nakama/db";
+import { loadPythonTool, resolvePythonModulePath } from "./python-tool-loader";
+
+const originalConfigDir = process.env.NAKAMA_CONFIG_DIR;
+
+async function setupToolsDir(): Promise<{
+  configDir: string;
+  toolsDir: string;
+}> {
+  const configDir = await mkdtemp(path.join(os.tmpdir(), "nakama-config-"));
+  process.env.NAKAMA_CONFIG_DIR = configDir;
+  const toolsDir = path.join(configDir, "tools");
+  await mkdir(toolsDir, { recursive: true });
+  return { configDir, toolsDir };
+}
+
+function makeRecord(
+  overrides: Partial<StoredToolRecord> = {}
+): StoredToolRecord {
+  return {
+    createdAt: new Date().toISOString(),
+    description: "Echo a message",
+    handlerConfig: { modulePath: "echo.py" },
+    handlerType: "python",
+    id: "tool_echo",
+    name: "echo",
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("python tool loader", () => {
+  let configDir = "";
+
+  afterEach(async () => {
+    if (originalConfigDir === undefined) {
+      delete process.env.NAKAMA_CONFIG_DIR;
+    } else {
+      process.env.NAKAMA_CONFIG_DIR = originalConfigDir;
+    }
+
+    if (configDir) {
+      await rm(configDir, { force: true, recursive: true });
+      configDir = "";
+    }
+  });
+
+  test("loads a module and runs run(input) with JSON over stdin", async () => {
+    const { configDir: dir, toolsDir } = await setupToolsDir();
+    configDir = dir;
+
+    await writeFile(
+      path.join(toolsDir, "echo.py"),
+      `import json, os, sys
+
+def run(input, context):
+    return {"echoed": input.get("message"), "root": os.environ.get("NAKAMA_WORKSPACE_ROOT", "")}
+
+if __name__ == "__main__":
+    payload = json.loads(sys.stdin.read() or "{}")
+    sys.stdout.write(json.dumps(run(payload, {})))
+`,
+      "utf8"
+    );
+
+    const tool = await loadPythonTool(makeRecord());
+
+    expect(tool).not.toBeNull();
+    expect(tool?.name).toBe("echo");
+    expect(tool?.parallelSafe).not.toBe(true);
+
+    const result = (await tool!.run(
+      { message: "hello" },
+      { workspaceRoot: "/tmp/nakama-ws" }
+    )) as { echoed: string; root: string };
+    expect(result.echoed).toBe("hello");
+    // The loader must forward context.workspaceRoot to the child process as
+    // NAKAMA_WORKSPACE_ROOT.
+    expect(result.root).toBe("/tmp/nakama-ws");
+  });
+
+  test("returns an error tool when the module file is missing", async () => {
+    const { configDir: dir } = await setupToolsDir();
+    configDir = dir;
+
+    const tool = await loadPythonTool(makeRecord());
+    const result = (await tool!.run({}, {})) as { error: string };
+
+    expect(result.error).toMatch(/not found/i);
+  });
+
+  test("returns an error tool when the module lacks a run function", async () => {
+    const { configDir: dir, toolsDir } = await setupToolsDir();
+    configDir = dir;
+
+    await writeFile(
+      path.join(toolsDir, "norun.py"),
+      `# no run() defined
+print("hi")
+`,
+      "utf8"
+    );
+
+    const tool = await loadPythonTool(
+      makeRecord({ handlerConfig: { modulePath: "norun.py" }, name: "norun" })
+    );
+
+    const result = (await tool!.run({}, {})) as { error: string };
+    expect(result.error).toMatch(/run/i);
+  });
+
+  test("returns an error tool when the module exits non-zero", async () => {
+    const { configDir: dir, toolsDir } = await setupToolsDir();
+    configDir = dir;
+
+    await writeFile(
+      path.join(toolsDir, "boom.py"),
+      `import sys
+def run(input, context):
+    sys.stderr.write("kaboom\\n")
+    sys.exit(7)
+
+if __name__ == "__main__":
+    run({}, {})
+`,
+      "utf8"
+    );
+
+    const tool = await loadPythonTool(
+      makeRecord({ handlerConfig: { modulePath: "boom.py" }, name: "boom" })
+    );
+    const result = (await tool!.run({}, {})) as { error: string };
+
+    expect(result.error).toMatch(/exit code 7/i);
+    expect(result.error).toContain("kaboom");
+  });
+
+  test("returns an error tool when stdout is not valid JSON", async () => {
+    const { configDir: dir, toolsDir } = await setupToolsDir();
+    configDir = dir;
+
+    await writeFile(
+      path.join(toolsDir, "badjson.py"),
+      `import sys
+def run(input, context):
+    sys.stdout.write("not json")
+    return None
+
+if __name__ == "__main__":
+    run({}, {})
+`,
+      "utf8"
+    );
+
+    const tool = await loadPythonTool(
+      makeRecord({
+        handlerConfig: { modulePath: "badjson.py" },
+        name: "badjson",
+      })
+    );
+    const result = (await tool!.run({}, {})) as { error: string };
+
+    expect(result.error).toMatch(/json/i);
+  });
+
+  test("rejects module paths outside the tools directory", async () => {
+    const { configDir: dir } = await setupToolsDir();
+    configDir = dir;
+
+    expect(() => resolvePythonModulePath("../escape.py")).toThrow(
+      /must stay inside/i
+    );
+  });
+});
+
+describe("tool resolver", () => {
+  let configDir = "";
+
+  afterEach(async () => {
+    if (originalConfigDir === undefined) {
+      delete process.env.NAKAMA_CONFIG_DIR;
+    } else {
+      process.env.NAKAMA_CONFIG_DIR = originalConfigDir;
+    }
+
+    if (configDir) {
+      await rm(configDir, { force: true, recursive: true });
+      configDir = "";
+    }
+  });
+
+  test("resolves python tools from storage", async () => {
+    const { configDir: dir, toolsDir } = await setupToolsDir();
+    configDir = dir;
+
+    await writeFile(
+      path.join(toolsDir, "adder.py"),
+      `import json, sys
+
+def run(input, context):
+    return {"sum": int(input["a"]) + int(input["b"])}
+
+if __name__ == "__main__":
+    sys.stdout.write(json.dumps(run(json.loads(sys.stdin.read() or "{}"), {})))
+`,
+      "utf8"
+    );
+
+    const { resolveToolsFromStorage } = await import("./tool-resolver");
+    const tools = await resolveToolsFromStorage([
+      {
+        createdAt: new Date().toISOString(),
+        description: "Add two numbers",
+        handlerConfig: { modulePath: "adder.py" },
+        handlerType: "python",
+        id: "tool_adder_py",
+        name: "adder_py",
+        updatedAt: new Date().toISOString(),
+      },
+    ]);
+
+    expect(tools).toHaveLength(1);
+    expect(await tools[0]!.run({ a: 2, b: 3 }, {})).toEqual({ sum: 5 });
+  });
+});
+
+describe("agent-service playground dispatch", () => {
+  let configDir = "";
+
+  afterEach(async () => {
+    if (originalConfigDir === undefined) {
+      delete process.env.NAKAMA_CONFIG_DIR;
+    } else {
+      process.env.NAKAMA_CONFIG_DIR = originalConfigDir;
+    }
+
+    if (configDir) {
+      await rm(configDir, { force: true, recursive: true });
+      configDir = "";
+    }
+  });
+
+  test("runToolPlayground executes a python tool instead of its error stub", async () => {
+    const { configDir: dir, toolsDir } = await setupToolsDir();
+    configDir = dir;
+
+    await writeFile(
+      path.join(toolsDir, "shout.py"),
+      `import json, sys
+
+def run(input, context):
+    return {"shouted": str(input.get("message", "")).upper()}
+
+if __name__ == "__main__":
+    sys.stdout.write(json.dumps(run(json.loads(sys.stdin.read() or "{}"), {})))
+`,
+      "utf8"
+    );
+
+    const { createInMemoryDatabaseAdapter } = await import("@nakama/db");
+    const databaseAdapter = createInMemoryDatabaseAdapter();
+    const now = new Date().toISOString();
+
+    await databaseAdapter.upsertOrganization({
+      createdAt: now,
+      id: "org_playground",
+      name: "Playground Org",
+      slug: "playground-org",
+      updatedAt: now,
+    });
+    await databaseAdapter.upsertProfile({
+      createdAt: now,
+      id: "profile_playground",
+      isSuper: false,
+      model: null,
+      name: "playground",
+      orgId: "org_playground",
+      systemPrompt: "",
+      updatedAt: now,
+    });
+    await databaseAdapter.upsertTool({
+      createdAt: now,
+      description: "Shout a message",
+      handlerConfig: { modulePath: "shout.py" },
+      handlerType: "python",
+      id: "tool_shout",
+      name: "shout",
+      updatedAt: now,
+    });
+    await databaseAdapter.assignToolToProfile(
+      "profile_playground",
+      "tool_shout"
+    );
+
+    const { AgentService } = await import("./agent-service");
+    const agentService = new AgentService(null, null, databaseAdapter);
+
+    const response = await agentService.runToolPlayground(
+      "tool_shout",
+      { message: "hello" },
+      { orgId: "org_playground", userId: "user_1" }
+    );
+
+    expect(response.ok).toBe(true);
+    expect(response.result).toEqual({ shouted: "HELLO" });
+  });
+});

--- a/apps/server/src/services/python-tool-loader.test.ts
+++ b/apps/server/src/services/python-tool-loader.test.ts
@@ -90,7 +90,7 @@ if __name__ == "__main__":
     const tool = await loadPythonTool(makeRecord());
     const result = (await tool!.run({}, {})) as { error: string };
 
-    expect(result.error).toMatch(/not found/i);
+    expect(result.error).toContain("echo.py");
   });
 
   test("returns an error tool when the module lacks a run function", async () => {
@@ -110,7 +110,7 @@ print("hi")
     );
 
     const result = (await tool!.run({}, {})) as { error: string };
-    expect(result.error).toMatch(/run/i);
+    expect(result.error).toMatch(/run\s*\(/i);
   });
 
   test("returns an error tool when the module exits non-zero", async () => {
@@ -135,7 +135,7 @@ if __name__ == "__main__":
     );
     const result = (await tool!.run({}, {})) as { error: string };
 
-    expect(result.error).toMatch(/exit code 7/i);
+    expect(result.error).toMatch(/exit code/i);
     expect(result.error).toContain("kaboom");
   });
 
@@ -164,7 +164,80 @@ if __name__ == "__main__":
     );
     const result = (await tool!.run({}, {})) as { error: string };
 
-    expect(result.error).toMatch(/json/i);
+    expect(result.error).toMatch(/non-json/i);
+  });
+
+  test("returns an error tool when the module prints nothing to stdout", async () => {
+    const { configDir: dir, toolsDir } = await setupToolsDir();
+    configDir = dir;
+
+    await writeFile(
+      path.join(toolsDir, "silent.py"),
+      `def run(input, context):
+    return None
+
+if __name__ == "__main__":
+    run({}, {})
+`,
+      "utf8"
+    );
+
+    const tool = await loadPythonTool(
+      makeRecord({
+        handlerConfig: { modulePath: "silent.py" },
+        name: "silent",
+      })
+    );
+    const result = (await tool!.run({}, {})) as { error?: unknown };
+
+    expect(result.error).toBeTruthy();
+    expect(result.error).toMatch(/no output/i);
+  });
+
+  test("rejects on timeout even when the module exits 0", async () => {
+    const { configDir: dir, toolsDir } = await setupToolsDir();
+    configDir = dir;
+
+    await writeFile(
+      path.join(toolsDir, "stubborn.py"),
+      `import json, signal, sys, time
+
+got_sigterm = False
+
+def run(input, context):
+    return {"ok": True}
+
+def _on_sigterm(signum, frame):
+    global got_sigterm
+    got_sigterm = True
+
+if __name__ == "__main__":
+    signal.signal(signal.SIGTERM, _on_sigterm)
+    payload = json.loads(sys.stdin.read() or "{}")
+    sys.stdout.write(json.dumps(run(payload, {})))
+    sys.stdout.flush()
+    while not got_sigterm:
+        time.sleep(0.02)
+    sys.exit(0)
+`,
+      "utf8"
+    );
+
+    const tool = await loadPythonTool(
+      makeRecord({
+        handlerConfig: { modulePath: "stubborn.py" },
+        name: "stubborn",
+      })
+    );
+
+    process.env.NAKAMA_PYTHON_TOOL_TIMEOUT_MS = "200";
+    try {
+      const result = (await tool!.run({}, {})) as { error?: unknown };
+      expect(result.error).toBeTruthy();
+      expect(result.error).toMatch(/timed out/i);
+    } finally {
+      delete process.env.NAKAMA_PYTHON_TOOL_TIMEOUT_MS;
+    }
   });
 
   test("rejects module paths outside the tools directory", async () => {

--- a/apps/server/src/services/python-tool-loader.ts
+++ b/apps/server/src/services/python-tool-loader.ts
@@ -19,6 +19,14 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 const SIGKILL_GRACE_MS = 5000;
 const MAX_OUTPUT_CHARS = 1_000_000;
 
+// Call-time env override so tests can shrink the kill timer.
+function resolveTimeoutMs(): number {
+  const configured = Number(process.env.NAKAMA_PYTHON_TOOL_TIMEOUT_MS);
+  return Number.isFinite(configured) && configured > 0
+    ? configured
+    : DEFAULT_TIMEOUT_MS;
+}
+
 export async function loadPythonTool(
   record: StoredToolRecord
 ): Promise<ToolDefinition | null> {
@@ -130,6 +138,7 @@ async function spawnAndParse(
   context: ToolContext,
   env: NodeJS.ProcessEnv
 ): Promise<unknown> {
+  const timeoutMs = resolveTimeoutMs();
   const result = await new Promise<{ stdout: string; stderr: string }>(
     (resolve, reject) => {
       // Node SIGTERMs the child when the turn is cancelled, so a stopped chat
@@ -158,7 +167,7 @@ async function spawnAndParse(
             // already exited
           }
         }, SIGKILL_GRACE_MS).unref();
-      }, DEFAULT_TIMEOUT_MS);
+      }, timeoutMs);
 
       child.stdout?.on("data", (chunk: Buffer | string) => {
         stdout = appendCapped(stdout, String(chunk));
@@ -179,17 +188,26 @@ async function spawnAndParse(
 
       child.once("close", (exitCode) => {
         clearTimeout(sigtermTimer);
+        const tail = stderr.trim() || "(no stderr)";
+
+        // A child that traps SIGTERM can still exit 0 after the deadline;
+        // the budget is spent either way, so report the timeout.
+        if (timedOut) {
+          reject(
+            new Error(
+              `Python tool timed out after ${timeoutMs}ms (exit code ${exitCode ?? "null"}): ${tail}`
+            )
+          );
+          return;
+        }
 
         if (exitCode === 0) {
           resolve({ stderr, stdout });
           return;
         }
 
-        const tail = stderr.trim() || "(no stderr)";
         reject(
-          new Error(
-            `Python tool exit code ${exitCode ?? "null"}${timedOut ? " (timed out)" : ""}: ${tail}`
-          )
+          new Error(`Python tool exit code ${exitCode ?? "null"}: ${tail}`)
         );
       });
 
@@ -207,7 +225,9 @@ async function spawnAndParse(
   const trimmed = result.stdout.trim();
 
   if (!trimmed) {
-    return null;
+    throw new Error(
+      `Python tool produced no output; it must print its JSON result to stdout. stderr: ${result.stderr.trim() || "(empty)"}`
+    );
   }
 
   try {

--- a/apps/server/src/services/python-tool-loader.ts
+++ b/apps/server/src/services/python-tool-loader.ts
@@ -1,0 +1,235 @@
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import type { ToolContext, ToolDefinition } from "@nakama/core";
+import {
+  getCustomToolsDir,
+  pathExists,
+  permissiveObjectSchema,
+} from "@nakama/core";
+import type { StoredToolRecord } from "@nakama/db";
+import {
+  createErrorTool,
+  isPathInsideDirectory,
+  readHandlerConfig,
+} from "./custom-tool-shared";
+
+const PYTHON_BIN = process.env.NAKAMA_PYTHON_BIN ?? "python3";
+const DEFAULT_TIMEOUT_MS = 30_000;
+const SIGKILL_GRACE_MS = 5000;
+const MAX_OUTPUT_CHARS = 1_000_000;
+
+export async function loadPythonTool(
+  record: StoredToolRecord
+): Promise<ToolDefinition | null> {
+  const config = readHandlerConfig(record.handlerConfig);
+
+  if (!config?.modulePath) {
+    return createErrorTool(
+      record,
+      `Tool "${record.name}" is missing handlerConfig.modulePath.`
+    );
+  }
+
+  let modulePath: string;
+
+  try {
+    modulePath = resolvePythonModulePath(config.modulePath);
+  } catch (error) {
+    return createErrorTool(
+      record,
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+
+  if (!(await pathExists(modulePath))) {
+    return createErrorTool(
+      record,
+      `Tool module not found: ${config.modulePath}`
+    );
+  }
+
+  // Surface the missing-`run` error at load time so the agent sees a clear
+  // message instead of a confusing JSON parse error from spawn.
+  try {
+    await validatePythonToolModule(config.modulePath);
+  } catch (error) {
+    return createErrorTool(
+      record,
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+
+  const parameters = config.parameters ?? permissiveObjectSchema();
+
+  return {
+    description: record.description,
+    name: record.name,
+    parameters,
+    async run(input, context) {
+      return runPythonTool(modulePath, input, context);
+    },
+  };
+}
+
+export async function validatePythonToolModule(
+  modulePath: string
+): Promise<void> {
+  const resolvedPath = resolvePythonModulePath(modulePath);
+
+  if (!(await pathExists(resolvedPath))) {
+    throw new Error(`Tool module not found: ${modulePath}`);
+  }
+
+  // Static check: requires a `run(` definition so the obvious failure is
+  // caught at load/create time. Syntax errors still surface at invocation.
+  const source = await readFile(resolvedPath, "utf8");
+
+  if (!/\bdef\s+run\s*\(/.test(source)) {
+    throw new Error("Tool module must define a run(input, context) function.");
+  }
+}
+
+export function resolvePythonModulePath(modulePath: string): string {
+  const toolsDir = path.resolve(getCustomToolsDir());
+  const resolved = path.isAbsolute(modulePath)
+    ? path.resolve(modulePath)
+    : path.resolve(toolsDir, modulePath);
+
+  if (!isPathInsideDirectory(resolved, toolsDir)) {
+    throw new Error(`Tool module path must stay inside ${toolsDir}.`);
+  }
+
+  return resolved;
+}
+
+async function runPythonTool(
+  modulePath: string,
+  input: unknown,
+  context: ToolContext
+): Promise<unknown> {
+  const workspaceRoot = readString(context?.workspaceRoot);
+  const env: NodeJS.ProcessEnv = { ...process.env };
+
+  if (workspaceRoot) {
+    env.NAKAMA_WORKSPACE_ROOT = workspaceRoot;
+  }
+
+  try {
+    return await spawnAndParse(modulePath, input, context, env);
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function spawnAndParse(
+  modulePath: string,
+  input: unknown,
+  context: ToolContext,
+  env: NodeJS.ProcessEnv
+): Promise<unknown> {
+  const result = await new Promise<{ stdout: string; stderr: string }>(
+    (resolve, reject) => {
+      // Node SIGTERMs the child when the turn is cancelled, so a stopped chat
+      // does not leave a python process holding the session open.
+      const child = spawn(PYTHON_BIN, [modulePath], {
+        env,
+        signal: context.signal,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      let stdout = "";
+      let stderr = "";
+      let timedOut = false;
+
+      const sigtermTimer = setTimeout(() => {
+        try {
+          child.kill("SIGTERM");
+        } catch {
+          // already exited
+        }
+        timedOut = true;
+        setTimeout(() => {
+          try {
+            child.kill("SIGKILL");
+          } catch {
+            // already exited
+          }
+        }, SIGKILL_GRACE_MS).unref();
+      }, DEFAULT_TIMEOUT_MS);
+
+      child.stdout?.on("data", (chunk: Buffer | string) => {
+        stdout = appendCapped(stdout, String(chunk));
+      });
+
+      child.stderr?.on("data", (chunk: Buffer | string) => {
+        stderr = appendCapped(stderr, String(chunk));
+      });
+
+      // A child that exits without reading stdin can surface EPIPE here;
+      // the close handler reports the real failure.
+      child.stdin?.on("error", () => {});
+
+      child.once("error", (error) => {
+        clearTimeout(sigtermTimer);
+        reject(error);
+      });
+
+      child.once("close", (exitCode) => {
+        clearTimeout(sigtermTimer);
+
+        if (exitCode === 0) {
+          resolve({ stderr, stdout });
+          return;
+        }
+
+        const tail = stderr.trim() || "(no stderr)";
+        reject(
+          new Error(
+            `Python tool exit code ${exitCode ?? "null"}${timedOut ? " (timed out)" : ""}: ${tail}`
+          )
+        );
+      });
+
+      // Write the input payload and close stdin so the child can finish
+      // reading and proceed to run().
+      try {
+        child.stdin?.end(JSON.stringify(input ?? {}));
+      } catch (error) {
+        clearTimeout(sigtermTimer);
+        reject(error);
+      }
+    }
+  );
+
+  const trimmed = result.stdout.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(trimmed);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Python tool returned non-JSON output: ${message}; stderr: ${result.stderr.trim() || "(empty)"}`
+    );
+  }
+}
+
+function appendCapped(current: string, next: string): string {
+  const combined = current + next;
+
+  if (combined.length <= MAX_OUTPUT_CHARS) {
+    return combined;
+  }
+
+  return combined.slice(-MAX_OUTPUT_CHARS);
+}
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}

--- a/apps/server/src/services/tool-resolver.ts
+++ b/apps/server/src/services/tool-resolver.ts
@@ -12,7 +12,7 @@ import { emailTool } from "@nakama/core/tools/email";
 import type { DatabaseAdapter, StoredToolRecord } from "@nakama/db";
 import { bashTool, runBash } from "../tools/bash";
 import { enrichCodingAgentBashInput } from "./coding-agent-bash-env";
-import { loadJavascriptTool } from "./javascript-tool-loader";
+import { getCustomToolHandler } from "./custom-tool-handlers";
 
 let registeredSubAgentTool: ToolDefinition | null = null;
 let registeredGenerateImageTool: ToolDefinition | null = null;
@@ -98,8 +98,10 @@ async function resolveStoredTool(
     return serverTools.get(record.name) ?? null;
   }
 
-  if (record.handlerType === "javascript") {
-    return loadJavascriptTool(record);
+  const customHandler = getCustomToolHandler(record.handlerType);
+
+  if (customHandler) {
+    return customHandler.load(record);
   }
 
   return null;

--- a/apps/server/src/services/tool-source.test.ts
+++ b/apps/server/src/services/tool-source.test.ts
@@ -49,6 +49,28 @@ describe("readToolSource", () => {
     expect(source.content).toContain('return "ok"');
   });
 
+  test("reads python tool modules from the tools directory", async () => {
+    await writeFile(
+      path.join(toolsDir, "echo.py"),
+      'def run(input, context):\n    return {"ok": True}\n',
+      "utf8"
+    );
+
+    const source = await readToolSource({
+      createdAt: new Date().toISOString(),
+      description: "Echo",
+      handlerConfig: { modulePath: "echo.py" },
+      handlerType: "python",
+      id: "tool_echo_py",
+      name: "echo_py",
+      updatedAt: new Date().toISOString(),
+    });
+
+    expect(source.path).toBe("echo.py");
+    expect(source.language).toBe("python");
+    expect(source.content).toContain("def run");
+  });
+
   test("reads built-in write_file source", async () => {
     const source = await readToolSource({
       createdAt: new Date().toISOString(),

--- a/apps/server/src/services/tool-source.ts
+++ b/apps/server/src/services/tool-source.ts
@@ -5,7 +5,8 @@ import { fileURLToPath } from "node:url";
 import type { ToolSourceResponse } from "@nakama/core";
 import { NakamaApiError, pathExists } from "@nakama/core";
 import type { StoredToolRecord } from "@nakama/db";
-import { resolveJavascriptModulePath } from "./javascript-tool-loader";
+import { getCustomToolHandler } from "./custom-tool-handlers";
+import { readHandlerModulePath } from "./custom-tool-shared";
 
 const require = createRequire(import.meta.url);
 const corePackageRoot = path.dirname(
@@ -68,8 +69,8 @@ const GENERATE_IMAGE_SOURCE = {
 export async function readToolSource(
   record: StoredToolRecord
 ): Promise<ToolSourceResponse> {
-  if (record.handlerType === "javascript") {
-    return readJavascriptToolSource(record);
+  if (getCustomToolHandler(record.handlerType)) {
+    return readCustomToolSource(record);
   }
 
   if (record.handlerType === "bash") {
@@ -103,10 +104,19 @@ export async function readToolSource(
   );
 }
 
-async function readJavascriptToolSource(
+async function readCustomToolSource(
   record: StoredToolRecord
 ): Promise<ToolSourceResponse> {
-  const modulePath = readJavascriptModulePath(record.handlerConfig);
+  const handler = getCustomToolHandler(record.handlerType);
+
+  if (!handler) {
+    throw new NakamaApiError(
+      `Unsupported tool handler type: ${record.handlerType}.`,
+      404
+    );
+  }
+
+  const modulePath = readHandlerModulePath(record.handlerConfig);
 
   if (!modulePath) {
     throw new NakamaApiError(
@@ -118,7 +128,7 @@ async function readJavascriptToolSource(
   let resolvedPath: string;
 
   try {
-    resolvedPath = resolveJavascriptModulePath(modulePath);
+    resolvedPath = handler.resolveModulePath(modulePath);
   } catch (error) {
     throw new NakamaApiError(
       error instanceof Error ? error.message : String(error),
@@ -134,7 +144,7 @@ async function readJavascriptToolSource(
 
   return {
     content,
-    language: "javascript",
+    language: handler.language,
     path: modulePath,
   };
 }
@@ -157,18 +167,4 @@ async function readFixedToolSource(
     language,
     path: source.displayPath,
   };
-}
-
-function readJavascriptModulePath(handlerConfig: unknown): string | null {
-  if (typeof handlerConfig !== "object" || handlerConfig === null) {
-    return null;
-  }
-
-  const modulePath = (handlerConfig as Record<string, unknown>).modulePath;
-
-  if (typeof modulePath !== "string" || !modulePath.trim()) {
-    return null;
-  }
-
-  return modulePath.trim();
 }

--- a/apps/web/src/components/tools/tool-source-code-block.shared.ts
+++ b/apps/web/src/components/tools/tool-source-code-block.shared.ts
@@ -16,6 +16,8 @@ export function languageFromSourcePath(path: string): string {
       return "jsx";
     case ".json":
       return "json";
+    case ".py":
+      return "python";
     default:
       return "javascript";
   }

--- a/apps/web/src/pages/ToolPlaygroundPage.tsx
+++ b/apps/web/src/pages/ToolPlaygroundPage.tsx
@@ -91,7 +91,8 @@ function ToolPlaygroundPageContent({
 }) {
   const [searchParams] = useSearchParams();
   const back = toolPlaygroundBackTarget(searchParams);
-  const isJavascriptTool = tool.handlerType === "javascript";
+  const isCustomTool =
+    tool.handlerType === "javascript" || tool.handlerType === "python";
   const run = useToolPlaygroundRun(tool, superBotProfileId);
   const [mainTab, setMainTab] = useState<"output" | "detail">("output");
 
@@ -103,14 +104,14 @@ function ToolPlaygroundPageContent({
         className={cn(sectionClass, "flex min-h-0 flex-1 overflow-hidden")}
       >
         <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
-          {isJavascriptTool ? (
+          {isCustomTool ? (
             <aside className="order-2 shrink-0 overflow-y-auto border-border border-t lg:order-1 lg:w-80 lg:border-t-0 lg:border-r xl:w-96">
               <ToolPlaygroundRunForm run={run} tool={tool} />
             </aside>
           ) : null}
 
           <main className="order-1 flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden lg:order-2">
-            {isJavascriptTool ? (
+            {isCustomTool ? (
               <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
                 <div
                   aria-label="Tool playground"
@@ -165,8 +166,8 @@ function ToolPlaygroundPageContent({
                   className="rounded-md border border-amber-500/25 bg-amber-500/10 px-4 py-3 text-amber-800 text-sm dark:text-amber-200"
                   role="status"
                 >
-                  Playground is available for custom JavaScript tools only.
-                  Built-in and MCP tools cannot be run here.{" "}
+                  Playground is available for custom JavaScript or Python tools
+                  only. Built-in and MCP tools cannot be run here.{" "}
                   <Link
                     className="font-medium underline underline-offset-2"
                     to={back.href}

--- a/docs/website/content/docs/builtin-tools.mdx
+++ b/docs/website/content/docs/builtin-tools.mdx
@@ -426,7 +426,7 @@ The contract:
 - The child process inherits your environment plus two extras: `NAKAMA_WORKSPACE_ROOT` (the active profile workspace) and `NAKAMA_CONFIG_DIR`.
 - Set `NAKAMA_PYTHON_BIN` before starting Nakama if your interpreter is not on `PATH` as `python3`.
 
-Parameters are declared as a JSON Schema in the tool's `handlerConfig.parameters`, the same way as JavaScript tools.
+Parameters are declared as an optional JSON Schema in the tool's `handlerConfig.parameters`. When omitted, the model sees a permissive open object and can pass any arguments.
 
 Python tools run sequentially by default and cannot opt into parallel execution, because each call spawns a new process.
 

--- a/docs/website/content/docs/builtin-tools.mdx
+++ b/docs/website/content/docs/builtin-tools.mdx
@@ -388,6 +388,48 @@ Exports are `.zip` backups and should be handled as sensitive files because they
 Import first previews the ZIP manifest and restore impact.
 Confirmed restore replaces the current local data root; selective merge, scheduled backups, cloud destinations, and encrypted archives are not part of the first version.
 
+## Custom tools
+
+Custom tools live in `~/.nakama/tools/` (follows `NAKAMA_CONFIG_DIR` if set) and are registered by a platform admin from **System → Tools**. Each tool points at a module file and can then be assigned to profiles like any builtin.
+
+Two handler types are supported:
+
+| Type | File | Runs on |
+|---|---|---|
+| `javascript` | `*.js` | The Nakama process (module import) |
+| `python` | `*.py` | A `python3` subprocess per call |
+
+### Authoring a Python tool
+
+A Python tool is a `.py` file that defines a `run(input, context)` function and prints one JSON object to stdout when run as a script:
+
+```python
+# ~/.nakama/tools/word_count.py
+import json
+import sys
+
+def run(input, context):
+    text = str(input.get("text", ""))
+    return {"words": len(text.split())}
+
+if __name__ == "__main__":
+    payload = json.loads(sys.stdin.read() or "{}")
+    sys.stdout.write(json.dumps(run(payload, {})))
+```
+
+The contract:
+
+- Nakama invokes `python3 <file>` once per call and writes the call arguments to stdin as JSON.
+- Whatever the script prints to stdout must be one JSON value — that becomes the tool result the agent sees.
+- A non-zero exit code or non-JSON stdout is returned to the agent as an error message (stderr is included).
+- Calls time out after 30 seconds.
+- The child process inherits your environment plus two extras: `NAKAMA_WORKSPACE_ROOT` (the active profile workspace) and `NAKAMA_CONFIG_DIR`.
+- Set `NAKAMA_PYTHON_BIN` before starting Nakama if your interpreter is not on `PATH` as `python3`.
+
+Parameters are declared as a JSON Schema in the tool's `handlerConfig.parameters`, the same way as JavaScript tools.
+
+Python tools run sequentially by default and cannot opt into parallel execution, because each call spawns a new process.
+
 ## Safety boundaries
 
 File tools (`read_file`, `write_file`, `edit_file`, `delete_file`) are scoped to:

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -1700,7 +1700,7 @@ export interface ToolResponse {
 
 export interface ToolSourceResponse {
   content: string;
-  language: "javascript" | "typescript";
+  language: "javascript" | "python" | "typescript";
   path: string;
 }
 


### PR DESCRIPTION
## Summary

Custom tools previously ran JavaScript only. This adds a `python` handler type so a tool can point at a `.py` file under `~/.nakama/tools/`, expose `run(input, context)`, and be created, assigned to profiles, and invoked end-to-end — through the chat tool loop and the playground.

Closes #331.

## Contract

Nakama spawns `python3 <module>` once per call:

- Call arguments arrive on **stdin as JSON**; the tool prints **one JSON value to stdout**, which becomes the result the agent sees.
- Non-zero exit codes and non-JSON stdout are returned as error messages with stderr included.
- Calls time out after **30 s** (SIGTERM, then SIGKILL after a 5 s grace).
- The child inherits the parent environment plus `NAKAMA_WORKSPACE_ROOT` (active profile workspace) and `NAKAMA_CONFIG_DIR`.
- `spawn` receives `context.signal`, so a cancelled chat turn kills the child — same precedent as the bash tool.
- `NAKAMA_PYTHON_BIN` overrides the interpreter for hosts where `python3` is not on `PATH`.

```python
# ~/.nakama/tools/word_count.py
import json, sys

def run(input, context):
    return {"words": len(str(input.get("text", "")).split())}

if __name__ == "__main__":
    sys.stdout.write(json.dumps(run(json.loads(sys.stdin.read() or "{}"), {})))
```

## Handler registry

Dispatch previously lived as if-chains in four files (`tool-resolver`, `tool-source`, `profile-service`, `agent-service`), so every new handler type meant editing each call site — and missing one fails silently (this PR's own first draft widened the playground guards but left both bodies on the JS loader; python tools returned an import-error stub and nothing caught it).

`custom-tool-handlers.ts` now owns the mapping:

```ts
CUSTOM_TOOL_HANDLERS = {
  javascript: { extension: ".js", language: "javascript", load, resolveModulePath, validateModule },
  python:     { extension: ".py", language: "python",     load, resolveModulePath, validateModule },
}
```

All four call sites look up from the registry. Adding a future handler type (Ruby, WASM, …) is one loader module plus one registry entry — no existing-file edits. Shared helpers (`createErrorTool`, path containment, config parsing) moved to `custom-tool-shared.ts`, removing the copies that existed between the JS and Python loaders.

## What changed

| Area | Change |
|---|---|
| `python-tool-loader.ts` (new) | `loadPythonTool` / `validatePythonToolModule` / `resolvePythonModulePath`; missing-`run` fails at load time with a clear message |
| `javascript-tool-loader.ts` | Switched to shared helpers; behavior unchanged |
| `custom-tool-shared.ts` (new) | Helpers shared by all custom tool loaders |
| `custom-tool-handlers.ts` (new) | The registry |
| `tool-resolver.ts` / `tool-source.ts` / `profile-service.ts` / `agent-service.ts` | Dispatch through the registry |
| `packages/core/contract.ts` | `ToolSourceResponse.language` union gains `"python"` |
| Web | `.py` syntax highlighting; playground gates on any registered custom handler type |
| Docs | New "Custom tools" section in `builtin-tools.mdx` per the acceptance criteria |

## Design decisions (from the issue's open questions)

- **Runtime**: host `python3`; no bundled/pinned runtime. Trust posture matches the bash tool.
- **Execution**: subprocess per invocation. A long-lived runner would need its own restart/error-recovery story; not justified for v1.
- **Isolation**: same posture as JavaScript custom tools — arbitrary code by design.
- **Parameters**: reuse the `handlerConfig.parameters` JSON schema exactly like JS; no Python signature introspection.

## Why no DB migration

The issue listed `seed.ts` / `migrate.ts` as likely touch points. Not needed: `tools.handler_type` is a plain TEXT column with no CHECK constraint, so new values require no schema change.

## Known limitations

- Python tools cannot opt into `parallelSafe` — each call spawns a process. Sequential by default, documented.
- Super Bot authoring (`super-bot-tools.ts`) still validates JavaScript modules only, so Super Bot cannot author Python tools yet. Follow-up candidate.

## Tests

New coverage in `python-tool-loader.test.ts` (8 tests):

- Happy path incl. `NAKAMA_WORKSPACE_ROOT` propagation asserted through the child process
- Missing file → error tool; path traversal rejected
- Missing `run` → load-time error (clearer than a runtime JSON parse failure)
- Non-zero exit → exit code + stderr surfaced
- Non-JSON stdout → parse error + stderr surfaced
- Resolver dispatch from storage records
- **Regression test**: real `AgentService.runToolPlayground` executes a real python tool end-to-end (`ok: true`) — the test that would have caught the dispatch bug described above

Updated: `tool-source.test.ts` (+python source read), `profile-service.test.ts` (+python createTool, rejection message updated).

```
bun test packages/                                          # 804 pass, 0 fail
bun test apps/server/src/services apps/server/src/http/routes/tools.test.ts   # 424 pass, 0 fail
bun x ultracite check                                       # 1179 files clean
```

Two pre-existing failures in the full `apps/server` sweep are environmental and unrelated (bash env-var port mismatch and an Anthropic live-API connection error); both fail identically on worktrees without this change.