### PR TITLE
fix(web): keep live OpenRouter stealth models visible

### DIFF
--- a/apps/web/src/lib/openrouter-models.test.ts
+++ b/apps/web/src/lib/openrouter-models.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  isOpenRouterModelDeprecated,
   isOpenRouterModelFree,
   mergeOpenRouterModelOptions,
   normalizeOpenRouterModels,
@@ -37,6 +38,16 @@ const fixture = {
       name: "Owl Alpha",
       pricing: { completion: "0", prompt: "0" },
       supported_parameters: [],
+    },
+    {
+      architecture: { input_modalities: ["text", "image", "video"] },
+      context_length: 1_048_576,
+      description: "Stealth preview",
+      expiration_date: "2098-12-31",
+      id: "stealth/ox-alpha",
+      name: "Ox Alpha",
+      pricing: { completion: "0", prompt: "0" },
+      supported_parameters: ["tools", "reasoning"],
     },
   ],
 };
@@ -83,10 +94,11 @@ describe("normalizeOpenRouterModels", () => {
   test("marks free models and sorts free first", () => {
     const rows = normalizeOpenRouterModels(fixture);
 
-    expect(rows).toHaveLength(3);
+    expect(rows).toHaveLength(4);
     expect(rows[0]?.isFree).toBe(true);
     expect(rows[1]?.isFree).toBe(true);
-    expect(rows[2]?.isFree).toBe(false);
+    expect(rows[2]?.isFree).toBe(true);
+    expect(rows[3]?.isFree).toBe(false);
     expect(rows.find((row) => row.id.endsWith(":free"))?.isFree).toBe(true);
   });
 
@@ -103,11 +115,33 @@ describe("normalizeOpenRouterModels", () => {
     expect(paid?.outputPerMillionUsd).toBe(2.5);
   });
 
-  test("marks deprecated when expiration_date is set", () => {
+  test("marks deprecated when expiration_date is a real sunset", () => {
     const rows = normalizeOpenRouterModels(fixture);
     const owl = rows.find((row) => row.id === "openrouter/owl-alpha");
 
     expect(owl?.deprecated).toBe(true);
+  });
+
+  test("does not treat OpenRouter sentinel expiration dates as deprecated", () => {
+    const rows = normalizeOpenRouterModels(fixture);
+    const oxAlpha = rows.find((row) => row.id === "stealth/ox-alpha");
+
+    expect(oxAlpha?.deprecated).toBe(false);
+  });
+});
+
+describe("isOpenRouterModelDeprecated", () => {
+  test("returns false for missing expiration", () => {
+    expect(isOpenRouterModelDeprecated(null)).toBe(false);
+    expect(isOpenRouterModelDeprecated(undefined)).toBe(false);
+  });
+
+  test("returns true for a scheduled sunset", () => {
+    expect(isOpenRouterModelDeprecated("2026-08-24")).toBe(true);
+  });
+
+  test("returns false for far-future sentinel dates", () => {
+    expect(isOpenRouterModelDeprecated("2098-12-31")).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/openrouter-models.ts
+++ b/apps/web/src/lib/openrouter-models.ts
@@ -79,6 +79,20 @@ export function isOpenRouterModelFree(
   return prompt === 0 && completion === 0;
 }
 
+/** OpenRouter uses 2098-12-31 as a placeholder on live stealth/preview models. */
+const OPENROUTER_SENTINEL_EXPIRATION_YEAR = 2090;
+
+export function isOpenRouterModelDeprecated(
+  expirationDate: string | null | undefined
+): boolean {
+  if (!expirationDate) {
+    return false;
+  }
+
+  const year = Number.parseInt(expirationDate.slice(0, 4), 10);
+  return Number.isFinite(year) && year < OPENROUTER_SENTINEL_EXPIRATION_YEAR;
+}
+
 export function normalizeOpenRouterModel(
   entry: OpenRouterApiModel
 ): OpenRouterModelRow {
@@ -88,7 +102,7 @@ export function normalizeOpenRouterModel(
 
   return {
     contextLength: entry.context_length ?? 0,
-    deprecated: entry.expiration_date != null,
+    deprecated: isOpenRouterModelDeprecated(entry.expiration_date),
     description: truncateDescription(entry.description ?? ""),
     id: entry.id,
     isFree: isOpenRouterModelFree(entry.pricing),


### PR DESCRIPTION
## Summary

Searching OpenRouter browse for `stealth/ox-alpha` returned **No models found** while Hide deprecated was on. Those live stealth/preview models now appear.

OpenRouter stamps `expiration_date: 2098-12-31` on models that are not actually sunsetting. The filter treated any expiration as deprecated, so Hide deprecated hid them. Real near-term sunsets (`2026-08-24` and similar) stay hidden.

## Test plan

- [ ] Open OpenRouter provider → Browse OpenRouter, keep **Hide deprecated** on, search `stealth/ox-alpha` — Ox Alpha appears
- [ ] Confirm still-sunsetting models (e.g. `nvidia/nemotron-3-nano-30b-a3b:free` expiring `2026-08-24`) stay hidden until the checkbox is cleared

`bun test apps/web/src/lib/openrouter-models.test.ts` — 13 pass. Live catalog on 2026-08-21 confirmed `stealth/ox-alpha` and four Z.ai models use the 2098 sentinel.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Cursor](https://img.shields.io/badge/Grok_4.6-000000?logo=cursor&logoColor=white)
