### PR TITLE
fix(core): isolate discovery-provider helper from node-only modules

### DIFF
--- a/apps/web/src/components/settings/use-provider-instance-card.ts
+++ b/apps/web/src/components/settings/use-provider-instance-card.ts
@@ -3,8 +3,8 @@ import type {
   ProviderModelOption,
   UpdateProviderRequest,
 } from "@nakama/core/contract";
+import { isDiscoveryModelProvider } from "@nakama/core/discovery-providers";
 import { defaultMinimaxBaseUrl } from "@nakama/core/minimax-provider-config";
-import { isDiscoveryModelProvider } from "@nakama/core/provider-resolution";
 import { useMemo, useState } from "react";
 import { isCatalogShortlistProvider } from "@/components/catalog-provider-model-fields.shared";
 import type { ModelListRow } from "@/components/ModelListEditor";

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,7 @@
     "./cloudflare-provider-config": "./src/cloudflare-provider-config.ts",
     "./minimax-provider-config": "./src/minimax-provider-config.ts",
     "./ollama-provider-config": "./src/ollama-provider-config.ts",
+    "./discovery-providers": "./src/discovery-providers.ts",
     "./provider-inference": "./src/provider-inference.ts",
     "./provider-label": "./src/provider-label.ts",
     "./provider-resolution": "./src/provider-resolution.ts",

--- a/packages/core/src/discovery-providers.ts
+++ b/packages/core/src/discovery-providers.ts
@@ -1,0 +1,12 @@
+import type { ProviderName } from "./contract";
+
+// Providers whose model lists are discovered live from the platform's
+// /models endpoint and stored as instance custom models, instead of a
+// hardcoded catalog. Adding a discovery-based provider is one entry here
+// plus its type/env-key/label/base-URL wiring — no resolution edits.
+export const DISCOVERY_MODEL_PROVIDERS: ReadonlySet<ProviderName> =
+  new Set<ProviderName>(["openai_compatible", "minimax", "minimax_cn"]);
+
+export function isDiscoveryModelProvider(provider: ProviderName): boolean {
+  return DISCOVERY_MODEL_PROVIDERS.has(provider);
+}

--- a/packages/core/src/provider-resolution.ts
+++ b/packages/core/src/provider-resolution.ts
@@ -20,16 +20,10 @@ export const USER_PROVIDER_NAMES: readonly UserProviderName[] = [
   "minimax_cn",
 ] as const;
 
-// Providers whose model lists are discovered live from the platform's
-// /models endpoint and stored as instance custom models, instead of a
-// hardcoded catalog. Adding a discovery-based provider is one entry here
-// plus its type/env-key/label/base-URL wiring — no resolution edits.
-export const DISCOVERY_MODEL_PROVIDERS: ReadonlySet<UserProviderName> =
-  new Set<UserProviderName>(["openai_compatible", "minimax", "minimax_cn"]);
-
-export function isDiscoveryModelProvider(provider: UserProviderName): boolean {
-  return DISCOVERY_MODEL_PROVIDERS.has(provider);
-}
+export {
+  DISCOVERY_MODEL_PROVIDERS,
+  isDiscoveryModelProvider,
+} from "./discovery-providers";
 
 export function parseProviderName(
   value: string | undefined


### PR DESCRIPTION
## Problem

`main` is red on the Docker Publish job. The web-builder stage fails with:

```
../../packages/core/src/fs.ts (3:2): "access" is not exported by "__vite-browser-external", imported by "../../packages/core/src/fs.ts".
```

The MiniMax integration added a runtime import in the web settings card:

```ts
import { isDiscoveryModelProvider } from "@nakama/core/provider-resolution";
```

`provider-resolution.ts` imports `readEnvValue` from `./config`, and `config.ts` re-exports `./runtime` and `./user-config` — both Node-only modules that import `node:fs` / `node:os` / `node:path`. That drags `fs.ts` into the Vite browser bundle, and its named import `access` from `node:fs/promises` has no browser stub.

## Fix

Move `DISCOVERY_MODEL_PROVIDERS` and `isDiscoveryModelProvider` into a new browser-safe module `packages/core/src/discovery-providers.ts` that only type-imports from `./contract`.

- `provider-resolution.ts` re-exports both, so server (`apps/server/src/providers/models.ts`) and test imports keep working unchanged.
- `use-provider-instance-card.ts` now imports from `@nakama/core/discovery-providers`.
- Added the `./discovery-providers` subpath to `packages/core/package.json` exports.

## Verification

- `bun run --filter @nakama/web build` — passes, no `node:fs` / `__vite-browser-external` error.
- `bun test packages/core/src/provider-resolution.test.ts` — 13 pass, 0 fail.
- Full `docker buildx build --load --platform=linux/amd64` — builds and exports the image.
- `ultracite check` — clean.

## Risk

Low. Any future *runtime* import of `@nakama/core/provider-resolution` in web code would reintroduce the same Node drag via `./config`; worth a follow-up to split the node-only `config.ts` re-exports from `readEnvValue`.