### PR TITLE
fix(automations): scope internal run to the owning org

### DIFF
--- a/apps/platform/automation/src/scheduler.test.ts
+++ b/apps/platform/automation/src/scheduler.test.ts
@@ -9,14 +9,14 @@ import { AutomationWorkerScheduler } from "./scheduler";
 function createMockClient(
   overrides: Partial<{
     listAutomationSchedules: () => Promise<AutomationSchedule[]>;
-    runAutomationInternal: (id: string) => Promise<void>;
+    runAutomationInternal: (id: string, orgId: string) => Promise<void>;
     getTimezone: () => Promise<string>;
   }> = {}
 ): NakamaClient {
   return {
     getTimezone: async () => "UTC",
     listAutomationSchedules: async () => [],
-    runAutomationInternal: async () => {},
+    runAutomationInternal: async (_id: string, _orgId: string) => {},
     ...overrides,
   } as unknown as NakamaClient;
 }

--- a/apps/platform/automation/src/scheduler.ts
+++ b/apps/platform/automation/src/scheduler.ts
@@ -23,7 +23,7 @@ export class AutomationWorkerScheduler {
     this.scheduler = new AutomationScheduler({
       getDefaultTimezone: () => this.fetchDefaultTimezone(),
       listScheduledAutomations: () => this.fetchSchedules(),
-      runAutomation: (id) => this.runAutomation(id),
+      runAutomation: (id, orgId) => this.runAutomation(id, orgId),
     });
   }
 
