### PR TITLE
chore(tools): shrink Python create_tool harness checks

### DIFF
--- a/apps/server/src/services/python-tool-loader.ts
+++ b/apps/server/src/services/python-tool-loader.ts
@@ -97,15 +97,13 @@ export async function validatePythonToolModule(
     throw new Error("Tool module must define a run(input, context) function.");
   }
 
-  if (!/if\s+__name__\s*==\s*["']__main__["']\s*:/.test(source)) {
+  const hasHarness =
+    /if\s+__name__\s*==\s*["']__main__["']\s*:/.test(source) &&
+    source.includes("sys.stdin") &&
+    source.includes("sys.stdout");
+  if (!hasHarness) {
     throw new Error(
       'Python tools must include an if __name__ == "__main__" harness that reads JSON from sys.stdin and writes JSON to sys.stdout.'
-    );
-  }
-
-  if (!(source.includes("sys.stdin") && source.includes("sys.stdout"))) {
-    throw new Error(
-      "Python tool __main__ harness must read JSON from sys.stdin and write JSON to sys.stdout."
     );
   }
 }

--- a/apps/server/src/tools/super-bot-tools.test.ts
+++ b/apps/server/src/tools/super-bot-tools.test.ts
@@ -224,32 +224,6 @@ if __name__ == "__main__":
     expect(createToolCalled).toBe(false);
   });
 
-  test("rejects shell wrapper module paths", async () => {
-    let createToolCalled = false;
-
-    const createTool = getCreateToolTool({
-      async createTool(): Promise<ToolDetail> {
-        createToolCalled = true;
-        throw new Error("should not be called");
-      },
-    });
-
-    const error = await captureError(
-      createTool.run(
-        {
-          description: "Shell wrapper",
-          handlerConfig: { modulePath: "wrapper.sh" },
-          handlerType: "javascript",
-          name: "wrapper",
-        },
-        { sessionId: SESSION_ID }
-      )
-    );
-
-    expect(error?.message).toMatch(/ending in "\.js"/i);
-    expect(createToolCalled).toBe(false);
-  });
-
   test("rejects missing javascript modules before storing the tool", async () => {
     tempConfigDir = await mkdtemp(path.join(os.tmpdir(), "nakama-super-tool-"));
     process.env.NAKAMA_CONFIG_DIR = tempConfigDir;

--- a/apps/server/src/tools/super-bot-tools.ts
+++ b/apps/server/src/tools/super-bot-tools.ts
@@ -207,7 +207,7 @@ export function createSuperBotTools(
 
         if (!isCustomToolType(handlerType)) {
           throw new Error(
-            `Super Bot can only create ${customToolTypesLabel()} tools. Use handlerType "javascript" or "python".`
+            `Super Bot can only create ${customToolTypesLabel()} tools. Use handlerType ${customToolTypesLabel()}.`
           );
         }
 


### PR DESCRIPTION
## Summary

Python `create_tool` validation is shorter; same reject behavior as #403.

**Before:** two harness throws + hardcoded `"javascript" or "python"` + duplicate `.sh` test
**After:** one harness check, `customToolTypesLabel()` in the error, extension coverage via existing missing-`.js` test

Why safe:
1. Same `def run` + `__main__` + stdin/stdout gates — one error string
2. Shell wrappers still fail `endsWith(handler.extension)`
3. −28 lines, no spawn/runtime change

Only re-add a distinct stdin/stdout error if Super Bot keeps fixing the wrong line after a harness reject.

## Test plan
- [x] `bun test apps/server/src/tools/super-bot-tools.test.ts apps/server/src/services/python-tool-loader.test.ts` (24 pass)
- [ ] Ask Super Bot for `handlerType: "custom"` — message still lists javascript or python
