### PR TITLE
fix(auth): require platform admin to rotate local auth token (#370)

### DIFF
--- a/apps/server/src/http/app.test.ts
+++ b/apps/server/src/http/app.test.ts
@@ -549,6 +549,71 @@ describe("createHonoApp", () => {
     }
   });
 
+  test("rejects local auth token rotation for non-platform-admin browser sessions", async () => {
+    const configDir = await mkdtemp(
+      join(tmpdir(), "nakama-rotate-auth-member-")
+    );
+    process.env.NAKAMA_CONFIG_DIR = configDir;
+
+    try {
+      const options = createServerOptions();
+      const app = createHonoApp(options);
+      const setupResponse = await app.fetch(
+        new Request("http://localhost:4310/v1/auth/setup", {
+          body: JSON.stringify(
+            buildSetupAuthBody("admin@example.com", {
+              admin: { password: "secret123" },
+            })
+          ),
+          headers: { "Content-Type": "application/json" },
+          method: "POST",
+        })
+      );
+      expect(setupResponse.status).toBe(201);
+      const orgId = await seedOrgForUser(
+        options.databaseAdapter,
+        "admin@example.com"
+      );
+
+      const now = new Date().toISOString();
+      await options.databaseAdapter.createUser({
+        createdAt: now,
+        email: "member@example.com",
+        id: "user_member_rotate",
+        passwordHash: await options.authService.hashPassword("secret123"),
+        updatedAt: now,
+      });
+      await options.databaseAdapter.upsertOrgMember({
+        createdAt: now,
+        orgId,
+        role: "member",
+        userId: "user_member_rotate",
+      });
+
+      const member = await loginUserSession(
+        app,
+        "member@example.com",
+        "secret123",
+        orgId
+      );
+
+      const rotateResponse = await app.fetch(
+        new Request("http://localhost:4310/v1/auth/local-token/rotate", {
+          headers: member.headers({ "X-CSRF-Token": member.csrfToken }),
+          method: "POST",
+        })
+      );
+
+      expect(rotateResponse.status).toBe(403);
+      await expect(rotateResponse.json()).resolves.toEqual({
+        error: "Forbidden",
+      });
+    } finally {
+      delete process.env.NAKAMA_CONFIG_DIR;
+      await rm(configDir, { force: true, recursive: true });
+    }
+  });
+
   test("serves health through the Hono fetch boundary", async () => {
     const options = createServerOptions();
     const app = createHonoApp(options);

--- a/apps/server/src/http/routes/auth.ts
+++ b/apps/server/src/http/routes/auth.ts
@@ -18,7 +18,10 @@ import {
   resolveRequestClientOrigin,
 } from "../../services/composio-callback-url";
 import type { ServerOptions } from "../context";
-import { requirePlatformAdminFromContext } from "../org-guards";
+import {
+  requirePlatformAdmin,
+  requirePlatformAdminFromContext,
+} from "../org-guards";
 import {
   assertBrowserCsrf,
   authenticateRequest,
@@ -611,6 +614,7 @@ export function registerAuthRoutes(app: HonoApp, options: ServerOptions): void {
       );
     }
 
+    requirePlatformAdmin(auth);
     assertBrowserCsrf(c.req.raw, auth, authService);
 
     try {


### PR DESCRIPTION
## Summary

`POST /v1/auth/local-token/rotate` previously accepted **any** browser session. Org members and viewers could rotate the installation-wide `tc_local_` credential used by the CLI and channel workers (Telegram / Discord / WhatsApp), causing availability sabotage and violating least privilege.

This PR adds `requirePlatformAdmin(auth)` after the browser-session check, matching other sensitive install-scoped routes.

Closes #370

## Changes

- Guard `POST /v1/auth/local-token/rotate` with `requirePlatformAdmin`
- Keep existing constraints: must be browser-session auth (not bearer) + CSRF
- Regression test: org **member** browser session gets `403 Forbidden`; platform-admin setup session still rotates successfully

## Why it matters

The local token is a shared install credential (synthetic `local-client@nakama.internal`). Rotation invalidates every worker/CLI that still holds the old token until an admin re-syncs. That must not be reachable from the lowest-privilege dashboard roles.

## Test plan

- [x] `bun test apps/server/src/http/app.test.ts -t "local auth token"` — rotate as setup admin (200), reject bearer (403), reject member browser session (403)
- [x] Manual: sign in as platform admin → rotate local token succeeds; sign in as org member/viewer → rotate returns 403
- [x] Confirm CLI/workers that already hold the old token fail until they pick up the new one (expected after a successful admin rotate)


Made with [Cursor](https://cursor.com)