@@ -73,10 +73,11 @@ export class AutomationWorkerScheduler {
   }
 
   private async runAutomation(
-    automationId: string
+    automationId: string,
+    orgId: string
   ): Promise<{ ok: boolean; skipped?: boolean; error?: string }> {
     try {
-      await this.client.runAutomationInternal(automationId);
+      await this.client.runAutomationInternal(automationId, orgId);
       return { ok: true };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/apps/server/src/http/routes/internal-automations.test.ts
+++ b/apps/server/src/http/routes/internal-automations.test.ts
@@ -9,6 +9,12 @@ import { seedLocalClientUser } from "../test-org-helpers";
 
 const PROFILE_ID = "profile_default";
 const ORG_ID = "org_default";
+const ORG_OTHER = "org_other";
+
+function internalRunUrl(automationId: string, orgId: string): string {
+  const params = new URLSearchParams({ orgId });
+  return `http://localhost:4310/v1/internal/automations/${encodeURIComponent(automationId)}/run?${params}`;
+}
 
 function createServerOptions(overrides: Record<string, unknown> = {}) {
   const databaseAdapter = createInMemoryDatabaseAdapter();
@@ -129,6 +135,35 @@ describe("internal automation routes", () => {
     const token = await loadLocalAuthToken();
 
     const response = await app.fetch(
+      new Request(internalRunUrl(automation.id, ORG_ID), {
+        headers: { Authorization: `Bearer ${token}` },
+        method: "POST",
+      })
+    );
+
+    expect(response.status).toBe(204);
+  });
+
+  test("returns 400 when orgId query parameter is missing", async () => {
+    const options = createServerOptions();
+    await seedOrgAndProfile(options.databaseAdapter);
+    await seedLocalClientUser(options.databaseAdapter);
+
+    const automation = await options.automationService.create(
+      ORG_ID,
+      {
+        description: "Ping",
+        name: "Hourly",
+        prompt: "Ping",
+        trigger: { cron: "0 * * * *", timezone: "UTC", type: "schedule" },
+      },
+      PROFILE_ID
+    );
+
+    const app = createHonoApp(options);
+    const token = await loadLocalAuthToken();
+
+    const response = await app.fetch(
       new Request(
         `http://localhost:4310/v1/internal/automations/${encodeURIComponent(automation.id)}/run`,
         {
@@ -138,7 +173,65 @@ describe("internal automation routes", () => {
       )
     );
 
-    expect(response.status).toBe(204);
+    expect(response.status).toBe(400);
+  });
+
+  test("returns 404 and does not run when orgId does not own the automation", async () => {
+    const runCalls: string[] = [];
+    const options = createServerOptions({
+      agent: {
+        providerConfigured: true,
+        runAutomation: async (automationId: string) => {
+          runCalls.push(automationId);
+          return { skipped: false };
+        },
+      } as any,
+    });
+    await seedOrgAndProfile(options.databaseAdapter);
+    await seedLocalClientUser(options.databaseAdapter);
+    const now = new Date().toISOString();
+    await options.databaseAdapter.upsertOrganization({
+      createdAt: now,
+      id: ORG_OTHER,
+      name: "Other Org",
+      slug: "other-org",
+      updatedAt: now,
+    });
+    await options.databaseAdapter.upsertProfile({
+      createdAt: now,
+      id: "profile_other",
+      isDefault: true,
+      isSuper: false,
+      model: null,
+      name: "Other Bot",
+      orgId: ORG_OTHER,
+      systemPrompt: "",
+      updatedAt: now,
+    });
+
+    const automation = await options.automationService.create(
+      ORG_OTHER,
+      {
+        description: "Ping",
+        name: "Hourly",
+        prompt: "Ping",
+        trigger: { cron: "0 * * * *", timezone: "UTC", type: "schedule" },
+      },
+      "profile_other"
+    );
+
+    const app = createHonoApp(options);
+    const token = await loadLocalAuthToken();
+
+    const response = await app.fetch(
+      new Request(internalRunUrl(automation.id, ORG_ID), {
+        headers: { Authorization: `Bearer ${token}` },
+        method: "POST",
+      })
+    );
+
+    expect(response.status).toBe(404);
+    expect(runCalls).toEqual([]);
   });
 
   test("returns 404 for unknown automation run", async () => {
@@ -150,13 +243,10 @@ describe("internal automation routes", () => {
     const token = await loadLocalAuthToken();
 
     const response = await app.fetch(
-      new Request(
-        "http://localhost:4310/v1/internal/automations/unknown-automation/run",
-        {
-          headers: { Authorization: `Bearer ${token}` },
-          method: "POST",
-        }
-      )
+      new Request(internalRunUrl("unknown-automation", ORG_ID), {
+        headers: { Authorization: `Bearer ${token}` },
+        method: "POST",
+      })
     );
 
     expect(response.status).toBe(404);
@@ -190,13 +280,10 @@ describe("internal automation routes", () => {
     const token = await loadLocalAuthToken();
 
     const response = await app.fetch(
-      new Request(
-        `http://localhost:4310/v1/internal/automations/${encodeURIComponent(automation.id)}/run`,
-        {
-          headers: { Authorization: `Bearer ${token}` },
-          method: "POST",
-        }
-      )
+      new Request(internalRunUrl(automation.id, ORG_ID), {
+        headers: { Authorization: `Bearer ${token}` },
+        method: "POST",
+      })
     );
 
     expect(response.status).toBe(409);
@@ -266,13 +353,10 @@ describe("internal automation routes", () => {
     const app = createHonoApp(options);
     const token = await loadLocalAuthToken();
     const response = await app.fetch(
-      new Request(
-        `http://localhost:4310/v1/internal/automations/${encodeURIComponent(automation.id)}/run`,
-        {
-          headers: { Authorization: `Bearer ${token}` },
-          method: "POST",
-        }
-      )
+      new Request(internalRunUrl(automation.id, ORG_ID), {
+        headers: { Authorization: `Bearer ${token}` },
+        method: "POST",
+      })
     );
 
     expect(response.status).toBe(404);

--- a/apps/server/src/http/routes/internal-automations.ts
+++ b/apps/server/src/http/routes/internal-automations.ts
@@ -65,7 +65,12 @@ export function registerInternalAutomationRoutes(
     }
 
     const automationId = decodeURIComponent(c.req.param("automationId"));
-    const automation = await automationService.get(automationId);
+    const orgId = c.req.query("orgId")?.trim();
+    if (!orgId) {
+      return errorResponse("orgId query parameter is required.", 400);
+    }
+
+    const automation = await automationService.get(automationId, orgId);
 
     if (!automation) {
       return errorResponse("Automation not found", 404);

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -62,10 +62,10 @@ test("automation run requests disable Bun fetch idle timeout", async () => {
     },
   });
 
-  await client.runAutomationInternal("auto_1");
+  await client.runAutomationInternal("auto_1", "org_1");
 
   expect(String(fetchCalls[0]!.input)).toBe(
-    "http://localhost:4310/v1/internal/automations/auto_1/run"
+    "http://localhost:4310/v1/internal/automations/auto_1/run?orgId=org_1"
   );
   expect(
     (fetchCalls[0]!.init as RequestInit & { idleTimeout?: number }).idleTimeout

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1284,9 +1284,13 @@ export class NakamaClient {
     );
   }
 
-  async runAutomationInternal(automationId: string): Promise<void> {
+  async runAutomationInternal(
+    automationId: string,
+    orgId: string
+  ): Promise<void> {
+    const params = new URLSearchParams({ orgId });
     await this.request(
-      `/v1/internal/automations/${encodeURIComponent(automationId)}/run`,
+      `/v1/internal/automations/${encodeURIComponent(automationId)}/run?${params}`,
       withStreamFetchIdle({
         method: "POST",
       })

--- a/packages/core/src/automation-scheduler.test.ts
+++ b/packages/core/src/automation-scheduler.test.ts
@@ -49,6 +49,31 @@ describe("AutomationScheduler", () => {
     scheduler.stop();
   });
 
+  test("passes orgId from the schedule into runAutomation", async () => {
+    const runs: Array<{ id: string; orgId: string }> = [];
+    const delegate = createDelegate({
+      listScheduledAutomations: async () => [
+        schedule({
+          cron: undefined,
+          id: "a1",
+          orgId: "org_z",
+          runAt: new Date(Date.now() + 5).toISOString(),
+        }),
+      ],
+      runAutomation: async (id, orgId) => {
+        runs.push({ id, orgId });
+        return { ok: true };
+      },
+    });
+
+    const scheduler = new AutomationScheduler(delegate);
+    await scheduler.start();
+    await Bun.sleep(30);
+    scheduler.stop();
+
+    expect(runs).toEqual([{ id: "a1", orgId: "org_z" }]);
+  });
+
   test("reload stops old jobs and registers current schedules", async () => {
     let automations: AutomationSchedule[] = [schedule({ id: "a1" })];
     const delegate = createDelegate({

--- a/packages/core/src/automation-scheduler.ts
+++ b/packages/core/src/automation-scheduler.ts
@@ -9,7 +9,8 @@ export interface AutomationSchedulerDelegate {
   getDefaultTimezone(): Promise<string>;
   listScheduledAutomations(): Promise<AutomationSchedule[]>;
   runAutomation(
-    automationId: string
+    automationId: string,
+    orgId: string
   ): Promise<{ ok: boolean; skipped?: boolean; error?: string }>;
 }
 
@@ -83,7 +84,7 @@ export class AutomationScheduler {
         },
         () => {
           void this.delegate
-            .runAutomation(automation.id)
+            .runAutomation(automation.id, automation.orgId)
             .catch((error: unknown) => {
               const message =
                 error instanceof Error ? error.message : String(error);
@@ -110,7 +111,7 @@ export class AutomationScheduler {
     const timer = setTimeout(() => {
       this.timers.delete(automation.id);
       void this.delegate
-        .runAutomation(automation.id)
+        .runAutomation(automation.id, automation.orgId)
         .catch((error: unknown) => {
           const message =
             error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary

Scheduled automation runs are scoped to the owning org. Wrong org → 404 and no run.

**Before:** `POST /v1/internal/automations/:id/run` looked up the job by ID only.
**After:** requires `?orgId=`; `automationService.get(id, orgId)`.

Why safe:
1. Scheduler already has `automation.orgId` on the schedule
2. Missing `orgId` → 400; wrong org → 404 and `runAutomation` is never called
3. Worker and client thread the same argument — no ID-only fallback

Only re-add ID-only lookup if a non-org caller still needs to fire a job (none in-tree).

## Test plan
- [x] `bun test packages/core/src/automation-scheduler.test.ts packages/client/src/client.test.ts apps/platform/automation/src/scheduler.test.ts apps/server/src/http/routes/internal-automations.test.ts` (31 pass)
- [ ] Trigger one scheduled automation in a real org — it still runs
