### PR TITLE
feat(error-tracking): configure the DSN from the Integrations tab

### DIFF
--- a/apps/platform/discord/src/index.ts
+++ b/apps/platform/discord/src/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@nakama/client";
+import { installErrorHandlers, installErrorTrackingSink } from "@nakama/core";
 import {
   ChannelOrgStore,
   getChannelOrgSelectionPath,
@@ -21,6 +22,9 @@ import { createBot } from "./bot";
 import { loadConfig } from "./config";
 import { SessionStore } from "./session-store";
 import { ThreadStore } from "./thread-store";
+
+installErrorHandlers("worker:discord");
+void installErrorTrackingSink();
 
 let spawnedChild: Bun.Subprocess | null = null;
 let clientStop: (() => void) | null = null;

--- a/apps/platform/telegram/src/index.ts
+++ b/apps/platform/telegram/src/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@nakama/client";
+import { installErrorHandlers, installErrorTrackingSink } from "@nakama/core";
 import {
   ChannelOrgStore,
   getChannelOrgSelectionPath,
@@ -20,6 +21,9 @@ import { TelegramAuthStore } from "./auth-store";
 import { createBot } from "./bot";
 import { loadConfig } from "./config";
 import { SessionStore } from "./session-store";
+
+installErrorHandlers("worker:telegram");
+void installErrorTrackingSink();
 
 let spawnedChild: Bun.Subprocess | null = null;
 let botStop: (() => void) | null = null;

--- a/apps/platform/whatsapp/src/index.ts
+++ b/apps/platform/whatsapp/src/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@nakama/client";
+import { installErrorHandlers, installErrorTrackingSink } from "@nakama/core";
 import {
   ChannelOrgStore,
   getChannelOrgSelectionPath,
@@ -23,6 +24,9 @@ import { loadConfig } from "./config";
 import { startWhatsAppOutboundServer } from "./outbound-server";
 import { SessionStore } from "./session-store";
 import { createWhatsAppSocket } from "./socket";
+
+installErrorHandlers("worker:whatsapp");
+void installErrorTrackingSink();
 
 let spawnedChild: Bun.Subprocess | null = null;
 let socketHandle: {

--- a/apps/server/src/http/routes/error-tracking.test.ts
+++ b/apps/server/src/http/routes/error-tracking.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createInMemoryDatabaseAdapter } from "@nakama/db";
+import { AgentService } from "../../services/agent-service";
+import { AuthService } from "../../services/auth-service";
+import { createMinimalHonoApp } from "../test-app-helpers";
+import { loginUserSession, seedOrgAdmin } from "../test-session-helpers";
+
+const DSN = "https://publickey@errors.example.com/42";
+
+async function createApp() {
+  process.env.NAKAMA_CONFIG_DIR = await mkdtemp(
+    join(tmpdir(), "nakama-error-tracking-route-")
+  );
+
+  const databaseAdapter = createInMemoryDatabaseAdapter();
+  const authService = new AuthService();
+
+  return createMinimalHonoApp({
+    agent: new AgentService(null, null, databaseAdapter),
+    authService,
+    databaseAdapter,
+  });
+}
+
+async function seedMember(
+  databaseAdapter: ReturnType<typeof createInMemoryDatabaseAdapter>,
+  authService: AuthService,
+  role: "member" | "viewer"
+) {
+  const now = new Date().toISOString();
+  const email = `${role}@example.com`;
+  const password = "password123";
+
+  await databaseAdapter.createUser({
+    createdAt: now,
+    email,
+    id: `user_${role}`,
+    passwordHash: await authService.hashPassword(password),
+    updatedAt: now,
+  });
+  await databaseAdapter.upsertOrganization({
+    createdAt: now,
+    id: "org_test",
+    name: "Test Org",
+    slug: "test-org",
+    updatedAt: now,
+  });
+  await databaseAdapter.upsertOrgMember({
+    createdAt: now,
+    orgId: "org_test",
+    role,
+    userId: `user_${role}`,
+  });
+
+  return { email, orgId: "org_test", password };
+}
+
+describe("error tracking routes", () => {
+  test("an org admin saves a DSN and reads it back masked", async () => {
+    const { app, databaseAdapter } = await createApp();
+    const { email, password, orgId } = await seedOrgAdmin(databaseAdapter);
+    const session = await loginUserSession(app, email, password, orgId);
+
+    const saved = await app.fetch(
+      new Request("http://localhost:4310/v1/settings/error-tracking", {
+        body: JSON.stringify({ dsn: DSN }),
+        headers: session.headers({
+          "Content-Type": "application/json",
+          "X-CSRF-Token": session.csrfToken,
+        }),
+        method: "PUT",
+      })
+    );
+
+    expect(saved.status).toBe(200);
+    const body = (await saved.json()) as {
+      configured: boolean;
+      dsnMasked: string | null;
+    };
+    expect(body.configured).toBe(true);
+    // The whole point of the masked field: the response must not carry the key.
+    expect(body.dsnMasked).not.toContain("publickey");
+    expect(JSON.stringify(body)).not.toContain(DSN);
+  });
+
+  test("a malformed DSN is rejected instead of being saved", async () => {
+    const { app, databaseAdapter } = await createApp();
+    const { email, password, orgId } = await seedOrgAdmin(databaseAdapter);
+    const session = await loginUserSession(app, email, password, orgId);
+
+    const response = await app.fetch(
+      new Request("http://localhost:4310/v1/settings/error-tracking", {
+        body: JSON.stringify({ dsn: "not-a-dsn" }),
+        headers: session.headers({
+          "Content-Type": "application/json",
+          "X-CSRF-Token": session.csrfToken,
+        }),
+        method: "PUT",
+      })
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  for (const role of ["member", "viewer"] as const) {
+    test(`a ${role} cannot write the workspace-wide DSN`, async () => {
+      const { app, databaseAdapter, authService } = await createApp();
+      const { email, password, orgId } = await seedMember(
+        databaseAdapter,
+        authService,
+        role
+      );
+      const session = await loginUserSession(app, email, password, orgId);
+
+      const response = await app.fetch(
+        new Request("http://localhost:4310/v1/settings/error-tracking", {
+          body: JSON.stringify({ dsn: DSN }),
+          headers: session.headers({
+            "Content-Type": "application/json",
+            "X-CSRF-Token": session.csrfToken,
+          }),
+          method: "PUT",
+        })
+      );
+
+      expect(response.status).toBe(403);
+    });
+  }
+
+  test("the test event is refused before a DSN is saved", async () => {
+    const { app, databaseAdapter } = await createApp();
+    const { email, password, orgId } = await seedOrgAdmin(databaseAdapter);
+    const session = await loginUserSession(app, email, password, orgId);
+
+    const response = await app.fetch(
+      new Request("http://localhost:4310/v1/settings/error-tracking/test", {
+        headers: session.headers({ "X-CSRF-Token": session.csrfToken }),
+        method: "POST",
+      })
+    );
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/apps/server/src/http/routes/error-tracking.test.ts
+++ b/apps/server/src/http/routes/error-tracking.test.ts
@@ -86,6 +86,35 @@ describe("error tracking routes", () => {
     expect(JSON.stringify(body)).not.toContain(DSN);
   });
 
+  test("an empty DSN clears a saved one instead of keeping it", async () => {
+    const { app, databaseAdapter } = await createApp();
+    const { email, password, orgId } = await seedOrgAdmin(databaseAdapter);
+    const session = await loginUserSession(app, email, password, orgId);
+
+    const put = (dsn: string) =>
+      app.fetch(
+        new Request("http://localhost:4310/v1/settings/error-tracking", {
+          body: JSON.stringify({ dsn }),
+          headers: session.headers({
+            "Content-Type": "application/json",
+            "X-CSRF-Token": session.csrfToken,
+          }),
+          method: "PUT",
+        })
+      );
+
+    await put(DSN);
+    const cleared = await put("");
+
+    expect(cleared.status).toBe(200);
+    // Off has to be reachable from the same field that turned it on, or an operator
+    // who wants delivery stopped has to go and edit config.ini by hand.
+    expect(await cleared.json()).toMatchObject({
+      configured: false,
+      dsnMasked: null,
+    });
+  });
+
   test("a malformed DSN is rejected instead of being saved", async () => {
     const { app, databaseAdapter } = await createApp();
     const { email, password, orgId } = await seedOrgAdmin(databaseAdapter);

--- a/apps/server/src/http/routes/models.ts
+++ b/apps/server/src/http/routes/models.ts
@@ -145,6 +145,18 @@ export function registerModelRoutes(
     .object({})
     .passthrough()
     .openapi("ComposioSettingsResponse");
+  const errorTrackingSettingsSchema = z
+    .object({})
+    .passthrough()
+    .openapi("ErrorTrackingSettingsResponse");
+  const updateErrorTrackingRequestSchema = z
+    .object({})
+    .passthrough()
+    .openapi("UpdateErrorTrackingSettingsRequest");
+  const sendErrorTrackingTestSchema = z
+    .object({})
+    .passthrough()
+    .openapi("SendErrorTrackingTestResponse");
   const emailSettingsSchema = z
     .object({})
     .passthrough()
@@ -865,6 +877,65 @@ export function registerModelRoutes(
   );
   app.openAPIRegistry.registerPath(
     createRoute({
+      method: "get",
+      operationId: "getErrorTrackingSettings",
+      path: "/v1/settings/error-tracking",
+      responses: {
+        200: {
+          content: {
+            "application/json": { schema: errorTrackingSettingsSchema },
+          },
+          description: "Error tracking settings",
+        },
+      },
+      summary: "Get error tracking settings",
+      tags: ["Models"],
+    })
+  );
+  app.openAPIRegistry.registerPath(
+    createRoute({
+      method: "put",
+      operationId: "setErrorTrackingSettings",
+      path: "/v1/settings/error-tracking",
+      request: {
+        body: {
+          content: {
+            "application/json": { schema: updateErrorTrackingRequestSchema },
+          },
+          required: true,
+        },
+      },
+      responses: {
+        200: {
+          content: {
+            "application/json": { schema: errorTrackingSettingsSchema },
+          },
+          description: "Error tracking settings",
+        },
+      },
+      summary: "Set error tracking settings",
+      tags: ["Models"],
+    })
+  );
+  app.openAPIRegistry.registerPath(
+    createRoute({
+      method: "post",
+      operationId: "sendErrorTrackingTest",
+      path: "/v1/settings/error-tracking/test",
+      responses: {
+        200: {
+          content: {
+            "application/json": { schema: sendErrorTrackingTestSchema },
+          },
+          description: "Test event result",
+        },
+      },
+      summary: "Send a test event",
+      tags: ["Models"],
+    })
+  );
+  app.openAPIRegistry.registerPath(
+    createRoute({
       method: "put",
       operationId: "setComposioSettings",
       path: "/v1/settings/composio",
@@ -1465,6 +1536,48 @@ export function registerModelRoutes(
       return errorResponse(message, 400);
     }
   });
+  app.get("/v1/settings/error-tracking", async (c) => {
+    getRequestAuth(c);
+    return json<ErrorTrackingSettingsResponse>(
+      await agent.getErrorTrackingSettings()
+    );
+  });
+
+  app.put("/v1/settings/error-tracking", async (c) => {
+    // Workspace-global config, so there is no org to scope it to and a role guard is
+    // the only thing standing between a viewer and the whole install's error routing.
+    requireOrgAdminOrPlatformAdminFromContext(c);
+    const body = await readJson<UpdateErrorTrackingSettingsRequest>(c.req.raw);
+
+    try {
+      return json<ErrorTrackingSettingsResponse>(
+        await agent.setErrorTrackingSettings(body)
+      );
+    } catch (error) {
+      if (error instanceof NakamaApiError) {
+        return errorResponse(error.message, error.status);
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      return errorResponse(message, 400);
+    }
+  });
+
+  app.post("/v1/settings/error-tracking/test", async (c) => {
+    requireOrgAdminOrPlatformAdminFromContext(c);
+
+    try {
+      return json<SendErrorTrackingTestResponse>(
+        await agent.sendErrorTrackingTest()
+      );
+    } catch (error) {
+      if (error instanceof NakamaApiError) {
+        return errorResponse(error.message, error.status);
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      return errorResponse(message, 400);
+    }
+  });
+
   app.get("/v1/settings/whatsapp", async (c) => {
     getRequestAuth(c);
     return json<WhatsAppSettingsResponse>(await agent.getWhatsAppSettings());

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,9 +1,24 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  flushPendingErrorReports,
+  installErrorHandlers,
+  installErrorTrackingSink,
+} from "@nakama/core";
 import type { Server } from "bun";
 import { ensureProcessPath } from "./lib/ensure-process-path";
 
 ensureProcessPath();
+installErrorHandlers("server");
+
+/**
+ * Only the server drains the queue. Four processes share one config dir, and the
+ * queue is a read-modify-write on a single file, so draining from all of them would
+ * race. The workers are spawned by the server, so it is the one that is always up.
+ * ponytail: single drainer, give the queue per-process files if a worker ever runs
+ * without a server.
+ */
+void installErrorTrackingSink().then(() => flushPendingErrorReports());
 
 import { generateSkillConsolidateMarkdown } from "@nakama/agent";
 import {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -9,6 +9,8 @@ import type { Server } from "bun";
 import { ensureProcessPath } from "./lib/ensure-process-path";
 
 ensureProcessPath();
+// Position is cosmetic: ESM evaluates every import above before this line runs, so a throw
+// inside @nakama/db or @nakama/agent module init is already past. Everything after is covered.
 installErrorHandlers("server");
 
 /**

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -35,6 +35,7 @@ import type {
   DiscoverModelsRequest,
   DocumentAttachment,
   EmailSettingsResponse,
+  ErrorTrackingSettingsResponse,
   GenerateImageRequest,
   GenerateImageResponse,
   ImageAttachment,
@@ -58,6 +59,7 @@ import type {
   ProviderClient,
   RunToolResponse,
   SendEmailTestResponse,
+  SendErrorTrackingTestResponse,
   SkillResponse,
   SoulStackResponse,
   SoulStatusResponse,
@@ -77,6 +79,7 @@ import type {
   UpdateComposioSettingsRequest,
   UpdateDiscordSettingsRequest,
   UpdateEmailSettingsRequest,
+  UpdateErrorTrackingSettingsRequest,
   UpdateImageGenerationRequest,
   UpdateProfileRequest,
   UpdateProviderRequest,
@@ -98,11 +101,13 @@ import type {
 import {
   apiKeyEnvVarForProvider,
   appendOrgMemorySection,
+  buildErrorReport,
   buildThinkingProviderOptions,
   buildToolExecutionContext,
   buildUserContextStatus,
   composeKnowledgeBaseCatalog,
   composeSoulSystemPrompt,
+  createErrorTrackingSink,
   createSmtpSender,
   DEFAULT_THINKING_EFFORT,
   DEFAULT_THINKING_ENABLED,
@@ -123,6 +128,7 @@ import {
   loadDiscordSettingsPublic,
   loadEmailConfig,
   loadEmailSettingsPublic,
+  loadErrorTrackingSettingsPublic,
   loadSoulStack,
   loadTelegramSettingsPublic,
   loadUserConfig,
@@ -137,10 +143,12 @@ import {
   normalizeUserContextContent,
   type OrgRole,
   ollamaRequiresApiKey,
+  parseSentryDsn,
   persistInlineAttachmentsInContent,
   readArtifactFile,
   readBundledSkillBody,
   readEnvValue,
+  refreshErrorTrackingEnabled,
   regenerateDiscordHandshake,
   regenerateTelegramHandshake,
   regenerateWhatsAppPairingCode,
@@ -152,6 +160,7 @@ import {
   saveComposioConfig,
   saveDiscordConfig,
   saveEmailConfig,
+  saveErrorTrackingDsn,
   saveTelegramConfig,
   saveUserConfig,
   saveUserThinkingSettings,
@@ -1120,6 +1129,55 @@ export class AgentService {
     }
 
     return this.getComposioSettings();
+  }
+
+  async getErrorTrackingSettings(): Promise<ErrorTrackingSettingsResponse> {
+    return loadErrorTrackingSettingsPublic();
+  }
+
+  async setErrorTrackingSettings(
+    input: UpdateErrorTrackingSettingsRequest
+  ): Promise<ErrorTrackingSettingsResponse> {
+    const dsn = input.dsn?.trim() ?? "";
+
+    if (dsn && !parseSentryDsn(dsn)) {
+      throw new NakamaApiError(
+        "That does not look like a Sentry-compatible DSN.",
+        400
+      );
+    }
+
+    await saveErrorTrackingDsn(dsn || null);
+    // The flag gates whether anything is recorded at all, so it has to move with the
+    // DSN or saving one would need a restart to take effect.
+    await refreshErrorTrackingEnabled();
+    return this.getErrorTrackingSettings();
+  }
+
+  /**
+   * Sends one event immediately rather than through reportError, so a failed test does
+   * not leave a fake crash sitting in the delivery queue.
+   */
+  async sendErrorTrackingTest(): Promise<SendErrorTrackingTestResponse> {
+    const { configured } = await loadErrorTrackingSettingsPublic();
+
+    if (!configured) {
+      throw new NakamaApiError("Save a DSN first.", 400);
+    }
+
+    const delivered = await createErrorTrackingSink()(
+      buildErrorReport(new Error("Test event from nakama"), {
+        kind: "invariant",
+        source: "settings",
+      })
+    );
+
+    return {
+      delivered,
+      message: delivered
+        ? "Test event delivered. It should appear in your project within a few seconds."
+        : "The ingest rejected the event or could not be reached. Check the DSN.",
+    };
   }
 
   async getEmailSettings(): Promise<EmailSettingsResponse> {

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -1167,7 +1167,7 @@ export class AgentService {
 
     const delivered = await createErrorTrackingSink()(
       buildErrorReport(new Error("Test event from nakama"), {
-        kind: "invariant",
+        kind: "test",
         source: "settings",
       })
     );

--- a/apps/web/src/components/ErrorTrackingSettingsCard.tsx
+++ b/apps/web/src/components/ErrorTrackingSettingsCard.tsx
@@ -1,6 +1,9 @@
 import { Link01Icon, ViewIcon, ViewOffIcon } from "hugeicons-react";
 import { useState } from "react";
-import { IntegrationCardShell } from "@/components/integration-settings.shared";
+import {
+  IntegrationCardShell,
+  IntegrationStatusHeader,
+} from "@/components/integration-settings.shared";
 import { Button } from "@/components/ui/button";
 import {
   InputGroup,
@@ -15,27 +18,6 @@ import {
   useSendErrorTrackingTest,
 } from "@/hooks/use-error-tracking";
 import { formatError } from "@/lib/client";
-
-function StatusBadge({ configured }: { configured: boolean }) {
-  if (configured) {
-    return (
-      <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-0.5 font-medium text-emerald-800 text-xs dark:border-emerald-800/60 dark:bg-emerald-950/40 dark:text-emerald-200">
-        <span aria-hidden className="size-1.5 rounded-full bg-emerald-500" />
-        Sending
-      </span>
-    );
-  }
-
-  return (
-    <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border bg-background px-2.5 py-0.5 font-medium text-muted-foreground text-xs">
-      <span
-        aria-hidden
-        className="size-1.5 rounded-full bg-muted-foreground/60"
-      />
-      Off
-    </span>
-  );
-}
 
 export function ErrorTrackingSettingsCard() {
   const {
@@ -90,18 +72,13 @@ export function ErrorTrackingSettingsCard() {
 
   return (
     <IntegrationCardShell>
-      <div className="flex items-start justify-between gap-4 p-5 pb-4">
-        <div className="min-w-0 space-y-1">
-          <h2 className="font-semibold text-base text-foreground leading-tight [text-wrap:balance]">
-            Error tracking
-          </h2>
-          <p className="text-muted-foreground text-sm leading-snug [text-wrap:pretty]">
-            Send this instance's own errors to the error tracker you already
-            run.
-          </p>
-        </div>
-        <StatusBadge configured={configured} />
-      </div>
+      {/* One state, not the channels' three: a saved DSN means it is sending. */}
+      <IntegrationStatusHeader
+        configured={configured}
+        connected={configured}
+        statusBadge={configured ? "Sending" : "Off"}
+        title="Error tracking"
+      />
 
       <div className="border-border border-t" />
 

--- a/apps/web/src/components/ErrorTrackingSettingsCard.tsx
+++ b/apps/web/src/components/ErrorTrackingSettingsCard.tsx
@@ -1,0 +1,229 @@
+import { Link01Icon, ViewIcon, ViewOffIcon } from "hugeicons-react";
+import { useState } from "react";
+import { IntegrationCardShell } from "@/components/integration-settings.shared";
+import { Button } from "@/components/ui/button";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@/components/ui/input-group";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  useErrorTrackingSettings,
+  useSaveErrorTrackingSettings,
+  useSendErrorTrackingTest,
+} from "@/hooks/use-error-tracking";
+import { formatError } from "@/lib/client";
+import { cn } from "@/lib/utils";
+
+function StatusBadge({ configured }: { configured: boolean }) {
+  if (configured) {
+    return (
+      <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-0.5 font-medium text-emerald-800 text-xs dark:border-emerald-800/60 dark:bg-emerald-950/40 dark:text-emerald-200">
+        <span aria-hidden className="size-1.5 rounded-full bg-emerald-500" />
+        Sending
+      </span>
+    );
+  }
+
+  return (
+    <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border bg-background px-2.5 py-0.5 font-medium text-muted-foreground text-xs">
+      <span
+        aria-hidden
+        className="size-1.5 rounded-full bg-muted-foreground/60"
+      />
+      Off
+    </span>
+  );
+}
+
+export function ErrorTrackingSettingsCard({
+  embedded = false,
+}: {
+  embedded?: boolean;
+}) {
+  const {
+    data: settings,
+    isLoading,
+    error: loadError,
+  } = useErrorTrackingSettings();
+  const saveMutation = useSaveErrorTrackingSettings();
+  const testMutation = useSendErrorTrackingTest();
+  const [dsn, setDsn] = useState("");
+  const [showDsn, setShowDsn] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [testResult, setTestResult] = useState<string | null>(null);
+
+  if (isLoading) {
+    return (
+      <IntegrationCardShell
+        busyLabel="Loading error tracking settings"
+        embedded={embedded}
+      >
+        <div className={cn("space-y-2", embedded ? "pb-1.5" : "p-5")}>
+          <div className="h-4 w-40 rounded bg-muted" />
+          <div className="h-9 w-full rounded bg-muted" />
+        </div>
+      </IntegrationCardShell>
+    );
+  }
+
+  const configured = settings?.configured === true;
+  const errorMessage = formError ?? (loadError ? formatError(loadError) : null);
+  const sectionPadding = embedded ? "pb-1.5" : "p-5";
+  const footerPadding = embedded ? "pt-1.5" : "px-5 py-3";
+
+  async function handleSave() {
+    setFormError(null);
+    setTestResult(null);
+
+    try {
+      await saveMutation.mutateAsync({ dsn: dsn.trim() });
+      setDsn("");
+    } catch (error) {
+      setFormError(formatError(error));
+    }
+  }
+
+  async function handleTest() {
+    setFormError(null);
+    setTestResult(null);
+
+    try {
+      const result = await testMutation.mutateAsync();
+      setTestResult(result.message);
+    } catch (error) {
+      setFormError(formatError(error));
+    }
+  }
+
+  return (
+    <IntegrationCardShell embedded={embedded}>
+      {embedded ? null : (
+        <>
+          <div className="flex items-start justify-between gap-4 p-5 pb-4">
+            <div className="min-w-0 space-y-1">
+              <h2 className="font-semibold text-base text-foreground leading-tight [text-wrap:balance]">
+                Error tracking
+              </h2>
+              <p className="text-muted-foreground text-sm leading-snug [text-wrap:pretty]">
+                Send this instance's own errors to the error tracker you already
+                run.
+              </p>
+            </div>
+            <StatusBadge configured={configured} />
+          </div>
+
+          <div className="border-border border-t" />
+        </>
+      )}
+
+      <div className={cn("space-y-2", sectionPadding, embedded && "pt-0")}>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0 space-y-1">
+            <p className="font-medium text-foreground text-sm">
+              Sentry-compatible DSN
+            </p>
+            <p className="text-muted-foreground text-sm [text-wrap:pretty]">
+              Works with Sentry, GlitchTip, Bugsink and a self-hosted Sentry.
+              Leave it empty to send nothing.
+            </p>
+          </div>
+          {embedded ? <StatusBadge configured={configured} /> : null}
+        </div>
+
+        <div className="flex items-center gap-2">
+          <InputGroup className="h-9 min-w-0 flex-1">
+            <InputGroupInput
+              autoComplete="off"
+              disabled={saveMutation.isPending}
+              onChange={(event) => {
+                setDsn(event.target.value);
+                if (formError) {
+                  setFormError(null);
+                }
+              }}
+              placeholder={
+                configured && settings?.dsnMasked
+                  ? `Saved (${settings.dsnMasked})`
+                  : "https://<key>@sentry.example.com/42"
+              }
+              type={showDsn ? "text" : "password"}
+              value={dsn}
+            />
+            <InputGroupAddon align="inline-end">
+              <InputGroupButton
+                aria-label={showDsn ? "Hide DSN" : "Show DSN"}
+                className="relative before:absolute before:-inset-2 before:content-['']"
+                onClick={() => setShowDsn((current) => !current)}
+                size="icon-xs"
+                type="button"
+              >
+                {showDsn ? (
+                  <ViewOffIcon className="size-4" />
+                ) : (
+                  <ViewIcon className="size-4" />
+                )}
+              </InputGroupButton>
+            </InputGroupAddon>
+          </InputGroup>
+          <Button
+            className="min-w-[4.5rem] shrink-0"
+            disabled={saveMutation.isPending}
+            onClick={() => void handleSave()}
+            size="sm"
+            type="button"
+          >
+            {saveMutation.isPending ? <Spinner className="size-4" /> : "Save"}
+          </Button>
+          {/* Without this the only way to learn the DSN is wrong is to wait for
+              a real crash. */}
+          <Button
+            className="shrink-0"
+            disabled={!configured || testMutation.isPending}
+            onClick={() => void handleTest()}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            {testMutation.isPending ? (
+              <Spinner className="size-4" />
+            ) : (
+              "Send test event"
+            )}
+          </Button>
+        </div>
+
+        {testResult ? (
+          <p className="text-muted-foreground text-sm" role="status">
+            {testResult}
+          </p>
+        ) : null}
+
+        {errorMessage ? (
+          <p className="text-destructive text-sm" role="alert">
+            {errorMessage}
+          </p>
+        ) : null}
+      </div>
+
+      <div className={cn(footerPadding)}>
+        <a
+          className="inline-flex items-center gap-2 text-muted-foreground text-sm transition-colors hover:text-foreground"
+          href="https://docs.sentry.io/concepts/key-terms/dsn-explainer/"
+          rel="noreferrer"
+          target="_blank"
+        >
+          <Link01Icon aria-hidden className="size-3.5 shrink-0" />
+          <span>
+            Find your DSN:{" "}
+            <span className={cn("font-medium text-primary")}>
+              Project Settings → Client Keys
+            </span>
+          </span>
+        </a>
+      </div>
+    </IntegrationCardShell>
+  );
+}

--- a/apps/web/src/components/ErrorTrackingSettingsCard.tsx
+++ b/apps/web/src/components/ErrorTrackingSettingsCard.tsx
@@ -15,7 +15,6 @@ import {
   useSendErrorTrackingTest,
 } from "@/hooks/use-error-tracking";
 import { formatError } from "@/lib/client";
-import { cn } from "@/lib/utils";
 
 function StatusBadge({ configured }: { configured: boolean }) {
   if (configured) {
@@ -38,11 +37,7 @@ function StatusBadge({ configured }: { configured: boolean }) {
   );
 }
 
-export function ErrorTrackingSettingsCard({
-  embedded = false,
-}: {
-  embedded?: boolean;
-}) {
+export function ErrorTrackingSettingsCard() {
   const {
     data: settings,
     isLoading,
@@ -57,11 +52,8 @@ export function ErrorTrackingSettingsCard({
 
   if (isLoading) {
     return (
-      <IntegrationCardShell
-        busyLabel="Loading error tracking settings"
-        embedded={embedded}
-      >
-        <div className={cn("space-y-2", embedded ? "pb-1.5" : "p-5")}>
+      <IntegrationCardShell busyLabel="Loading error tracking settings">
+        <div className="space-y-2 p-5">
           <div className="h-4 w-40 rounded bg-muted" />
           <div className="h-9 w-full rounded bg-muted" />
         </div>
@@ -71,8 +63,6 @@ export function ErrorTrackingSettingsCard({
 
   const configured = settings?.configured === true;
   const errorMessage = formError ?? (loadError ? formatError(loadError) : null);
-  const sectionPadding = embedded ? "pb-1.5" : "p-5";
-  const footerPadding = embedded ? "pt-1.5" : "px-5 py-3";
 
   async function handleSave() {
     setFormError(null);
@@ -99,38 +89,31 @@ export function ErrorTrackingSettingsCard({
   }
 
   return (
-    <IntegrationCardShell embedded={embedded}>
-      {embedded ? null : (
-        <>
-          <div className="flex items-start justify-between gap-4 p-5 pb-4">
-            <div className="min-w-0 space-y-1">
-              <h2 className="font-semibold text-base text-foreground leading-tight [text-wrap:balance]">
-                Error tracking
-              </h2>
-              <p className="text-muted-foreground text-sm leading-snug [text-wrap:pretty]">
-                Send this instance's own errors to the error tracker you already
-                run.
-              </p>
-            </div>
-            <StatusBadge configured={configured} />
-          </div>
+    <IntegrationCardShell>
+      <div className="flex items-start justify-between gap-4 p-5 pb-4">
+        <div className="min-w-0 space-y-1">
+          <h2 className="font-semibold text-base text-foreground leading-tight [text-wrap:balance]">
+            Error tracking
+          </h2>
+          <p className="text-muted-foreground text-sm leading-snug [text-wrap:pretty]">
+            Send this instance's own errors to the error tracker you already
+            run.
+          </p>
+        </div>
+        <StatusBadge configured={configured} />
+      </div>
 
-          <div className="border-border border-t" />
-        </>
-      )}
+      <div className="border-border border-t" />
 
-      <div className={cn("space-y-2", sectionPadding, embedded && "pt-0")}>
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <div className="min-w-0 space-y-1">
-            <p className="font-medium text-foreground text-sm">
-              Sentry-compatible DSN
-            </p>
-            <p className="text-muted-foreground text-sm [text-wrap:pretty]">
-              Works with Sentry, GlitchTip, Bugsink and a self-hosted Sentry.
-              Leave it empty to send nothing.
-            </p>
-          </div>
-          {embedded ? <StatusBadge configured={configured} /> : null}
+      <div className="space-y-2 p-5">
+        <div className="min-w-0 space-y-1">
+          <p className="font-medium text-foreground text-sm">
+            Sentry-compatible DSN
+          </p>
+          <p className="text-muted-foreground text-sm [text-wrap:pretty]">
+            Works with Sentry, GlitchTip, Bugsink and a self-hosted Sentry.
+            Leave it empty to send nothing.
+          </p>
         </div>
 
         <div className="flex items-center gap-2">
@@ -208,7 +191,7 @@ export function ErrorTrackingSettingsCard({
         ) : null}
       </div>
 
-      <div className={cn(footerPadding)}>
+      <div className="px-5 py-3">
         <a
           className="inline-flex items-center gap-2 text-muted-foreground text-sm transition-colors hover:text-foreground"
           href="https://docs.sentry.io/concepts/key-terms/dsn-explainer/"
@@ -218,7 +201,7 @@ export function ErrorTrackingSettingsCard({
           <Link01Icon aria-hidden className="size-3.5 shrink-0" />
           <span>
             Find your DSN:{" "}
-            <span className={cn("font-medium text-primary")}>
+            <span className="font-medium text-primary">
               Project Settings → Client Keys
             </span>
           </span>

--- a/apps/web/src/components/ErrorTrackingSettingsCard.tsx
+++ b/apps/web/src/components/ErrorTrackingSettingsCard.tsx
@@ -96,8 +96,10 @@ export function ErrorTrackingSettingsCard() {
         <div className="flex items-center gap-2">
           <InputGroup className="h-9 min-w-0 flex-1">
             <InputGroupInput
+              aria-label="Sentry-compatible DSN"
               autoComplete="off"
               disabled={saveMutation.isPending}
+              id="error-tracking-dsn"
               onChange={(event) => {
                 setDsn(event.target.value);
                 if (formError) {

--- a/apps/web/src/components/integration-settings.shared.tsx
+++ b/apps/web/src/components/integration-settings.shared.tsx
@@ -117,7 +117,8 @@ export function IntegrationStatusHeader({
   className,
 }: {
   title: string;
-  subtitle: string;
+  /** Omit it when the title already says everything, per the AGENTS.md React rule. */
+  subtitle?: string;
   statusBadge: string;
   configured: boolean;
   connected: boolean;
@@ -148,7 +149,11 @@ export function IntegrationStatusHeader({
             {statusBadge}
           </span>
         </div>
-        <p className="text-pretty text-muted-foreground text-xs">{subtitle}</p>
+        {subtitle ? (
+          <p className="text-pretty text-muted-foreground text-xs">
+            {subtitle}
+          </p>
+        ) : null}
       </div>
     </div>
   );

--- a/apps/web/src/hooks/use-error-tracking.ts
+++ b/apps/web/src/hooks/use-error-tracking.ts
@@ -1,0 +1,34 @@
+import type { UpdateErrorTrackingSettingsRequest } from "@nakama/core/contract";
+import {
+  queryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { client } from "@/lib/client";
+import { queryKeys } from "@/lib/query-keys";
+
+export const errorTrackingSettingsQueryOptions = queryOptions({
+  queryFn: () => client.getErrorTrackingSettings(),
+  queryKey: queryKeys.errorTracking.settings,
+});
+
+export function useErrorTrackingSettings() {
+  return useQuery(errorTrackingSettingsQueryOptions);
+}
+
+export function useSaveErrorTrackingSettings() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: UpdateErrorTrackingSettingsRequest) =>
+      client.setErrorTrackingSettings(request),
+    onSuccess: (saved) => {
+      queryClient.setQueryData(queryKeys.errorTracking.settings, saved);
+    },
+  });
+}
+
+export function useSendErrorTrackingTest() {
+  return useMutation({ mutationFn: () => client.sendErrorTrackingTest() });
+}

--- a/apps/web/src/hooks/use-error-tracking.ts
+++ b/apps/web/src/hooks/use-error-tracking.ts
@@ -1,20 +1,13 @@
 import type { UpdateErrorTrackingSettingsRequest } from "@nakama/core/contract";
-import {
-  queryOptions,
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { client } from "@/lib/client";
 import { queryKeys } from "@/lib/query-keys";
 
-export const errorTrackingSettingsQueryOptions = queryOptions({
-  queryFn: () => client.getErrorTrackingSettings(),
-  queryKey: queryKeys.errorTracking.settings,
-});
-
 export function useErrorTrackingSettings() {
-  return useQuery(errorTrackingSettingsQueryOptions);
+  return useQuery({
+    queryFn: () => client.getErrorTrackingSettings(),
+    queryKey: queryKeys.errorTracking.settings,
+  });
 }
 
 export function useSaveErrorTrackingSettings() {

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -25,6 +25,9 @@ export const queryKeys = {
   email: {
     settings: ["email", "settings"] as const,
   },
+  errorTracking: {
+    settings: ["error-tracking", "settings"] as const,
+  },
   health: ["health"] as const,
   imageGenerationSettings: ["imageGeneration", "settings"] as const,
   knowledgeBase: {

--- a/apps/web/src/pages/IntegrationsPage.tsx
+++ b/apps/web/src/pages/IntegrationsPage.tsx
@@ -1,4 +1,5 @@
 import {
+  Bug01Icon,
   CodeIcon,
   CpuChargeIcon,
   HashtagIcon,
@@ -13,6 +14,7 @@ import { CodingAgentsSettingsCard } from "@/components/CodingAgentsSettingsCard"
 import { ComposioConnectionsCard } from "@/components/ComposioConnectionsCard";
 import { ComposioSettingsCard } from "@/components/ComposioSettingsCard";
 import { DiscordSettingsCard } from "@/components/DiscordSettingsCard";
+import { ErrorTrackingSettingsCard } from "@/components/ErrorTrackingSettingsCard";
 import { LocalAuthTokenCard } from "@/components/LocalAuthTokenCard";
 import { NotificationDestinationsCard } from "@/components/NotificationDestinationsCard";
 import { TelegramSettingsCard } from "@/components/TelegramSettingsCard";
@@ -65,6 +67,11 @@ const INTEGRATION_SECTIONS = [
     id: "optimization",
     label: "Context savings",
   },
+  {
+    icon: Bug01Icon,
+    id: "error-tracking",
+    label: "Error tracking",
+  },
 ] as const;
 
 type IntegrationSectionId = (typeof INTEGRATION_SECTIONS)[number]["id"];
@@ -77,6 +84,7 @@ function resolveSection(value: string | null): IntegrationSectionId {
     value === "discord" ||
     value === "composio" ||
     value === "optimization" ||
+    value === "error-tracking" ||
     value === "coding-agents"
   ) {
     return value;
@@ -170,6 +178,8 @@ export function IntegrationsPage() {
           {section === "notifications" ? (
             <NotificationDestinationsCard />
           ) : null}
+
+          {section === "error-tracking" ? <ErrorTrackingSettingsCard /> : null}
 
           {section === "whatsapp" ? <WhatsAppSettingsCard /> : null}
         </div>

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -52,6 +52,7 @@ import type {
   DraftTaskPromptRequest,
   DraftTaskPromptResponse,
   EmailSettingsResponse,
+  ErrorTrackingSettingsResponse,
   GenerateImageRequest,
   GenerateImageResponse,
   HealthResponse,
@@ -119,6 +120,7 @@ import type {
   RunToolResponse,
   SendEmailTestRequest,
   SendEmailTestResponse,
+  SendErrorTrackingTestResponse,
   SendMessageResponse,
   SessionMessagesResponse,
   SessionStatusResponse,
@@ -161,6 +163,7 @@ import type {
   UpdateComposioSettingsRequest,
   UpdateDiscordSettingsRequest,
   UpdateEmailSettingsRequest,
+  UpdateErrorTrackingSettingsRequest,
   UpdateImageGenerationRequest,
   UpdateMcpServerRequest,
   UpdateNotificationDestinationRequest,
@@ -1547,6 +1550,28 @@ export class NakamaClient {
       {
         method: "POST",
       }
+    );
+  }
+
+  async getErrorTrackingSettings(): Promise<ErrorTrackingSettingsResponse> {
+    return this.request<ErrorTrackingSettingsResponse>(
+      "/v1/settings/error-tracking"
+    );
+  }
+
+  async setErrorTrackingSettings(
+    request: UpdateErrorTrackingSettingsRequest
+  ): Promise<ErrorTrackingSettingsResponse> {
+    return this.request<ErrorTrackingSettingsResponse>(
+      "/v1/settings/error-tracking",
+      { body: JSON.stringify(request), method: "PUT" }
+    );
+  }
+
+  async sendErrorTrackingTest(): Promise<SendErrorTrackingTestResponse> {
+    return this.request<SendErrorTrackingTestResponse>(
+      "/v1/settings/error-tracking/test",
+      { method: "POST" }
     );
   }
 

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -1239,6 +1239,21 @@ export interface UpdateComposioSettingsRequest {
   apiKey?: string;
 }
 
+export interface ErrorTrackingSettingsResponse {
+  configured: boolean;
+  dsnMasked: string | null;
+}
+
+export interface UpdateErrorTrackingSettingsRequest {
+  /** Empty string clears the DSN and turns error tracking off. */
+  dsn?: string;
+}
+
+export interface SendErrorTrackingTestResponse {
+  delivered: boolean;
+  message: string;
+}
+
 export type NotificationDestinationChannel = "telegram";
 
 export type NotificationWebhookLevel = "info" | "success" | "warning" | "error";

--- a/packages/core/src/error-tracking-config.test.ts
+++ b/packages/core/src/error-tracking-config.test.ts
@@ -86,9 +86,3 @@ test("the env DSN overrides the file, and an empty one means off", () => {
     resolveErrorTrackingDsn({ dsn: DSN }, { NAKAMA_ERROR_TRACKING_DSN: "" })
   ).toBeNull();
 });
-
-test("a saved DSN takes effect without a restart", async () => {
-  expect(await isErrorTrackingEnabled()).toBe(false);
-  await saveErrorTrackingDsn(DSN);
-  expect(await isErrorTrackingEnabled()).toBe(true);
-});

--- a/packages/core/src/error-tracking-config.ts
+++ b/packages/core/src/error-tracking-config.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import { maskSecret } from "./email-config";
 import { parseIni, readTextOrNull, writeTextFile } from "./fs";
 import { getUserConfigDir } from "./user-config";
 
@@ -74,4 +75,22 @@ export async function saveErrorTrackingDsn(
 
 export async function isErrorTrackingEnabled(): Promise<boolean> {
   return resolveErrorTrackingDsn(await loadErrorTrackingConfig()) !== null;
+}
+
+export interface ErrorTrackingSettingsPublic {
+  configured: boolean;
+  dsnMasked: string | null;
+}
+
+/**
+ * The raw DSN never leaves the server. It carries the operator's ingest key, and an
+ * API response is the easiest place for it to end up in a log or a browser cache.
+ */
+export async function loadErrorTrackingSettingsPublic(): Promise<ErrorTrackingSettingsPublic> {
+  const { dsn } = await loadErrorTrackingConfig();
+
+  return {
+    configured: Boolean(dsn),
+    dsnMasked: dsn ? maskSecret(dsn) : null,
+  };
 }

--- a/packages/core/src/error-tracking-config.ts
+++ b/packages/core/src/error-tracking-config.ts
@@ -50,6 +50,10 @@ export function resolveErrorTrackingDsn(
   return file.dsn;
 }
 
+/**
+ * Callers must follow this with refreshErrorTrackingEnabled(): reportError reads a
+ * cached flag so it can decide synchronously, and the file alone does not move it.
+ */
 export async function saveErrorTrackingDsn(
   dsn: string | null
 ): Promise<ErrorTrackingConfig> {

--- a/packages/core/src/error-tracking-config.ts
+++ b/packages/core/src/error-tracking-config.ts
@@ -68,10 +68,6 @@ export async function saveErrorTrackingDsn(
   return next;
 }
 
-export async function currentErrorTrackingDsn(): Promise<string | null> {
-  return resolveErrorTrackingDsn(await loadErrorTrackingConfig());
-}
-
 export async function isErrorTrackingEnabled(): Promise<boolean> {
-  return (await currentErrorTrackingDsn()) !== null;
+  return resolveErrorTrackingDsn(await loadErrorTrackingConfig()) !== null;
 }

--- a/packages/core/src/error-tracking-queue.ts
+++ b/packages/core/src/error-tracking-queue.ts
@@ -47,8 +47,10 @@ export function appendPendingErrorReport(report: ErrorReport): void {
     write(
       [...readPendingErrorReports(), report].slice(-MAX_PENDING_ERROR_REPORTS)
     );
-  } catch {
-    // A full or read-only config dir must not turn one crash into two.
+  } catch (error) {
+    // A full or read-only config dir must not turn one crash into two, but swallowing it
+    // outright leaves an operator with tracking on and no reports and no reason why.
+    console.error("[nakama:error-tracking] cannot queue report", error);
   }
 }
 

--- a/packages/core/src/error-tracking-scrub.test.ts
+++ b/packages/core/src/error-tracking-scrub.test.ts
@@ -8,39 +8,42 @@ import { scrubText } from "./error-tracking-scrub";
  * data, so a regression here is a third-party data incident, not a telemetry bug.
  */
 describe("scrubText removes credentials", () => {
-  const cases: Array<[string, string]> = [
+  // The secret is carried per case. Asserting all eight in every case reads as
+  // thorough and is not: seven of them were never in that input, so those
+  // assertions pass whatever scrubText does.
+  const cases: Array<[name: string, secret: string, message: string]> = [
     [
       "anthropic key",
-      "failed with sk-ant-api03-abcdefghijklmnopqrstuvwxyz012345",
+      "sk-ant-api03-abcdefghijklmnopqrstuvwxyz012345",
+      "failed with SECRET",
     ],
-    ["openai key", "Authorization header sk-proj-AAAABBBBCCCCDDDDEEEEFFFF"],
-    ["github token", "clone failed ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"],
-    ["slack token", "post failed xoxb-1234567890-ABCDEFGHIJKL"],
-    ["aws key id", "denied for AKIAIOSFODNN7EXAMPLE"],
+    [
+      "openai key",
+      "sk-proj-AAAABBBBCCCCDDDDEEEEFFFF",
+      "Authorization header SECRET",
+    ],
+    [
+      "github token",
+      "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+      "clone failed SECRET",
+    ],
+    ["slack token", "xoxb-1234567890-ABCDEFGHIJKL", "post failed SECRET"],
+    ["aws key id", "AKIAIOSFODNN7EXAMPLE", "denied for SECRET"],
     [
       "bearer header",
-      "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+      "Authorization: Bearer SECRET",
     ],
-    ["assignment", 'connect({ apiKey: "hunter2secretvalue" })'],
-    ["env style", "ANTHROPIC_TOKEN=abcd1234efgh5678"],
+    ["assignment", "hunter2secretvalue", 'connect({ apiKey: "SECRET" })'],
+    ["env style", "abcd1234efgh5678", "ANTHROPIC_TOKEN=SECRET"],
   ];
 
-  for (const [name, input] of cases) {
+  for (const [name, secret, message] of cases) {
     test(name, () => {
-      const scrubbed = scrubText(input);
+      const input = message.replace("SECRET", secret);
 
-      expect(scrubbed).not.toContain(
-        "sk-ant-api03-abcdefghijklmnopqrstuvwxyz012345"
-      );
-      expect(scrubbed).not.toContain("sk-proj-AAAABBBBCCCCDDDDEEEEFFFF");
-      expect(scrubbed).not.toContain(
-        "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-      );
-      expect(scrubbed).not.toContain("xoxb-1234567890-ABCDEFGHIJKL");
-      expect(scrubbed).not.toContain("AKIAIOSFODNN7EXAMPLE");
-      expect(scrubbed).not.toContain("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9");
-      expect(scrubbed).not.toContain("hunter2secretvalue");
-      expect(scrubbed).not.toContain("abcd1234efgh5678");
+      expect(input).toContain(secret);
+      expect(scrubText(input)).not.toContain(secret);
     });
   }
 });

--- a/packages/core/src/error-tracking-sentry.test.ts
+++ b/packages/core/src/error-tracking-sentry.test.ts
@@ -59,7 +59,7 @@ test("no user identity is sent", () => {
 
   // Reports go to the operator's own project, so there is nobody to count installs
   // for and nothing that needs a stable id attached to the event.
-  expect(event.user).toBeUndefined();
+  expect(event).not.toHaveProperty("user");
 });
 
 test("the event id is the report id, so a retry collapses into one event", () => {
@@ -128,7 +128,9 @@ test("sendSentryEvent posts the event with the auth header the ingest expects", 
 test("sendSentryEvent reports failure instead of throwing when the ingest is down", async () => {
   const dsn = parseSentryDsn("http://k@127.0.0.1:1/9");
 
-  expect(await sendSentryEvent(dsn!, {}, 200)).toBe(false);
+  expect(await sendSentryEvent(dsn!, toSentryEvent(sampleReport()), 200)).toBe(
+    false
+  );
 });
 
 async function countSinkHits(env: Record<string, string>): Promise<number> {

--- a/packages/core/src/error-tracking-sentry.ts
+++ b/packages/core/src/error-tracking-sentry.ts
@@ -18,6 +18,34 @@ export interface SentryDsn {
 }
 
 /**
+ * The slice of the Sentry store payload nakama actually sends. Hand-rolled because no
+ * SDK is in use, and named so the envelope is a checked shape rather than a bag: a
+ * typo in a key here is silently ignored by the ingest and impossible to spot later.
+ */
+export interface SentryEvent {
+  contexts: {
+    os: { name: string };
+    runtime: { name: string; version: string };
+  };
+  event_id: string;
+  exception: { values: { type: string; value: string }[] };
+  extra?: { stack: string };
+  fingerprint: string[];
+  level: "error" | "info";
+  logger: string;
+  platform: string;
+  tags: {
+    api_version: string;
+    arch: string;
+    bun: string;
+    kind: string;
+    os: string;
+    source: string;
+  };
+  timestamp: string;
+}
+
+/**
  * One protocol covers Sentry, GlitchTip, Bugsink and self-hosted Sentry: they all accept
  * the same store endpoint and X-Sentry-Auth header, so the operator picks the platform
  * and nakama does not have to know which one it is talking to.
@@ -53,7 +81,7 @@ export function parseSentryDsn(dsn: string): SentryDsn | null {
   };
 }
 
-export function toSentryEvent(report: ErrorReport): Record<string, unknown> {
+export function toSentryEvent(report: ErrorReport): SentryEvent {
   return {
     contexts: {
       os: { name: report.runtime.platform },
@@ -87,7 +115,7 @@ export function toSentryEvent(report: ErrorReport): Record<string, unknown> {
 
 export async function sendSentryEvent(
   dsn: SentryDsn,
-  event: Record<string, unknown>,
+  event: SentryEvent,
   timeoutMs = SEND_TIMEOUT_MS
 ): Promise<boolean> {
   try {

--- a/packages/core/src/error-tracking.test.ts
+++ b/packages/core/src/error-tracking.test.ts
@@ -124,6 +124,20 @@ test("a non-Error rejection still produces a report", () => {
   expect(report.fingerprint).toHaveLength(16);
 });
 
+test("a circular rejection reports rather than throwing, at a shared fingerprint", () => {
+  const circular: { self?: unknown } = {};
+  circular.self = circular;
+
+  const report = buildErrorReport(circular, { source: "worker:discord" });
+  const other: { self?: unknown; kind?: string } = { kind: "different" };
+  other.self = other;
+
+  expect(report.fingerprint).toHaveLength(16);
+  // Documented, not desired: JSON.stringify throws on a cycle and String() flattens every
+  // one of them to "[object Object]", so two unrelated circular rejections share an issue.
+  expect(buildErrorReport(other).fingerprint).toBe(report.fingerprint);
+});
+
 test("with no sink installed nothing is queued and nothing is sent", async () => {
   setErrorSink(null);
 
@@ -136,6 +150,7 @@ test("the sink receives the report", async () => {
   const delivered: ErrorReport[] = [];
   setErrorSink((report) => {
     delivered.push(report);
+    return true;
   });
 
   await reportError(new Error("boom"), { source: "server" });
@@ -171,6 +186,7 @@ test("the queue is written before the send, which is what survives a hard exit",
   let queuedWhenSinkRan = 0;
   setErrorSink(() => {
     queuedWhenSinkRan = readPendingErrorReports().length;
+    return true;
   });
 
   await reportError(new Error("boom"), { source: "server" });

--- a/packages/core/src/error-tracking.ts
+++ b/packages/core/src/error-tracking.ts
@@ -132,6 +132,9 @@ function errorToParts(error: unknown): {
       name: "NonError",
     };
   } catch {
+    // Circular and other unserializable values all land on "[object Object]", so they
+    // share one fingerprint. Accepted: separating them needs a walk of the object, and
+    // a rejection with a circular non-Error is rare enough not to pay for it.
     return { message: String(error), name: "NonError" };
   }
 }


### PR DESCRIPTION
## Summary

> **Draft until #443 merges.** Built on #443, which is built on #442, so their commits appear here too. The settings routes call into the core module from #442, so this cannot sit on `main` by itself. Fork PRs here land as squashes, so those commits will not become ancestors of `main` and this diff will not shrink on its own. Once the two below it land I will rebuild this branch from the new `main` with a cherry-pick of its own two commits, then mark it ready.


Phase 3 of #441: the operator can finally do this without a text editor. Adds an "Error tracking" section to the Integrations tab, so the DSN is saved from the UI instead of a hand-edited `~/.nakama/error-tracking/config.ini`. Stacked on #442 and #443.

**Before:** eight integration sections, no way to reach error tracking from the dashboard.
**After:** a ninth section with a DSN field, a status badge, and a test event button.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/fajarhide/tinyclaw/f9a84fd1fedc18f63b98a486b38008d937e47db6/assets/before-integrations.png" width="420"> | <img src="https://raw.githubusercontent.com/fajarhide/tinyclaw/f9a84fd1fedc18f63b98a486b38008d937e47db6/assets/after-error-tracking.png" width="420"> |

Same instance, same 1440x1000 viewport at 2x. The before shows the default section, since the point is that "Error tracking" is not in the list.

Saving a DSN and pressing "Send test event", against a local ingest that logged exactly one received event:

<img src="https://raw.githubusercontent.com/fajarhide/tinyclaw/f9a84fd1fedc18f63b98a486b38008d937e47db6/assets/after-test-event.png" width="640">

The badge went from "Off" to "Sending", the field shows the saved DSN masked, and the message is the real result of the send rather than an optimistic string.

Why safe:
1. Writes are org admin or platform admin only. The DSN is workspace-global so there is no org to scope it to, which makes the role guard the only thing between a viewer and the whole install's error routing. Removing the guard turns the member and viewer tests red, checked both ways.
2. The GET response carries a masked DSN. A test asserts the raw value appears nowhere in the response body.
3. A malformed DSN is rejected at save rather than accepted and then silently never delivering.
4. "Send test event" sends one event directly instead of going through `reportError`, so a failed test does not leave a fake crash sitting in the delivery queue. It is disabled until a DSN is saved, and the event carries kind `test` at a lower level so it never sits in a triage queue next to a real crash.

Trimmed after @ahmadrosid's cleanup landed on #442. `ErrorTrackingSettingsCard` carried an `embedded` prop that nothing passed, so the header fork, the second status badge and the two padding variables sat on a path that never ran. The card is 17 lines shorter and renders identical bytes, so the screenshots above are still current.

## Test plan
- [x] `bun run test` across all workspaces: 0 fail.
- [x] `bun test apps/server/src/http/routes/error-tracking.test.ts`: 5 pass.
- [x] Role guard removed on purpose: the member and viewer tests fail, then pass again with it restored.
- [x] The flow above driven through a real browser against a throwaway instance, not the shared one.
- [x] Card screenshotted before and after the trim on the same instance: identical sha256, 0 differing pixels. A one-word control edit moved 1663 pixels, so the comparison is not measuring nothing.

Refs #441. Phase 4, routing tool failures past their retry budget into the same tracker, is the part that closes the Agent Health Metrics requirement and is not started.


