### PR TITLE
chore(github): add issue forms for bug, enhancement, and new feature

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -1,0 +1,59 @@
+name: Bug report
+description: Something behaves differently from what it documents or intends.
+labels: ["bug"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What breaks, and where in the code. Name the file and line if you have it.
+      placeholder: |
+        `POST /v1/...` returns 500 when the org has no default profile.
+        apps/server/src/http/routes/....ts:61
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Measured on
+      description: Commit SHA, tag, or Docker image tag you observed this on.
+      placeholder: v0.3.9, or 25c6bf24
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: >
+        Steps, a curl command, or a failing test. A test that fails on the named
+        commit and passes after the fix is the strongest form.
+    validations:
+      required: true
+
+  - type: textarea
+    id: symptoms
+    attributes:
+      label: Expected vs actual
+      description: Paste the real output, not a description of it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: cause
+    attributes:
+      label: Root cause or proposed fix
+      description: Optional. Skip it if you have not traced it.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: security
+    attributes:
+      label: Security
+      options:
+        - label: >
+            This touches authentication, authorization, tenant isolation,
+            credentials, or untrusted code execution.
+          required: false

--- a/.github/ISSUE_TEMPLATE/2-enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/2-enhancement.yml
@@ -1,0 +1,46 @@
+name: Enhancement
+description: Improve a surface that already exists.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        If the capability does not exist yet (a new provider, channel, or
+        integration), use the **New feature** form instead.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What changes, on which existing surface.
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why it matters
+      description: What is painful today. One paragraph.
+    validations:
+      required: true
+
+  - type: textarea
+    id: touchpoints
+    attributes:
+      label: Implementation touch points
+      description: Optional. Files, routes, or packages you expect this to touch.
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: >
+        Checklist a reviewer can verify one item at a time. This is what the
+        closing PR is judged against, not the diff.
+      placeholder: |
+        - [ ] the endpoint returns 400 without ?orgId=
+        - [ ] existing callers keep working
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/3-new-feature.yml
+++ b/.github/ISSUE_TEMPLATE/3-new-feature.yml
@@ -1,0 +1,56 @@
+name: New feature
+description: A capability, surface, or integration that does not exist yet.
+labels: ["new-feature"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        If the surface already exists and you want it improved, use the
+        **Enhancement** form instead.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What the capability is, and who uses it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why
+      description: What is impossible today without it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Proposed scope and non-goals
+      description: >
+        Optional. Say what a first pass covers and what it deliberately leaves
+        out. Large items ship in phases here.
+    validations:
+      required: false
+
+  - type: textarea
+    id: touchpoints
+    attributes:
+      label: Implementation touch points
+      description: Optional. Files, routes, or packages you expect this to touch.
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: >
+        Checklist a reviewer can verify one item at a time. This is what the
+        closing PR is judged against, not the diff.
+      placeholder: |
+        - [ ] the endpoint returns 400 without ?orgId=
+        - [ ] existing callers keep working
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Contributing guide
+    url: https://github.com/ahmadrosid/nakama/blob/main/CONTRIBUTING.md
+    about: Setup, repo layout, tests, and the PR workflow.
+  - name: Documentation
+    url: https://ahmadrosid.github.io/nakama
+    about: Read this first if you are unsure whether the behaviour is intended.


### PR DESCRIPTION
## Summary

Contributors filing an issue get a blank box today. This adds three issue forms so a report arrives with the fields this repo already asks for.

**Before:** no `.github/ISSUE_TEMPLATE/`, so New issue opens an empty editor and the shape of a report depends on who writes it.
**After:** a chooser with Bug report, Enhancement, and New feature. Each applies its own type label. Blank issues stay enabled.

The fields are taken from the 48 open issues, not from a generic template. `## Acceptance criteria` appears in 27 of them and is what a closing PR gets judged against, so both feature forms require it. Bug reports require the commit they were measured on, a reproduction, and real output.

Enhancement and new feature are separate forms because the labels separate them: enhancement improves a surface that exists, new-feature adds one that does not. `priority:` and `stage:` stay with triage rather than becoming dropdowns, since a reporter cannot set them.

Why safe:
1. No application code touched. Four YAML files under `.github/`.
2. `blank_issues_enabled: true`, so batch and umbrella issues like #374 are still possible.
3. Wrong form is recoverable: labels are edited during triage anyway.

## Test plan
- [x] All four files parse as YAML.
- [ ] Form rendering not checked by me. Open the Preview tab on any of the three `.yml` files in this diff to see the chooser entries.
- [ ] Full suite not run: no application code changed, so CI is the check here.
