### PR TITLE
feat(providers): direct Groq integration with dynamic model discovery (#387)

### DIFF
--- a/apps/server/src/providers/create.test.ts
+++ b/apps/server/src/providers/create.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import type { ProviderInstance } from "@nakama/core";
+import { createProviderForInstance } from "./create";
+
+// Locks endpoint routing per provider family: the switch in create.ts must
+// dispatch each instance type to its platform base URL, or chat silently
+// goes to the wrong vendor. Offline by construction — the override points
+// at a local mock instead of the real API.
+describe("createProviderForInstance routing", () => {
+  test("routes groq instances to the configured base URL with auth", async () => {
+    let seenPath = "";
+    let seenAuth = "";
+    let seenModel = "";
+
+    const mock = Bun.serve({
+      fetch: async (request) => {
+        const url = new URL(request.url);
+        seenPath = url.pathname;
+        seenAuth = request.headers.get("authorization") ?? "";
+        const body = (await request.json()) as { model?: string };
+        seenModel = body.model ?? "";
+        return Response.json({
+          choices: [
+            {
+              finish_reason: "stop",
+              index: 0,
+              message: { content: "ok", role: "assistant" },
+            },
+          ],
+          created: 1,
+          id: "mock",
+          model: seenModel,
+          object: "chat.completion",
+          usage: {
+            completion_tokens: 1,
+            prompt_tokens: 1,
+            total_tokens: 2,
+          },
+        });
+      },
+      port: 0,
+    });
+
+    try {
+      const instance: ProviderInstance = {
+        apiKey: "test-key",
+        baseUrl: `http://127.0.0.1:${mock.port}/v1`,
+        createdAt: new Date().toISOString(),
+        // Mirrors what the settings Discover flow saves after fetching
+        // /models from the platform.
+        customModels: [{ default: true, id: "llama-3.3-70b" }],
+        id: "inst_groq",
+        label: "Groq",
+        type: "groq",
+        updatedAt: new Date().toISOString(),
+      };
+
+      const client = createProviderForInstance(instance, "llama-3.3-70b");
+
+      expect(client).not.toBeNull();
+      expect(client?.name).toBe("groq");
+
+      const result = await client!.generateChat({
+        messages: [{ content: "ping", role: "user" }],
+        model: "llama-3.3-70b",
+      });
+
+      expect(result.content).toBe("ok");
+      expect(seenPath).toBe("/v1/chat/completions");
+      expect(seenAuth).toBe("Bearer test-key");
+      expect(seenModel).toBe("llama-3.3-70b");
+    } finally {
+      mock.stop(true);
+    }
+  });
+});

--- a/apps/server/src/providers/create.ts
+++ b/apps/server/src/providers/create.ts
@@ -27,6 +27,7 @@ import { createOpenCodeGoProvider } from "./opencode-go";
 import { createOpenRouterProvider } from "./openrouter";
 
 const DEFAULT_DEEPSEEK_BASE_URL = "https://api.deepseek.com";
+const DEFAULT_GROQ_BASE_URL = "https://api.groq.com/openai/v1";
 
 export interface CreateProviderOptions {
   apiKey: string;
@@ -90,6 +91,13 @@ function createProvider(options: CreateProviderOptions): ProviderClient {
         baseUrl: baseUrlOverride ?? MINIMAX_CN_DEFAULT_BASE_URL,
         model,
         providerName: "minimax_cn",
+      });
+    case "groq":
+      return createOpenAIProvider({
+        apiKey: options.apiKey,
+        baseUrl: baseUrlOverride ?? DEFAULT_GROQ_BASE_URL,
+        model,
+        providerName: "groq",
       });
     case "opencode_go":
       return createOpenCodeGoProvider({

--- a/apps/server/src/providers/models.test.ts
+++ b/apps/server/src/providers/models.test.ts
@@ -157,6 +157,18 @@ describe("resolveModel", () => {
     expect(getDefaultModel("minimax_cn", customModels)).toBe("MiniMax-M3");
   });
 
+  test("resolves Groq models from discovered custom models", () => {
+    const customModels = [
+      { default: true, id: "llama-3.3-70b" },
+      { id: "qwen-2.5-coder-32b" },
+    ];
+
+    expect(resolveModel("groq", "qwen-2.5-coder-32b", customModels)).toBe(
+      "qwen-2.5-coder-32b"
+    );
+    expect(getDefaultModel("groq", customModels)).toBe("llama-3.3-70b");
+  });
+
   test("falls back to instance default for unknown MiniMax ids", () => {
     const customModels = [{ default: true, id: "MiniMax-M3" }];
     expect(resolveModel("minimax_cn", "not-a-real-model", customModels)).toBe(
@@ -172,6 +184,16 @@ describe("modelSupportsVision", () => {
     expect(
       modelSupportsVision("MiniMax-VL", "minimax_cn", [
         { id: "MiniMax-VL", supportsVision: true },
+      ])
+    ).toBe(true);
+  });
+
+  test("keeps Groq models opt-in only (vision variants flag via discovery)", () => {
+    expect(modelSupportsVision("llama-3.3-70b", "groq")).toBe(false);
+
+    expect(
+      modelSupportsVision("llama-scout-vision", "groq", [
+        { id: "llama-scout-vision", supportsVision: true },
       ])
     ).toBe(true);
   });

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -60,7 +60,8 @@ export function formatProviderLabel(
     provider === "openai_compatible" ||
     provider === "opencode_go" ||
     provider === "minimax" ||
-    provider === "minimax_cn"
+    provider === "minimax_cn" ||
+    provider === "groq"
   ) {
     return formatConfiguredProviderLabel(provider, displayName);
   }
@@ -81,6 +82,7 @@ export const PROVIDER_OPTIONS: Array<{ id: SelectedProvider; label: string }> =
     { id: "ollama", label: "Ollama" },
     { id: "opencode_go", label: "OpenCode Go" },
     { id: "minimax", label: "MiniMax" },
+    { id: "groq", label: "Groq" },
     { id: "minimax_cn", label: "MiniMax (CN)" },
     { id: "openai_compatible", label: "Custom (OpenAI-compatible)" },
   ];

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -1941,7 +1941,8 @@ export type ProviderName =
   | "opencode_go"
   | "cloudflare"
   | "minimax"
-  | "minimax_cn";
+  | "minimax_cn"
+  | "groq";
 
 export type OllamaHostMode = "local" | "cloud";
 

--- a/packages/core/src/discovery-providers.ts
+++ b/packages/core/src/discovery-providers.ts
@@ -5,7 +5,7 @@ import type { ProviderName } from "./contract";
 // hardcoded catalog. Adding a discovery-based provider is one entry here
 // plus its type/env-key/label/base-URL wiring — no resolution edits.
 export const DISCOVERY_MODEL_PROVIDERS: ReadonlySet<ProviderName> =
-  new Set<ProviderName>(["openai_compatible", "minimax", "minimax_cn"]);
+  new Set<ProviderName>(["openai_compatible", "minimax", "minimax_cn", "groq"]);
 
 export function isDiscoveryModelProvider(provider: ProviderName): boolean {
   return DISCOVERY_MODEL_PROVIDERS.has(provider);

--- a/packages/core/src/document-content.ts
+++ b/packages/core/src/document-content.ts
@@ -73,6 +73,7 @@ const NATIVE_DOCUMENT_MEDIA_TYPES: Record<ProviderName, ReadonlySet<string>> = {
     "text/csv",
     DOCX_MEDIA_TYPE,
   ]),
+  groq: new Set<string>(),
   minimax: new Set<string>(),
   minimax_cn: new Set<string>(),
   ollama: new Set<string>(),

--- a/packages/core/src/provider-label.ts
+++ b/packages/core/src/provider-label.ts
@@ -10,6 +10,7 @@ const BUILTIN_LABELS: Record<
   deepseek: "DeepSeek",
   fireworks: "Fireworks",
   gemini: "Gemini",
+  groq: "Groq",
   minimax: "MiniMax",
   minimax_cn: "MiniMax (CN)",
   ollama: "Ollama",

--- a/packages/core/src/provider-resolution.test.ts
+++ b/packages/core/src/provider-resolution.test.ts
@@ -18,6 +18,7 @@ describe("parseProviderName", () => {
     expect(parseProviderName("fireworks")).toBe("fireworks");
     expect(parseProviderName("minimax")).toBe("minimax");
     expect(parseProviderName("minimax_cn")).toBe("minimax_cn");
+    expect(parseProviderName("groq")).toBe("groq");
   });
 
   test("rejects unknown values", () => {
@@ -115,6 +116,10 @@ describe("apiKeyEnvVarForProvider", () => {
     expect(apiKeyEnvVarForProvider("minimax")).toBe("MINIMAX_API_KEY");
     expect(apiKeyEnvVarForProvider("minimax_cn")).toBe("MINIMAX_CN_API_KEY");
   });
+
+  test("maps Groq to its env key", () => {
+    expect(apiKeyEnvVarForProvider("groq")).toBe("GROQ_API_KEY");
+  });
 });
 
 describe("isDiscoveryModelProvider", () => {
@@ -122,6 +127,7 @@ describe("isDiscoveryModelProvider", () => {
     expect(isDiscoveryModelProvider("openai_compatible")).toBe(true);
     expect(isDiscoveryModelProvider("minimax")).toBe(true);
     expect(isDiscoveryModelProvider("minimax_cn")).toBe(true);
+    expect(isDiscoveryModelProvider("groq")).toBe(true);
   });
 
   test("excludes catalog providers", () => {

--- a/packages/core/src/provider-resolution.ts
+++ b/packages/core/src/provider-resolution.ts
@@ -18,6 +18,7 @@ export const USER_PROVIDER_NAMES: readonly UserProviderName[] = [
   "cloudflare",
   "minimax",
   "minimax_cn",
+  "groq",
 ] as const;
 
 export {
@@ -43,7 +44,8 @@ export function parseProviderName(
     normalized === "opencode_go" ||
     normalized === "cloudflare" ||
     normalized === "minimax" ||
-    normalized === "minimax_cn"
+    normalized === "minimax_cn" ||
+    normalized === "groq"
   ) {
     return normalized;
   }
@@ -81,6 +83,8 @@ export function apiKeyEnvVarForProvider(
       return "MINIMAX_API_KEY";
     case "minimax_cn":
       return "MINIMAX_CN_API_KEY";
+    case "groq":
+      return "GROQ_API_KEY";
   }
 }
 

--- a/packages/core/src/provider-setup-prompt.ts
+++ b/packages/core/src/provider-setup-prompt.ts
@@ -34,6 +34,7 @@ const PROVIDER_CHOICES: Array<{ id: UserProviderName; label: string }> = [
   { id: "openrouter", label: "OpenRouter" },
   { id: "gemini", label: "Gemini" },
   { id: "deepseek", label: "DeepSeek" },
+  { id: "groq", label: "Groq" },
   { id: "cerebras", label: "Cerebras" },
   { id: "cloudflare", label: "Cloudflare Worker AI" },
   { id: "fireworks", label: "Fireworks" },
@@ -183,7 +184,8 @@ function resolveProviderChoice(input: string): UserProviderName | null {
     normalized === "openai_compatible" ||
     normalized === "opencode_go" ||
     normalized === "minimax" ||
-    normalized === "minimax_cn"
+    normalized === "minimax_cn" ||
+    normalized === "groq"
   ) {
     return normalized;
   }

--- a/packages/core/src/user-config.ts
+++ b/packages/core/src/user-config.ts
@@ -75,6 +75,7 @@ const PROVIDER_TYPE_LABELS: Record<UserProviderName, string> = {
   deepseek: "DeepSeek",
   fireworks: "Fireworks",
   gemini: "Gemini",
+  groq: "Groq",
   minimax: "MiniMax",
   minimax_cn: "MiniMax (CN)",
   ollama: "Ollama",


### PR DESCRIPTION
## Summary

Adds **Groq** as a direct first-party provider — fast inference for open models, well suited to Nakama's tool-loop workloads.

| Platform | Endpoint | Type name | Env key | Label |
|---|---|---|---|---|
| Global | `https://api.groq.com/openai/v1` | `groq` | `GROQ_API_KEY` | Groq |

OpenAI-compatible; follows the DeepSeek template. Single global platform — no CN split.

Closes #387 (chat integration; Whisper STT deferred — see below).

## Dynamic model discovery — no hardcoded catalog

Same as MiniMax (#392), Zhipu (#394) and xAI (#396): model lists are fetched live from `{baseUrl}/models` and stored as instance custom models. **Especially valuable for Groq** — its hosted-model lineup rotates quickly, so live fetch means newly hosted models appear without code changes. Vision is opt-in via discovered metadata (llama vision variants flag themselves); text-only entries degrade through the existing non-vision fallback.

## Routing lock test (new coverage)

First provider PR to include it: `create.test.ts` spins a local mock server and drives the public `createProviderForInstance` entry for a groq instance, asserting:

- dispatch to the `"groq"` client
- request hits `/v1/chat/completions` on the configured base URL
- `Authorization: Bearer <key>` header
- model id passthrough into the request body

This closes the endpoint-routing coverage gap noted across the earlier provider-board reviews — previously nothing locked the switch dispatch; a regression would have sent chat to the wrong vendor silently.

## Capability handling

| Capability | Status |
|---|---|
| Chat vision | Opt-in via discovered metadata — depends on hosted model variants |
| Audio transcription | ⚠️ Groq hosts Whisper (`whisper-large-v3`) — **deferred**: Transcription-settings wiring is an audio-surface concern, deferred consistently with the other providers' STT follow-up |
| Image generation | n/a — Groq hosts none |
| Document input | Empty native sets (text-first baseline) |

## Wiring checklist

- `ProviderName` union += `"groq"` (`contract.ts`)
- `apiKeyEnvVarForProvider` → `GROQ_API_KEY`
- `DISCOVERY_MODEL_PROVIDERS` += `"groq"` (browser-safe module per #395)
- `create.ts` case with default base URL
- Labels across `user-config.ts`, `provider-label.ts`, `provider-setup-prompt.ts`
- `document-content.ts` empty native-doc set
- Web: `PROVIDER_OPTIONS` card + label chain

No config module needed: single endpoint, so the base URL lives in `create.ts` per the deepseek precedent.

## Tests

`provider-resolution.test.ts`: parse acceptance, env key, discovery-set membership.
`models.test.ts`: customModels passthrough, unknown-id fallback to instance default, vision opt-in via discovered metadata.
`create.test.ts` (new): offline routing lock test described above.

```
bun test packages/ + models.test + create.test + web models.test   # 859 pass, 0 fail
bun x ultracite check                                              # clean
bun run knip                                                       # clean
vite build (apps/web)                                              # succeeds — browser-safe ✓
tsc delta vs main                                                  # 0
```

## Live-key caveat

Model ids in tests (`llama-3.3-70b`, `qwen-2.5-coder-32b`) are illustrative — real ids come from Groq's `/models` response at runtime. Spot-check against console.groq.com docs with a live key before release.
