### PR TITLE
feat(error-tracking): install the handlers in the server and the workers

### DIFF
--- a/apps/platform/discord/src/index.ts
+++ b/apps/platform/discord/src/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@nakama/client";
+import { installErrorHandlers, installErrorTrackingSink } from "@nakama/core";
 import {
   ChannelOrgStore,
   getChannelOrgSelectionPath,
@@ -21,6 +22,9 @@ import { createBot } from "./bot";
 import { loadConfig } from "./config";
 import { SessionStore } from "./session-store";
 import { ThreadStore } from "./thread-store";
+
+installErrorHandlers("worker:discord");
+void installErrorTrackingSink();
 
 let spawnedChild: Bun.Subprocess | null = null;
 let clientStop: (() => void) | null = null;

--- a/apps/platform/telegram/src/index.ts
+++ b/apps/platform/telegram/src/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@nakama/client";
+import { installErrorHandlers, installErrorTrackingSink } from "@nakama/core";
 import {
   ChannelOrgStore,
   getChannelOrgSelectionPath,
@@ -20,6 +21,9 @@ import { TelegramAuthStore } from "./auth-store";
 import { createBot } from "./bot";
 import { loadConfig } from "./config";
 import { SessionStore } from "./session-store";
+
+installErrorHandlers("worker:telegram");
+void installErrorTrackingSink();
 
 let spawnedChild: Bun.Subprocess | null = null;
 let botStop: (() => void) | null = null;

--- a/apps/platform/whatsapp/src/index.ts
+++ b/apps/platform/whatsapp/src/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@nakama/client";
+import { installErrorHandlers, installErrorTrackingSink } from "@nakama/core";
 import {
   ChannelOrgStore,
   getChannelOrgSelectionPath,
@@ -23,6 +24,9 @@ import { loadConfig } from "./config";
 import { startWhatsAppOutboundServer } from "./outbound-server";
 import { SessionStore } from "./session-store";
 import { createWhatsAppSocket } from "./socket";
+
+installErrorHandlers("worker:whatsapp");
+void installErrorTrackingSink();
 
 let spawnedChild: Bun.Subprocess | null = null;
 let socketHandle: {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,9 +1,24 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  flushPendingErrorReports,
+  installErrorHandlers,
+  installErrorTrackingSink,
+} from "@nakama/core";
 import type { Server } from "bun";
 import { ensureProcessPath } from "./lib/ensure-process-path";
 
 ensureProcessPath();
+installErrorHandlers("server");
+
+/**
+ * Only the server drains the queue. Four processes share one config dir, and the
+ * queue is a read-modify-write on a single file, so draining from all of them would
+ * race. The workers are spawned by the server, so it is the one that is always up.
+ * ponytail: single drainer, give the queue per-process files if a worker ever runs
+ * without a server.
+ */
+void installErrorTrackingSink().then(() => flushPendingErrorReports());
 
 import { generateSkillConsolidateMarkdown } from "@nakama/agent";
 import {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -9,6 +9,8 @@ import type { Server } from "bun";
 import { ensureProcessPath } from "./lib/ensure-process-path";
 
 ensureProcessPath();
+// Position is cosmetic: ESM evaluates every import above before this line runs, so a throw
+// inside @nakama/db or @nakama/agent module init is already past. Everything after is covered.
 installErrorHandlers("server");
 
 /**

--- a/packages/core/src/error-tracking-config.test.ts
+++ b/packages/core/src/error-tracking-config.test.ts
@@ -86,9 +86,3 @@ test("the env DSN overrides the file, and an empty one means off", () => {
     resolveErrorTrackingDsn({ dsn: DSN }, { NAKAMA_ERROR_TRACKING_DSN: "" })
   ).toBeNull();
 });
-
-test("a saved DSN takes effect without a restart", async () => {
-  expect(await isErrorTrackingEnabled()).toBe(false);
-  await saveErrorTrackingDsn(DSN);
-  expect(await isErrorTrackingEnabled()).toBe(true);
-});

--- a/packages/core/src/error-tracking-config.ts
+++ b/packages/core/src/error-tracking-config.ts
@@ -50,6 +50,10 @@ export function resolveErrorTrackingDsn(
   return file.dsn;
 }
 
+/**
+ * Callers must follow this with refreshErrorTrackingEnabled(): reportError reads a
+ * cached flag so it can decide synchronously, and the file alone does not move it.
+ */
 export async function saveErrorTrackingDsn(
   dsn: string | null
 ): Promise<ErrorTrackingConfig> {

--- a/packages/core/src/error-tracking-config.ts
+++ b/packages/core/src/error-tracking-config.ts
@@ -68,10 +68,6 @@ export async function saveErrorTrackingDsn(
   return next;
 }
 
-export async function currentErrorTrackingDsn(): Promise<string | null> {
-  return resolveErrorTrackingDsn(await loadErrorTrackingConfig());
-}
-
 export async function isErrorTrackingEnabled(): Promise<boolean> {
-  return (await currentErrorTrackingDsn()) !== null;
+  return resolveErrorTrackingDsn(await loadErrorTrackingConfig()) !== null;
 }

--- a/packages/core/src/error-tracking-queue.ts
+++ b/packages/core/src/error-tracking-queue.ts
@@ -47,8 +47,10 @@ export function appendPendingErrorReport(report: ErrorReport): void {
     write(
       [...readPendingErrorReports(), report].slice(-MAX_PENDING_ERROR_REPORTS)
     );
-  } catch {
-    // A full or read-only config dir must not turn one crash into two.
+  } catch (error) {
+    // A full or read-only config dir must not turn one crash into two, but swallowing it
+    // outright leaves an operator with tracking on and no reports and no reason why.
+    console.error("[nakama:error-tracking] cannot queue report", error);
   }
 }
 

--- a/packages/core/src/error-tracking-scrub.test.ts
+++ b/packages/core/src/error-tracking-scrub.test.ts
@@ -8,39 +8,42 @@ import { scrubText } from "./error-tracking-scrub";
  * data, so a regression here is a third-party data incident, not a telemetry bug.
  */
 describe("scrubText removes credentials", () => {
-  const cases: Array<[string, string]> = [
+  // The secret is carried per case. Asserting all eight in every case reads as
+  // thorough and is not: seven of them were never in that input, so those
+  // assertions pass whatever scrubText does.
+  const cases: Array<[name: string, secret: string, message: string]> = [
     [
       "anthropic key",
-      "failed with sk-ant-api03-abcdefghijklmnopqrstuvwxyz012345",
+      "sk-ant-api03-abcdefghijklmnopqrstuvwxyz012345",
+      "failed with SECRET",
     ],
-    ["openai key", "Authorization header sk-proj-AAAABBBBCCCCDDDDEEEEFFFF"],
-    ["github token", "clone failed ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"],
-    ["slack token", "post failed xoxb-1234567890-ABCDEFGHIJKL"],
-    ["aws key id", "denied for AKIAIOSFODNN7EXAMPLE"],
+    [
+      "openai key",
+      "sk-proj-AAAABBBBCCCCDDDDEEEEFFFF",
+      "Authorization header SECRET",
+    ],
+    [
+      "github token",
+      "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+      "clone failed SECRET",
+    ],
+    ["slack token", "xoxb-1234567890-ABCDEFGHIJKL", "post failed SECRET"],
+    ["aws key id", "AKIAIOSFODNN7EXAMPLE", "denied for SECRET"],
     [
       "bearer header",
-      "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+      "Authorization: Bearer SECRET",
     ],
-    ["assignment", 'connect({ apiKey: "hunter2secretvalue" })'],
-    ["env style", "ANTHROPIC_TOKEN=abcd1234efgh5678"],
+    ["assignment", "hunter2secretvalue", 'connect({ apiKey: "SECRET" })'],
+    ["env style", "abcd1234efgh5678", "ANTHROPIC_TOKEN=SECRET"],
   ];
 
-  for (const [name, input] of cases) {
+  for (const [name, secret, message] of cases) {
     test(name, () => {
-      const scrubbed = scrubText(input);
+      const input = message.replace("SECRET", secret);
 
-      expect(scrubbed).not.toContain(
-        "sk-ant-api03-abcdefghijklmnopqrstuvwxyz012345"
-      );
-      expect(scrubbed).not.toContain("sk-proj-AAAABBBBCCCCDDDDEEEEFFFF");
-      expect(scrubbed).not.toContain(
-        "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-      );
-      expect(scrubbed).not.toContain("xoxb-1234567890-ABCDEFGHIJKL");
-      expect(scrubbed).not.toContain("AKIAIOSFODNN7EXAMPLE");
-      expect(scrubbed).not.toContain("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9");
-      expect(scrubbed).not.toContain("hunter2secretvalue");
-      expect(scrubbed).not.toContain("abcd1234efgh5678");
+      expect(input).toContain(secret);
+      expect(scrubText(input)).not.toContain(secret);
     });
   }
 });

--- a/packages/core/src/error-tracking-sentry.test.ts
+++ b/packages/core/src/error-tracking-sentry.test.ts
@@ -59,7 +59,7 @@ test("no user identity is sent", () => {
 
   // Reports go to the operator's own project, so there is nobody to count installs
   // for and nothing that needs a stable id attached to the event.
-  expect(event.user).toBeUndefined();
+  expect(event).not.toHaveProperty("user");
 });
 
 test("the event id is the report id, so a retry collapses into one event", () => {
@@ -128,7 +128,9 @@ test("sendSentryEvent posts the event with the auth header the ingest expects", 
 test("sendSentryEvent reports failure instead of throwing when the ingest is down", async () => {
   const dsn = parseSentryDsn("http://k@127.0.0.1:1/9");
 
-  expect(await sendSentryEvent(dsn!, {}, 200)).toBe(false);
+  expect(await sendSentryEvent(dsn!, toSentryEvent(sampleReport()), 200)).toBe(
+    false
+  );
 });
 
 async function countSinkHits(env: Record<string, string>): Promise<number> {

--- a/packages/core/src/error-tracking-sentry.ts
+++ b/packages/core/src/error-tracking-sentry.ts
@@ -18,6 +18,34 @@ export interface SentryDsn {
 }
 
 /**
+ * The slice of the Sentry store payload nakama actually sends. Hand-rolled because no
+ * SDK is in use, and named so the envelope is a checked shape rather than a bag: a
+ * typo in a key here is silently ignored by the ingest and impossible to spot later.
+ */
+export interface SentryEvent {
+  contexts: {
+    os: { name: string };
+    runtime: { name: string; version: string };
+  };
+  event_id: string;
+  exception: { values: { type: string; value: string }[] };
+  extra?: { stack: string };
+  fingerprint: string[];
+  level: "error" | "info";
+  logger: string;
+  platform: string;
+  tags: {
+    api_version: string;
+    arch: string;
+    bun: string;
+    kind: string;
+    os: string;
+    source: string;
+  };
+  timestamp: string;
+}
+
+/**
  * One protocol covers Sentry, GlitchTip, Bugsink and self-hosted Sentry: they all accept
  * the same store endpoint and X-Sentry-Auth header, so the operator picks the platform
  * and nakama does not have to know which one it is talking to.
@@ -53,7 +81,7 @@ export function parseSentryDsn(dsn: string): SentryDsn | null {
   };
 }
 
-export function toSentryEvent(report: ErrorReport): Record<string, unknown> {
+export function toSentryEvent(report: ErrorReport): SentryEvent {
   return {
     contexts: {
       os: { name: report.runtime.platform },
@@ -87,7 +115,7 @@ export function toSentryEvent(report: ErrorReport): Record<string, unknown> {
 
 export async function sendSentryEvent(
   dsn: SentryDsn,
-  event: Record<string, unknown>,
+  event: SentryEvent,
   timeoutMs = SEND_TIMEOUT_MS
 ): Promise<boolean> {
   try {

--- a/packages/core/src/error-tracking.test.ts
+++ b/packages/core/src/error-tracking.test.ts
@@ -124,6 +124,20 @@ test("a non-Error rejection still produces a report", () => {
   expect(report.fingerprint).toHaveLength(16);
 });
 
+test("a circular rejection reports rather than throwing, at a shared fingerprint", () => {
+  const circular: { self?: unknown } = {};
+  circular.self = circular;
+
+  const report = buildErrorReport(circular, { source: "worker:discord" });
+  const other: { self?: unknown; kind?: string } = { kind: "different" };
+  other.self = other;
+
+  expect(report.fingerprint).toHaveLength(16);
+  // Documented, not desired: JSON.stringify throws on a cycle and String() flattens every
+  // one of them to "[object Object]", so two unrelated circular rejections share an issue.
+  expect(buildErrorReport(other).fingerprint).toBe(report.fingerprint);
+});
+
 test("with no sink installed nothing is queued and nothing is sent", async () => {
   setErrorSink(null);
 
@@ -136,6 +150,7 @@ test("the sink receives the report", async () => {
   const delivered: ErrorReport[] = [];
   setErrorSink((report) => {
     delivered.push(report);
+    return true;
   });
 
   await reportError(new Error("boom"), { source: "server" });
@@ -171,6 +186,7 @@ test("the queue is written before the send, which is what survives a hard exit",
   let queuedWhenSinkRan = 0;
   setErrorSink(() => {
     queuedWhenSinkRan = readPendingErrorReports().length;
+    return true;
   });
 
   await reportError(new Error("boom"), { source: "server" });

--- a/packages/core/src/error-tracking.ts
+++ b/packages/core/src/error-tracking.ts
@@ -132,6 +132,9 @@ function errorToParts(error: unknown): {
       name: "NonError",
     };
   } catch {
+    // Circular and other unserializable values all land on "[object Object]", so they
+    // share one fingerprint. Accepted: separating them needs a walk of the object, and
+    // a rejection with a circular non-Error is rare enough not to pay for it.
     return { message: String(error), name: "NonError" };
   }
 }


### PR DESCRIPTION
## Summary

> Stacked on #442, and out of draft because #442's feature commit is already on `main`: @ahmadrosid landed it with his cleanup in #453. What is still shared is the work on top of it, the scrub test refactor and the review fixes, 8 files under `packages/core`. The four entrypoints under `apps/` are what this PR owns. Merging #442 first keeps that split; merging this one first carries those 8 files along and leaves #442 empty.


Phase 2 of #441: the four processes that can die now report it. The server and the Telegram, WhatsApp and Discord workers install the handlers from #442, and the server drains the queue at startup. Stacked on #442.

**Before:** a crash in any of the four exists only as stderr on the host.
**After:** the process queues the report synchronously, and the server delivers it to the operator's DSN.

Measured against a real `bun apps/server/src/index.ts`, with one report left in the queue by a previous process:

```
BEFORE  no config.ini at all (feature off)
  queue before: 1
  server up: 200
  ingest received: 0 event
  queue after: 1        <- left alone, not dropped

AFTER   operator saved their DSN
  queue before: 1
  server up: 200
  ingest received: 1 event
  queue after: 0
```

Why safe:
1. With no DSN nothing changes: no request, nothing written, and a queued report is left alone rather than discarded.
2. `installErrorHandlers` uses `uncaughtExceptionMonitor`, which observes the error and leaves Bun's own crash and exit intact. Exit codes are untouched. It does not reach a throw during module init of an imported package: ESM evaluates every import before the first statement runs, so the handler is not registered yet. The comment in `index.ts` says so.
3. Only the server drains. The four share one config directory and the queue is a read-modify-write on a single file, so draining from all of them would race. The workers are spawned by the server, so it is the one that is always up. The code carries the upgrade path if a worker ever runs alone.

Rebased on #442 after @ahmadrosid's cleanup landed on `main`. One line changed here while doing it: the "server is the only drainer" comment had been pasted into all three worker entrypoints, and the server file already explains the whole decision, so the three copies are gone.

There is no unit test here worth writing. The change is four call sites; what needed proving is that a real server drains at startup, which is the run above. The sender and the queue are covered by #442.

## Test plan
- [x] `bun run test` across all workspaces: 0 fail.
- [x] Both arms above, driven by the real server entrypoint rather than a harness.

Refs #441. #444 adds the Integrations form so the DSN can be saved from the UI.



