### PR TITLE
feat(providers): direct MiniMax integration with dynamic model discovery (#380)

### DIFF
--- a/apps/server/src/providers/create.ts
+++ b/apps/server/src/providers/create.ts
@@ -8,6 +8,10 @@ import {
   readEnvValue,
   type UserConfig,
 } from "@nakama/core";
+import {
+  MINIMAX_CN_DEFAULT_BASE_URL,
+  MINIMAX_DEFAULT_BASE_URL,
+} from "@nakama/core/minimax-provider-config";
 import { resolveDefaultModelForInstance } from "../services/provider-instance-helpers";
 import { createAnthropicProvider } from "./anthropic";
 import { createCerebrasProvider } from "./cerebras";
@@ -72,6 +76,20 @@ function createProvider(options: CreateProviderOptions): ProviderClient {
         baseUrl: baseUrlOverride ?? DEFAULT_DEEPSEEK_BASE_URL,
         model,
         providerName: "deepseek",
+      });
+    case "minimax":
+      return createOpenAIProvider({
+        apiKey: options.apiKey,
+        baseUrl: baseUrlOverride ?? MINIMAX_DEFAULT_BASE_URL,
+        model,
+        providerName: "minimax",
+      });
+    case "minimax_cn":
+      return createOpenAIProvider({
+        apiKey: options.apiKey,
+        baseUrl: baseUrlOverride ?? MINIMAX_CN_DEFAULT_BASE_URL,
+        model,
+        providerName: "minimax_cn",
       });
     case "opencode_go":
       return createOpenCodeGoProvider({

--- a/apps/server/src/providers/models.test.ts
+++ b/apps/server/src/providers/models.test.ts
@@ -142,9 +142,40 @@ describe("resolveModel", () => {
       "accounts/fireworks/models/glm-5p2"
     );
   });
+
+  test("resolves MiniMax models from discovered custom models", () => {
+    const customModels = [
+      { default: true, id: "MiniMax-M3" },
+      { id: "MiniMax-M2.7" },
+      { id: "MiniMax-M2.5" },
+    ];
+
+    expect(resolveModel("minimax", "MiniMax-M2.7", customModels)).toBe(
+      "MiniMax-M2.7"
+    );
+    expect(getDefaultModel("minimax", customModels)).toBe("MiniMax-M3");
+    expect(getDefaultModel("minimax_cn", customModels)).toBe("MiniMax-M3");
+  });
+
+  test("falls back to instance default for unknown MiniMax ids", () => {
+    const customModels = [{ default: true, id: "MiniMax-M3" }];
+    expect(resolveModel("minimax_cn", "not-a-real-model", customModels)).toBe(
+      "MiniMax-M3"
+    );
+  });
 });
 
 describe("modelSupportsVision", () => {
+  test("keeps MiniMax models opt-in only (discovered lists)", () => {
+    expect(modelSupportsVision("MiniMax-M3", "minimax")).toBe(false);
+
+    expect(
+      modelSupportsVision("MiniMax-VL", "minimax_cn", [
+        { id: "MiniMax-VL", supportsVision: true },
+      ])
+    ).toBe(true);
+  });
+
   test("treats openai-compatible models as opt-in only", () => {
     expect(
       modelSupportsVision("qwen-vl", "openai_compatible", [{ id: "qwen-vl" }])

--- a/apps/server/src/providers/models.ts
+++ b/apps/server/src/providers/models.ts
@@ -2,6 +2,7 @@ import type { ProviderName } from "@nakama/core";
 import {
   type CustomModelEntry,
   findCustomModel,
+  isDiscoveryModelProvider,
   validateCustomModels,
 } from "@nakama/core";
 import type { ProviderModelOption as ContractProviderModelOption } from "@nakama/core/contract";
@@ -526,13 +527,10 @@ export function getDefaultModel(
   provider: ProviderName,
   customModels?: CustomModelEntry[]
 ): string {
-  if (
-    provider === "openai_compatible" ||
-    provider === "minimax" ||
-    provider === "minimax_cn"
-  ) {
-    // MiniMax model lists are fetched live from the platform (/models) and
-    // stored as instance custom models — no hardcoded catalog.
+  if (isDiscoveryModelProvider(provider)) {
+    // Discovery providers fetch model lists live from the platform
+    // (/models) and store them as instance custom models — no hardcoded
+    // catalog.
     return resolveCompatibleDefaultModel(customModels);
   }
 
@@ -628,12 +626,7 @@ export function resolveModel(
     return resolveCompatibleDefaultModel(customModels, trimmed);
   }
 
-  if (
-    trimmed &&
-    (provider === "openai_compatible" ||
-      provider === "minimax" ||
-      provider === "minimax_cn")
-  ) {
+  if (trimmed && isDiscoveryModelProvider(provider)) {
     // Dynamic catalog: accept ids discovered from the platform's /models
     // endpoint (stored as instance custom models); otherwise resolve the
     // instance default.
@@ -696,11 +689,9 @@ export function modelSupportsVision(
   }
 
   if (
-    provider === "openai_compatible" ||
+    isDiscoveryModelProvider(provider) ||
     provider === "opencode_go" ||
-    provider === "deepseek" ||
-    provider === "minimax" ||
-    provider === "minimax_cn"
+    provider === "deepseek"
   ) {
     return false;
   }

--- a/apps/server/src/providers/models.ts
+++ b/apps/server/src/providers/models.ts
@@ -526,7 +526,13 @@ export function getDefaultModel(
   provider: ProviderName,
   customModels?: CustomModelEntry[]
 ): string {
-  if (provider === "openai_compatible") {
+  if (
+    provider === "openai_compatible" ||
+    provider === "minimax" ||
+    provider === "minimax_cn"
+  ) {
+    // MiniMax model lists are fetched live from the platform (/models) and
+    // stored as instance custom models — no hardcoded catalog.
     return resolveCompatibleDefaultModel(customModels);
   }
 
@@ -579,10 +585,6 @@ export function getDefaultModel(
   return models.find((model) => model.default)?.id ?? models[0]?.id ?? fallback;
 }
 
-export function isValidModel(model: string): boolean {
-  return AVAILABLE_MODELS.some((option) => option.id === model);
-}
-
 export function resolveModel(
   provider: ProviderName,
   model?: string,
@@ -626,7 +628,15 @@ export function resolveModel(
     return resolveCompatibleDefaultModel(customModels, trimmed);
   }
 
-  if (trimmed && provider === "openai_compatible") {
+  if (
+    trimmed &&
+    (provider === "openai_compatible" ||
+      provider === "minimax" ||
+      provider === "minimax_cn")
+  ) {
+    // Dynamic catalog: accept ids discovered from the platform's /models
+    // endpoint (stored as instance custom models); otherwise resolve the
+    // instance default.
     if (findCustomModel(customModels, trimmed)) {
       return trimmed;
     }
@@ -652,12 +662,13 @@ export function resolveModel(
     return resolveCompatibleDefaultModel(customModels, trimmed);
   }
 
-  if (trimmed && isValidModel(trimmed)) {
-    const option = getModelById(trimmed);
-
-    if (option?.provider === provider) {
-      return trimmed;
-    }
+  // Provider-scoped check: region variants (e.g. minimax vs minimax_cn) may
+  // expose identical model ids, so global id uniqueness must not be assumed.
+  if (
+    trimmed &&
+    getModelsForProvider(provider).some((model) => model.id === trimmed)
+  ) {
+    return trimmed;
   }
 
   if (
@@ -687,7 +698,9 @@ export function modelSupportsVision(
   if (
     provider === "openai_compatible" ||
     provider === "opencode_go" ||
-    provider === "deepseek"
+    provider === "deepseek" ||
+    provider === "minimax" ||
+    provider === "minimax_cn"
   ) {
     return false;
   }

--- a/apps/web/src/components/settings/use-provider-instance-card.ts
+++ b/apps/web/src/components/settings/use-provider-instance-card.ts
@@ -4,6 +4,7 @@ import type {
   UpdateProviderRequest,
 } from "@nakama/core/contract";
 import { defaultMinimaxBaseUrl } from "@nakama/core/minimax-provider-config";
+import { isDiscoveryModelProvider } from "@nakama/core/provider-resolution";
 import { useMemo, useState } from "react";
 import { isCatalogShortlistProvider } from "@/components/catalog-provider-model-fields.shared";
 import type { ModelListRow } from "@/components/ModelListEditor";
@@ -54,12 +55,12 @@ export function useProviderInstanceCard({
   const [manageModels, setManageModels] = useState<ModelListRow[]>([]);
 
   const providerType = instance.type as SelectedProvider;
-  const isCompatible = providerType === "openai_compatible";
   const isOllama = providerType === "ollama";
-  const isMinimax = providerType === "minimax" || providerType === "minimax_cn";
-  // MiniMax models are discovered live from the platform's /models endpoint,
-  // so its instances use the same base-URL + remote-browse editing flow.
-  const isCompatibleLike = isCompatible || isOllama || isMinimax;
+  // Discovery providers (OpenAI-compatible, MiniMax, …) fetch model lists
+  // live from the platform's /models endpoint, so their instances use the
+  // same base-URL + remote-browse editing flow.
+  const isDiscovery = isDiscoveryModelProvider(providerType);
+  const isCompatibleLike = isDiscovery || isOllama;
   const isOpenRouter = providerType === "openrouter";
   const isShortlistBrowse = isShortlistBrowseProvider(providerType);
   const isCatalogShortlist = isCatalogShortlistProvider(providerType);
@@ -108,8 +109,8 @@ export function useProviderInstanceCard({
       instance.baseUrl ??
         (isOllama
           ? defaultOllamaSetupBaseUrl(instance.hostMode ?? "local")
-          : isMinimax
-            ? defaultMinimaxBaseUrl(providerType)
+          : isDiscovery
+            ? (defaultMinimaxBaseUrl(providerType) ?? "")
             : "")
     );
     setManageModels(seedManageModelRows(instance.customModels, instanceModels));

--- a/apps/web/src/components/settings/use-provider-instance-card.ts
+++ b/apps/web/src/components/settings/use-provider-instance-card.ts
@@ -3,6 +3,7 @@ import type {
   ProviderModelOption,
   UpdateProviderRequest,
 } from "@nakama/core/contract";
+import { defaultMinimaxBaseUrl } from "@nakama/core/minimax-provider-config";
 import { useMemo, useState } from "react";
 import { isCatalogShortlistProvider } from "@/components/catalog-provider-model-fields.shared";
 import type { ModelListRow } from "@/components/ModelListEditor";
@@ -55,7 +56,10 @@ export function useProviderInstanceCard({
   const providerType = instance.type as SelectedProvider;
   const isCompatible = providerType === "openai_compatible";
   const isOllama = providerType === "ollama";
-  const isCompatibleLike = isCompatible || isOllama;
+  const isMinimax = providerType === "minimax" || providerType === "minimax_cn";
+  // MiniMax models are discovered live from the platform's /models endpoint,
+  // so its instances use the same base-URL + remote-browse editing flow.
+  const isCompatibleLike = isCompatible || isOllama || isMinimax;
   const isOpenRouter = providerType === "openrouter";
   const isShortlistBrowse = isShortlistBrowseProvider(providerType);
   const isCatalogShortlist = isCatalogShortlistProvider(providerType);
@@ -104,7 +108,9 @@ export function useProviderInstanceCard({
       instance.baseUrl ??
         (isOllama
           ? defaultOllamaSetupBaseUrl(instance.hostMode ?? "local")
-          : "")
+          : isMinimax
+            ? defaultMinimaxBaseUrl(providerType)
+            : "")
     );
     setManageModels(seedManageModelRows(instance.customModels, instanceModels));
     setEditOpen(true);

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -58,7 +58,9 @@ export function formatProviderLabel(
     provider === "fireworks" ||
     provider === "ollama" ||
     provider === "openai_compatible" ||
-    provider === "opencode_go"
+    provider === "opencode_go" ||
+    provider === "minimax" ||
+    provider === "minimax_cn"
   ) {
     return formatConfiguredProviderLabel(provider, displayName);
   }
@@ -78,6 +80,8 @@ export const PROVIDER_OPTIONS: Array<{ id: SelectedProvider; label: string }> =
     { id: "fireworks", label: "Fireworks" },
     { id: "ollama", label: "Ollama" },
     { id: "opencode_go", label: "OpenCode Go" },
+    { id: "minimax", label: "MiniMax" },
+    { id: "minimax_cn", label: "MiniMax (CN)" },
     { id: "openai_compatible", label: "Custom (OpenAI-compatible)" },
   ];
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,7 @@
     "./image-content": "./src/image-content.ts",
     "./normalize-task-prompt": "./src/normalize-task-prompt.ts",
     "./cloudflare-provider-config": "./src/cloudflare-provider-config.ts",
+    "./minimax-provider-config": "./src/minimax-provider-config.ts",
     "./ollama-provider-config": "./src/ollama-provider-config.ts",
     "./provider-inference": "./src/provider-inference.ts",
     "./provider-label": "./src/provider-label.ts",

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -1938,7 +1938,9 @@ export type ProviderName =
   | "ollama"
   | "openai_compatible"
   | "opencode_go"
-  | "cloudflare";
+  | "cloudflare"
+  | "minimax"
+  | "minimax_cn";
 
 export type OllamaHostMode = "local" | "cloud";
 

--- a/packages/core/src/document-content.ts
+++ b/packages/core/src/document-content.ts
@@ -73,6 +73,8 @@ const NATIVE_DOCUMENT_MEDIA_TYPES: Record<ProviderName, ReadonlySet<string>> = {
     "text/csv",
     DOCX_MEDIA_TYPE,
   ]),
+  minimax: new Set<string>(),
+  minimax_cn: new Set<string>(),
   ollama: new Set<string>(),
   openai: new Set([
     "application/pdf",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -74,6 +74,7 @@ export * from "./local-auth";
 export { createImapReader } from "./mail/imap-reader";
 export { createSmtpSender } from "./mail/smtp-sender";
 export * from "./message-content";
+export * from "./minimax-provider-config";
 export * from "./normalize-task-prompt";
 export * from "./notification-destinations";
 export * from "./ollama-provider-config";

--- a/packages/core/src/minimax-provider-config.ts
+++ b/packages/core/src/minimax-provider-config.ts
@@ -1,0 +1,20 @@
+import type { ProviderName } from "./contract";
+
+// MiniMax runs split platforms with separate keys and catalogs. Base URLs are
+// shared between the server provider factory and the web settings UI so both
+// default to the same region endpoints.
+
+export const MINIMAX_DEFAULT_BASE_URL = "https://api.minimax.io/v1";
+export const MINIMAX_CN_DEFAULT_BASE_URL = "https://api.minimaxi.com/v1";
+
+export function defaultMinimaxBaseUrl(provider: ProviderName): string | null {
+  if (provider === "minimax") {
+    return MINIMAX_DEFAULT_BASE_URL;
+  }
+
+  if (provider === "minimax_cn") {
+    return MINIMAX_CN_DEFAULT_BASE_URL;
+  }
+
+  return null;
+}

--- a/packages/core/src/provider-label.ts
+++ b/packages/core/src/provider-label.ts
@@ -10,6 +10,8 @@ const BUILTIN_LABELS: Record<
   deepseek: "DeepSeek",
   fireworks: "Fireworks",
   gemini: "Gemini",
+  minimax: "MiniMax",
+  minimax_cn: "MiniMax (CN)",
   ollama: "Ollama",
   openai: "OpenAI",
   opencode_go: "OpenCode Go",

--- a/packages/core/src/provider-resolution.test.ts
+++ b/packages/core/src/provider-resolution.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { parseProviderName, resolveProvider } from "./provider-resolution";
+import {
+  apiKeyEnvVarForProvider,
+  parseProviderName,
+  resolveProvider,
+} from "./provider-resolution";
 
 describe("parseProviderName", () => {
   test("accepts known providers", () => {
@@ -11,6 +15,8 @@ describe("parseProviderName", () => {
     expect(parseProviderName("deepseek")).toBe("deepseek");
     expect(parseProviderName("cerebras")).toBe("cerebras");
     expect(parseProviderName("fireworks")).toBe("fireworks");
+    expect(parseProviderName("minimax")).toBe("minimax");
+    expect(parseProviderName("minimax_cn")).toBe("minimax_cn");
   });
 
   test("rejects unknown values", () => {
@@ -100,5 +106,12 @@ describe("resolveProvider fireworks", () => {
     });
 
     expect(provider).toBe("fireworks");
+  });
+});
+
+describe("apiKeyEnvVarForProvider", () => {
+  test("maps MiniMax regions to distinct env keys", () => {
+    expect(apiKeyEnvVarForProvider("minimax")).toBe("MINIMAX_API_KEY");
+    expect(apiKeyEnvVarForProvider("minimax_cn")).toBe("MINIMAX_CN_API_KEY");
   });
 });

--- a/packages/core/src/provider-resolution.test.ts
+++ b/packages/core/src/provider-resolution.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   apiKeyEnvVarForProvider,
+  isDiscoveryModelProvider,
   parseProviderName,
   resolveProvider,
 } from "./provider-resolution";
@@ -113,5 +114,19 @@ describe("apiKeyEnvVarForProvider", () => {
   test("maps MiniMax regions to distinct env keys", () => {
     expect(apiKeyEnvVarForProvider("minimax")).toBe("MINIMAX_API_KEY");
     expect(apiKeyEnvVarForProvider("minimax_cn")).toBe("MINIMAX_CN_API_KEY");
+  });
+});
+
+describe("isDiscoveryModelProvider", () => {
+  test("includes providers whose models are discovered from /models", () => {
+    expect(isDiscoveryModelProvider("openai_compatible")).toBe(true);
+    expect(isDiscoveryModelProvider("minimax")).toBe(true);
+    expect(isDiscoveryModelProvider("minimax_cn")).toBe(true);
+  });
+
+  test("excludes catalog providers", () => {
+    expect(isDiscoveryModelProvider("deepseek")).toBe(false);
+    expect(isDiscoveryModelProvider("openai")).toBe(false);
+    expect(isDiscoveryModelProvider("opencode_go")).toBe(false);
   });
 });

--- a/packages/core/src/provider-resolution.ts
+++ b/packages/core/src/provider-resolution.ts
@@ -20,6 +20,17 @@ export const USER_PROVIDER_NAMES: readonly UserProviderName[] = [
   "minimax_cn",
 ] as const;
 
+// Providers whose model lists are discovered live from the platform's
+// /models endpoint and stored as instance custom models, instead of a
+// hardcoded catalog. Adding a discovery-based provider is one entry here
+// plus its type/env-key/label/base-URL wiring — no resolution edits.
+export const DISCOVERY_MODEL_PROVIDERS: ReadonlySet<UserProviderName> =
+  new Set<UserProviderName>(["openai_compatible", "minimax", "minimax_cn"]);
+
+export function isDiscoveryModelProvider(provider: UserProviderName): boolean {
+  return DISCOVERY_MODEL_PROVIDERS.has(provider);
+}
+
 export function parseProviderName(
   value: string | undefined
 ): UserProviderName | null {

--- a/packages/core/src/provider-resolution.ts
+++ b/packages/core/src/provider-resolution.ts
@@ -16,6 +16,8 @@ export const USER_PROVIDER_NAMES: readonly UserProviderName[] = [
   "openai_compatible",
   "opencode_go",
   "cloudflare",
+  "minimax",
+  "minimax_cn",
 ] as const;
 
 export function parseProviderName(
@@ -34,7 +36,9 @@ export function parseProviderName(
     normalized === "ollama" ||
     normalized === "openai_compatible" ||
     normalized === "opencode_go" ||
-    normalized === "cloudflare"
+    normalized === "cloudflare" ||
+    normalized === "minimax" ||
+    normalized === "minimax_cn"
   ) {
     return normalized;
   }
@@ -68,6 +72,10 @@ export function apiKeyEnvVarForProvider(
       return "OPENCODE_GO_API_KEY";
     case "cloudflare":
       return "CLOUDFLARE_API_KEY";
+    case "minimax":
+      return "MINIMAX_API_KEY";
+    case "minimax_cn":
+      return "MINIMAX_CN_API_KEY";
   }
 }
 

--- a/packages/core/src/provider-setup-prompt.ts
+++ b/packages/core/src/provider-setup-prompt.ts
@@ -39,6 +39,8 @@ const PROVIDER_CHOICES: Array<{ id: UserProviderName; label: string }> = [
   { id: "fireworks", label: "Fireworks" },
   { id: "ollama", label: "Ollama" },
   { id: "opencode_go", label: "OpenCode Go" },
+  { id: "minimax", label: "MiniMax" },
+  { id: "minimax_cn", label: "MiniMax (CN)" },
   { id: "openai_compatible", label: "Custom (OpenAI-compatible)" },
 ];
 
@@ -179,7 +181,9 @@ function resolveProviderChoice(input: string): UserProviderName | null {
     normalized === "fireworks" ||
     normalized === "ollama" ||
     normalized === "openai_compatible" ||
-    normalized === "opencode_go"
+    normalized === "opencode_go" ||
+    normalized === "minimax" ||
+    normalized === "minimax_cn"
   ) {
     return normalized;
   }

--- a/packages/core/src/user-config.ts
+++ b/packages/core/src/user-config.ts
@@ -74,6 +74,8 @@ const PROVIDER_TYPE_LABELS: Record<UserProviderName, string> = {
   deepseek: "DeepSeek",
   fireworks: "Fireworks",
   gemini: "Gemini",
+  minimax: "MiniMax",
+  minimax_cn: "MiniMax (CN)",
   ollama: "Ollama",
   openai: "OpenAI",
   openai_compatible: "Custom",

--- a/packages/core/src/user-config.ts
+++ b/packages/core/src/user-config.ts
@@ -33,6 +33,7 @@ import {
 export type { UserProviderName } from "./provider-resolution";
 export {
   apiKeyEnvVarForProvider,
+  isDiscoveryModelProvider,
   parseProviderName,
   resolveProvider,
 } from "./provider-resolution";


### PR DESCRIPTION
## Summary

Adds **MiniMax** as a direct first-party provider — the user brings their own MiniMax API key. MiniMax runs split international/China platforms with separate keys and catalogs, so this ships as two provider entries:

| Platform | Endpoint | Type name | Env key | Label |
|---|---|---|---|---|
| International | `https://api.minimax.io/v1` ✅ confirmed | `minimax` | `MINIMAX_API_KEY` | MiniMax |
| China | `https://api.minimaxi.com/v1` ✅ confirmed | `minimax_cn` | `MINIMAX_CN_API_KEY` | MiniMax (CN) |

Both are OpenAI-compatible; each follows the DeepSeek template (`createOpenAIProvider` with a region base URL).

Closes #380 (chat integration + region entries; image-01 deferred — see below).

## Dynamic model discovery — no hardcoded catalog

MiniMax model lists are **fetched live**, not hardcoded:

1. Adding a MiniMax instance prefills the region base URL (shared constant, below)
2. The settings card gets the same remote-browse editing flow as OpenAI-compatible endpoints — Browse hits `{baseUrl}/models`
3. Fetched models are stored as instance `customModels`; resolution, defaults, and vision flags derive from that list
4. New MiniMax releases appear without code changes

Region constants live in `@nakama/core/minimax-provider-config` so the server factory and web prefill share one source (mirrors `ollama-provider-config`).

## Region-safe model resolution (bug found by tests)

The first draft hardcoded six catalog entries and hit a real bug: `resolveModel` validated ids via **global** `getModelById`, which returns the first match. Region variants expose identical ids (`MiniMax-M3` on both platforms — the API must receive the lab's real id), so `minimax_cn` rejected its own models and silently fell back to the default.

Fix: validation is now **provider-scoped** (`getModelsForProvider(provider).some(...)`), which also generalizes to every future region-split provider on the board (#381 Zhipu, #384 Moonshot, #385 Qwen). The dynamic-model pivot then made the static catalog unnecessary entirely.

## Capability handling

| Capability | Status |
|---|---|
| Chat vision | Opt-in via discovered metadata (`supportsVision` on custom models); defaults to false — M2.x/M3 chat is text-only |
| Audio transcription | Not offered — MiniMax T2A is speech *output* only |
| Document input | Empty native sets (text-only), matching the deepseek precedent |
| Image generation | **Deferred** — see below |

### Deferred: image-01

Image generation is hard-allowlisted to `openai::gpt-image-2` in `agent-service.ts` (`isAllowedImageGenerationSelection`). Wiring MiniMax image-01 requires a new image-API call shape plus allowlist/settings extension — a follow-up PR referencing #380 rather than scope creep here.

## Wiring checklist

- `ProviderName` union += `"minimax"`, `"minimax_cn"` (`contract.ts`)
- `apiKeyEnvVarForProvider` → `MINIMAX_API_KEY` / `MINIMAX_CN_API_KEY`
- `create.ts` cases ×2 with region base URLs
- Labels across `user-config.ts`, `provider-label.ts`, `provider-setup-prompt.ts`
- `document-content.ts` empty native-doc sets
- Web: `PROVIDER_OPTIONS` cards, label chain, compatibleLike editing with region URL prefill
- New `packages/core/src/minimax-provider-config.ts`

## Tests

`models.test.ts`:
- customModels passthrough for discovered ids; unknown id falls back to instance default
- `getDefaultModel` resolves per-instance default for both regions
- Vision opt-in via discovered metadata (false by default, true when flagged)

`provider-resolution.test.ts`:
- `parseProviderName` accepts both types
- Distinct env keys per region

```
bun test packages/ + models.test + web models.test   # 847 pass, 0 fail
bun x ultracite check                                # clean
bun run knip                                         # clean
tsc error count                                      # identical to untouched-worktree baseline
```

## Live-key caveat

Discovered ids come straight from MiniMax's `/models` response, so context-window and cost metadata for usage tracking are only as good as that endpoint reports (same tradeoff openai_compatible users have today). Exact direct-API model ids should be spot-checked against platform.minimax.io with a live key before release — both base URLs themselves are reporter-confirmed.
