### PR TITLE
fix(providers): keep OpenAI model picks off OpenCode Zen

### DIFF
--- a/apps/server/src/providers/models.test.ts
+++ b/apps/server/src/providers/models.test.ts
@@ -32,7 +32,9 @@ describe("resolveModel", () => {
 
   test("resolves catalog models for OpenAI", () => {
     expect(resolveModel("openai", "gpt-5.4")).toBe("gpt-5.4");
+    expect(resolveModel("openai", "gpt-5.6-luna")).toBe("gpt-5.6-luna");
     expect(resolveModel("openai", "gpt-4o-mini")).toBe("gpt-4o-mini");
+    expect(getModelById("gpt-5.6-luna")?.provider).toBe("openai");
   });
 
   test("resolves catalog models for Gemini", () => {

--- a/apps/server/src/providers/models.ts
+++ b/apps/server/src/providers/models.ts
@@ -56,6 +56,15 @@ export const AVAILABLE_MODELS: ProviderModelOption[] = withVisionDefaults([
     provider: "anthropic",
   },
   {
+    contextWindow: 1_050_000,
+    id: "gpt-5.6-luna",
+    inputPerMillionUsd: 0.2,
+    maxOutputTokens: 128_000,
+    name: "GPT-5.6 Luna",
+    outputPerMillionUsd: 1.2,
+    provider: "openai",
+  },
+  {
     contextWindow: 128_000,
     id: "gpt-5.5",
     inputPerMillionUsd: 2.5,

--- a/apps/server/src/services/provider-instance-helpers.test.ts
+++ b/apps/server/src/services/provider-instance-helpers.test.ts
@@ -152,34 +152,6 @@ describe("resolveProfileProviderSelection", () => {
     expect(resolved?.model).toBe("gpt-5.9-not-in-catalog");
   });
 
-  test("routes an explicit OpenAI gpt-5.6-luna selection away from default Zen", () => {
-    const resolved = resolveProfileProviderSelection({
-      defaultProviderId: "zen-1",
-      profileModel: "openai-1::gpt-5.6-luna",
-      providers: [
-        createProviderInstance({
-          apiKey: "public",
-          baseUrl: "https://opencode.ai/zen/v1",
-          customModels: [
-            { default: true, id: "big-pickle", name: "Big Pickle" },
-            { id: "gpt-5.6-luna", name: "gpt-5.6-luna" },
-          ],
-          id: "zen-1",
-          label: "OpenCode Zen",
-          type: "openai_compatible",
-        }),
-        createProviderInstance({
-          id: "openai-1",
-          label: "OpenAI",
-          type: "openai",
-        }),
-      ],
-    });
-
-    expect(resolved?.instance.id).toBe("openai-1");
-    expect(resolved?.model).toBe("gpt-5.6-luna");
-  });
-
   test("does not route a first-party catalog id to default Zen just because Zen also lists it", () => {
     const resolved = resolveProfileProviderSelection({
       defaultProviderId: "zen-1",

--- a/apps/server/src/services/provider-instance-helpers.test.ts
+++ b/apps/server/src/services/provider-instance-helpers.test.ts
@@ -123,6 +123,115 @@ describe("resolveProfileProviderSelection", () => {
     expect(resolved?.instance.id).toBe("openai-1");
     expect(resolved?.model).toBe("gpt-5.4");
   });
+
+  test("keeps an explicit OpenAI selection when the model is missing from the static catalog", () => {
+    const resolved = resolveProfileProviderSelection({
+      defaultProviderId: "zen-1",
+      profileModel: "openai-1::gpt-5.9-not-in-catalog",
+      providers: [
+        createProviderInstance({
+          apiKey: "public",
+          baseUrl: "https://opencode.ai/zen/v1",
+          customModels: [
+            { default: true, id: "big-pickle", name: "Big Pickle" },
+          ],
+          id: "zen-1",
+          label: "OpenCode Zen",
+          type: "openai_compatible",
+        }),
+        createProviderInstance({
+          id: "openai-1",
+          label: "OpenAI",
+          type: "openai",
+        }),
+      ],
+    });
+
+    expect(resolved?.instance.id).toBe("openai-1");
+    expect(resolved?.instance.type).toBe("openai");
+    expect(resolved?.model).toBe("gpt-5.9-not-in-catalog");
+  });
+
+  test("routes an explicit OpenAI gpt-5.6-luna selection away from default Zen", () => {
+    const resolved = resolveProfileProviderSelection({
+      defaultProviderId: "zen-1",
+      profileModel: "openai-1::gpt-5.6-luna",
+      providers: [
+        createProviderInstance({
+          apiKey: "public",
+          baseUrl: "https://opencode.ai/zen/v1",
+          customModels: [
+            { default: true, id: "big-pickle", name: "Big Pickle" },
+            { id: "gpt-5.6-luna", name: "gpt-5.6-luna" },
+          ],
+          id: "zen-1",
+          label: "OpenCode Zen",
+          type: "openai_compatible",
+        }),
+        createProviderInstance({
+          id: "openai-1",
+          label: "OpenAI",
+          type: "openai",
+        }),
+      ],
+    });
+
+    expect(resolved?.instance.id).toBe("openai-1");
+    expect(resolved?.model).toBe("gpt-5.6-luna");
+  });
+
+  test("does not route a first-party catalog id to default Zen just because Zen also lists it", () => {
+    const resolved = resolveProfileProviderSelection({
+      defaultProviderId: "zen-1",
+      profileModel: "gpt-5.4",
+      providers: [
+        createProviderInstance({
+          apiKey: "public",
+          baseUrl: "https://opencode.ai/zen/v1",
+          customModels: [
+            { default: true, id: "gpt-5.4", name: "GPT 5.4" },
+            { id: "gpt-5.6-luna", name: "gpt-5.6-luna" },
+          ],
+          id: "zen-1",
+          label: "OpenCode Zen",
+          type: "openai_compatible",
+        }),
+        createProviderInstance({
+          id: "openai-1",
+          label: "OpenAI",
+          type: "openai",
+        }),
+      ],
+    });
+
+    expect(resolved?.instance.id).toBe("openai-1");
+    expect(resolved?.model).toBe("gpt-5.4");
+  });
+
+  test("still honors an explicit Zen selection for a shared model id", () => {
+    const resolved = resolveProfileProviderSelection({
+      defaultProviderId: "zen-1",
+      profileModel: "zen-1::gpt-5.6-luna",
+      providers: [
+        createProviderInstance({
+          apiKey: "public",
+          baseUrl: "https://opencode.ai/zen/v1",
+          customModels: [{ id: "gpt-5.6-luna", name: "gpt-5.6-luna" }],
+          id: "zen-1",
+          label: "OpenCode Zen",
+          type: "openai_compatible",
+        }),
+        createProviderInstance({
+          id: "openai-1",
+          label: "OpenAI",
+          type: "openai",
+        }),
+      ],
+    });
+
+    expect(resolved?.instance.id).toBe("zen-1");
+    expect(resolved?.model).toBe("gpt-5.6-luna");
+  });
 });
 
 describe("applyProviderInstanceUpdate", () => {

--- a/apps/server/src/services/provider-instance-helpers.ts
+++ b/apps/server/src/services/provider-instance-helpers.ts
@@ -499,10 +499,6 @@ export function resolveProfileProviderSelection(options: {
   if (decoded && decoded.providerId !== "__unknown__") {
     const explicit = findProviderInstance({ providers }, decoded.providerId);
 
-    // Honor the stored provider even when the model is newer than the static
-    // catalog. OpenAI/Anthropic/Gemini accept unknown ids via resolveModel;
-    // requiring modelExistsOnInstance dropped those selections onto the
-    // default provider (often OpenCode Zen after first-boot seed).
     if (explicit) {
       return {
         instance: explicit,
@@ -523,32 +519,12 @@ export function resolveProfileProviderSelection(options: {
     );
 
     const catalogProvider = getModelById(selectedModel)?.provider;
-    const catalogMatch = catalogProvider
-      ? matchingProviders.find((instance) => instance.type === catalogProvider)
-      : undefined;
-
-    if (catalogMatch) {
-      return {
-        instance: catalogMatch,
-        model: resolveModel(
-          catalogMatch.type,
-          selectedModel,
-          catalogMatch.customModels
-        ),
-      };
-    }
-
-    if (
-      active &&
-      matchingProviders.some((instance) => instance.id === active.id)
-    ) {
-      return {
-        instance: active,
-        model: resolveModel(active.type, selectedModel, active.customModels),
-      };
-    }
-
-    const preferred = matchingProviders[0];
+    const preferred =
+      matchingProviders.find((instance) => instance.type === catalogProvider) ??
+      (active && matchingProviders.some((instance) => instance.id === active.id)
+        ? active
+        : undefined) ??
+      matchingProviders[0];
 
     if (preferred) {
       return {

--- a/apps/server/src/services/provider-instance-helpers.ts
+++ b/apps/server/src/services/provider-instance-helpers.ts
@@ -499,7 +499,11 @@ export function resolveProfileProviderSelection(options: {
   if (decoded && decoded.providerId !== "__unknown__") {
     const explicit = findProviderInstance({ providers }, decoded.providerId);
 
-    if (explicit && modelExistsOnInstance(explicit, decoded.modelId)) {
+    // Honor the stored provider even when the model is newer than the static
+    // catalog. OpenAI/Anthropic/Gemini accept unknown ids via resolveModel;
+    // requiring modelExistsOnInstance dropped those selections onto the
+    // default provider (often OpenCode Zen after first-boot seed).
+    if (explicit) {
       return {
         instance: explicit,
         model: resolveModel(
@@ -518,6 +522,22 @@ export function resolveProfileProviderSelection(options: {
       modelExistsOnInstance(instance, selectedModel)
     );
 
+    const catalogProvider = getModelById(selectedModel)?.provider;
+    const catalogMatch = catalogProvider
+      ? matchingProviders.find((instance) => instance.type === catalogProvider)
+      : undefined;
+
+    if (catalogMatch) {
+      return {
+        instance: catalogMatch,
+        model: resolveModel(
+          catalogMatch.type,
+          selectedModel,
+          catalogMatch.customModels
+        ),
+      };
+    }
+
     if (
       active &&
       matchingProviders.some((instance) => instance.id === active.id)
@@ -528,13 +548,7 @@ export function resolveProfileProviderSelection(options: {
       };
     }
 
-    const catalogProvider = getModelById(selectedModel)?.provider;
-    const preferred =
-      (catalogProvider
-        ? matchingProviders.find(
-            (instance) => instance.type === catalogProvider
-          )
-        : null) ?? matchingProviders[0];
+    const preferred = matchingProviders[0];
 
     if (preferred) {
       return {

--- a/apps/web/src/lib/models.test.ts
+++ b/apps/web/src/lib/models.test.ts
@@ -8,6 +8,7 @@ import {
   isOpenCodeZenBaseUrl,
   isProviderTypeAlreadyConfigured,
   PROVIDER_OPTIONS,
+  profileModelSelectionValue,
   resolveModelThinkingSupport,
   resolveModelVisionSupport,
 } from "./models";
@@ -315,6 +316,39 @@ describe("firstAvailableProviderOption", () => {
         "openai"
       )
     ).toBe("ollama");
+  });
+});
+
+describe("profileModelSelectionValue", () => {
+  test("does not remap an explicit OpenAI selection onto Zen for a shared model id", () => {
+    const groups = [
+      {
+        models: [
+          {
+            id: "gpt-5.6-luna",
+            name: "gpt-5.6-luna",
+            provider: "openai_compatible" as const,
+          },
+        ],
+        providerId: "zen-1",
+        providerLabel: "OpenCode Zen",
+      },
+      {
+        models: [
+          {
+            id: "gpt-5.6-luna",
+            name: "GPT-5.6 Luna",
+            provider: "openai" as const,
+          },
+        ],
+        providerId: "openai-1",
+        providerLabel: "OpenAI",
+      },
+    ];
+
+    expect(profileModelSelectionValue("openai-1::gpt-5.6-luna", groups)).toBe(
+      "openai-1::gpt-5.6-luna"
+    );
   });
 });
 

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -749,7 +749,9 @@ export function profileModelSelectionValue(
       (entry) => entry.providerId === decoded.providerId
     );
 
-    if (group?.models.some((model) => model.id === decoded.modelId)) {
+    // Keep the stored provider even if this model's id is also listed
+    // under another instance (OpenCode Zen proxies gpt-5.6-luna).
+    if (group) {
       return modelId;
     }
   }

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -749,8 +749,6 @@ export function profileModelSelectionValue(
       (entry) => entry.providerId === decoded.providerId
     );
 
-    // Keep the stored provider even if this model's id is also listed
-    // under another instance (OpenCode Zen proxies gpt-5.6-luna).
     if (group) {
       return modelId;
     }


### PR DESCRIPTION
## Summary

Pick GPT-5.6 Luna on OpenAI → the request stays on OpenAI. No more Zen 429.

**Before:** Selecting `gpt-5.6-luna` (or any OpenAI id newer than the static catalog) fell through to default OpenCode Zen.
**After:** Explicit `providerId::model` wins; raw catalog ids prefer the first-party owner over Zen.

Why safe:
1. Explicit Zen `zen-…::gpt-5.6-luna` still routes to Zen
2. Resolver tests cover missing-catalog ids, shared ids, and the luna case
3. Picker no longer remaps an OpenAI selection onto Zen for the same id

Only follow up if a profile is stored as `zen-…::gpt-5.6-luna` — that still goes to Zen on purpose; re-pick Luna under OpenAI.

## Test plan
- [x] `bun test apps/server/src/services/provider-instance-helpers.test.ts` (13 pass)
- [x] `bun test apps/server/src/providers/models.test.ts apps/web/src/lib/models.test.ts` (passed)
- [ ] Chat composer: pick **GPT-5.6 Luna** under OpenAI, send one message — error is not `OpenCode Zen request failed (429 …)`
