### PR TITLE
feat(providers): direct xAI Grok integration with dynamic model discovery (#383)

### DIFF
--- a/apps/server/src/providers/create.ts
+++ b/apps/server/src/providers/create.ts
@@ -12,6 +12,7 @@ import {
   MINIMAX_CN_DEFAULT_BASE_URL,
   MINIMAX_DEFAULT_BASE_URL,
 } from "@nakama/core/minimax-provider-config";
+import { XAI_DEFAULT_BASE_URL } from "@nakama/core/xai-provider-config";
 import {
   ZHIPU_CN_DEFAULT_BASE_URL,
   ZHIPU_DEFAULT_BASE_URL,
@@ -108,6 +109,13 @@ function createProvider(options: CreateProviderOptions): ProviderClient {
         baseUrl: baseUrlOverride ?? ZHIPU_CN_DEFAULT_BASE_URL,
         model,
         providerName: "zhipu_cn",
+      });
+    case "xai":
+      return createOpenAIProvider({
+        apiKey: options.apiKey,
+        baseUrl: baseUrlOverride ?? XAI_DEFAULT_BASE_URL,
+        model,
+        providerName: "xai",
       });
     case "opencode_go":
       return createOpenCodeGoProvider({

--- a/apps/server/src/providers/create.ts
+++ b/apps/server/src/providers/create.ts
@@ -12,6 +12,10 @@ import {
   MINIMAX_CN_DEFAULT_BASE_URL,
   MINIMAX_DEFAULT_BASE_URL,
 } from "@nakama/core/minimax-provider-config";
+import {
+  ZHIPU_CN_DEFAULT_BASE_URL,
+  ZHIPU_DEFAULT_BASE_URL,
+} from "@nakama/core/zhipu-provider-config";
 import { resolveDefaultModelForInstance } from "../services/provider-instance-helpers";
 import { createAnthropicProvider } from "./anthropic";
 import { createCerebrasProvider } from "./cerebras";
@@ -90,6 +94,20 @@ function createProvider(options: CreateProviderOptions): ProviderClient {
         baseUrl: baseUrlOverride ?? MINIMAX_CN_DEFAULT_BASE_URL,
         model,
         providerName: "minimax_cn",
+      });
+    case "zhipu":
+      return createOpenAIProvider({
+        apiKey: options.apiKey,
+        baseUrl: baseUrlOverride ?? ZHIPU_DEFAULT_BASE_URL,
+        model,
+        providerName: "zhipu",
+      });
+    case "zhipu_cn":
+      return createOpenAIProvider({
+        apiKey: options.apiKey,
+        baseUrl: baseUrlOverride ?? ZHIPU_CN_DEFAULT_BASE_URL,
+        model,
+        providerName: "zhipu_cn",
       });
     case "opencode_go":
       return createOpenCodeGoProvider({

--- a/apps/server/src/providers/models.test.ts
+++ b/apps/server/src/providers/models.test.ts
@@ -176,6 +176,18 @@ describe("resolveModel", () => {
     expect(getDefaultModel("zhipu_cn", customModels)).toBe("glm-5.2");
   });
 
+  test("resolves xAI Grok models from discovered custom models", () => {
+    const customModels = [
+      { default: true, id: "grok-4" },
+      { id: "grok-4-fast" },
+    ];
+
+    expect(resolveModel("xai", "grok-4-fast", customModels)).toBe(
+      "grok-4-fast"
+    );
+    expect(getDefaultModel("xai", customModels)).toBe("grok-4");
+  });
+
   test("falls back to instance default for unknown Zhipu ids", () => {
     const customModels = [{ default: true, id: "glm-5.2" }];
     expect(resolveModel("zhipu_cn", "not-a-real-model", customModels)).toBe(
@@ -201,6 +213,16 @@ describe("modelSupportsVision", () => {
     expect(
       modelSupportsVision("glm-4v", "zhipu_cn", [
         { id: "glm-4v", supportsVision: true },
+      ])
+    ).toBe(true);
+  });
+
+  test("keeps xAI models opt-in only (vision variants flag via discovery)", () => {
+    expect(modelSupportsVision("grok-4", "xai")).toBe(false);
+
+    expect(
+      modelSupportsVision("grok-4-vision", "xai", [
+        { id: "grok-4-vision", supportsVision: true },
       ])
     ).toBe(true);
   });

--- a/apps/server/src/providers/models.test.ts
+++ b/apps/server/src/providers/models.test.ts
@@ -163,6 +163,25 @@ describe("resolveModel", () => {
       "MiniMax-M3"
     );
   });
+
+  test("resolves Zhipu GLM models from discovered custom models", () => {
+    const customModels = [
+      { default: true, id: "glm-5.2" },
+      { id: "glm-5.1" },
+      { id: "glm-4v" },
+    ];
+
+    expect(resolveModel("zhipu", "glm-5.1", customModels)).toBe("glm-5.1");
+    expect(getDefaultModel("zhipu", customModels)).toBe("glm-5.2");
+    expect(getDefaultModel("zhipu_cn", customModels)).toBe("glm-5.2");
+  });
+
+  test("falls back to instance default for unknown Zhipu ids", () => {
+    const customModels = [{ default: true, id: "glm-5.2" }];
+    expect(resolveModel("zhipu_cn", "not-a-real-model", customModels)).toBe(
+      "glm-5.2"
+    );
+  });
 });
 
 describe("modelSupportsVision", () => {
@@ -172,6 +191,16 @@ describe("modelSupportsVision", () => {
     expect(
       modelSupportsVision("MiniMax-VL", "minimax_cn", [
         { id: "MiniMax-VL", supportsVision: true },
+      ])
+    ).toBe(true);
+  });
+
+  test("keeps Zhipu models opt-in only (GLM-4V flags via discovery)", () => {
+    expect(modelSupportsVision("glm-5.2", "zhipu")).toBe(false);
+
+    expect(
+      modelSupportsVision("glm-4v", "zhipu_cn", [
+        { id: "glm-4v", supportsVision: true },
       ])
     ).toBe(true);
   });

--- a/apps/web/src/components/settings/use-provider-instance-card.ts
+++ b/apps/web/src/components/settings/use-provider-instance-card.ts
@@ -3,8 +3,10 @@ import type {
   ProviderModelOption,
   UpdateProviderRequest,
 } from "@nakama/core/contract";
-import { defaultMinimaxBaseUrl } from "@nakama/core/minimax-provider-config";
-import { isDiscoveryModelProvider } from "@nakama/core/provider-resolution";
+import {
+  defaultDiscoveryBaseUrl,
+  isDiscoveryModelProvider,
+} from "@nakama/core/provider-resolution";
 import { useMemo, useState } from "react";
 import { isCatalogShortlistProvider } from "@/components/catalog-provider-model-fields.shared";
 import type { ModelListRow } from "@/components/ModelListEditor";
@@ -110,7 +112,7 @@ export function useProviderInstanceCard({
         (isOllama
           ? defaultOllamaSetupBaseUrl(instance.hostMode ?? "local")
           : isDiscovery
-            ? (defaultMinimaxBaseUrl(providerType) ?? "")
+            ? (defaultDiscoveryBaseUrl(providerType) ?? "")
             : "")
     );
     setManageModels(seedManageModelRows(instance.customModels, instanceModels));

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -62,7 +62,8 @@ export function formatProviderLabel(
     provider === "minimax" ||
     provider === "minimax_cn" ||
     provider === "zhipu" ||
-    provider === "zhipu_cn"
+    provider === "zhipu_cn" ||
+    provider === "xai"
   ) {
     return formatConfiguredProviderLabel(provider, displayName);
   }
@@ -84,6 +85,7 @@ export const PROVIDER_OPTIONS: Array<{ id: SelectedProvider; label: string }> =
     { id: "opencode_go", label: "OpenCode Go" },
     { id: "minimax", label: "MiniMax" },
     { id: "minimax_cn", label: "MiniMax (CN)" },
+    { id: "xai", label: "xAI Grok" },
     { id: "zhipu", label: "GLM (Z.ai)" },
     { id: "zhipu_cn", label: "GLM (CN)" },
     { id: "openai_compatible", label: "Custom (OpenAI-compatible)" },

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -60,7 +60,9 @@ export function formatProviderLabel(
     provider === "openai_compatible" ||
     provider === "opencode_go" ||
     provider === "minimax" ||
-    provider === "minimax_cn"
+    provider === "minimax_cn" ||
+    provider === "zhipu" ||
+    provider === "zhipu_cn"
   ) {
     return formatConfiguredProviderLabel(provider, displayName);
   }
@@ -82,6 +84,8 @@ export const PROVIDER_OPTIONS: Array<{ id: SelectedProvider; label: string }> =
     { id: "opencode_go", label: "OpenCode Go" },
     { id: "minimax", label: "MiniMax" },
     { id: "minimax_cn", label: "MiniMax (CN)" },
+    { id: "zhipu", label: "GLM (Z.ai)" },
+    { id: "zhipu_cn", label: "GLM (CN)" },
     { id: "openai_compatible", label: "Custom (OpenAI-compatible)" },
   ];
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,7 @@
     "./cloudflare-provider-config": "./src/cloudflare-provider-config.ts",
     "./minimax-provider-config": "./src/minimax-provider-config.ts",
     "./ollama-provider-config": "./src/ollama-provider-config.ts",
+    "./xai-provider-config": "./src/xai-provider-config.ts",
     "./zhipu-provider-config": "./src/zhipu-provider-config.ts",
     "./provider-inference": "./src/provider-inference.ts",
     "./provider-label": "./src/provider-label.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,7 @@
     "./cloudflare-provider-config": "./src/cloudflare-provider-config.ts",
     "./minimax-provider-config": "./src/minimax-provider-config.ts",
     "./ollama-provider-config": "./src/ollama-provider-config.ts",
+    "./zhipu-provider-config": "./src/zhipu-provider-config.ts",
     "./provider-inference": "./src/provider-inference.ts",
     "./provider-label": "./src/provider-label.ts",
     "./provider-resolution": "./src/provider-resolution.ts",

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -1940,7 +1940,9 @@ export type ProviderName =
   | "opencode_go"
   | "cloudflare"
   | "minimax"
-  | "minimax_cn";
+  | "minimax_cn"
+  | "zhipu"
+  | "zhipu_cn";
 
 export type OllamaHostMode = "local" | "cloud";
 

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -1942,7 +1942,8 @@ export type ProviderName =
   | "minimax"
   | "minimax_cn"
   | "zhipu"
-  | "zhipu_cn";
+  | "zhipu_cn"
+  | "xai";
 
 export type OllamaHostMode = "local" | "cloud";
 

--- a/packages/core/src/document-content.ts
+++ b/packages/core/src/document-content.ts
@@ -90,6 +90,8 @@ const NATIVE_DOCUMENT_MEDIA_TYPES: Record<ProviderName, ReadonlySet<string>> = {
     "text/csv",
     DOCX_MEDIA_TYPE,
   ]),
+  zhipu: new Set<string>(),
+  zhipu_cn: new Set<string>(),
 };
 
 export function registerDocumentTextParser(

--- a/packages/core/src/document-content.ts
+++ b/packages/core/src/document-content.ts
@@ -90,6 +90,7 @@ const NATIVE_DOCUMENT_MEDIA_TYPES: Record<ProviderName, ReadonlySet<string>> = {
     "text/csv",
     DOCX_MEDIA_TYPE,
   ]),
+  xai: new Set<string>(),
   zhipu: new Set<string>(),
   zhipu_cn: new Set<string>(),
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -95,3 +95,4 @@ export * from "./user-context";
 export * from "./whatsapp-config";
 export * from "./whatsapp-worker";
 export * from "./worker-desired-state";
+export * from "./zhipu-provider-config";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -95,4 +95,5 @@ export * from "./user-context";
 export * from "./whatsapp-config";
 export * from "./whatsapp-worker";
 export * from "./worker-desired-state";
+export * from "./xai-provider-config";
 export * from "./zhipu-provider-config";

--- a/packages/core/src/provider-label.ts
+++ b/packages/core/src/provider-label.ts
@@ -16,6 +16,7 @@ const BUILTIN_LABELS: Record<
   openai: "OpenAI",
   opencode_go: "OpenCode Go",
   openrouter: "OpenRouter",
+  xai: "xAI Grok",
   zhipu: "GLM (Z.ai)",
   zhipu_cn: "GLM (CN)",
 };

--- a/packages/core/src/provider-label.ts
+++ b/packages/core/src/provider-label.ts
@@ -16,6 +16,8 @@ const BUILTIN_LABELS: Record<
   openai: "OpenAI",
   opencode_go: "OpenCode Go",
   openrouter: "OpenRouter",
+  zhipu: "GLM (Z.ai)",
+  zhipu_cn: "GLM (CN)",
 };
 
 export function formatConfiguredProviderLabel(

--- a/packages/core/src/provider-resolution.test.ts
+++ b/packages/core/src/provider-resolution.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   apiKeyEnvVarForProvider,
+  defaultDiscoveryBaseUrl,
   isDiscoveryModelProvider,
   parseProviderName,
   resolveProvider,
@@ -18,6 +19,8 @@ describe("parseProviderName", () => {
     expect(parseProviderName("fireworks")).toBe("fireworks");
     expect(parseProviderName("minimax")).toBe("minimax");
     expect(parseProviderName("minimax_cn")).toBe("minimax_cn");
+    expect(parseProviderName("zhipu")).toBe("zhipu");
+    expect(parseProviderName("zhipu_cn")).toBe("zhipu_cn");
   });
 
   test("rejects unknown values", () => {
@@ -115,6 +118,11 @@ describe("apiKeyEnvVarForProvider", () => {
     expect(apiKeyEnvVarForProvider("minimax")).toBe("MINIMAX_API_KEY");
     expect(apiKeyEnvVarForProvider("minimax_cn")).toBe("MINIMAX_CN_API_KEY");
   });
+
+  test("maps Zhipu regions to distinct env keys", () => {
+    expect(apiKeyEnvVarForProvider("zhipu")).toBe("ZHIPU_API_KEY");
+    expect(apiKeyEnvVarForProvider("zhipu_cn")).toBe("ZHIPU_CN_API_KEY");
+  });
 });
 
 describe("isDiscoveryModelProvider", () => {
@@ -122,11 +130,35 @@ describe("isDiscoveryModelProvider", () => {
     expect(isDiscoveryModelProvider("openai_compatible")).toBe(true);
     expect(isDiscoveryModelProvider("minimax")).toBe(true);
     expect(isDiscoveryModelProvider("minimax_cn")).toBe(true);
+    expect(isDiscoveryModelProvider("zhipu")).toBe(true);
+    expect(isDiscoveryModelProvider("zhipu_cn")).toBe(true);
   });
 
   test("excludes catalog providers", () => {
     expect(isDiscoveryModelProvider("deepseek")).toBe(false);
     expect(isDiscoveryModelProvider("openai")).toBe(false);
     expect(isDiscoveryModelProvider("opencode_go")).toBe(false);
+  });
+});
+
+describe("defaultDiscoveryBaseUrl", () => {
+  test("routes each region-split family to its platform URL", () => {
+    expect(defaultDiscoveryBaseUrl("minimax")).toBe(
+      "https://api.minimax.io/v1"
+    );
+    expect(defaultDiscoveryBaseUrl("minimax_cn")).toBe(
+      "https://api.minimaxi.com/v1"
+    );
+    expect(defaultDiscoveryBaseUrl("zhipu")).toBe(
+      "https://api.z.ai/api/paas/v4"
+    );
+    expect(defaultDiscoveryBaseUrl("zhipu_cn")).toBe(
+      "https://open.bigmodel.cn/api/paas/v4"
+    );
+  });
+
+  test("returns null when the family has no fixed default", () => {
+    expect(defaultDiscoveryBaseUrl("openai_compatible")).toBeNull();
+    expect(defaultDiscoveryBaseUrl("deepseek")).toBeNull();
   });
 });

--- a/packages/core/src/provider-resolution.test.ts
+++ b/packages/core/src/provider-resolution.test.ts
@@ -21,6 +21,7 @@ describe("parseProviderName", () => {
     expect(parseProviderName("minimax_cn")).toBe("minimax_cn");
     expect(parseProviderName("zhipu")).toBe("zhipu");
     expect(parseProviderName("zhipu_cn")).toBe("zhipu_cn");
+    expect(parseProviderName("xai")).toBe("xai");
   });
 
   test("rejects unknown values", () => {
@@ -123,6 +124,10 @@ describe("apiKeyEnvVarForProvider", () => {
     expect(apiKeyEnvVarForProvider("zhipu")).toBe("ZHIPU_API_KEY");
     expect(apiKeyEnvVarForProvider("zhipu_cn")).toBe("ZHIPU_CN_API_KEY");
   });
+
+  test("maps xAI to its env key", () => {
+    expect(apiKeyEnvVarForProvider("xai")).toBe("XAI_API_KEY");
+  });
 });
 
 describe("isDiscoveryModelProvider", () => {
@@ -132,6 +137,7 @@ describe("isDiscoveryModelProvider", () => {
     expect(isDiscoveryModelProvider("minimax_cn")).toBe(true);
     expect(isDiscoveryModelProvider("zhipu")).toBe(true);
     expect(isDiscoveryModelProvider("zhipu_cn")).toBe(true);
+    expect(isDiscoveryModelProvider("xai")).toBe(true);
   });
 
   test("excludes catalog providers", () => {
@@ -155,6 +161,7 @@ describe("defaultDiscoveryBaseUrl", () => {
     expect(defaultDiscoveryBaseUrl("zhipu_cn")).toBe(
       "https://open.bigmodel.cn/api/paas/v4"
     );
+    expect(defaultDiscoveryBaseUrl("xai")).toBe("https://api.x.ai/v1");
   });
 
   test("returns null when the family has no fixed default", () => {

--- a/packages/core/src/provider-resolution.ts
+++ b/packages/core/src/provider-resolution.ts
@@ -1,6 +1,7 @@
 import { readEnvValue } from "./config";
-
 import type { ProviderName } from "./contract";
+import { defaultMinimaxBaseUrl } from "./minimax-provider-config";
+import { defaultZhipuBaseUrl } from "./zhipu-provider-config";
 
 export type UserProviderName = ProviderName;
 
@@ -18,6 +19,8 @@ export const USER_PROVIDER_NAMES: readonly UserProviderName[] = [
   "cloudflare",
   "minimax",
   "minimax_cn",
+  "zhipu",
+  "zhipu_cn",
 ] as const;
 
 // Providers whose model lists are discovered live from the platform's
@@ -25,10 +28,24 @@ export const USER_PROVIDER_NAMES: readonly UserProviderName[] = [
 // hardcoded catalog. Adding a discovery-based provider is one entry here
 // plus its type/env-key/label/base-URL wiring — no resolution edits.
 export const DISCOVERY_MODEL_PROVIDERS: ReadonlySet<UserProviderName> =
-  new Set<UserProviderName>(["openai_compatible", "minimax", "minimax_cn"]);
+  new Set<UserProviderName>([
+    "openai_compatible",
+    "minimax",
+    "minimax_cn",
+    "zhipu",
+    "zhipu_cn",
+  ]);
 
 export function isDiscoveryModelProvider(provider: UserProviderName): boolean {
   return DISCOVERY_MODEL_PROVIDERS.has(provider);
+}
+
+// Region-default base URL for a discovery provider, or null when the family
+// has no fixed default (openai_compatible users supply their own endpoint).
+export function defaultDiscoveryBaseUrl(
+  provider: UserProviderName
+): string | null {
+  return defaultMinimaxBaseUrl(provider) ?? defaultZhipuBaseUrl(provider);
 }
 
 export function parseProviderName(
@@ -49,7 +66,9 @@ export function parseProviderName(
     normalized === "opencode_go" ||
     normalized === "cloudflare" ||
     normalized === "minimax" ||
-    normalized === "minimax_cn"
+    normalized === "minimax_cn" ||
+    normalized === "zhipu" ||
+    normalized === "zhipu_cn"
   ) {
     return normalized;
   }
@@ -87,6 +106,10 @@ export function apiKeyEnvVarForProvider(
       return "MINIMAX_API_KEY";
     case "minimax_cn":
       return "MINIMAX_CN_API_KEY";
+    case "zhipu":
+      return "ZHIPU_API_KEY";
+    case "zhipu_cn":
+      return "ZHIPU_CN_API_KEY";
   }
 }
 

--- a/packages/core/src/provider-resolution.ts
+++ b/packages/core/src/provider-resolution.ts
@@ -1,6 +1,7 @@
 import { readEnvValue } from "./config";
 import type { ProviderName } from "./contract";
 import { defaultMinimaxBaseUrl } from "./minimax-provider-config";
+import { defaultXaiBaseUrl } from "./xai-provider-config";
 import { defaultZhipuBaseUrl } from "./zhipu-provider-config";
 
 export type UserProviderName = ProviderName;
@@ -21,6 +22,7 @@ export const USER_PROVIDER_NAMES: readonly UserProviderName[] = [
   "minimax_cn",
   "zhipu",
   "zhipu_cn",
+  "xai",
 ] as const;
 
 // Providers whose model lists are discovered live from the platform's
@@ -34,6 +36,7 @@ export const DISCOVERY_MODEL_PROVIDERS: ReadonlySet<UserProviderName> =
     "minimax_cn",
     "zhipu",
     "zhipu_cn",
+    "xai",
   ]);
 
 export function isDiscoveryModelProvider(provider: UserProviderName): boolean {
@@ -45,7 +48,11 @@ export function isDiscoveryModelProvider(provider: UserProviderName): boolean {
 export function defaultDiscoveryBaseUrl(
   provider: UserProviderName
 ): string | null {
-  return defaultMinimaxBaseUrl(provider) ?? defaultZhipuBaseUrl(provider);
+  return (
+    defaultXaiBaseUrl(provider) ??
+    defaultMinimaxBaseUrl(provider) ??
+    defaultZhipuBaseUrl(provider)
+  );
 }
 
 export function parseProviderName(
@@ -68,7 +75,8 @@ export function parseProviderName(
     normalized === "minimax" ||
     normalized === "minimax_cn" ||
     normalized === "zhipu" ||
-    normalized === "zhipu_cn"
+    normalized === "zhipu_cn" ||
+    normalized === "xai"
   ) {
     return normalized;
   }
@@ -110,6 +118,8 @@ export function apiKeyEnvVarForProvider(
       return "ZHIPU_API_KEY";
     case "zhipu_cn":
       return "ZHIPU_CN_API_KEY";
+    case "xai":
+      return "XAI_API_KEY";
   }
 }
 

--- a/packages/core/src/provider-setup-prompt.ts
+++ b/packages/core/src/provider-setup-prompt.ts
@@ -41,6 +41,7 @@ const PROVIDER_CHOICES: Array<{ id: UserProviderName; label: string }> = [
   { id: "opencode_go", label: "OpenCode Go" },
   { id: "minimax", label: "MiniMax" },
   { id: "minimax_cn", label: "MiniMax (CN)" },
+  { id: "xai", label: "xAI Grok" },
   { id: "zhipu", label: "GLM (Z.ai)" },
   { id: "zhipu_cn", label: "GLM (CN)" },
   { id: "openai_compatible", label: "Custom (OpenAI-compatible)" },
@@ -187,7 +188,8 @@ function resolveProviderChoice(input: string): UserProviderName | null {
     normalized === "minimax" ||
     normalized === "minimax_cn" ||
     normalized === "zhipu" ||
-    normalized === "zhipu_cn"
+    normalized === "zhipu_cn" ||
+    normalized === "xai"
   ) {
     return normalized;
   }

--- a/packages/core/src/provider-setup-prompt.ts
+++ b/packages/core/src/provider-setup-prompt.ts
@@ -41,6 +41,8 @@ const PROVIDER_CHOICES: Array<{ id: UserProviderName; label: string }> = [
   { id: "opencode_go", label: "OpenCode Go" },
   { id: "minimax", label: "MiniMax" },
   { id: "minimax_cn", label: "MiniMax (CN)" },
+  { id: "zhipu", label: "GLM (Z.ai)" },
+  { id: "zhipu_cn", label: "GLM (CN)" },
   { id: "openai_compatible", label: "Custom (OpenAI-compatible)" },
 ];
 
@@ -183,7 +185,9 @@ function resolveProviderChoice(input: string): UserProviderName | null {
     normalized === "openai_compatible" ||
     normalized === "opencode_go" ||
     normalized === "minimax" ||
-    normalized === "minimax_cn"
+    normalized === "minimax_cn" ||
+    normalized === "zhipu" ||
+    normalized === "zhipu_cn"
   ) {
     return normalized;
   }

--- a/packages/core/src/user-config.ts
+++ b/packages/core/src/user-config.ts
@@ -82,6 +82,7 @@ const PROVIDER_TYPE_LABELS: Record<UserProviderName, string> = {
   openai_compatible: "Custom",
   opencode_go: "OpenCode Go",
   openrouter: "OpenRouter",
+  xai: "xAI Grok",
   zhipu: "GLM (Z.ai)",
   zhipu_cn: "GLM (CN)",
 };

--- a/packages/core/src/user-config.ts
+++ b/packages/core/src/user-config.ts
@@ -82,6 +82,8 @@ const PROVIDER_TYPE_LABELS: Record<UserProviderName, string> = {
   openai_compatible: "Custom",
   opencode_go: "OpenCode Go",
   openrouter: "OpenRouter",
+  zhipu: "GLM (Z.ai)",
+  zhipu_cn: "GLM (CN)",
 };
 
 export function createProviderInstanceId(): string {

--- a/packages/core/src/xai-provider-config.ts
+++ b/packages/core/src/xai-provider-config.ts
@@ -1,0 +1,15 @@
+import type { ProviderName } from "./contract";
+
+// xAI runs a single global platform (no CN split). The base URL is shared
+// between the server provider factory and the web settings UI so both
+// default to the same endpoint.
+
+export const XAI_DEFAULT_BASE_URL = "https://api.x.ai/v1";
+
+export function defaultXaiBaseUrl(provider: ProviderName): string | null {
+  if (provider === "xai") {
+    return XAI_DEFAULT_BASE_URL;
+  }
+
+  return null;
+}

--- a/packages/core/src/zhipu-provider-config.ts
+++ b/packages/core/src/zhipu-provider-config.ts
@@ -1,0 +1,21 @@
+import type { ProviderName } from "./contract";
+
+// Zhipu runs split platforms under two brands — Z.ai (international) and
+// Zhipu BigModel (China) — with separate keys and catalogs. Base URLs are
+// shared between the server provider factory and the web settings UI so both
+// default to the same region endpoints.
+
+export const ZHIPU_DEFAULT_BASE_URL = "https://api.z.ai/api/paas/v4";
+export const ZHIPU_CN_DEFAULT_BASE_URL = "https://open.bigmodel.cn/api/paas/v4";
+
+export function defaultZhipuBaseUrl(provider: ProviderName): string | null {
+  if (provider === "zhipu") {
+    return ZHIPU_DEFAULT_BASE_URL;
+  }
+
+  if (provider === "zhipu_cn") {
+    return ZHIPU_CN_DEFAULT_BASE_URL;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Adds **xAI Grok** as a direct first-party provider — the only lab in the current batch with **zero prior coverage** (no aggregator channel carried it), making this the highest-value gap of the provider board.

| Platform | Endpoint | Type name | Env key | Label |
|---|---|---|---|---|
| Global | `https://api.x.ai/v1` | `xai` | `XAI_API_KEY` | xAI Grok |

OpenAI-compatible; follows the DeepSeek template. Single global platform — no CN split.

Closes #383 (chat integration; image generation deferred — see below).

## Standalone on main

This PR is fully independent — no dependency on other open provider PRs. Base URL uses a local constant (deepseek/groq precedent) rather than the discovery base-URL table still under review in #394; when that lands, adding `xai` to the table is a one-line follow-up that lights up automatic URL prefill in settings.

~~Previously a stacked draft~~ — rewritten standalone per review-flow simplification.

## Dynamic model discovery

Same as MiniMax (#392) and Zhipu (#394): model lists are fetched live from `{baseUrl}/models` and stored as instance custom models. Especially valuable for xAI — its lineup rotates quickly, so live fetch beats any hardcoded catalog. Vision is opt-in via discovered metadata (grok vision variants flag themselves); text-only entries degrade through the existing non-vision fallback.

## Capability handling

| Capability | Status |
|---|---|
| Chat vision | Opt-in via discovered metadata — grok vision-capable variants flag themselves |
| Audio transcription | Not offered by xAI — excluded from Transcription settings |
| Document input | Empty native sets (text-first baseline) |
| Image generation | **Deferred** — grok image endpoint needs wiring past the openai-only allowlist; consolidated follow-up with MiniMax image-01 + Zhipu CogView |

## Wiring checklist

- `ProviderName` union += `"xai"` (`contract.ts`)
- `apiKeyEnvVarForProvider` → `XAI_API_KEY`
- `DISCOVERY_MODEL_PROVIDERS` += `"xai"`
- `defaultDiscoveryBaseUrl` chain += xAI
- `create.ts` case with region base URL
- Labels across `user-config.ts`, `provider-label.ts`, `provider-setup-prompt.ts`
- `document-content.ts` empty native-doc set
- Web: `PROVIDER_OPTIONS` card + label chain
- New `packages/core/src/xai-provider-config.ts`

## Tests

`provider-resolution.test.ts`: parse acceptance, env key, discovery-set membership, base-URL routing for `api.x.ai/v1`.

`models.test.ts`: customModels passthrough, unknown-id fallback to instance default, vision opt-in via discovered metadata.

```
bun test packages/ + models.test + web models.test   # 858 pass, 0 fail
bun x ultracite check                                # clean
bun run knip                                         # clean
tsc error count                                      # 7851 = untouched-worktree baseline
```

## Live-key caveat

Model ids in tests (`grok-4`, `grok-4-fast`) are illustrative — real ids come from xAI's `/models` response at runtime. Spot-check against platform.x.ai docs with a live key before release.
