### PR TITLE
refactor(providers): fall through discovery OpenAI-compatible create arms

### DIFF
--- a/apps/server/src/providers/create.ts
+++ b/apps/server/src/providers/create.ts
@@ -78,18 +78,14 @@ function createProvider(options: CreateProviderOptions): ProviderClient {
         providerName: "deepseek",
       });
     case "minimax":
-      return createOpenAIProvider({
-        apiKey: options.apiKey,
-        baseUrl: baseUrlOverride ?? discoveryBaseUrl,
-        model,
-        providerName: "minimax",
-      });
     case "minimax_cn":
+    case "zhipu":
+    case "zhipu_cn":
       return createOpenAIProvider({
         apiKey: options.apiKey,
         baseUrl: baseUrlOverride ?? discoveryBaseUrl,
         model,
-        providerName: "minimax_cn",
+        providerName: options.provider,
       });
     case "xai":
       return createOpenAIProvider({
@@ -97,20 +93,6 @@ function createProvider(options: CreateProviderOptions): ProviderClient {
         baseUrl: baseUrlOverride ?? DEFAULT_XAI_BASE_URL,
         model,
         providerName: "xai",
-      });
-    case "zhipu":
-      return createOpenAIProvider({
-        apiKey: options.apiKey,
-        baseUrl: baseUrlOverride ?? discoveryBaseUrl,
-        model,
-        providerName: "zhipu",
-      });
-    case "zhipu_cn":
-      return createOpenAIProvider({
-        apiKey: options.apiKey,
-        baseUrl: baseUrlOverride ?? discoveryBaseUrl,
-        model,
-        providerName: "zhipu_cn",
       });
     case "opencode_go":
       return createOpenCodeGoProvider({


### PR DESCRIPTION
## Summary

MiniMax + Zhipu GLM provider factory arms share one switch fall-through → same OpenAI-compatible client with `providerName: options.provider`.

**Before:** four copy-pasted `createOpenAIProvider` cases (`minimax` / `minimax_cn` / `zhipu` / `zhipu_cn`).
**After:** one fall-through block (−18 lines); xAI stays separate (different default base URL).

Why safe:
1. Same args as before; only `providerName` literal → `options.provider`
2. xAI untouched (`DEFAULT_XAI_BASE_URL`)
3. No behavior change for discovery URL resolution

Only re-add split cases if a region needs a non-shared factory option.

## Test plan
- [x] `bun test apps/server/src/providers/create.test.ts apps/server/src/providers/models.test.ts packages/core/src/provider-resolution.test.ts` (45 pass)
- [ ] Add a MiniMax or Zhipu instance in Settings and confirm Discover still hits the region base URL

Follow-up from ponytail on #394.
