### PR TITLE
chore(rbac): shrink viewer guard follow-up from #401

### DIFF
--- a/apps/server/src/http/routes/rbac-mutations.test.ts
+++ b/apps/server/src/http/routes/rbac-mutations.test.ts
@@ -21,33 +21,15 @@ function createApp() {
 
   const result = createMinimalHonoApp({
     agent: {
-      branchSession: async () => {
-        calls.push("agent.branchSession");
-        return { sessionId: "branched" };
-      },
-      clearSession: async () => {
-        calls.push("agent.clearSession");
-        return true;
-      },
-      compactSession: async () => {
-        calls.push("agent.compactSession");
-        return { compacted: true };
-      },
-      createSession: async () => {
-        calls.push("agent.createSession");
-        return "session_x";
-      },
+      branchSession: record("agent.branchSession"),
+      clearSession: record("agent.clearSession"),
+      compactSession: record("agent.compactSession"),
+      createSession: record("agent.createSession"),
       draftAutomation: record("agent.draftAutomation"),
       draftTaskPrompt: record("agent.draftTaskPrompt"),
-      generateImage: async () => {
-        calls.push("agent.generateImage");
-        return { imageUrl: "x" };
-      },
+      generateImage: record("agent.generateImage"),
       listProfiles: async () => ({ profiles: [{ id: "default" }] }),
-      purgeSession: async () => {
-        calls.push("agent.purgeSession");
-        return true;
-      },
+      purgeSession: record("agent.purgeSession"),
       runAutomation: async () => {
         calls.push("agent.runAutomation");
         return { skipped: false };
@@ -56,10 +38,7 @@ function createApp() {
         calls.push("agent.runTask");
         return { skipped: false };
       },
-      transcribeAudio: async () => {
-        calls.push("agent.transcribeAudio");
-        return { text: "x" };
-      },
+      transcribeAudio: record("agent.transcribeAudio"),
     },
     automationService: {
       create: record("automationService.create"),

--- a/apps/server/src/http/routes/sessions.ts
+++ b/apps/server/src/http/routes/sessions.ts
@@ -1,17 +1,16 @@
 import { createRoute, z } from "@hono/zod-openapi";
-import {
-  type BranchSessionRequest,
-  type BranchSessionResponse,
-  type CompactionResponse,
-  type CompactSessionRequest,
-  type CreateSessionRequest,
-  type CreateSessionResponse,
-  type ListSessionsResponse,
-  NakamaApiError,
-  type SendMessageRequest,
-  type SendMessageResponse,
-  type SessionMessagesResponse,
-  type SessionStatusResponse,
+import type {
+  BranchSessionRequest,
+  BranchSessionResponse,
+  CompactionResponse,
+  CompactSessionRequest,
+  CreateSessionRequest,
+  CreateSessionResponse,
+  ListSessionsResponse,
+  SendMessageRequest,
+  SendMessageResponse,
+  SessionMessagesResponse,
+  SessionStatusResponse,
 } from "@nakama/core";
 import { resolveRequestClientOrigin } from "../../services/composio-callback-url";
 import { sessionTurnRegistry } from "../../services/session-turn-registry";
@@ -485,10 +484,6 @@ export function registerSessionRoutes(
 
       return json<BranchSessionResponse>(result, 201);
     } catch (error) {
-      if (error instanceof NakamaApiError) {
-        return errorResponse(error.message, error.status);
-      }
-
       const message = error instanceof Error ? error.message : String(error);
       return errorResponse(message, 400);
     }


### PR DESCRIPTION
## Summary

Viewer RBAC matrix stays green with −26 lines of dead catch + stub boilerplate from #401.

**Before:** branch catch remapped `NakamaApiError` (guard already outside try); seven hand-written agent stubs.
**After:** original catch only; stubs use `record()` like the rest of the matrix.

Why safe:
1. `requireNotViewerFromContext` is outside the branch `try`
2. Viewer tests only assert `403` + empty `calls` — return shape unused
3. Same matrix coverage as #401

Only re-add shaped stubs if a future member-success path needs real agent return values.

## Test plan
- [x] `bun test apps/server/src/http/routes/rbac-mutations.test.ts` (19 pass)
- [ ] Spot-check viewer still gets 403 on `POST /v1/sessions/:id/branch`
