### PR TITLE
fix(server): SIGKILL agent-browser version probes that trap SIGTERM

### DIFF
--- a/apps/server/src/services/agent-browser-service.test.ts
+++ b/apps/server/src/services/agent-browser-service.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createInMemoryDatabaseAdapter } from "@nakama/db";
@@ -58,20 +58,9 @@ describe("agent-browser service", () => {
     expect(status.nextStep).toBeNull();
   });
 
-  test("a CLI that hangs on --version resolves as not installed", async () => {
-    await installFakeBinary(tempBinDir, "agent-browser", "hangs");
-
-    const started = Date.now();
-    const status = await getAgentBrowserStatus();
-
-    expect(status.installed).toBe(false);
-    expect(status.ready).toBe(false);
-    expect(status.nextStep).toBe("install");
-    expect(Date.now() - started).toBeLessThan(15_000);
-  }, 20_000);
-
-  test("a CLI that ignores SIGTERM still resolves the readiness probe", async () => {
+  test("a CLI that traps SIGTERM is killed once the version probe times out", async () => {
     await installFakeBinary(tempBinDir, "agent-browser", "stubborn");
+    const pidFile = join(tempBinDir, "pid");
 
     const started = Date.now();
     const status = await getAgentBrowserStatus();
@@ -79,7 +68,11 @@ describe("agent-browser service", () => {
     expect(status.installed).toBe(false);
     expect(status.ready).toBe(false);
     expect(Date.now() - started).toBeLessThan(15_000);
-  }, 20_000);
+
+    const pid = Number.parseInt(await readFile(pidFile, "utf8"), 10);
+    expect(Number.isInteger(pid)).toBe(true);
+    expect(await waitForExit(pid, 15_000)).toBe(true);
+  }, 45_000);
 });
 
 describe("agent-browser settings routes", () => {
@@ -286,7 +279,11 @@ exit 0
 setInterval(() => {}, 1000);
 `;
   } else if (mode === "stubborn") {
+    // Hangs on --version and swallows SIGTERM, so only the SIGKILL escalation
+    // ends it. It records its own pid because the probe never exposes the child.
+    const pidFile = join(binDir, "pid");
     script = `#!${process.execPath}
+require("node:fs").writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));
 process.on("SIGTERM", () => {});
 setInterval(() => {}, 1000);
 `;
@@ -294,4 +291,20 @@ setInterval(() => {}, 1000);
 
   await writeFile(scriptPath, script, "utf8");
   await chmod(scriptPath, 0o755);
+}
+
+async function waitForExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return true;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  return false;
 }

--- a/apps/server/src/services/agent-browser-service.ts
+++ b/apps/server/src/services/agent-browser-service.ts
@@ -58,6 +58,9 @@ function extractVersion(stdout: string, stderr: string): string | null {
   return output.split(/\r?\n/, 1)[0]?.trim() || null;
 }
 
+/** How long a timed-out child gets to honour SIGTERM before it is killed. */
+const SIGTERM_GRACE_MS = 2000;
+
 async function probeAgentBrowserVersion(): Promise<{
   installed: boolean;
   version: string | null;
@@ -85,6 +88,7 @@ async function probeAgentBrowserVersion(): Promise<{
 
     let stdout = "";
     let stderr = "";
+    let killTimeoutId: ReturnType<typeof setTimeout> | undefined;
 
     // Settings awaits this probe, so a CLI that never answers --version
     // would otherwise hold GET /v1/settings/agent-browser open forever.
@@ -94,6 +98,10 @@ async function probeAgentBrowserVersion(): Promise<{
     // on its PATH retry.
     const timeoutId = setTimeout(() => {
       child.kill("SIGTERM");
+      // A CLI that traps SIGTERM outlives the probe, and its open stdio
+      // pipes then keep this process alive too. Same escalation as
+      // probeHarnessVersion (#338).
+      killTimeoutId = setTimeout(() => child.kill("SIGKILL"), SIGTERM_GRACE_MS);
       resolve({ installed: false, missing: false, version: null });
     }, timeoutMs);
 
@@ -105,6 +113,7 @@ async function probeAgentBrowserVersion(): Promise<{
     });
     child.once("error", (error) => {
       clearTimeout(timeoutId);
+      clearTimeout(killTimeoutId);
       resolve({
         installed: false,
         missing: (error as NodeJS.ErrnoException).code === "ENOENT",
@@ -113,6 +122,7 @@ async function probeAgentBrowserVersion(): Promise<{
     });
     child.once("close", (code) => {
       clearTimeout(timeoutId);
+      clearTimeout(killTimeoutId);
       resolve({
         installed: code === 0,
         missing: false,


### PR DESCRIPTION
## Summary

Agent-browser `--version` probes that trap SIGTERM get SIGKILL after 2s — no orphan child pinning Settings.

**Before:** timeout resolved + SIGTERM only; stubborn CLI kept running (open stdio).
**After:** `probeAgentBrowserVersion` matches `probeHarnessVersion` — SIGKILL after `SIGTERM_GRACE_MS`, test asserts the pid exits.

Why safe:
1. Same pattern already merged for harness probes (#338)
2. Clear kill timer on close/error so healthy CLIs are untouched
3. Stubborn stub writes pid; waitForExit pins the escalation

Only re-add a shared `probeCliVersion` helper if these twins drift again.

## Test plan
- [x] `bun test apps/server/src/services/agent-browser-service.test.ts` (6 pass)
- [ ] Open System → Settings with a fake stubborn agent-browser on PATH — status returns in ~5s, no leftover node process
