### PR TITLE
feat(orgs): let platform admins archive an organization

### DIFF
--- a/apps/server/src/http/org-middleware.ts
+++ b/apps/server/src/http/org-middleware.ts
@@ -74,6 +74,12 @@ export function createOrgContextMiddleware(
       return;
     }
 
+    const organization = await databaseAdapter.getOrganizationById(orgId);
+    if (!organization || organization.archivedAt) {
+      c.res = errorResponse("Not found", 404);
+      return;
+    }
+
     const member = await databaseAdapter.getOrgMember(orgId, auth.user.id);
     if (!member) {
       c.res = errorResponse("Not found", 404);

--- a/apps/server/src/http/platform-orgs.test.ts
+++ b/apps/server/src/http/platform-orgs.test.ts
@@ -67,6 +67,7 @@ describe("platform org routes", () => {
         temporaryPassword: null,
       },
       organization: {
+        archivedAt: null,
         createdAt: expect.any(String),
         id: expect.stringMatching(/^org_/),
         name: "Acme Corp",
@@ -185,5 +186,200 @@ describe("platform org routes", () => {
     await expect(second.json()).resolves.toEqual({
       error: "Organization slug already exists.",
     });
+  });
+
+  test("platform admin can archive an organization", async () => {
+    const { app, authService, databaseAdapter } = createPlatformApp();
+    const session = await loginPlatformAdminSession(
+      app,
+      authService,
+      databaseAdapter
+    );
+    const headers = session.headers({
+      "X-CSRF-Token": session.csrfToken,
+    });
+
+    const first = await app.fetch(
+      new Request("http://localhost:4310/v1/platform/orgs", {
+        body: JSON.stringify({ name: "Acme", slug: "acme-del" }),
+        headers,
+        method: "POST",
+      })
+    );
+    expect(first.status).toBe(201);
+    const created = (await first.json()) as { organization: { id: string } };
+
+    const second = await app.fetch(
+      new Request("http://localhost:4310/v1/platform/orgs", {
+        body: JSON.stringify({ name: "Beta", slug: "beta-del" }),
+        headers,
+        method: "POST",
+      })
+    );
+    expect(second.status).toBe(201);
+
+    const archived = await app.fetch(
+      new Request(
+        `http://localhost:4310/v1/platform/orgs/${created.organization.id}`,
+        {
+          headers,
+          method: "DELETE",
+        }
+      )
+    );
+    expect(archived.status).toBe(200);
+    const payload = (await archived.json()) as {
+      organization: { archivedAt: string | null; id: string };
+    };
+    expect(payload.organization.id).toBe(created.organization.id);
+    expect(payload.organization.archivedAt).toBeTruthy();
+  });
+
+  test("org admin cannot archive via platform delete", async () => {
+    const { app, authService, databaseAdapter } = createPlatformApp();
+    const platformSession = await loginPlatformAdminSession(
+      app,
+      authService,
+      databaseAdapter
+    );
+
+    const createResponse = await app.fetch(
+      new Request("http://localhost:4310/v1/platform/orgs", {
+        body: JSON.stringify({
+          admin: {
+            email: "admin@acme.com",
+            name: "Acme Admin",
+            phone: "+628123456789",
+          },
+          name: "Acme Corp",
+          slug: "acme-forbid-del",
+        }),
+        headers: platformSession.headers({
+          "X-CSRF-Token": platformSession.csrfToken,
+        }),
+        method: "POST",
+      })
+    );
+    expect(createResponse.status).toBe(201);
+    const created = (await createResponse.json()) as {
+      organization: { id: string };
+      adminMember: { temporaryPassword: string };
+    };
+
+    const orgAdminLogin = await app.fetch(
+      new Request("http://localhost:4310/v1/auth/login", {
+        body: JSON.stringify({
+          email: "admin@acme.com",
+          password: created.adminMember.temporaryPassword,
+        }),
+        method: "POST",
+      })
+    );
+    expect(orgAdminLogin.status).toBe(200);
+    const orgAdminSession = browserSessionFromResponse(
+      orgAdminLogin,
+      created.organization.id
+    );
+
+    const response = await app.fetch(
+      new Request(
+        `http://localhost:4310/v1/platform/orgs/${created.organization.id}`,
+        {
+          headers: orgAdminSession.headers({
+            "X-CSRF-Token": orgAdminSession.csrfToken,
+          }),
+          method: "DELETE",
+        }
+      )
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  test("refuses to archive the last active organization", async () => {
+    const { app, authService, databaseAdapter } = createPlatformApp();
+    const session = await loginPlatformAdminSession(
+      app,
+      authService,
+      databaseAdapter
+    );
+    const headers = session.headers({
+      "X-CSRF-Token": session.csrfToken,
+    });
+
+    const created = await app.fetch(
+      new Request("http://localhost:4310/v1/platform/orgs", {
+        body: JSON.stringify({ name: "Only", slug: "only-del" }),
+        headers,
+        method: "POST",
+      })
+    );
+    expect(created.status).toBe(201);
+    const payload = (await created.json()) as { organization: { id: string } };
+
+    const response = await app.fetch(
+      new Request(
+        `http://localhost:4310/v1/platform/orgs/${payload.organization.id}`,
+        {
+          headers,
+          method: "DELETE",
+        }
+      )
+    );
+    expect(response.status).toBe(409);
+  });
+
+  test("archived org context is not found", async () => {
+    const { app, authService, databaseAdapter } = createPlatformApp();
+    const session = await loginPlatformAdminSession(
+      app,
+      authService,
+      databaseAdapter
+    );
+    const headers = session.headers({
+      "X-CSRF-Token": session.csrfToken,
+    });
+
+    const first = await app.fetch(
+      new Request("http://localhost:4310/v1/platform/orgs", {
+        body: JSON.stringify({ name: "Acme", slug: "acme-stale" }),
+        headers,
+        method: "POST",
+      })
+    );
+    expect(first.status).toBe(201);
+    const created = (await first.json()) as { organization: { id: string } };
+
+    const second = await app.fetch(
+      new Request("http://localhost:4310/v1/platform/orgs", {
+        body: JSON.stringify({ name: "Beta", slug: "beta-stale" }),
+        headers,
+        method: "POST",
+      })
+    );
+    expect(second.status).toBe(201);
+
+    const archived = await app.fetch(
+      new Request(
+        `http://localhost:4310/v1/platform/orgs/${created.organization.id}`,
+        {
+          headers,
+          method: "DELETE",
+        }
+      )
+    );
+    expect(archived.status).toBe(200);
+
+    const members = await app.fetch(
+      new Request(
+        `http://localhost:4310/v1/orgs/${created.organization.id}/members`,
+        {
+          headers: session.headers({
+            "X-Org-Id": created.organization.id,
+          }),
+        }
+      )
+    );
+    expect(members.status).toBe(404);
   });
 });

--- a/apps/server/src/http/routes/internal-automations.test.ts
+++ b/apps/server/src/http/routes/internal-automations.test.ts
@@ -201,4 +201,80 @@ describe("internal automation routes", () => {
 
     expect(response.status).toBe(409);
   });
+
+  test("omits automations on archived orgs from the schedule list", async () => {
+    const options = createServerOptions();
+    await seedOrgAndProfile(options.databaseAdapter);
+    await seedLocalClientUser(options.databaseAdapter);
+    const now = new Date().toISOString();
+    await options.databaseAdapter.upsertOrganization({
+      archivedAt: now,
+      createdAt: now,
+      id: ORG_ID,
+      name: "Default Org",
+      slug: "default-org",
+      updatedAt: now,
+    });
+
+    await options.automationService.create(
+      ORG_ID,
+      {
+        description: "Ping",
+        name: "Hourly",
+        prompt: "Ping",
+        trigger: { cron: "0 * * * *", timezone: "UTC", type: "schedule" },
+      },
+      PROFILE_ID
+    );
+
+    const app = createHonoApp(options);
+    const token = await loadLocalAuthToken();
+    const response = await app.fetch(
+      new Request("http://localhost:4310/v1/internal/automations/schedules", {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual([]);
+  });
+
+  test("does not run an automation for an archived org", async () => {
+    const options = createServerOptions();
+    await seedOrgAndProfile(options.databaseAdapter);
+    await seedLocalClientUser(options.databaseAdapter);
+    const automation = await options.automationService.create(
+      ORG_ID,
+      {
+        description: "Ping",
+        name: "Hourly",
+        prompt: "Ping",
+        trigger: { cron: "0 * * * *", timezone: "UTC", type: "schedule" },
+      },
+      PROFILE_ID
+    );
+    const now = new Date().toISOString();
+    await options.databaseAdapter.upsertOrganization({
+      archivedAt: now,
+      createdAt: now,
+      id: ORG_ID,
+      name: "Default Org",
+      slug: "default-org",
+      updatedAt: now,
+    });
+
+    const app = createHonoApp(options);
+    const token = await loadLocalAuthToken();
+    const response = await app.fetch(
+      new Request(
+        `http://localhost:4310/v1/internal/automations/${encodeURIComponent(automation.id)}/run`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+          method: "POST",
+        }
+      )
+    );
+
+    expect(response.status).toBe(404);
+  });
 });

--- a/apps/server/src/http/routes/internal-automations.ts
+++ b/apps/server/src/http/routes/internal-automations.ts
@@ -7,7 +7,7 @@ export function registerInternalAutomationRoutes(
   app: HonoApp,
   options: ServerOptions
 ): void {
-  const { agent, automationService } = options;
+  const { agent, automationService, orgService } = options;
 
   app.get("/v1/internal/automations/schedules", async (c) => {
     const auth = c.get("auth");
@@ -16,8 +16,19 @@ export function registerInternalAutomationRoutes(
     }
 
     const automations = await automationService.listAll();
+    const archivedOrgIds = new Set(
+      orgService
+        ? (await orgService.listOrganizations())
+            .filter((organization) => organization.archivedAt)
+            .map((organization) => organization.id)
+        : []
+    );
     const schedules: AutomationSchedule[] = automations
-      .filter((automation) => isWorkerSchedulable(automation))
+      .filter(
+        (automation) =>
+          isWorkerSchedulable(automation) &&
+          !(automation.orgId && archivedOrgIds.has(automation.orgId))
+      )
       .map((automation) => {
         if (automation.trigger.type === "runAt") {
           return {
@@ -58,6 +69,13 @@ export function registerInternalAutomationRoutes(
 
     if (!automation) {
       return errorResponse("Automation not found", 404);
+    }
+
+    if (automation.orgId && orgService) {
+      const organization = await orgService.getOrganization(automation.orgId);
+      if (!organization || organization.archivedAt) {
+        return errorResponse("Not found", 404);
+      }
     }
 
     const result = await agent.runAutomation(automationId);

--- a/apps/server/src/http/routes/internal-curator.ts
+++ b/apps/server/src/http/routes/internal-curator.ts
@@ -38,6 +38,11 @@ export function registerInternalCuratorRoutes(
     }
 
     const orgId = decodeURIComponent(c.req.param("orgId"));
+    const organization = await orgService.getOrganization(orgId);
+    if (!organization || organization.archivedAt) {
+      return errorResponse("Not found", 404);
+    }
+
     const body = await readJson<RunSkillCuratorInternalRequest>(c.req.raw);
     const trigger = body.trigger === "seed" ? "seed" : "schedule";
     const result = await skillCuratorService.run(orgId, { trigger });

--- a/apps/server/src/http/routes/notification-webhooks.test.ts
+++ b/apps/server/src/http/routes/notification-webhooks.test.ts
@@ -40,6 +40,13 @@ describe("notification webhook routes", () => {
 
     try {
       const { app, databaseAdapter, authService } = await createApp();
+      await databaseAdapter.upsertOrganization({
+        createdAt: "2026-07-04T10:00:00.000Z",
+        id: "org_1",
+        name: "Acme",
+        slug: "acme",
+        updatedAt: "2026-07-04T10:00:00.000Z",
+      });
       await databaseAdapter.upsertNotificationDestination({
         channel: "telegram",
         config: { chatId: 1001, topicId: 22 },
@@ -104,5 +111,52 @@ describe("notification webhook routes", () => {
     );
 
     expect(response.status).toBe(401);
+  });
+
+  test("does not deliver for an archived organization", async () => {
+    const telegramCalls: unknown[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (_input, init) => {
+      telegramCalls.push(init?.body);
+      return new Response("ok", { status: 200 });
+    };
+
+    try {
+      const { app, databaseAdapter, authService } = await createApp();
+      await databaseAdapter.upsertOrganization({
+        archivedAt: "2026-08-21T00:00:00.000Z",
+        createdAt: "2026-07-04T10:00:00.000Z",
+        id: "org_1",
+        name: "Acme",
+        slug: "acme",
+        updatedAt: "2026-08-21T00:00:00.000Z",
+      });
+      await databaseAdapter.upsertNotificationDestination({
+        channel: "telegram",
+        config: { chatId: 1001, topicId: null },
+        createdAt: "2026-07-04T10:00:00.000Z",
+        id: "dest_1",
+        name: "Payments",
+        orgId: "org_1",
+        secretHash: authService.hashToken("secret_key"),
+        updatedAt: "2026-07-04T10:00:00.000Z",
+      });
+
+      const response = await app.fetch(
+        new Request("http://localhost:4310/v1/notify/dest_1", {
+          body: JSON.stringify({ body: "Hello" }),
+          headers: {
+            "Content-Type": "application/json",
+            "X-API-Key": "secret_key",
+          },
+          method: "POST",
+        })
+      );
+
+      expect(response.status).toBe(404);
+      expect(telegramCalls).toEqual([]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/apps/server/src/http/routes/org-curator.test.ts
+++ b/apps/server/src/http/routes/org-curator.test.ts
@@ -217,6 +217,57 @@ describe("org curator routes", () => {
     const body = (await response.json()) as { orgs: Array<{ id: string }> };
     expect(body.orgs.map((org) => org.id)).toEqual([orgId]);
   });
+
+  test("internal org list omits archived orgs", async () => {
+    const { app, databaseAdapter, orgService } = createMinimalHonoApp();
+    await seedLocalClientUser(databaseAdapter);
+    const session = await setupFreshInstallSession(app, databaseAdapter);
+    const orgId = session.orgId!;
+    await orgService.updateOrganization(orgId, { skillsCuratorEnabled: true });
+    await databaseAdapter.upsertOrganization({
+      ...(await databaseAdapter.getOrganizationById(orgId))!,
+      archivedAt: NOW.toISOString(),
+      updatedAt: NOW.toISOString(),
+    });
+
+    const token = await loadLocalAuthToken();
+    const response = await app.fetch(
+      new Request(`${BASE}/v1/internal/curator/orgs`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { orgs: Array<{ id: string }> };
+    expect(body.orgs).toEqual([]);
+  });
+
+  test("internal curator run returns 404 for an archived org", async () => {
+    const { app, databaseAdapter, orgService } = createMinimalHonoApp();
+    await seedLocalClientUser(databaseAdapter);
+    const session = await setupFreshInstallSession(app, databaseAdapter);
+    const orgId = session.orgId!;
+    await orgService.updateOrganization(orgId, { skillsCuratorEnabled: true });
+    await databaseAdapter.upsertOrganization({
+      ...(await databaseAdapter.getOrganizationById(orgId))!,
+      archivedAt: NOW.toISOString(),
+      updatedAt: NOW.toISOString(),
+    });
+
+    const token = await loadLocalAuthToken();
+    const response = await app.fetch(
+      new Request(`${BASE}/v1/internal/curator/orgs/${orgId}/run`, {
+        body: JSON.stringify({ trigger: "schedule" }),
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      })
+    );
+
+    expect(response.status).toBe(404);
+  });
 });
 
 async function addUnusedSkill(input: {

--- a/apps/server/src/http/routes/platform-orgs.ts
+++ b/apps/server/src/http/routes/platform-orgs.ts
@@ -196,6 +196,65 @@ export function registerPlatformOrgRoutes(
 
   app.openAPIRegistry.registerPath(
     createRoute({
+      method: "delete",
+      operationId: "archivePlatformOrganization",
+      path: "/v1/platform/orgs/{orgId}",
+      request: {
+        params: z.object({
+          orgId: z.string().openapi({ param: { in: "path", name: "orgId" } }),
+        }),
+      },
+      responses: {
+        200: {
+          content: {
+            "application/json": {
+              schema: z
+                .object({})
+                .passthrough()
+                .openapi("OrganizationResponse"),
+            },
+          },
+          description: "Organization archived",
+        },
+        403: {
+          content: { "application/json": { schema: errorSchema } },
+          description: "Error",
+        },
+        404: {
+          content: { "application/json": { schema: errorSchema } },
+          description: "Error",
+        },
+        409: {
+          content: { "application/json": { schema: errorSchema } },
+          description: "Error",
+        },
+        500: {
+          content: { "application/json": { schema: errorSchema } },
+          description: "Error",
+        },
+      },
+      summary: "Archive an organization",
+      tags: ["Platform"],
+    })
+  );
+
+  app.delete("/v1/platform/orgs/:orgId", async (c) => {
+    const auth = requirePlatformAdminFromContext(c);
+
+    if (!orgService) {
+      return errorResponse("Organization service not configured", 500);
+    }
+
+    const orgId = decodeURIComponent(c.req.param("orgId"));
+    const organization = await orgService.archiveOrganization(
+      orgId,
+      auth.user.id
+    );
+    return json<OrganizationResponse>({ organization });
+  });
+
+  app.openAPIRegistry.registerPath(
+    createRoute({
       method: "post",
       operationId: "createPlatformOrganizationInvite",
       path: "/v1/platform/orgs/{orgId}/invites",

--- a/apps/server/src/services/notification-webhook-service.test.ts
+++ b/apps/server/src/services/notification-webhook-service.test.ts
@@ -15,6 +15,13 @@ describe("NotificationWebhookService", () => {
       parseMode?: "HTML";
     }> = [];
 
+    await databaseAdapter.upsertOrganization({
+      createdAt: "2026-07-04T10:00:00.000Z",
+      id: "org_1",
+      name: "Acme",
+      slug: "acme",
+      updatedAt: "2026-07-04T10:00:00.000Z",
+    });
     await databaseAdapter.upsertNotificationDestination({
       channel: "telegram",
       config: { chatId: 1001, topicId: 22 },

--- a/apps/server/src/services/notification-webhook-service.ts
+++ b/apps/server/src/services/notification-webhook-service.ts
@@ -60,6 +60,13 @@ export class NotificationWebhookService {
       throw new NakamaApiError("Invalid notification credentials.", 401);
     }
 
+    const organization = await this.databaseAdapter.getOrganizationById(
+      destination.orgId
+    );
+    if (!organization || organization.archivedAt) {
+      throw new NakamaApiError("Not found", 404);
+    }
+
     const normalized = normalizeNotificationWebhookRequest(payload);
     const result = await this.telegram.send({
       chatIds: [destination.config.chatId],

--- a/apps/server/src/services/org-service.test.ts
+++ b/apps/server/src/services/org-service.test.ts
@@ -489,6 +489,47 @@ describe("OrgService", () => {
     expect(resolved).toBe(second.organization.id);
   });
 
+  test("clears a stale session org when the user has no remaining memberships", async () => {
+    const { orgService, authService, databaseAdapter } = createOrgService();
+    const bootstrapped = await orgService.bootstrapInitialSetup({
+      admin: {
+        email: "admin@acme.com",
+        name: "Acme Admin",
+        passwordHash: await authService.hashPassword("password123"),
+        phone: "",
+      },
+      organization: { name: "Acme", slug: "acme-session-clear" },
+    });
+    await databaseAdapter.createBrowserSession({
+      activeOrgId: bootstrapped.organization.id,
+      createdAt: new Date().toISOString(),
+      csrfTokenHash: "csrf",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      id: "session_stale",
+      lastUsedAt: null,
+      revokedAt: null,
+      sessionTokenHash: "token_stale",
+      userId: bootstrapped.user.id,
+    });
+    await databaseAdapter.upsertOrganization({
+      ...(await databaseAdapter.getOrganizationById(
+        bootstrapped.organization.id
+      ))!,
+      archivedAt: new Date().toISOString(),
+    });
+
+    const resolved = await orgService.resolveActiveOrgId(
+      bootstrapped.user.id,
+      "session_stale",
+      bootstrapped.organization.id
+    );
+    expect(resolved).toBeNull();
+
+    const session =
+      await databaseAdapter.getBrowserSessionBySessionTokenHash("token_stale");
+    expect(session?.activeOrgId).toBeNull();
+  });
+
   test("refuses to archive the actor's last remaining membership", async () => {
     const { orgService, authService } = createOrgService();
     const bootstrapped = await orgService.bootstrapInitialSetup({
@@ -510,7 +551,10 @@ describe("OrgService", () => {
         bootstrapped.organization.id,
         bootstrapped.user.id
       )
-    ).rejects.toMatchObject({ status: 409 });
+    ).rejects.toMatchObject({
+      message: "Cannot archive your last remaining organization.",
+      status: 409,
+    });
   });
 
   test("refuses updates on an archived org", async () => {
@@ -549,7 +593,10 @@ describe("OrgService", () => {
 
     await expect(
       orgService.archiveOrganization(created.organization.id)
-    ).rejects.toMatchObject({ status: 409 });
+    ).rejects.toMatchObject({
+      message: "Cannot archive the last remaining organization.",
+      status: 409,
+    });
 
     const stillListed = await orgService.listOrganizations();
     expect(stillListed).toHaveLength(1);

--- a/apps/server/src/services/org-service.test.ts
+++ b/apps/server/src/services/org-service.test.ts
@@ -551,10 +551,7 @@ describe("OrgService", () => {
         bootstrapped.organization.id,
         bootstrapped.user.id
       )
-    ).rejects.toMatchObject({
-      message: "Cannot archive your last remaining organization.",
-      status: 409,
-    });
+    ).rejects.toMatchObject({ status: 409 });
   });
 
   test("refuses updates on an archived org", async () => {
@@ -593,10 +590,7 @@ describe("OrgService", () => {
 
     await expect(
       orgService.archiveOrganization(created.organization.id)
-    ).rejects.toMatchObject({
-      message: "Cannot archive the last remaining organization.",
-      status: 409,
-    });
+    ).rejects.toMatchObject({ status: 409 });
 
     const stillListed = await orgService.listOrganizations();
     expect(stillListed).toHaveLength(1);

--- a/apps/server/src/services/org-service.test.ts
+++ b/apps/server/src/services/org-service.test.ts
@@ -513,6 +513,33 @@ describe("OrgService", () => {
     ).rejects.toMatchObject({ status: 409 });
   });
 
+  test("refuses updates on an archived org", async () => {
+    const { orgService, authService } = createOrgService();
+    const bootstrapped = await orgService.bootstrapInitialSetup({
+      admin: {
+        email: "admin@acme.com",
+        name: "Acme Admin",
+        passwordHash: await authService.hashPassword("password123"),
+        phone: "",
+      },
+      organization: { name: "Acme", slug: "acme-update-archive" },
+    });
+    await orgService.createOrganization(
+      { name: "Beta", slug: "beta-update-archive" },
+      bootstrapped.user.id
+    );
+    await orgService.archiveOrganization(
+      bootstrapped.organization.id,
+      bootstrapped.user.id
+    );
+
+    await expect(
+      orgService.updateOrganization(bootstrapped.organization.id, {
+        name: "Renamed",
+      })
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
   test("refuses to archive the last active org", async () => {
     const { orgService } = createOrgService();
     const created = await orgService.createOrganization({

--- a/apps/server/src/services/org-service.test.ts
+++ b/apps/server/src/services/org-service.test.ts
@@ -443,4 +443,151 @@ describe("OrgService", () => {
       status: 409,
     });
   });
+
+  test("archives an org and hides it from membership lists", async () => {
+    const { orgService, authService, databaseAdapter } = createOrgService();
+    const bootstrapped = await orgService.bootstrapInitialSetup({
+      admin: {
+        email: "admin@acme.com",
+        name: "Acme Admin",
+        passwordHash: await authService.hashPassword("password123"),
+        phone: "",
+      },
+      organization: { name: "Acme", slug: "acme-archive" },
+    });
+    const second = await orgService.createOrganization(
+      { name: "Beta", slug: "beta-archive" },
+      bootstrapped.user.id
+    );
+
+    const archived = await orgService.archiveOrganization(
+      bootstrapped.organization.id,
+      bootstrapped.user.id
+    );
+
+    expect(archived.archivedAt).toBeTruthy();
+    const listed = await orgService.listUserOrgs(bootstrapped.user.id);
+    expect(listed.orgs.map((org) => org.id)).toEqual([second.organization.id]);
+
+    const stored = await databaseAdapter.getOrganizationById(
+      bootstrapped.organization.id
+    );
+    expect(stored?.archivedAt).toBeTruthy();
+
+    await expect(
+      orgService.setActiveOrg({
+        orgId: bootstrapped.organization.id,
+        userId: bootstrapped.user.id,
+      })
+    ).rejects.toMatchObject({ status: 404 });
+
+    const resolved = await orgService.resolveActiveOrgId(
+      bootstrapped.user.id,
+      undefined,
+      bootstrapped.organization.id
+    );
+    expect(resolved).toBe(second.organization.id);
+  });
+
+  test("refuses to archive the actor's last remaining membership", async () => {
+    const { orgService, authService } = createOrgService();
+    const bootstrapped = await orgService.bootstrapInitialSetup({
+      admin: {
+        email: "admin@acme.com",
+        name: "Acme Admin",
+        passwordHash: await authService.hashPassword("password123"),
+        phone: "",
+      },
+      organization: { name: "Acme", slug: "acme-last-membership" },
+    });
+    await orgService.createOrganization({
+      name: "Other",
+      slug: "other-last-membership",
+    });
+
+    await expect(
+      orgService.archiveOrganization(
+        bootstrapped.organization.id,
+        bootstrapped.user.id
+      )
+    ).rejects.toMatchObject({ status: 409 });
+  });
+
+  test("refuses to archive the last active org", async () => {
+    const { orgService } = createOrgService();
+    const created = await orgService.createOrganization({
+      name: "Only",
+      slug: "only-org",
+    });
+
+    await expect(
+      orgService.archiveOrganization(created.organization.id)
+    ).rejects.toMatchObject({ status: 409 });
+
+    const stillListed = await orgService.listOrganizations();
+    expect(stillListed).toHaveLength(1);
+    expect(stillListed[0]?.archivedAt).toBeNull();
+  });
+
+  test("refuses a second archive and unknown id", async () => {
+    const { orgService, authService } = createOrgService();
+    const bootstrapped = await orgService.bootstrapInitialSetup({
+      admin: {
+        email: "admin@acme.com",
+        name: "Acme Admin",
+        passwordHash: await authService.hashPassword("password123"),
+        phone: "",
+      },
+      organization: { name: "Acme", slug: "acme-twice" },
+    });
+    await orgService.createOrganization(
+      { name: "Beta", slug: "beta-twice" },
+      bootstrapped.user.id
+    );
+    await orgService.archiveOrganization(
+      bootstrapped.organization.id,
+      bootstrapped.user.id
+    );
+
+    await expect(
+      orgService.archiveOrganization(
+        bootstrapped.organization.id,
+        bootstrapped.user.id
+      )
+    ).rejects.toMatchObject({ status: 404 });
+    await expect(
+      orgService.archiveOrganization("org_missing")
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  test("rejects invite accept for an archived org", async () => {
+    const { orgService, authService } = createOrgService();
+    const bootstrapped = await orgService.bootstrapInitialSetup({
+      admin: {
+        email: "admin@acme.com",
+        name: "Acme Admin",
+        passwordHash: await authService.hashPassword("password123"),
+        phone: "",
+      },
+      organization: { name: "Acme", slug: "acme-invite-archive" },
+    });
+    await orgService.createOrganization(
+      { name: "Beta", slug: "beta-invite-archive" },
+      bootstrapped.user.id
+    );
+    const invite = await orgService.createInvite({
+      email: "guest@acme.com",
+      invitedByUserId: bootstrapped.user.id,
+      orgId: bootstrapped.organization.id,
+      role: "member",
+    });
+    await orgService.archiveOrganization(
+      bootstrapped.organization.id,
+      bootstrapped.user.id
+    );
+
+    await expect(
+      orgService.acceptInvite({ password: "secret123", token: invite.token })
+    ).rejects.toMatchObject({ status: 404 });
+  });
 });

--- a/apps/server/src/services/org-service.ts
+++ b/apps/server/src/services/org-service.ts
@@ -58,14 +58,21 @@ export class OrgService {
     return org ? toOrganizationSummary(org) : null;
   }
 
-  async archiveOrganization(
-    orgId: string,
-    actorUserId?: string
-  ): Promise<OrganizationSummary> {
+  private async requireActiveOrganization(
+    orgId: string
+  ): Promise<StoredOrganizationRecord> {
     const org = await this.databaseAdapter.getOrganizationById(orgId);
     if (!org || org.archivedAt) {
       throw new NakamaApiError("Not found", 404);
     }
+    return org;
+  }
+
+  async archiveOrganization(
+    orgId: string,
+    actorUserId?: string
+  ): Promise<OrganizationSummary> {
+    const org = await this.requireActiveOrganization(orgId);
 
     const organizations = await this.databaseAdapter.listOrganizations();
     const activeCount = organizations.filter(
@@ -589,10 +596,7 @@ export class OrgService {
     role: OrgRole;
     invitedByUserId: string;
   }): Promise<OrgInviteCreatedResponse> {
-    const org = await this.databaseAdapter.getOrganizationById(input.orgId);
-    if (!org || org.archivedAt) {
-      throw new NakamaApiError("Not found", 404);
-    }
+    await this.requireActiveOrganization(input.orgId);
 
     const email = normalizeEmail(input.email);
     if (!EMAIL_PATTERN.test(email)) {
@@ -672,12 +676,7 @@ export class OrgService {
 
     assertInviteUsable(invite);
 
-    const inviteOrg = await this.databaseAdapter.getOrganizationById(
-      invite.orgId
-    );
-    if (!inviteOrg || inviteOrg.archivedAt) {
-      throw new NakamaApiError("Not found", 404);
-    }
+    await this.requireActiveOrganization(invite.orgId);
 
     const password = request.password?.trim();
     if (!password) {

--- a/apps/server/src/services/org-service.ts
+++ b/apps/server/src/services/org-service.ts
@@ -38,6 +38,10 @@ import {
 } from "@nakama/db";
 import type { AuthService } from "./auth-service";
 
+const LAST_MEMBERSHIP_MESSAGE =
+  "Cannot archive your last remaining organization.";
+const LAST_ORGANIZATION_MESSAGE =
+  "Cannot archive the last remaining organization.";
 const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const PHONE_PATTERN = /^[+0-9()\-\s]{6,32}$/;
@@ -74,38 +78,34 @@ export class OrgService {
   ): Promise<OrganizationSummary> {
     const org = await this.requireActiveOrganization(orgId);
 
-    const organizations = await this.databaseAdapter.listOrganizations();
-    const activeCount = organizations.filter(
-      (organization) => !organization.archivedAt
-    ).length;
-    if (activeCount <= 1) {
-      throw new NakamaApiError(
-        "Cannot archive the last remaining organization.",
-        409
-      );
-    }
-
     if (actorUserId) {
       const memberships =
         await this.databaseAdapter.listUserOrganizations(actorUserId);
       const onlyMembership =
         memberships.length === 1 && memberships[0]?.organization.id === orgId;
       if (onlyMembership) {
-        throw new NakamaApiError(
-          "Cannot archive the last remaining organization.",
-          409
-        );
+        throw new NakamaApiError(LAST_MEMBERSHIP_MESSAGE, 409);
       }
     }
 
     const now = new Date().toISOString();
-    const updated: StoredOrganizationRecord = {
+    const archived = await this.databaseAdapter.tryMarkOrganizationArchived(
+      orgId,
+      now
+    );
+    if (!archived) {
+      const current = await this.databaseAdapter.getOrganizationById(orgId);
+      if (!current || current.archivedAt) {
+        throw new NakamaApiError("Not found", 404);
+      }
+      throw new NakamaApiError(LAST_ORGANIZATION_MESSAGE, 409);
+    }
+
+    return toOrganizationSummary({
       ...org,
       archivedAt: now,
       updatedAt: now,
-    };
-    await this.databaseAdapter.upsertOrganization(updated);
-    return toOrganizationSummary(updated);
+    });
   }
 
   async updateOrganization(
@@ -234,6 +234,12 @@ export class OrgService {
     const memberships =
       await this.databaseAdapter.listUserOrganizations(userId);
     if (memberships.length === 0) {
+      if (sessionId) {
+        await this.databaseAdapter.updateBrowserSessionActiveOrgId(
+          sessionId,
+          null
+        );
+      }
       return null;
     }
 

--- a/apps/server/src/services/org-service.ts
+++ b/apps/server/src/services/org-service.ts
@@ -112,10 +112,7 @@ export class OrgService {
     orgId: string,
     request: UpdateOrganizationRequest
   ): Promise<OrganizationSummary> {
-    const org = await this.databaseAdapter.getOrganizationById(orgId);
-    if (!org) {
-      throw new NakamaApiError("Not found", 404);
-    }
+    const org = await this.requireActiveOrganization(orgId);
 
     const name = request.name === undefined ? org.name : request.name.trim();
     if (request.name !== undefined && !name) {

--- a/apps/server/src/services/org-service.ts
+++ b/apps/server/src/services/org-service.ts
@@ -58,6 +58,49 @@ export class OrgService {
     return org ? toOrganizationSummary(org) : null;
   }
 
+  async archiveOrganization(
+    orgId: string,
+    actorUserId?: string
+  ): Promise<OrganizationSummary> {
+    const org = await this.databaseAdapter.getOrganizationById(orgId);
+    if (!org || org.archivedAt) {
+      throw new NakamaApiError("Not found", 404);
+    }
+
+    const organizations = await this.databaseAdapter.listOrganizations();
+    const activeCount = organizations.filter(
+      (organization) => !organization.archivedAt
+    ).length;
+    if (activeCount <= 1) {
+      throw new NakamaApiError(
+        "Cannot archive the last remaining organization.",
+        409
+      );
+    }
+
+    if (actorUserId) {
+      const memberships =
+        await this.databaseAdapter.listUserOrganizations(actorUserId);
+      const onlyMembership =
+        memberships.length === 1 && memberships[0]?.organization.id === orgId;
+      if (onlyMembership) {
+        throw new NakamaApiError(
+          "Cannot archive the last remaining organization.",
+          409
+        );
+      }
+    }
+
+    const now = new Date().toISOString();
+    const updated: StoredOrganizationRecord = {
+      ...org,
+      archivedAt: now,
+      updatedAt: now,
+    };
+    await this.databaseAdapter.upsertOrganization(updated);
+    return toOrganizationSummary(updated);
+  }
+
   async updateOrganization(
     orgId: string,
     request: UpdateOrganizationRequest
@@ -118,7 +161,7 @@ export class OrgService {
   > {
     const organizations = await this.databaseAdapter.listOrganizations();
     return organizations
-      .filter((org) => org.skillsCuratorEnabled)
+      .filter((org) => org.skillsCuratorEnabled && !org.archivedAt)
       .map((org) => ({
         id: org.id,
         skillsCuratorEnabled: true,
@@ -547,7 +590,7 @@ export class OrgService {
     invitedByUserId: string;
   }): Promise<OrgInviteCreatedResponse> {
     const org = await this.databaseAdapter.getOrganizationById(input.orgId);
-    if (!org) {
+    if (!org || org.archivedAt) {
       throw new NakamaApiError("Not found", 404);
     }
 
@@ -628,6 +671,13 @@ export class OrgService {
     }
 
     assertInviteUsable(invite);
+
+    const inviteOrg = await this.databaseAdapter.getOrganizationById(
+      invite.orgId
+    );
+    if (!inviteOrg || inviteOrg.archivedAt) {
+      throw new NakamaApiError("Not found", 404);
+    }
 
     const password = request.password?.trim();
     if (!password) {
@@ -867,6 +917,7 @@ function toOrganizationSummary(
   record: StoredOrganizationRecord
 ): OrganizationSummary {
   return {
+    archivedAt: record.archivedAt ?? null,
     createdAt: record.createdAt,
     id: record.id,
     name: record.name,

--- a/apps/web/src/components/OrgSwitcher.tsx
+++ b/apps/web/src/components/OrgSwitcher.tsx
@@ -1,5 +1,5 @@
 import type { UserOrgSummary } from "@nakama/core/contract";
-import { Add01Icon, ArrowDown01Icon, PencilIcon } from "hugeicons-react";
+import { Add01Icon, ArrowDown01Icon, Edit03Icon } from "hugeicons-react";
 import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
@@ -206,7 +206,7 @@ export function OrgSwitcher({ collapsed = false }: OrgSwitcherProps) {
                     type="button"
                     variant="ghost"
                   >
-                    <PencilIcon aria-hidden className="size-3.5" />
+                    <Edit03Icon aria-hidden className="size-3.5" />
                   </Button>
                 ) : null}
               </DropdownMenuItem>

--- a/apps/web/src/components/settings/OrgArchiveCard.tsx
+++ b/apps/web/src/components/settings/OrgArchiveCard.tsx
@@ -26,6 +26,19 @@ export function OrgArchiveCard() {
 
   const orgName = activeOrg.name;
 
+  async function handleArchive() {
+    setPending(true);
+    setFormError(null);
+    try {
+      await archiveOrg(activeOrg.id);
+      setConfirmOpen(false);
+    } catch (error) {
+      setFormError(formatError(error));
+    } finally {
+      setPending(false);
+    }
+  }
+
   return (
     <Card className="gap-0 py-0">
       <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-4 sm:px-5">
@@ -74,18 +87,7 @@ export function OrgArchiveCard() {
             <Button
               disabled={pending}
               onClick={() => {
-                void (async () => {
-                  setPending(true);
-                  setFormError(null);
-                  try {
-                    await archiveOrg(activeOrg.id);
-                    setConfirmOpen(false);
-                  } catch (error) {
-                    setFormError(formatError(error));
-                  } finally {
-                    setPending(false);
-                  }
-                })();
+                void handleArchive();
               }}
               type="button"
               variant="destructive"

--- a/apps/web/src/components/settings/OrgArchiveCard.tsx
+++ b/apps/web/src/components/settings/OrgArchiveCard.tsx
@@ -1,0 +1,100 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Spinner } from "@/components/ui/spinner";
+import { useAuth } from "@/context/use-auth";
+import { formatError } from "@/lib/client";
+import { canArchiveOrganization } from "@/lib/org-archive";
+
+export function OrgArchiveCard() {
+  const { user, activeOrg, archiveOrg } = useAuth();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [pending, setPending] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  if (!(canArchiveOrganization(user?.isPlatformAdmin === true) && activeOrg)) {
+    return null;
+  }
+
+  const orgName = activeOrg.name;
+
+  return (
+    <Card className="gap-0 py-0">
+      <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-4 sm:px-5">
+        <h2 className="font-medium text-sm">Delete organization</h2>
+        <Button
+          onClick={() => {
+            setFormError(null);
+            setConfirmOpen(true);
+          }}
+          type="button"
+          variant="destructive"
+        >
+          Delete
+        </Button>
+      </div>
+      <Dialog
+        onOpenChange={(open) => {
+          if (!(open || pending)) {
+            setConfirmOpen(false);
+          }
+        }}
+        open={confirmOpen}
+      >
+        <DialogContent className="gap-6 p-6 sm:max-w-md">
+          <DialogHeader className="gap-3">
+            <DialogTitle>Delete organization?</DialogTitle>
+            <DialogDescription>
+              {orgName} will disappear from the switcher and chat. Members,
+              profiles, and files stay on disk. Nakama cannot restore it.
+            </DialogDescription>
+          </DialogHeader>
+          {formError ? (
+            <p className="text-destructive text-sm" role="alert">
+              {formError}
+            </p>
+          ) : null}
+          <DialogFooter className="mx-0 mb-0 gap-2 border-0 bg-transparent p-0 sm:flex-row sm:justify-end">
+            <Button
+              disabled={pending}
+              onClick={() => setConfirmOpen(false)}
+              type="button"
+              variant="outline"
+            >
+              Cancel
+            </Button>
+            <Button
+              disabled={pending}
+              onClick={() => {
+                void (async () => {
+                  setPending(true);
+                  setFormError(null);
+                  try {
+                    await archiveOrg(activeOrg.id);
+                    setConfirmOpen(false);
+                  } catch (error) {
+                    setFormError(formatError(error));
+                  } finally {
+                    setPending(false);
+                  }
+                })();
+              }}
+              type="button"
+              variant="destructive"
+            >
+              {pending ? <Spinner className="size-4" /> : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}

--- a/apps/web/src/components/system/OrganizationPanel.tsx
+++ b/apps/web/src/components/system/OrganizationPanel.tsx
@@ -1,3 +1,4 @@
+import { OrgArchiveCard } from "@/components/settings/OrgArchiveCard";
 import { OrgMembersCard } from "@/components/settings/OrgMembersCard";
 import { OrgMemoryCard } from "@/components/settings/OrgMemoryCard";
 import { SkillsCuratorOrgCard } from "@/components/settings/SkillsCuratorOrgCard";
@@ -12,6 +13,7 @@ export function OrganizationPanel() {
       <SkillsPostTurnReviewOrgCard />
       <SkillsCuratorOrgCard />
       <OrgMemoryCard />
+      <OrgArchiveCard />
     </div>
   );
 }

--- a/apps/web/src/context/auth-context-shared.ts
+++ b/apps/web/src/context/auth-context-shared.ts
@@ -8,6 +8,7 @@ import { createContext } from "react";
 
 export interface AuthContextValue {
   activeOrg: UserOrgSummary | null;
+  archiveOrg: (orgId: string) => Promise<void>;
   createOrg: (input: { name: string; slug: string }) => Promise<void>;
   isAuthenticated: boolean;
   isLoading: boolean;

--- a/apps/web/src/context/auth-context.tsx
+++ b/apps/web/src/context/auth-context.tsx
@@ -16,6 +16,7 @@ import {
   type AuthContextValue,
 } from "@/context/auth-context-shared";
 import { client } from "@/lib/client";
+import { nextOrgIdAfterArchive } from "@/lib/org-archive";
 import { queryClient } from "@/lib/query-client";
 
 function refreshAuthenticatedQueries(): void {
@@ -108,6 +109,29 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     refreshAuthenticatedQueries();
   }, []);
 
+  const archiveOrg = useCallback(
+    async (orgId: string) => {
+      if (!user?.isPlatformAdmin) {
+        throw new Error("Only platform admins can delete organizations.");
+      }
+
+      await client.archivePlatformOrganization(orgId);
+      const { orgs: nextOrgs } = await client.listUserOrgs();
+      const nextOrgId = nextOrgIdAfterArchive(nextOrgs, orgId);
+      if (!nextOrgId) {
+        setOrgs(nextOrgs);
+        refreshAuthenticatedQueries();
+        return;
+      }
+
+      const nextUser = await client.setActiveOrg(nextOrgId);
+      setOrgs(nextOrgs);
+      setUser(nextUser);
+      refreshAuthenticatedQueries();
+    },
+    [user?.isPlatformAdmin]
+  );
+
   const createOrg = useCallback(
     async (input: { name: string; slug: string }) => {
       if (!user?.isPlatformAdmin) {
@@ -153,6 +177,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const value = useMemo<AuthContextValue>(
     () => ({
       activeOrg,
+      archiveOrg,
       createOrg,
       isAuthenticated: user !== null,
       isLoading,
@@ -174,6 +199,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       login,
       logout,
       switchOrg,
+      archiveOrg,
       createOrg,
       updateOrg,
       refreshSession,

--- a/apps/web/src/context/auth-context.tsx
+++ b/apps/web/src/context/auth-context.tsx
@@ -16,7 +16,10 @@ import {
   type AuthContextValue,
 } from "@/context/auth-context-shared";
 import { client } from "@/lib/client";
-import { nextOrgIdAfterArchive } from "@/lib/org-archive";
+import {
+  canArchiveOrganization,
+  nextOrgIdAfterArchive,
+} from "@/lib/org-archive";
 import { queryClient } from "@/lib/query-client";
 
 function refreshAuthenticatedQueries(): void {
@@ -111,22 +114,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const archiveOrg = useCallback(
     async (orgId: string) => {
-      if (!user?.isPlatformAdmin) {
+      if (!canArchiveOrganization(user?.isPlatformAdmin === true)) {
         throw new Error("Only platform admins can delete organizations.");
       }
 
       await client.archivePlatformOrganization(orgId);
       const { orgs: nextOrgs } = await client.listUserOrgs();
       const nextOrgId = nextOrgIdAfterArchive(nextOrgs, orgId);
-      if (!nextOrgId) {
-        setOrgs(nextOrgs);
-        refreshAuthenticatedQueries();
-        return;
-      }
-
-      const nextUser = await client.setActiveOrg(nextOrgId);
       setOrgs(nextOrgs);
-      setUser(nextUser);
+      if (nextOrgId) {
+        setUser(await client.setActiveOrg(nextOrgId));
+      }
       refreshAuthenticatedQueries();
     },
     [user?.isPlatformAdmin]

--- a/apps/web/src/context/auth-context.tsx
+++ b/apps/web/src/context/auth-context.tsx
@@ -124,6 +124,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setOrgs(nextOrgs);
       if (nextOrgId) {
         setUser(await client.setActiveOrg(nextOrgId));
+      } else {
+        client.setOrgId(null);
       }
       refreshAuthenticatedQueries();
     },

--- a/apps/web/src/lib/org-archive.test.ts
+++ b/apps/web/src/lib/org-archive.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { canArchiveOrganization, nextOrgIdAfterArchive } from "./org-archive";
+
+describe("org archive helpers", () => {
+  test("only platform admins can archive", () => {
+    expect(canArchiveOrganization(true)).toBe(true);
+    expect(canArchiveOrganization(false)).toBe(false);
+  });
+
+  test("picks a remaining org after archive", () => {
+    expect(
+      nextOrgIdAfterArchive([{ id: "org_a" }, { id: "org_b" }], "org_a")
+    ).toBe("org_b");
+  });
+
+  test("returns null when no remaining org exists", () => {
+    expect(nextOrgIdAfterArchive([{ id: "org_a" }], "org_a")).toBeNull();
+  });
+});

--- a/apps/web/src/lib/org-archive.ts
+++ b/apps/web/src/lib/org-archive.ts
@@ -1,0 +1,10 @@
+export function canArchiveOrganization(isPlatformAdmin: boolean): boolean {
+  return isPlatformAdmin;
+}
+
+export function nextOrgIdAfterArchive(
+  orgs: Array<{ id: string }>,
+  archivedOrgId: string
+): string | null {
+  return orgs.find((org) => org.id !== archivedOrgId)?.id ?? null;
+}

--- a/docs/website/content/docs/multi-tenancy.mdx
+++ b/docs/website/content/docs/multi-tenancy.mdx
@@ -34,7 +34,7 @@ For example:
 
 | Actor | Scope | Capabilities |
 |---|---|---|
-| Platform admin | Whole deployment | Create orgs and manage shared system-level bot resources |
+| Platform admin | Whole deployment | Create orgs, remove an org from use, and manage shared system-level bot resources |
 | Org admin | One organization | Invite members and manage roles |
 | Org member | One organization | Chat with profiles and use the workspace |
 | Org viewer | One organization | Read chat history only — no org memory, agent invoke, or mutations |
@@ -67,6 +67,16 @@ Use separate organizations when you want clear separation between:
 - Different privacy boundaries
 
 If one team needs different bots but should still share users and data boundaries, use multiple **profiles** inside one organization instead.
+
+## Remove an organization
+
+A leftover or test organization can stay in the switcher and keep scheduled work running. A **platform admin** can take it out of use from **System → Organization**.
+
+1. Switch into the organization you want to remove
+2. Open **System → Organization**
+3. Confirm **Delete organization**
+
+That hides the organization from the switcher, chat, and workers. Members, profiles, and files stay on disk. The last remaining organization cannot be removed. Org admins cannot do this.
 
 ## Important limitation
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1921,6 +1921,17 @@ export class NakamaClient {
     );
   }
 
+  async archivePlatformOrganization(
+    orgId: string
+  ): Promise<OrganizationResponse> {
+    return this.request<OrganizationResponse>(
+      `/v1/platform/orgs/${encodeURIComponent(orgId)}`,
+      {
+        method: "DELETE",
+      }
+    );
+  }
+
   async setActiveOrg(orgId: string): Promise<AuthUserResponse> {
     const response = await this.request<AuthUserResponse>(
       "/v1/auth/active-org",

--- a/packages/core/src/channel-org.test.ts
+++ b/packages/core/src/channel-org.test.ts
@@ -55,6 +55,21 @@ describe("prepareChannelOrgContext", () => {
     expect(saved).toBe("org_a");
   });
 
+  test("prompts when the stored org is gone and one other remains", async () => {
+    let saved: string | undefined;
+
+    const result = await prepareChannelOrgContext({
+      getSelectedOrgId: () => "org_archived",
+      listOrgs: async () => ({ orgs: [orgs[0]!] }),
+      saveSelectedOrgId: async (orgId) => {
+        saved = orgId;
+      },
+    });
+
+    expect(result.status).toBe("prompt");
+    expect(saved).toBeUndefined();
+  });
+
   test("prompts when multiple orgs and nothing stored", async () => {
     const result = await prepareChannelOrgContext({
       getSelectedOrgId: () => undefined,

--- a/packages/core/src/channel-org.ts
+++ b/packages/core/src/channel-org.ts
@@ -156,7 +156,27 @@ export async function prepareChannelOrgContext(options: {
 
   if (orgs.length === 1) {
     const org = orgs[0];
-    if (options.getSelectedOrgId() !== org.id) {
+    const storedOrgId = options.getSelectedOrgId();
+    if (storedOrgId && storedOrgId !== org.id) {
+      const selectionInput = options.text?.trim();
+      if (selectionInput) {
+        const picked = findOrgBySelectionInput(selectionInput, orgs);
+        if (picked) {
+          await options.saveSelectedOrgId(picked.id);
+          return {
+            justSelected: true,
+            orgId: picked.id,
+            orgName: picked.name,
+            status: "ready",
+          };
+        }
+      }
+      return {
+        message: formatOrgSelectionPrompt(orgs, storedOrgId),
+        status: "prompt",
+      };
+    }
+    if (storedOrgId !== org.id) {
       await options.saveSelectedOrgId(org.id);
     }
     return { orgId: org.id, orgName: org.name, status: "ready" };

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -396,6 +396,7 @@ export type OrgRole = "admin" | "member" | "viewer";
 export type ChannelType = "telegram" | "whatsapp" | "discord";
 
 export interface OrganizationSummary {
+  archivedAt?: string | null;
   createdAt: string;
   id: string;
   name: string;

--- a/packages/db/sql/schema.sql
+++ b/packages/db/sql/schema.sql
@@ -259,6 +259,7 @@ CREATE TABLE IF NOT EXISTS organizations (
   skills_post_turn_review INTEGER NOT NULL DEFAULT 0,
   skills_curator_enabled INTEGER NOT NULL DEFAULT 0,
   skills_curator_last_run_at TEXT,
+  archived_at TEXT,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL
 );

--- a/packages/db/src/adapters/in-memory.ts
+++ b/packages/db/src/adapters/in-memory.ts
@@ -1099,7 +1099,7 @@ export function createInMemoryDatabaseAdapter(): DatabaseAdapter {
         .filter((member) => member.userId === userId)
         .map((member) => {
           const organization = organizations.get(member.orgId);
-          if (!organization) {
+          if (!organization || organization.archivedAt) {
             return null;
           }
 

--- a/packages/db/src/adapters/in-memory.ts
+++ b/packages/db/src/adapters/in-memory.ts
@@ -1192,6 +1192,29 @@ export function createInMemoryDatabaseAdapter(): DatabaseAdapter {
       usersByEmail.set(updated.email, updated);
     },
 
+    async tryMarkOrganizationArchived(orgId, archivedAt) {
+      const activeCount = Array.from(organizations.values()).filter(
+        (organization) => !organization.archivedAt
+      ).length;
+      if (activeCount <= 1) {
+        return false;
+      }
+
+      const organization = organizations.get(orgId);
+      if (!organization || organization.archivedAt) {
+        return false;
+      }
+
+      const updated = {
+        ...organization,
+        archivedAt,
+        updatedAt: archivedAt,
+      };
+      organizations.set(orgId, updated);
+      organizationsBySlug.set(updated.slug, updated);
+      return true;
+    },
+
     async unassignMcpServerFromProfile(profileId, serverId) {
       const assigned = profileMcpServers.get(profileId);
 

--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -2514,35 +2514,14 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
 
     async listUserOrganizations(userId) {
       return listUserOrganizationsStmt.all(userId).map((row) => {
-        const record = row as {
-          id: string;
-          name: string;
-          slug: string;
-          skills_write_approval: number;
-          skills_post_turn_review: number;
-          skills_curator_enabled: number;
-          skills_curator_last_run_at: string | null;
-          archived_at: string | null;
-          created_at: string;
-          updated_at: string;
-          role: string;
+        const record = row as OrganizationRow & {
           joined_at: string;
+          role: string;
         };
 
         return {
           joinedAt: record.joined_at,
-          organization: {
-            archivedAt: record.archived_at,
-            createdAt: record.created_at,
-            id: record.id,
-            name: record.name,
-            skillsCuratorEnabled: record.skills_curator_enabled !== 0,
-            skillsCuratorLastRunAt: record.skills_curator_last_run_at,
-            skillsPostTurnReview: record.skills_post_turn_review !== 0,
-            skillsWriteApproval: record.skills_write_approval !== 0,
-            slug: record.slug,
-            updatedAt: record.updated_at,
-          },
+          organization: toOrganizationRecord(record),
           role: record.role as StoredUserOrganizationRecord["role"],
         };
       });

--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -1218,6 +1218,13 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
     SET active_org_id = ?
     WHERE id = ?
   `);
+  const tryMarkOrganizationArchivedStmt = db.prepare(`
+    UPDATE organizations
+    SET archived_at = ?, updated_at = ?
+    WHERE id = ?
+      AND archived_at IS NULL
+      AND (SELECT COUNT(*) FROM organizations WHERE archived_at IS NULL) > 1
+  `);
   const upsertOrganizationStmt = db.prepare(`
     INSERT INTO organizations (id, name, slug, skills_write_approval, skills_post_turn_review, skills_curator_enabled, skills_curator_last_run_at, archived_at, created_at, updated_at)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -2579,6 +2586,15 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
 
     async setUserContext(orgId, userId, content, _updatedAt) {
       setUserContextStmt.run(content, orgId, userId);
+    },
+
+    async tryMarkOrganizationArchived(orgId, archivedAt) {
+      const result = tryMarkOrganizationArchivedStmt.run(
+        archivedAt,
+        archivedAt,
+        orgId
+      );
+      return result.changes > 0;
     },
 
     async unassignMcpServerFromProfile(profileId, serverId) {

--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -308,6 +308,7 @@ interface BrowserSessionRow {
 }
 
 interface OrganizationRow {
+  archived_at: string | null;
   created_at: string;
   id: string;
   name: string;
@@ -1218,8 +1219,8 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
     WHERE id = ?
   `);
   const upsertOrganizationStmt = db.prepare(`
-    INSERT INTO organizations (id, name, slug, skills_write_approval, skills_post_turn_review, skills_curator_enabled, skills_curator_last_run_at, created_at, updated_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO organizations (id, name, slug, skills_write_approval, skills_post_turn_review, skills_curator_enabled, skills_curator_last_run_at, archived_at, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(id) DO UPDATE SET
       name = excluded.name,
       slug = excluded.slug,
@@ -1227,21 +1228,22 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
       skills_post_turn_review = excluded.skills_post_turn_review,
       skills_curator_enabled = excluded.skills_curator_enabled,
       skills_curator_last_run_at = excluded.skills_curator_last_run_at,
+      archived_at = excluded.archived_at,
       updated_at = excluded.updated_at
   `);
   const listOrganizationsStmt = db.prepare(`
-    SELECT id, name, slug, skills_write_approval, skills_post_turn_review, skills_curator_enabled, skills_curator_last_run_at, created_at, updated_at
+    SELECT id, name, slug, skills_write_approval, skills_post_turn_review, skills_curator_enabled, skills_curator_last_run_at, archived_at, created_at, updated_at
     FROM organizations
     ORDER BY name ASC
   `);
   const getOrganizationBySlugStmt = db.prepare(`
-    SELECT id, name, slug, skills_write_approval, skills_post_turn_review, skills_curator_enabled, skills_curator_last_run_at, created_at, updated_at
+    SELECT id, name, slug, skills_write_approval, skills_post_turn_review, skills_curator_enabled, skills_curator_last_run_at, archived_at, created_at, updated_at
     FROM organizations
     WHERE slug = ?
     LIMIT 1
   `);
   const getOrganizationByIdStmt = db.prepare(`
-    SELECT id, name, slug, skills_write_approval, skills_post_turn_review, skills_curator_enabled, skills_curator_last_run_at, created_at, updated_at
+    SELECT id, name, slug, skills_write_approval, skills_post_turn_review, skills_curator_enabled, skills_curator_last_run_at, archived_at, created_at, updated_at
     FROM organizations
     WHERE id = ?
     LIMIT 1
@@ -1504,6 +1506,7 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
       o.skills_post_turn_review,
       o.skills_curator_enabled,
       o.skills_curator_last_run_at,
+      o.archived_at,
       o.created_at,
       o.updated_at,
       om.role,
@@ -1511,6 +1514,7 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
     FROM org_members om
     INNER JOIN organizations o ON o.id = om.org_id
     WHERE om.user_id = ?
+      AND o.archived_at IS NULL
     ORDER BY o.name ASC
   `);
   const deleteOrgMemberStmt = db.prepare(`
@@ -2518,6 +2522,7 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
           skills_post_turn_review: number;
           skills_curator_enabled: number;
           skills_curator_last_run_at: string | null;
+          archived_at: string | null;
           created_at: string;
           updated_at: string;
           role: string;
@@ -2527,6 +2532,7 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
         return {
           joinedAt: record.joined_at,
           organization: {
+            archivedAt: record.archived_at,
             createdAt: record.created_at,
             id: record.id,
             name: record.name,
@@ -2804,6 +2810,7 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
         record.skillsPostTurnReview ? 1 : 0,
         record.skillsCuratorEnabled ? 1 : 0,
         record.skillsCuratorLastRunAt ?? null,
+        record.archivedAt ?? null,
         record.createdAt,
         record.updatedAt
       );
@@ -3487,6 +3494,7 @@ function toUserRecord(row: UserRow): StoredUserRecord {
 
 function toOrganizationRecord(row: OrganizationRow): StoredOrganizationRecord {
   return {
+    archivedAt: row.archived_at,
     createdAt: row.created_at,
     id: row.id,
     name: row.name,

--- a/packages/db/src/migrate.test.ts
+++ b/packages/db/src/migrate.test.ts
@@ -660,6 +660,40 @@ describe("organization schema migration", () => {
     }
   });
 
+  test("adds archived_at to legacy organizations table", () => {
+    const db = new Database(":memory:");
+
+    try {
+      db.exec(`
+        CREATE TABLE organizations (
+          id TEXT PRIMARY KEY NOT NULL,
+          name TEXT NOT NULL,
+          slug TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        );
+      `);
+      db.exec(`
+        INSERT INTO organizations (id, name, slug, created_at, updated_at)
+        VALUES ('org_legacy', 'Legacy', 'legacy', '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z');
+      `);
+
+      migrateDatabase(db);
+
+      const columns = db
+        .prepare("PRAGMA table_info(organizations)")
+        .all() as Array<{ name: string }>;
+      expect(columns.map((column) => column.name)).toContain("archived_at");
+
+      const row = db
+        .prepare("SELECT archived_at FROM organizations WHERE id = ?")
+        .get("org_legacy") as { archived_at: string | null };
+      expect(row.archived_at).toBeNull();
+    } finally {
+      db.close();
+    }
+  });
+
   test("adds org_id to tenant tables and composite unique indexes", () => {
     const db = new Database(":memory:");
 

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -22,6 +22,7 @@ export function migrateDatabase(db: Database): void {
   migrateSkillsWriteApprovalColumns(db);
   migrateSkillsPostTurnReviewColumns(db);
   migrateSkillsCuratorColumns(db);
+  migrateOrganizationArchivedAt(db);
   migrateSkillUsageTables(db);
   migrateTenantOrgScope(db);
   migrateSkillOrgIds(db);
@@ -555,6 +556,17 @@ function migrateSkillsCuratorColumns(db: Database): void {
     db.exec(
       "ALTER TABLE organizations ADD COLUMN skills_curator_last_run_at TEXT;"
     );
+  }
+}
+
+function migrateOrganizationArchivedAt(db: Database): void {
+  const orgColumns = db
+    .prepare("PRAGMA table_info(organizations)")
+    .all() as Array<{ name: string }>;
+  const names = new Set(orgColumns.map((column) => column.name));
+
+  if (!names.has("archived_at")) {
+    db.exec("ALTER TABLE organizations ADD COLUMN archived_at TEXT;");
   }
 }
 

--- a/packages/db/src/organization-archive.test.ts
+++ b/packages/db/src/organization-archive.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { createInMemoryDatabaseAdapter } from "./adapters/in-memory";
+
+describe("organization archive persistence", () => {
+  test("upsert and get round-trip archivedAt", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const archivedAt = "2026-08-21T00:00:00.000Z";
+
+    await db.upsertOrganization({
+      archivedAt,
+      createdAt: archivedAt,
+      id: "org_archived",
+      name: "Archived",
+      slug: "archived",
+      updatedAt: archivedAt,
+    });
+
+    const loaded = await db.getOrganizationById("org_archived");
+    expect(loaded?.archivedAt).toBe(archivedAt);
+
+    const listed = await db.listOrganizations();
+    expect(listed.some((org) => org.id === "org_archived")).toBe(true);
+  });
+
+  test("listUserOrganizations omits archived orgs and keeps active ones", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const now = "2026-08-21T00:00:00.000Z";
+
+    await db.upsertOrganization({
+      createdAt: now,
+      id: "org_active",
+      name: "Active",
+      slug: "active",
+      updatedAt: now,
+    });
+    await db.upsertOrganization({
+      archivedAt: now,
+      createdAt: now,
+      id: "org_hidden",
+      name: "Hidden",
+      slug: "hidden",
+      updatedAt: now,
+    });
+    await db.upsertOrgMember({
+      createdAt: now,
+      orgId: "org_active",
+      role: "admin",
+      userId: "user_1",
+    });
+    await db.upsertOrgMember({
+      createdAt: now,
+      orgId: "org_hidden",
+      role: "admin",
+      userId: "user_1",
+    });
+
+    const memberships = await db.listUserOrganizations("user_1");
+    expect(memberships.map((membership) => membership.organization.id)).toEqual(
+      ["org_active"]
+    );
+  });
+});

--- a/packages/db/src/organization-archive.test.ts
+++ b/packages/db/src/organization-archive.test.ts
@@ -59,4 +59,41 @@ describe("organization archive persistence", () => {
       ["org_active"]
     );
   });
+
+  test("tryMarkOrganizationArchived refuses the last active org", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const now = "2026-08-21T00:00:00.000Z";
+    await db.upsertOrganization({
+      createdAt: now,
+      id: "org_only",
+      name: "Only",
+      slug: "only",
+      updatedAt: now,
+    });
+
+    expect(await db.tryMarkOrganizationArchived("org_only", now)).toBe(false);
+    expect((await db.getOrganizationById("org_only"))?.archivedAt).toBeFalsy();
+  });
+
+  test("tryMarkOrganizationArchived archives when another org remains", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const now = "2026-08-21T00:00:00.000Z";
+    await db.upsertOrganization({
+      createdAt: now,
+      id: "org_a",
+      name: "A",
+      slug: "a",
+      updatedAt: now,
+    });
+    await db.upsertOrganization({
+      createdAt: now,
+      id: "org_b",
+      name: "B",
+      slug: "b",
+      updatedAt: now,
+    });
+
+    expect(await db.tryMarkOrganizationArchived("org_a", now)).toBe(true);
+    expect((await db.getOrganizationById("org_a"))?.archivedAt).toBe(now);
+  });
 });

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -385,6 +385,7 @@ export interface StoredUserRecord {
 }
 
 export interface StoredOrganizationRecord {
+  archivedAt?: string | null;
   createdAt: string;
   id: string;
   name: string;

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -847,6 +847,11 @@ export interface DatabaseAdapter {
     content: string,
     updatedAt: string
   ): Promise<void>;
+
+  tryMarkOrganizationArchived(
+    orgId: string,
+    archivedAt: string
+  ): Promise<boolean>;
   unassignMcpServerFromProfile(
     profileId: string,
     serverId: string
@@ -920,7 +925,6 @@ export interface DatabaseAdapter {
   upsertNotificationDestination(
     record: StoredNotificationDestinationRecord
   ): Promise<void>;
-
   upsertOrganization(record: StoredOrganizationRecord): Promise<void>;
   upsertOrgMember(record: StoredOrgMemberRecord): Promise<void>;
   upsertProfile(record: StoredProfileRecord): Promise<void>;


### PR DESCRIPTION
## Summary

Platform admins can archive the current org from **System → Organization**. Members, profiles, and on-disk files stay; Nakama cannot restore it.

Org admins cannot archive. The last live org, and a platform admin’s last remaining membership, return 409. Archived orgs drop out of the switcher, org APIs, automations, curator, and notify webhooks. Stale Telegram/Discord/WhatsApp orgs prompt instead of silently rebinding.

## Test plan

- [ ] Platform admin with two orgs: Delete → confirm; switcher lands on the remaining org
- [ ] Org admin does not see Delete
- [ ] Last remaining org (and last remaining membership) returns 409
- [ ] After archive, that org is 404 on org-scoped routes; automations, curator, and `/v1/notify` skip it
- [ ] Telegram/Discord/WhatsApp with a stored archived org prompts instead of hopping tenants

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Cursor](https://img.shields.io/badge/Grok_4.6-000000)
