### PR TITLE
feat(tools): let Super Bot author Python custom tools (#397)

### DIFF
--- a/apps/server/src/services/profile-service.test.ts
+++ b/apps/server/src/services/profile-service.test.ts
@@ -15,6 +15,17 @@ const tinyPngBase64 =
 
 const ORG_ID = "org_test";
 
+const PYTHON_ECHO_TOOL = `import json
+import sys
+
+def run(input, context):
+    return {"echoed": input.get("message")}
+
+if __name__ == "__main__":
+    payload = json.loads(sys.stdin.read() or "{}")
+    sys.stdout.write(json.dumps(run(payload, {})))
+`;
+
 describe("profile service createTool", () => {
   let tempConfigDir = "";
 
@@ -66,10 +77,7 @@ describe("profile service createTool", () => {
     const toolsDir = path.join(tempConfigDir, "tools");
     await mkdir(toolsDir, { recursive: true });
 
-    await writeFile(
-      path.join(toolsDir, "echo.py"),
-      `def run(input, context):\n    return {"echoed": input.get("message")}\n`
-    );
+    await writeFile(path.join(toolsDir, "echo.py"), PYTHON_ECHO_TOOL);
 
     const service = new ProfileService(createInMemoryDatabaseAdapter());
     const tool = await service.createTool({
@@ -90,10 +98,7 @@ describe("profile service createTool", () => {
     const toolsDir = path.join(tempConfigDir, "tools");
     await mkdir(toolsDir, { recursive: true });
 
-    await writeFile(
-      path.join(toolsDir, "echo.py"),
-      `def run(input, context):\n    return {"echoed": input.get("message")}\n`
-    );
+    await writeFile(path.join(toolsDir, "echo.py"), PYTHON_ECHO_TOOL);
 
     const parameters = {
       properties: { message: { type: "string" } },
@@ -127,10 +132,7 @@ describe("profile service createTool", () => {
     const toolsDir = path.join(tempConfigDir, "tools");
     await mkdir(toolsDir, { recursive: true });
 
-    await writeFile(
-      path.join(toolsDir, "echo.py"),
-      `def run(input, context):\n    return {"echoed": input.get("message")}\n`
-    );
+    await writeFile(path.join(toolsDir, "echo.py"), PYTHON_ECHO_TOOL);
 
     const service = new ProfileService(createInMemoryDatabaseAdapter());
     const tool = await service.createTool({

--- a/apps/server/src/services/python-tool-loader.test.ts
+++ b/apps/server/src/services/python-tool-loader.test.ts
@@ -113,19 +113,43 @@ print("hi")
     expect(result.error).toMatch(/run\s*\(/i);
   });
 
+  test("returns an error tool when the module lacks a stdin/stdout harness", async () => {
+    const { configDir: dir, toolsDir } = await setupToolsDir();
+    configDir = dir;
+
+    await writeFile(
+      path.join(toolsDir, "noharness.py"),
+      `def run(input, context):
+    return input
+`,
+      "utf8"
+    );
+
+    const tool = await loadPythonTool(
+      makeRecord({
+        handlerConfig: { modulePath: "noharness.py" },
+        name: "noharness",
+      })
+    );
+
+    const result = (await tool!.run({}, {})) as { error: string };
+    expect(result.error).toMatch(/__main__/i);
+  });
+
   test("returns an error tool when the module exits non-zero", async () => {
     const { configDir: dir, toolsDir } = await setupToolsDir();
     configDir = dir;
 
     await writeFile(
       path.join(toolsDir, "boom.py"),
-      `import sys
+      `import json, sys
 def run(input, context):
     sys.stderr.write("kaboom\\n")
     sys.exit(7)
 
 if __name__ == "__main__":
-    run({}, {})
+    payload = json.loads(sys.stdin.read() or "{}")
+    sys.stdout.write(json.dumps(run(payload, {})))
 `,
       "utf8"
     );
@@ -145,13 +169,14 @@ if __name__ == "__main__":
 
     await writeFile(
       path.join(toolsDir, "badjson.py"),
-      `import sys
+      `import json, sys
 def run(input, context):
-    sys.stdout.write("not json")
     return None
 
 if __name__ == "__main__":
-    run({}, {})
+    payload = json.loads(sys.stdin.read() or "{}")
+    run(payload, {})
+    sys.stdout.write("not json")
 `,
       "utf8"
     );
@@ -173,11 +198,15 @@ if __name__ == "__main__":
 
     await writeFile(
       path.join(toolsDir, "silent.py"),
-      `def run(input, context):
+      `import json, sys
+def run(input, context):
     return None
 
 if __name__ == "__main__":
-    run({}, {})
+    payload = json.loads(sys.stdin.read() or "{}")
+    result = run(payload, {})
+    if result is not None:
+        sys.stdout.write(json.dumps(result))
 `,
       "utf8"
     );

--- a/apps/server/src/services/python-tool-loader.ts
+++ b/apps/server/src/services/python-tool-loader.ts
@@ -89,12 +89,24 @@ export async function validatePythonToolModule(
     throw new Error(`Tool module not found: ${modulePath}`);
   }
 
-  // Static check: requires a `run(` definition so the obvious failure is
-  // caught at load/create time. Syntax errors still surface at invocation.
+  // Static checks catch the obvious authoring failures before registration.
+  // Syntax errors still surface at invocation.
   const source = await readFile(resolvedPath, "utf8");
 
   if (!/\bdef\s+run\s*\(/.test(source)) {
     throw new Error("Tool module must define a run(input, context) function.");
+  }
+
+  if (!/if\s+__name__\s*==\s*["']__main__["']\s*:/.test(source)) {
+    throw new Error(
+      'Python tools must include an if __name__ == "__main__" harness that reads JSON from sys.stdin and writes JSON to sys.stdout.'
+    );
+  }
+
+  if (!(source.includes("sys.stdin") && source.includes("sys.stdout"))) {
+    throw new Error(
+      "Python tool __main__ harness must read JSON from sys.stdin and write JSON to sys.stdout."
+    );
   }
 }
 

--- a/apps/server/src/tools/super-bot-tools.test.ts
+++ b/apps/server/src/tools/super-bot-tools.test.ts
@@ -36,7 +36,7 @@ describe("super bot create_tool", () => {
     }
   });
 
-  test("always registers agent-authored tools as javascript", async () => {
+  test("defaults agent-authored tools to javascript when handlerType is omitted", async () => {
     tempConfigDir = await mkdtemp(path.join(os.tmpdir(), "nakama-super-tool-"));
     process.env.NAKAMA_CONFIG_DIR = tempConfigDir;
     const toolsDir = path.join(tempConfigDir, "tools");
@@ -97,6 +97,68 @@ describe("super bot create_tool", () => {
     });
   });
 
+  test("registers python tools when handlerType is python", async () => {
+    tempConfigDir = await mkdtemp(path.join(os.tmpdir(), "nakama-super-tool-"));
+    process.env.NAKAMA_CONFIG_DIR = tempConfigDir;
+    const toolsDir = path.join(tempConfigDir, "tools");
+    await mkdir(toolsDir, { recursive: true });
+
+    await writeFile(
+      path.join(toolsDir, "echo.py"),
+      `import json
+import sys
+
+def run(input, context):
+    return input
+
+if __name__ == "__main__":
+    payload = json.loads(sys.stdin.read() or "{}")
+    sys.stdout.write(json.dumps(run(payload, {})))
+`,
+      "utf8"
+    );
+
+    const capturedRequests: CreateToolRequest[] = [];
+
+    const createTool = getCreateToolTool({
+      async createTool(request: CreateToolRequest): Promise<ToolDetail> {
+        capturedRequests.push(request);
+
+        return {
+          createdAt: "2026-01-01T00:00:00.000Z",
+          description: request.description,
+          handlerConfig: request.handlerConfig ?? {},
+          handlerType: request.handlerType ?? "javascript",
+          id: "tool_echo_py",
+          name: request.name,
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        };
+      },
+    });
+
+    const result = await createTool.run(
+      {
+        description: "Echo input in Python",
+        handlerConfig: { modulePath: "echo.py" },
+        handlerType: "python",
+        name: "echo_py",
+      },
+      { sessionId: SESSION_ID }
+    );
+
+    expect(capturedRequests[0]?.handlerType).toBe("python");
+    expect(capturedRequests[0]?.handlerConfig).toEqual({
+      modulePath: "echo.py",
+    });
+    expect(result).toMatchObject({
+      tool: {
+        handlerType: "python",
+        id: "tool_echo_py",
+        name: "echo_py",
+      },
+    });
+  });
+
   test('rejects handlerType "custom"', async () => {
     let createToolCalled = false;
 
@@ -119,7 +181,33 @@ describe("super bot create_tool", () => {
       )
     );
 
-    expect(error?.message).toMatch(/only create javascript tools/i);
+    expect(error?.message).toMatch(/javascript or python/i);
+    expect(createToolCalled).toBe(false);
+  });
+
+  test("rejects shell wrapper module paths", async () => {
+    let createToolCalled = false;
+
+    const createTool = getCreateToolTool({
+      async createTool(): Promise<ToolDetail> {
+        createToolCalled = true;
+        throw new Error("should not be called");
+      },
+    });
+
+    const error = await captureError(
+      createTool.run(
+        {
+          description: "Shell wrapper",
+          handlerConfig: { modulePath: "wrapper.sh" },
+          handlerType: "javascript",
+          name: "wrapper",
+        },
+        { sessionId: SESSION_ID }
+      )
+    );
+
+    expect(error?.message).toMatch(/ending in "\.js"/i);
     expect(createToolCalled).toBe(false);
   });
 

--- a/apps/server/src/tools/super-bot-tools.test.ts
+++ b/apps/server/src/tools/super-bot-tools.test.ts
@@ -159,6 +159,45 @@ if __name__ == "__main__":
     });
   });
 
+  test("rejects python tools that lack a stdin/stdout harness", async () => {
+    tempConfigDir = await mkdtemp(path.join(os.tmpdir(), "nakama-super-tool-"));
+    process.env.NAKAMA_CONFIG_DIR = tempConfigDir;
+    const toolsDir = path.join(tempConfigDir, "tools");
+    await mkdir(toolsDir, { recursive: true });
+
+    await writeFile(
+      path.join(toolsDir, "noharness.py"),
+      `def run(input, context):
+    return input
+`,
+      "utf8"
+    );
+
+    let createToolCalled = false;
+
+    const createTool = getCreateToolTool({
+      async createTool(): Promise<ToolDetail> {
+        createToolCalled = true;
+        throw new Error("should not be called");
+      },
+    });
+
+    const error = await captureError(
+      createTool.run(
+        {
+          description: "Missing harness",
+          handlerConfig: { modulePath: "noharness.py" },
+          handlerType: "python",
+          name: "noharness",
+        },
+        { sessionId: SESSION_ID }
+      )
+    );
+
+    expect(error?.message).toMatch(/__main__/i);
+    expect(createToolCalled).toBe(false);
+  });
+
   test('rejects handlerType "custom"', async () => {
     let createToolCalled = false;
 

--- a/apps/server/src/tools/super-bot-tools.ts
+++ b/apps/server/src/tools/super-bot-tools.ts
@@ -4,7 +4,11 @@ import {
   type ToolContext,
   type ToolDefinition,
 } from "@nakama/core";
-import { validateJavascriptToolModule } from "../services/javascript-tool-loader";
+import {
+  CUSTOM_TOOL_HANDLERS,
+  customToolTypesLabel,
+  isCustomToolType,
+} from "../services/custom-tool-handlers";
 import type { ProfileService } from "../services/profile-service";
 import {
   PROFILE_CREATE_CONFIRMATION_MESSAGE,
@@ -169,7 +173,7 @@ export function createSuperBotTools(
     },
     {
       description:
-        "Register a JavaScript tool. Workflow: list_tools (check name) → write_file (~/.nakama/tools/<name>.js) → create_tool. Do not call list_profiles as part of this workflow.",
+        "Register a custom tool (javascript or python). Workflow: list_tools (check name) → write_file (~/.nakama/tools/<name>.js|.py) → create_tool. Do not call list_profiles as part of this workflow.",
       name: "create_tool",
       parameters: {
         additionalProperties: false,
@@ -178,11 +182,11 @@ export function createSuperBotTools(
           handlerConfig: {
             additionalProperties: true,
             description:
-              'For javascript tools: { "modulePath": "my-tool.js" } relative to ~/.nakama/tools/. The file must already exist and export run(input, context) plus optional parameters JSON schema.',
+              'Handler config: { "modulePath": "my-tool.js" } or { "modulePath": "my-tool.py" } relative to ~/.nakama/tools/. The file must already exist. JS modules export run(input, context) plus optional parameters. Python modules define def run(input, context) and a __main__ stdin/stdout JSON harness.',
             type: "object",
           },
           handlerType: {
-            description: 'Handler type. Must be "javascript".',
+            description: 'Handler type: "javascript" (default) or "python".',
             type: "string",
           },
           name: { description: "Unique tool name.", type: "string" },
@@ -199,24 +203,25 @@ export function createSuperBotTools(
         }
 
         const requestedHandlerType = readString(input, "handlerType");
-        const handlerType = "javascript";
-        const handlerConfig = readObject(input, "handlerConfig");
+        const handlerType = requestedHandlerType ?? "javascript";
 
-        if (requestedHandlerType && requestedHandlerType !== handlerType) {
+        if (!isCustomToolType(handlerType)) {
           throw new Error(
-            'Super Bot can only create JavaScript tools. Use handlerType "javascript".'
+            `Super Bot can only create ${customToolTypesLabel()} tools. Use handlerType "javascript" or "python".`
           );
         }
 
+        const handler = CUSTOM_TOOL_HANDLERS[handlerType];
+        const handlerConfig = readObject(input, "handlerConfig");
         const modulePath = readModulePath(handlerConfig);
 
-        if (!modulePath?.endsWith(".js")) {
+        if (!modulePath?.endsWith(handler.extension)) {
           throw new Error(
-            'JavaScript tools require handlerConfig.modulePath ending in ".js". Write the module with write_file to ~/.nakama/tools/ first.'
+            `${handlerType} tools require handlerConfig.modulePath ending in "${handler.extension}". Write the module with write_file to ~/.nakama/tools/ first.`
           );
         }
 
-        await validateJavascriptToolModule(modulePath);
+        await handler.validateModule(modulePath);
 
         const tool = await profileService.createTool({
           description,

--- a/packages/db/src/constants.ts
+++ b/packages/db/src/constants.ts
@@ -17,10 +17,10 @@ export const SUPER_BOT_SYSTEM_PROMPT = `You are Super Bot, the Nakama orchestrat
 - New bot or agent → draft soul files and a tool plan in chat, wait for explicit OK, then create_profile (no tool calls on the first turn).
 - Workflow to remember → skill_manage.
 - Scheduled task → create_automation.
-- New callable tool → list_tools, write JS, create_tool (see tool authoring rules).
+- New callable tool → list_tools, write JS or Python, create_tool (see tool authoring rules).
 
 ## Tools
-read/write/edit/delete_file, search_files, web_search, bash, create_profile/get_profile/list_profiles, create_tool/list_tools/assign_tool_to_profile, create_automation/list_automations/delete_automation/run_automation. Tool schemas are authoritative; persistent tools use JavaScript only (see tool authoring rules).
+read/write/edit/delete_file, search_files, web_search, bash, create_profile/get_profile/list_profiles, create_tool/list_tools/assign_tool_to_profile, create_automation/list_automations/delete_automation/run_automation. Tool schemas are authoritative; persistent tools use JavaScript or Python (see tool authoring rules).
 
 ## Automations
 Confirm schedule in the user's timezone, then create_automation (manual, 5-field cron, or runAt ISO one-shot). Prefer runAt for one-time reminders. Set delivery for Telegram/WhatsApp/email/Discord when asked; omit when results only need saving. Test via list_automations → run_automation. Default to Super Bot unless told to target another profile.
@@ -42,15 +42,16 @@ When creating a persistent tool:
 - Do not call list_profiles or assign_tool_to_profile during tool creation
 - If the same name already exists, do not create a duplicate placeholder or pretend it works
 - If the existing tool is stale or broken, say it must be repaired or replaced before it can be used
-- Write a JavaScript file to ~/.nakama/tools/<tool-name>.js using write_file
-- Export async function run(input, context) and optional export const parameters
-- Register with create_tool using handlerType "javascript" and handlerConfig { "modulePath": "<tool-name>.js" }
-- If the user provides curl/bash example commands, translate them into JavaScript code inside the tool
-- The only accepted handlerType for agent-authored tools is "javascript"
+- Write either a JavaScript file (~/.nakama/tools/<tool-name>.js) or a Python file (~/.nakama/tools/<tool-name>.py) using write_file
+- JavaScript: export async function run(input, context) and optional export const parameters; register with handlerType "javascript" and handlerConfig { "modulePath": "<tool-name>.js" }
+- Python: define def run(input, context) and include a __main__ harness that reads one JSON object from stdin and writes one JSON result to stdout; register with handlerType "python" and handlerConfig { "modulePath": "<tool-name>.py" }
+- Prefer JavaScript unless the user asks for Python or the logic fits Python better
+- If the user provides curl/bash example commands, translate them into JavaScript or Python inside the tool — never leave them as a shell wrapper
+- The only accepted handlerType values for agent-authored tools are "javascript" and "python"
 - Do NOT write bash scripts (.sh) or shell wrappers for tools
 - Do NOT create .sh, .bash, .command, or wrapper files for persistent tools
 - Use bash only for one-off host tasks, never for tool implementations
-- If you wrote a shell file by mistake, delete it and replace it with a .js module before continuing
+- If you wrote a shell file by mistake, delete it and replace it with a .js or .py module before continuing
 - Never describe a placeholder or partial setup as a working tool
 - A tool is registered after list_tools, write_file, and create_tool succeed
 - After registration succeeds, tell the user they can assign the tool to a profile from the dashboard if needed

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -33,6 +33,7 @@ const SUPPORTED_TOOL_HANDLER_TYPES = new Set([
   "builtin",
   "bash",
   "javascript",
+  "python",
   "sub_agent",
   "generate_image",
 ]);


### PR DESCRIPTION
## Summary

[#352](https://github.com/ahmadrosid/nakama/pull/352) added a `python` custom-tool handler so `.py` files under `~/.nakama/tools/` can run. Super Bot still could not author them: `create_tool` hard-coded `handlerType: "javascript"`, validated only JS modules, and the Super Bot prompts said persistent tools were JavaScript-only.

This PR wires Super Bot through the existing handler registry so it can create **javascript or python** tools end-to-end, and keeps Python tools from being wiped on seed.

Closes #397

## Changes

### `create_tool` (Super Bot)

- Default `handlerType` remains `"javascript"` when omitted
- Accepts `"javascript"` | `"python"` via `isCustomToolType` / `CUSTOM_TOOL_HANDLERS`
- Validates `modulePath` against the handler’s extension (`.js` / `.py`)
- Calls `handler.validateModule` instead of JS-only validation
- Rejects unknown types (`custom`, etc.) and shell wrappers (`.sh` fails the extension check)

### Prompts

- `SUPER_BOT_SYSTEM_PROMPT` + `SUPER_BOT_TOOL_AUTHORING_RULES`: document JS **or** Python; keep the ban on `.sh` / shell wrappers
- Python authoring: `def run(input, context)` plus `__main__` stdin/stdout JSON harness (matches current runtime — no spawn-contract change)

### Seed hygiene

- Add `"python"` to `SUPPORTED_TOOL_HANDLER_TYPES` so `removeUnsupportedTools` does not delete registered Python tools on startup

## Out of scope (per issue)

- Changing Python spawn timeout / env / isolation
- Shared runtime harness so Super Bot only writes `def run` (preferred follow-up; today the prompt teaches the `__main__` boilerplate)
- Other future handler types for Super Bot

## Test plan

- [x] `bun test apps/server/src/tools/super-bot-tools.test.ts` — default JS, create python, reject `custom`, reject `.sh`, missing `.js` still fails before store
- [ ] Manual Super Bot chat: `write_file` a `.py` tool with `run` + `__main__` → `create_tool` with `handlerType: "python"` → invoke / playground succeeds
- [ ] Confirm JS authoring path unchanged
- [ ] Restart with a registered Python tool present → seed does not delete it


Made with [Cursor](https://cursor.com)