### PR TITLE
fix(auth): revoke all browser sessions on password change (#355)

### DIFF
--- a/apps/server/src/http/org-invites.test.ts
+++ b/apps/server/src/http/org-invites.test.ts
@@ -176,6 +176,13 @@ describe("direct org member provisioning", () => {
 
     expect(changePasswordResponse.status).toBe(200);
 
+    const staleMe = await app.fetch(
+      new Request("http://localhost:4310/v1/auth/me", {
+        headers: memberSession.headers(),
+      })
+    );
+    expect(staleMe.status).toBe(401);
+
     const relogin = await app.fetch(
       new Request("http://localhost:4310/v1/auth/login", {
         body: JSON.stringify({

--- a/apps/server/src/http/routes/auth.ts
+++ b/apps/server/src/http/routes/auth.ts
@@ -558,7 +558,9 @@ export function registerAuthRoutes(app: HonoApp, options: ServerOptions): void {
       userId: auth.user.id,
     });
 
-    return json({ ok: true });
+    const response = c.json({ ok: true }, 200);
+    clearBrowserSessionCookies(response.headers);
+    return response;
   });
 
   app.openAPIRegistry.registerPath(acceptInviteRoute);

--- a/apps/server/src/services/org-service.test.ts
+++ b/apps/server/src/services/org-service.test.ts
@@ -247,6 +247,58 @@ describe("OrgService", () => {
     });
   });
 
+  test("revokes all browser sessions when password changes", async () => {
+    const { orgService, databaseAdapter } = createOrgService();
+    const created = await orgService.createOrganization({
+      admin: {
+        email: "admin@acme.com",
+        name: "Acme Admin",
+        phone: "+628123456789",
+      },
+      name: "Acme",
+      slug: "acme-revoke-sessions",
+    });
+
+    const userId = created.adminMember!.member.userId;
+    const now = new Date().toISOString();
+    const expiresAt = new Date(Date.now() + 86_400_000).toISOString();
+
+    await databaseAdapter.createBrowserSession({
+      createdAt: now,
+      csrfTokenHash: "csrf_a",
+      expiresAt,
+      id: "bs_a",
+      lastUsedAt: null,
+      revokedAt: null,
+      sessionTokenHash: "hash_a",
+      userId,
+    });
+    await databaseAdapter.createBrowserSession({
+      createdAt: now,
+      csrfTokenHash: "csrf_b",
+      expiresAt,
+      id: "bs_b",
+      lastUsedAt: null,
+      revokedAt: null,
+      sessionTokenHash: "hash_b",
+      userId,
+    });
+
+    await orgService.changePassword({
+      currentPassword: created.adminMember!.temporaryPassword!,
+      newPassword: "new-password-123",
+      userId,
+    });
+
+    const sessionA =
+      await databaseAdapter.getBrowserSessionBySessionTokenHash("hash_a");
+    const sessionB =
+      await databaseAdapter.getBrowserSessionBySessionTokenHash("hash_b");
+
+    expect(sessionA?.revokedAt).toBeTruthy();
+    expect(sessionB?.revokedAt).toBeTruthy();
+  });
+
   test("updates own profile email phone and name", async () => {
     const { orgService } = createOrgService();
     const created = await orgService.createOrganization({

--- a/apps/server/src/services/org-service.ts
+++ b/apps/server/src/services/org-service.ts
@@ -715,6 +715,7 @@ export class OrgService {
       await this.authService.hashPassword(newPassword),
       now
     );
+    await this.databaseAdapter.revokeBrowserSessionsForUser(user.id, now);
   }
 
   private async assertCanChangeAdminMembership(

--- a/apps/web/src/components/SidebarUserMenu.tsx
+++ b/apps/web/src/components/SidebarUserMenu.tsx
@@ -170,7 +170,15 @@ export function SidebarUserMenu() {
         email={user.email}
         name={user.name ?? ""}
         onOpenChange={setProfileOpen}
-        onSaved={() => void refreshSession()}
+        onSaved={({ passwordChanged }) => {
+          if (passwordChanged) {
+            // Server revoked all sessions and cleared cookies; drop local auth
+            // so AuthGuard sends the user to login with the new password.
+            void logout();
+            return;
+          }
+          void refreshSession();
+        }}
         open={profileOpen}
         phone={user.phone ?? ""}
       />
@@ -197,7 +205,7 @@ function UserProfileDialog({
   email: string;
   name: string;
   phone: string;
-  onSaved: () => void;
+  onSaved: (result: { passwordChanged: boolean }) => void;
 }) {
   const [formName, setFormName] = useState(name);
   const [formEmail, setFormEmail] = useState(email);
@@ -258,9 +266,12 @@ function UserProfileDialog({
           currentPassword,
           newPassword,
         });
+        onOpenChange(false);
+        onSaved({ passwordChanged: true });
+        return;
       }
 
-      onSaved();
+      onSaved({ passwordChanged: false });
       onOpenChange(false);
     } catch (err) {
       setError(formatError(err));

--- a/apps/web/src/context/auth-context.tsx
+++ b/apps/web/src/context/auth-context.tsx
@@ -96,7 +96,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   );
 
   const logout = useCallback(async () => {
-    await client.logout();
+    try {
+      await client.logout();
+    } catch {
+      // Session may already be revoked (e.g. after password change clears
+      // cookies and revokes every browser session server-side).
+    }
     client.setOrgId(null);
     setUser(null);
     setOrgs([]);

--- a/packages/db/src/adapters/in-memory.ts
+++ b/packages/db/src/adapters/in-memory.ts
@@ -1175,6 +1175,21 @@ export function createInMemoryDatabaseAdapter(): DatabaseAdapter {
       return true;
     },
 
+    async revokeBrowserSessionsForUser(userId, revokedAt) {
+      let revoked = 0;
+
+      for (const [hash, session] of browserSessionsByHash) {
+        if (session.userId !== userId || session.revokedAt) {
+          continue;
+        }
+
+        browserSessionsByHash.set(hash, { ...session, revokedAt });
+        revoked += 1;
+      }
+
+      return revoked;
+    },
+
     async setUserContext(orgId, userId, content, updatedAt) {
       const memberKey = `${orgId}:${userId}`;
       const member = orgMembers.get(memberKey);

--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -1207,6 +1207,11 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
     SET revoked_at = ?
     WHERE session_token_hash = ? AND revoked_at IS NULL
   `);
+  const revokeBrowserSessionsForUserStmt = db.prepare(`
+    UPDATE browser_sessions
+    SET revoked_at = ?
+    WHERE user_id = ? AND revoked_at IS NULL
+  `);
   const updateBrowserSessionLastUsedAtStmt = db.prepare(`
     UPDATE browser_sessions
     SET last_used_at = ?
@@ -2590,6 +2595,11 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
         sessionTokenHash
       );
       return result.changes > 0;
+    },
+
+    async revokeBrowserSessionsForUser(userId, revokedAt) {
+      const result = revokeBrowserSessionsForUserStmt.run(revokedAt, userId);
+      return result.changes;
     },
 
     async setUserContext(orgId, userId, content, _updatedAt) {

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -840,6 +840,10 @@ export interface DatabaseAdapter {
     sessionTokenHash: string,
     revokedAt: string
   ): Promise<boolean>;
+  revokeBrowserSessionsForUser(
+    userId: string,
+    revokedAt: string
+  ): Promise<number>;
   setUserContext(
     orgId: string,
     userId: string,


### PR DESCRIPTION
## Summary

Changing a password only updated the password hash. Existing browser session cookies remained valid for up to 7 days, so a stolen session survived credential rotation.

After a successful `changePassword`, Nakama now revokes **every** browser session for that user (including the one that performed the change) and clears session cookies on the HTTP response so the caller must sign in again.

Closes #355

## Changes

- New DB API: `revokeBrowserSessionsForUser(userId, revokedAt)` on `DatabaseAdapter`
  - SQLite: `UPDATE browser_sessions SET revoked_at = ? WHERE user_id = ? AND revoked_at IS NULL`
  - In-memory: iterate sessions by `userId`
- `OrgService.changePassword` calls revoke-all after `updateUserPassword`
- `POST /v1/auth/change-password` clears cookies via `clearBrowserSessionCookies` (same helper as logout)
- Auth middleware already rejects sessions with `revokedAt` set

## Acceptance mapping

| Criterion | Behavior |
|---|---|
| All sessions revoked | Yes — every active row for `userId` |
| Current session revoked too | Yes — user must re-login |
| Revocation beats expiry | Yes — `revokedAt` checked before expiry |
| Accept-invite / sign-out-everywhere | Deferred (optional in the issue) |

## Test plan

- [x] `bun test apps/server/src/services/org-service.test.ts` — two sessions for one user both get `revokedAt` after password change
- [x] `bun test apps/server/src/http/org-invites.test.ts` — after change-password, prior cookies → `/v1/auth/me` is 401; relogin with new password works
- [ ] Manual: two browsers signed in as same user; change password in one; both are logged out; login with new password succeeds


Made with [Cursor](https://cursor.com)