### PR TITLE
fix(rbac): block viewers from session mutations and paid provider routes (#356)

### DIFF
--- a/apps/server/src/http/routes/models.ts
+++ b/apps/server/src/http/routes/models.ts
@@ -50,6 +50,7 @@ import { getTimezoneCatalog } from "../../services/timezone-catalog-service";
 import { streamAgentBrowserInstall } from "../coding-harness-install-stream";
 import type { ServerOptions } from "../context";
 import {
+  requireNotViewerFromContext,
   requireOrgAdminFromContext,
   requireOrgAdminOrPlatformAdminFromContext,
 } from "../org-guards";
@@ -1249,7 +1250,7 @@ export function registerModelRoutes(
   });
 
   app.post("/v1/audio/transcribe", async (c) => {
-    getRequestAuth(c);
+    requireNotViewerFromContext(c);
     const body = await readJson<TranscribeAudioRequest>(c.req.raw);
 
     try {
@@ -1290,7 +1291,7 @@ export function registerModelRoutes(
   });
 
   app.post("/v1/images/generate", async (c) => {
-    getRequestAuth(c);
+    requireNotViewerFromContext(c);
     const body = await readJson<GenerateImageRequest>(c.req.raw);
 
     try {

--- a/apps/server/src/http/routes/rbac-mutations.test.ts
+++ b/apps/server/src/http/routes/rbac-mutations.test.ts
@@ -21,9 +21,33 @@ function createApp() {
 
   const result = createMinimalHonoApp({
     agent: {
+      branchSession: async () => {
+        calls.push("agent.branchSession");
+        return { sessionId: "branched" };
+      },
+      clearSession: async () => {
+        calls.push("agent.clearSession");
+        return true;
+      },
+      compactSession: async () => {
+        calls.push("agent.compactSession");
+        return { compacted: true };
+      },
+      createSession: async () => {
+        calls.push("agent.createSession");
+        return "session_x";
+      },
       draftAutomation: record("agent.draftAutomation"),
       draftTaskPrompt: record("agent.draftTaskPrompt"),
+      generateImage: async () => {
+        calls.push("agent.generateImage");
+        return { imageUrl: "x" };
+      },
       listProfiles: async () => ({ profiles: [{ id: "default" }] }),
+      purgeSession: async () => {
+        calls.push("agent.purgeSession");
+        return true;
+      },
       runAutomation: async () => {
         calls.push("agent.runAutomation");
         return { skipped: false };
@@ -31,6 +55,10 @@ function createApp() {
       runTask: async () => {
         calls.push("agent.runTask");
         return { skipped: false };
+      },
+      transcribeAudio: async () => {
+        calls.push("agent.transcribeAudio");
+        return { text: "x" };
       },
     },
     automationService: {
@@ -109,9 +137,32 @@ const MUTATING_ROUTES: Array<{ method: string; path: string; body?: unknown }> =
     { body: { title: "x" }, method: "PUT", path: "/v1/tasks/t1" },
     { method: "DELETE", path: "/v1/tasks/t1" },
     { method: "POST", path: "/v1/tasks/t1/run" },
+    {
+      body: { channel: "web", profileId: "default" },
+      method: "POST",
+      path: "/v1/sessions",
+    },
+    { method: "DELETE", path: "/v1/sessions/s1" },
+    { method: "DELETE", path: "/v1/sessions/s1?purge=true" },
+    { body: { force: true }, method: "POST", path: "/v1/sessions/s1/compact" },
+    {
+      body: { messageIndex: 0 },
+      method: "POST",
+      path: "/v1/sessions/s1/branch",
+    },
+    {
+      body: { audioBase64: "YQ==", mimeType: "audio/wav" },
+      method: "POST",
+      path: "/v1/audio/transcribe",
+    },
+    {
+      body: { prompt: "a cat" },
+      method: "POST",
+      path: "/v1/images/generate",
+    },
   ];
 
-describe("RBAC: viewer cannot reach state-changing automation/task routes", () => {
+describe("RBAC: viewer cannot reach state-changing automation/task/session routes", () => {
   for (const route of MUTATING_ROUTES) {
     test(`${route.method} ${route.path} -> 403 for viewer`, async () => {
       const { app, databaseAdapter, authService, calls } = createApp();

--- a/apps/server/src/http/routes/sessions.ts
+++ b/apps/server/src/http/routes/sessions.ts
@@ -1,16 +1,17 @@
 import { createRoute, z } from "@hono/zod-openapi";
-import type {
-  BranchSessionRequest,
-  BranchSessionResponse,
-  CompactionResponse,
-  CompactSessionRequest,
-  CreateSessionRequest,
-  CreateSessionResponse,
-  ListSessionsResponse,
-  SendMessageRequest,
-  SendMessageResponse,
-  SessionMessagesResponse,
-  SessionStatusResponse,
+import {
+  type BranchSessionRequest,
+  type BranchSessionResponse,
+  type CompactionResponse,
+  type CompactSessionRequest,
+  type CreateSessionRequest,
+  type CreateSessionResponse,
+  type ListSessionsResponse,
+  NakamaApiError,
+  type SendMessageRequest,
+  type SendMessageResponse,
+  type SessionMessagesResponse,
+  type SessionStatusResponse,
 } from "@nakama/core";
 import { resolveRequestClientOrigin } from "../../services/composio-callback-url";
 import { sessionTurnRegistry } from "../../services/session-turn-registry";
@@ -21,7 +22,6 @@ import {
 } from "../org-guards";
 import {
   errorResponse,
-  getRequestAuth,
   json,
   parseChannel,
   readJson,
@@ -341,7 +341,7 @@ export function registerSessionRoutes(
   );
 
   app.post("/v1/sessions", async (c) => {
-    const auth = getRequestAuth(c);
+    const auth = requireNotViewerFromContext(c);
     const orgId = requireActiveOrgIdFromContext(c);
     const body = await readJson<CreateSessionRequest>(c.req.raw);
     const channel = parseChannel(body.channel);
@@ -374,6 +374,7 @@ export function registerSessionRoutes(
   });
 
   app.delete("/v1/sessions/:sessionId", async (c) => {
+    requireNotViewerFromContext(c);
     const orgId = requireActiveOrgIdFromContext(c);
     const sessionId = decodeURIComponent(c.req.param("sessionId"));
     const purge = c.req.query("purge") === "true";
@@ -389,6 +390,7 @@ export function registerSessionRoutes(
   });
 
   app.post("/v1/sessions/:sessionId/compact", async (c) => {
+    requireNotViewerFromContext(c);
     const orgId = requireActiveOrgIdFromContext(c);
     const sessionId = decodeURIComponent(c.req.param("sessionId"));
     const body = await readJson<CompactSessionRequest>(c.req.raw).catch(
@@ -466,6 +468,7 @@ export function registerSessionRoutes(
   });
 
   app.post("/v1/sessions/:sessionId/branch", async (c) => {
+    requireNotViewerFromContext(c);
     try {
       const orgId = requireActiveOrgIdFromContext(c);
       const sessionId = decodeURIComponent(c.req.param("sessionId"));
@@ -482,6 +485,10 @@ export function registerSessionRoutes(
 
       return json<BranchSessionResponse>(result, 201);
     } catch (error) {
+      if (error instanceof NakamaApiError) {
+        return errorResponse(error.message, error.status);
+      }
+
       const message = error instanceof Error ? error.message : String(error);
       return errorResponse(message, 400);
     }


### PR DESCRIPTION
## Summary

Org **viewers** are documented as read-chat-only, but several mutating routes only checked org membership (or bare auth), not role. Viewers could:

- Create / delete / purge sessions (including irreversible history wipe)
- Compact and branch sessions
- Call paid OpenAI paths: `POST /v1/audio/transcribe` and `POST /v1/images/generate`

This PR applies `requireNotViewerFromContext` the same way `POST .../messages` already does, and extends the RBAC mutation matrix so it cannot regress.

Closes #356

## Changes

| Route | Guard |
|---|---|
| `POST /v1/sessions` | `requireNotViewerFromContext` |
| `DELETE /v1/sessions/:sessionId` (incl. `?purge=true`) | same |
| `POST /v1/sessions/:sessionId/compact` | same |
| `POST /v1/sessions/:sessionId/branch` | same (creates a session → guarded intentionally) |
| `POST /v1/audio/transcribe` | same |
| `POST /v1/images/generate` | same |

- `rbac-mutations.test.ts`: extend `MUTATING_ROUTES` + stub agent methods; assert `403` and **no** side-effect calls for viewers

## Out of scope

- Service-layer role checks inside `agent-service` (route guards match existing org patterns)
- Broader viewer audit beyond the routes named in #356

## Test plan

- [x] `bun test apps/server/src/http/routes/rbac-mutations.test.ts` — all listed session/model routes return 403 for viewer with empty `calls`
- [x] Manual: viewer cannot create/delete/compact/branch a session; member/admin still can
- [x] Manual: viewer cannot transcribe audio or generate images; member still can (provider configured)


Made with [Cursor](https://cursor.com)