### PR TITLE
feat(whatsapp): handle group chats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ Path: `~/.nakama/orgs/{orgId}/profiles/{profileId}/` (`getProfileSoulDir`). Load
 | `sub_agent` | Opt-in same-profile delegate (not repo coding) |
 | `coding-agent` | Codex / Claude Code / OpenCode / pi / Cursor Agent (`agent`) via `bash` |
 | `agent-browser` | Opt-in browser CLI; needs host install — `docs/website/agent-browser.md` |
-| `create-profile` | Super Bot only, confirm-first — `apps/server/src/tools/super-bot-tools.ts` |
+| `create-profile` | Super Bot only, confirm-first — `apps/server/src/tools/super-bot-tools.ts` (`create_profile`, `update_profile` for stored `systemPrompt`) |
 | `skill_manage` | Interactive web/cli with `manage-skills` — create/patch/edit/delete profile skills + supporting-file write/remove + auto-assign (`apps/server/src/tools/skill-manage-tool.ts`). When org/profile **write approval** is enabled, mutations stage as proposals for org-admin review instead of writing immediately. When present, file tools refuse any path under `skills/*/` (`forbidProfileSkillMarkdownWrites`). Not injected for automations or Telegram/WhatsApp/Discord. Opt-in **post-turn skill review** (`skills_post_turn_review`) may suggest or stage create/patch after complex turns without writing into model history. Opt-in **skill curator** (`skills_curator_enabled`, default off) archives unused agent/human profile skills at 90 days (stale report at 30 days) via `SkillCuratorService` — rename to `skills/.archive/`, never delete; bundled skills and profiles with enabled automations are skipped. |
 | Composio | Org toolkits + per-user OAuth — `docs/website/composio.md` |
 

--- a/apps/platform/whatsapp/README.md
+++ b/apps/platform/whatsapp/README.md
@@ -20,3 +20,4 @@ Notes:
 - Auth state is stored in `~/.nakama/whatsapp/auth/`
 - Chat session mappings are stored in `~/.nakama/whatsapp/chat-sessions.json`
 - Restart the bridge after changing the saved phone number
+- Groups reply only to a mention of the linked number, a reply to a Nakama message, or a `/command`. Pair in a private chat first.

--- a/apps/platform/whatsapp/README.md
+++ b/apps/platform/whatsapp/README.md
@@ -20,4 +20,4 @@ Notes:
 - Auth state is stored in `~/.nakama/whatsapp/auth/`
 - Chat session mappings are stored in `~/.nakama/whatsapp/chat-sessions.json`
 - Restart the bridge after changing the saved phone number
-- Groups reply only to a mention of the linked number, a reply to a Nakama message, or a `/command`. Pair in a private chat first.
+- Groups reply only to a mention of the linked number, a reply to a Nakama message, or a `/command`. Pair in a private chat, or mention the bot and send a pairing code in the group.

--- a/apps/platform/whatsapp/src/auth-store.ts
+++ b/apps/platform/whatsapp/src/auth-store.ts
@@ -2,6 +2,7 @@ import type { WhatsAppConfigFile } from "@nakama/core/whatsapp-config";
 import {
   isWhatsAppUserAuthorized,
   loadWhatsAppConfigFile,
+  rememberWhatsAppPairedIdentities,
   verifyAndPairWhatsAppUser,
 } from "@nakama/core/whatsapp-config";
 
@@ -17,12 +18,17 @@ export class WhatsAppAuthStore {
     return this.config;
   }
 
-  isAuthorized(jid: string): boolean {
+  isAuthorized(jid: string | readonly string[]): boolean {
     if (!this.config) {
       return false;
     }
 
     return isWhatsAppUserAuthorized(jid, this.config);
+  }
+
+  async rememberIdentities(jids: readonly string[]): Promise<void> {
+    await rememberWhatsAppPairedIdentities(jids);
+    await this.reload();
   }
 
   async tryPair(

--- a/apps/platform/whatsapp/src/chat-handler.test.ts
+++ b/apps/platform/whatsapp/src/chat-handler.test.ts
@@ -771,10 +771,12 @@ const BOT_ME = {
 function groupInbound(options: {
   text: string;
   senderJid?: string;
+  senderJids?: string[];
   mentionedJids?: string[];
   quotedParticipant?: string | null;
   fromMe?: boolean;
 }) {
+  const senderJid = options.senderJid ?? PAIRED_JID;
   return {
     fromMe: options.fromMe ?? false,
     isGroup: true,
@@ -782,7 +784,8 @@ function groupInbound(options: {
     me: BOT_ME,
     mentionedJids: options.mentionedJids ?? [],
     quotedParticipant: options.quotedParticipant ?? null,
-    senderJid: options.senderJid ?? PAIRED_JID,
+    senderJid,
+    senderJids: options.senderJids ?? [senderJid],
     text: options.text,
   };
 }
@@ -893,15 +896,54 @@ describe("createChatHandler group chats", () => {
         groupInbound({
           mentionedJids: [BOT_ME.id],
           senderJid: "9999999999@s.whatsapp.net",
-          text: "@Nakama ABCD1234",
+          text: "@Nakama hello",
         })
       );
 
       expect(sent.map((message) => message.text)).toEqual([
-        "Link your account in a private chat with Nakama first.",
+        "This WhatsApp number is not linked yet. Open a private chat with this account and send your pairing code from Integrations → WhatsApp.",
       ]);
       expect(calls.sendStream).toBe(0);
       expect(authStore.isAuthorized("9999999999@s.whatsapp.net")).toBe(false);
+    });
+  });
+
+  test("pairs an unpaired group sender when they send a pairing code", async () => {
+    await withTempHome(async (homeDir) => {
+      await writeWhatsAppConfigIni(homeDir, {
+        pairingCode: "ABCD1234",
+        phoneNumber: "1234567890",
+      });
+
+      const authStore = new WhatsAppAuthStore();
+      await authStore.reload();
+      const { client, calls } = createMockClient();
+      const sessionStore = new SessionStore(
+        path.join(homeDir, ".nakama", "whatsapp", "chat-sessions.json")
+      );
+      const orgStore = createTestOrgStore(homeDir);
+      await orgStore.load();
+      const { socket, sent } = createMockSocket();
+      const handleMessage = createChatHandler({
+        authStore,
+        client,
+        config: { phoneNumber: "1234567890", profileId: "default" },
+        getSocket: () => socket as any,
+        orgStore,
+        sessionStore,
+      });
+
+      await handleMessage(
+        groupInbound({
+          mentionedJids: [BOT_ME.id],
+          senderJid: "9999999999@s.whatsapp.net",
+          text: "@Nakama ABCD1234",
+        })
+      );
+
+      expect(sent[0]?.text).toContain("Linked successfully");
+      expect(authStore.isAuthorized("9999999999@s.whatsapp.net")).toBe(true);
+      expect(calls.sendStream).toBe(0);
     });
   });
 
@@ -973,6 +1015,155 @@ describe("createChatHandler group chats", () => {
       expect(calls.createSession).toBe(2);
       expect(sessionStore.get(PAIRED_JID)?.sessionId).toBe("session_test");
       expect(sessionStore.get(GROUP_JID)?.sessionId).toBe("session_test");
+    });
+  });
+
+  test("authorizes a group sender when any of their JIDs matches the paired number", async () => {
+    await withTempHome(async (homeDir) => {
+      await writeWhatsAppConfigIni(homeDir, {
+        pairedJid: PAIRED_JID,
+        phoneNumber: "1234567890",
+      });
+
+      const authStore = new WhatsAppAuthStore();
+      await authStore.reload();
+      const { client, calls } = createMockClient();
+      const sessionStore = new SessionStore(
+        path.join(homeDir, ".nakama", "whatsapp", "chat-sessions.json")
+      );
+      const orgStore = createTestOrgStore(homeDir);
+      await orgStore.load();
+      const { socket } = createMockSocket();
+      const handleMessage = createChatHandler({
+        authStore,
+        client,
+        config: { phoneNumber: "1234567890", profileId: "default" },
+        getSocket: () => socket as any,
+        orgStore,
+        sessionStore,
+      });
+
+      await handleMessage(
+        groupInbound({
+          mentionedJids: [BOT_ME.id],
+          senderJid: "104784384290844@lid",
+          senderJids: ["104784384290844@lid", PAIRED_JID],
+          text: "@Nakama hello",
+        })
+      );
+
+      expect(calls.sendStream).toBe(1);
+      expect(authStore.getConfig()?.pairedLid).toBe("104784384290844@lid");
+    });
+  });
+
+  test("authorizes the linked WhatsApp account in a group even when pairing stored a different JID", async () => {
+    await withTempHome(async (homeDir) => {
+      await writeWhatsAppConfigIni(homeDir, {
+        pairedJid: PAIRED_JID,
+        phoneNumber: "1234567890",
+      });
+
+      const authStore = new WhatsAppAuthStore();
+      await authStore.reload();
+      const { client, calls } = createMockClient();
+      const sessionStore = new SessionStore(
+        path.join(homeDir, ".nakama", "whatsapp", "chat-sessions.json")
+      );
+      const orgStore = createTestOrgStore(homeDir);
+      await orgStore.load();
+      const { socket } = createMockSocket();
+      const handleMessage = createChatHandler({
+        authStore,
+        client,
+        config: { phoneNumber: "1234567890", profileId: "default" },
+        getSocket: () => socket as any,
+        orgStore,
+        sessionStore,
+      });
+
+      await handleMessage(
+        groupInbound({
+          mentionedJids: [BOT_ME.id],
+          senderJid: BOT_ME.lid,
+          senderJids: [BOT_ME.lid ?? BOT_ME.id],
+          text: "@Nakama hello",
+        })
+      );
+
+      expect(calls.sendStream).toBe(1);
+    });
+  });
+
+  test("tells an already-linked private chat that a pairing code is unnecessary", async () => {
+    await withTempHome(async (homeDir) => {
+      await writeWhatsAppConfigIni(homeDir, {
+        pairedJid: PAIRED_JID,
+        phoneNumber: "1234567890",
+      });
+
+      const authStore = new WhatsAppAuthStore();
+      await authStore.reload();
+      const { client, calls } = createMockClient();
+      const sessionStore = new SessionStore(
+        path.join(homeDir, ".nakama", "whatsapp", "chat-sessions.json")
+      );
+      const orgStore = createTestOrgStore(homeDir);
+      await orgStore.load();
+      const { socket, sent } = createMockSocket();
+      const handleMessage = createChatHandler({
+        authStore,
+        client,
+        config: { phoneNumber: "1234567890", profileId: "default" },
+        getSocket: () => socket as any,
+        orgStore,
+        sessionStore,
+      });
+
+      await handleMessage({ jid: PAIRED_JID, text: "7A2F629D" });
+
+      expect(sent.map((message) => message.text)).toEqual([
+        "This number is already linked.",
+      ]);
+      expect(calls.sendStream).toBe(0);
+    });
+  });
+
+  test("allows an allowlisted phone to talk in a group", async () => {
+    await withTempHome(async (homeDir) => {
+      await writeWhatsAppConfigIni(homeDir, {
+        allowedPhones: ["628111111111"],
+        pairedJid: PAIRED_JID,
+        phoneNumber: "1234567890",
+      });
+
+      const authStore = new WhatsAppAuthStore();
+      await authStore.reload();
+      const { client, calls } = createMockClient();
+      const sessionStore = new SessionStore(
+        path.join(homeDir, ".nakama", "whatsapp", "chat-sessions.json")
+      );
+      const orgStore = createTestOrgStore(homeDir);
+      await orgStore.load();
+      const { socket } = createMockSocket();
+      const handleMessage = createChatHandler({
+        authStore,
+        client,
+        config: { phoneNumber: "1234567890", profileId: "default" },
+        getSocket: () => socket as any,
+        orgStore,
+        sessionStore,
+      });
+
+      await handleMessage(
+        groupInbound({
+          mentionedJids: [BOT_ME.id],
+          senderJid: "628111111111@s.whatsapp.net",
+          text: "@Nakama hello",
+        })
+      );
+
+      expect(calls.sendStream).toBe(1);
     });
   });
 });

--- a/apps/platform/whatsapp/src/chat-handler.test.ts
+++ b/apps/platform/whatsapp/src/chat-handler.test.ts
@@ -761,3 +761,218 @@ describe("bridge API integration", () => {
     });
   });
 });
+
+const GROUP_JID = "120363042000000000@g.us";
+const BOT_ME = {
+  id: "628100000000@s.whatsapp.net",
+  lid: "236283431522503@lid",
+};
+
+function groupInbound(options: {
+  text: string;
+  senderJid?: string;
+  mentionedJids?: string[];
+  quotedParticipant?: string | null;
+  fromMe?: boolean;
+}) {
+  return {
+    fromMe: options.fromMe ?? false,
+    isGroup: true,
+    jid: GROUP_JID,
+    me: BOT_ME,
+    mentionedJids: options.mentionedJids ?? [],
+    quotedParticipant: options.quotedParticipant ?? null,
+    senderJid: options.senderJid ?? PAIRED_JID,
+    text: options.text,
+  };
+}
+
+describe("createChatHandler group chats", () => {
+  test("ignores plain group messages without mention", async () => {
+    await withTempHome(async (homeDir) => {
+      await writeWhatsAppConfigIni(homeDir, {
+        pairedJid: PAIRED_JID,
+        phoneNumber: "1234567890",
+      });
+
+      const authStore = new WhatsAppAuthStore();
+      await authStore.reload();
+      const { client, calls } = createMockClient();
+      const sessionStore = new SessionStore(
+        path.join(homeDir, ".nakama", "whatsapp", "chat-sessions.json")
+      );
+      const orgStore = createTestOrgStore(homeDir);
+      await orgStore.load();
+      const { socket, sent } = createMockSocket();
+      const handleMessage = createChatHandler({
+        authStore,
+        client,
+        config: { phoneNumber: "1234567890", profileId: "default" },
+        getSocket: () => socket as any,
+        orgStore,
+        sessionStore,
+      });
+
+      await handleMessage(groupInbound({ text: "hello everyone" }));
+
+      expect(sent).toEqual([]);
+      expect(calls.createSession).toBe(0);
+      expect(calls.sendStream).toBe(0);
+    });
+  });
+
+  test("group @mention triggers agent when sender is paired", async () => {
+    await withTempHome(async (homeDir) => {
+      await writeWhatsAppConfigIni(homeDir, {
+        pairedJid: PAIRED_JID,
+        phoneNumber: "1234567890",
+      });
+
+      const authStore = new WhatsAppAuthStore();
+      await authStore.reload();
+      const { client, calls } = createMockClient();
+      const sessionStore = new SessionStore(
+        path.join(homeDir, ".nakama", "whatsapp", "chat-sessions.json")
+      );
+      const orgStore = createTestOrgStore(homeDir);
+      await orgStore.load();
+      const { socket, sent } = createMockSocket();
+      const handleMessage = createChatHandler({
+        authStore,
+        client,
+        config: { phoneNumber: "1234567890", profileId: "default" },
+        getSocket: () => socket as any,
+        orgStore,
+        sessionStore,
+      });
+
+      await handleMessage(
+        groupInbound({
+          mentionedJids: [BOT_ME.id],
+          text: "@Nakama hello",
+        })
+      );
+
+      expect(calls.createSession).toBe(1);
+      expect(calls.sendStream).toBe(1);
+      expect(sessionStore.get(GROUP_JID)?.sessionId).toBe("session_test");
+      expect(calls.streamInputs[0]).toEqual({
+        message:
+          "[WhatsApp group — your reply is visible to everyone in this group.]\nhello",
+      });
+      expect(sent.at(-1)?.jid).toBe(GROUP_JID);
+    });
+  });
+
+  test("unpaired @mention redirects to private chat without pairing", async () => {
+    await withTempHome(async (homeDir) => {
+      await writeWhatsAppConfigIni(homeDir, {
+        pairingCode: "ABCD1234",
+        phoneNumber: "1234567890",
+      });
+
+      const authStore = new WhatsAppAuthStore();
+      await authStore.reload();
+      const { client, calls } = createMockClient();
+      const sessionStore = new SessionStore(
+        path.join(homeDir, ".nakama", "whatsapp", "chat-sessions.json")
+      );
+      const orgStore = createTestOrgStore(homeDir);
+      await orgStore.load();
+      const { socket, sent } = createMockSocket();
+      const handleMessage = createChatHandler({
+        authStore,
+        client,
+        config: { phoneNumber: "1234567890", profileId: "default" },
+        getSocket: () => socket as any,
+        orgStore,
+        sessionStore,
+      });
+
+      await handleMessage(
+        groupInbound({
+          mentionedJids: [BOT_ME.id],
+          senderJid: "9999999999@s.whatsapp.net",
+          text: "@Nakama ABCD1234",
+        })
+      );
+
+      expect(sent.map((message) => message.text)).toEqual([
+        "Link your account in a private chat with Nakama first.",
+      ]);
+      expect(calls.sendStream).toBe(0);
+      expect(authStore.isAuthorized("9999999999@s.whatsapp.net")).toBe(false);
+    });
+  });
+
+  test("/org in group stores selection under group org key", async () => {
+    await withTempHome(async (homeDir) => {
+      await writeWhatsAppConfigIni(homeDir, {
+        pairedJid: PAIRED_JID,
+        phoneNumber: "1234567890",
+      });
+
+      const authStore = new WhatsAppAuthStore();
+      await authStore.reload();
+      const { client } = createMockClient({ orgs: createMultiTestOrgs() });
+      const sessionStore = new SessionStore(
+        path.join(homeDir, ".nakama", "whatsapp", "chat-sessions.json")
+      );
+      const orgStore = createTestOrgStore(homeDir);
+      await orgStore.load();
+      const { socket } = createMockSocket();
+      const handleMessage = createChatHandler({
+        authStore,
+        client,
+        config: { phoneNumber: "1234567890", profileId: "default" },
+        getSocket: () => socket as any,
+        orgStore,
+        sessionStore,
+      });
+
+      await handleMessage(groupInbound({ text: "/org 1" }));
+
+      expect(orgStore.get(`g:${GROUP_JID}`)?.orgId).toBe("org_a");
+      expect(orgStore.get(PAIRED_JID)).toBeUndefined();
+    });
+  });
+
+  test("group and private chats keep separate sessions", async () => {
+    await withTempHome(async (homeDir) => {
+      await writeWhatsAppConfigIni(homeDir, {
+        pairedJid: PAIRED_JID,
+        phoneNumber: "1234567890",
+      });
+
+      const authStore = new WhatsAppAuthStore();
+      await authStore.reload();
+      const { client, calls } = createMockClient();
+      const sessionStore = new SessionStore(
+        path.join(homeDir, ".nakama", "whatsapp", "chat-sessions.json")
+      );
+      const orgStore = createTestOrgStore(homeDir);
+      await orgStore.load();
+      const { socket } = createMockSocket();
+      const handleMessage = createChatHandler({
+        authStore,
+        client,
+        config: { phoneNumber: "1234567890", profileId: "default" },
+        getSocket: () => socket as any,
+        orgStore,
+        sessionStore,
+      });
+
+      await handleMessage({ jid: PAIRED_JID, text: "hello privately" });
+      await handleMessage(
+        groupInbound({
+          mentionedJids: [BOT_ME.lid ?? BOT_ME.id],
+          text: "@Nakama hello group",
+        })
+      );
+
+      expect(calls.createSession).toBe(2);
+      expect(sessionStore.get(PAIRED_JID)?.sessionId).toBe("session_test");
+      expect(sessionStore.get(GROUP_JID)?.sessionId).toBe("session_test");
+    });
+  });
+});

--- a/apps/platform/whatsapp/src/chat-handler.test.ts
+++ b/apps/platform/whatsapp/src/chat-handler.test.ts
@@ -774,6 +774,7 @@ function groupInbound(options: {
   senderJids?: string[];
   mentionedJids?: string[];
   quotedParticipant?: string | null;
+  quotedText?: string | null;
   fromMe?: boolean;
 }) {
   const senderJid = options.senderJid ?? PAIRED_JID;
@@ -784,6 +785,7 @@ function groupInbound(options: {
     me: BOT_ME,
     mentionedJids: options.mentionedJids ?? [],
     quotedParticipant: options.quotedParticipant ?? null,
+    quotedText: options.quotedText ?? null,
     senderJid,
     senderJids: options.senderJids ?? [senderJid],
     text: options.text,
@@ -864,6 +866,48 @@ describe("createChatHandler group chats", () => {
           "[WhatsApp group — your reply is visible to everyone in this group.]\nhello",
       });
       expect(sent.at(-1)?.jid).toBe(GROUP_JID);
+    });
+  });
+
+  test("includes quoted group message text in the agent turn", async () => {
+    await withTempHome(async (homeDir) => {
+      await writeWhatsAppConfigIni(homeDir, {
+        pairedJid: PAIRED_JID,
+        phoneNumber: "1234567890",
+      });
+
+      const authStore = new WhatsAppAuthStore();
+      await authStore.reload();
+      const { client, calls } = createMockClient();
+      const sessionStore = new SessionStore(
+        path.join(homeDir, ".nakama", "whatsapp", "chat-sessions.json")
+      );
+      const orgStore = createTestOrgStore(homeDir);
+      await orgStore.load();
+      const { socket } = createMockSocket();
+      const handleMessage = createChatHandler({
+        authStore,
+        client,
+        config: { phoneNumber: "1234567890", profileId: "default" },
+        getSocket: () => socket as any,
+        orgStore,
+        sessionStore,
+      });
+
+      await handleMessage(
+        groupInbound({
+          mentionedJids: [BOT_ME.id],
+          quotedParticipant: "6281352311912@s.whatsapp.net",
+          quotedText: "Update Daily Well PHSS 20-08-2026\nSFT-01 Unload flow",
+          text: "@Nakama ini data laporan hari berikutnya",
+        })
+      );
+
+      expect(calls.sendStream).toBe(1);
+      expect(calls.streamInputs[0]).toEqual({
+        message:
+          "[WhatsApp group — your reply is visible to everyone in this group.]\n[Quoted message]\nUpdate Daily Well PHSS 20-08-2026\nSFT-01 Unload flow\n\nini data laporan hari berikutnya",
+      });
     });
   });
 

--- a/apps/platform/whatsapp/src/chat-handler.ts
+++ b/apps/platform/whatsapp/src/chat-handler.ts
@@ -26,6 +26,7 @@ import {
 } from "./format";
 import {
   explainGroupMessageHandling,
+  isWhatsAppBotAddress,
   resolveChannelOrgKey,
   stripWhatsAppBotMention,
 } from "./group-message";
@@ -40,7 +41,9 @@ const GROUP_MESSAGE_PREFIX =
   "[WhatsApp group — your reply is visible to everyone in this group.]\n";
 
 const LINK_IN_PRIVATE_REPLY =
-  "Link your account in a private chat with Nakama first.";
+  "This WhatsApp number is not linked yet. Open a private chat with this account and send your pairing code from Integrations → WhatsApp.";
+
+const ALREADY_LINKED_REPLY = "This number is already linked.";
 
 const PAIRING_PROMPT =
   "Welcome to Nakama.\n\n" +
@@ -111,11 +114,26 @@ export function createChatHandler(deps: ChatHandlerDeps) {
 
     await withChatLock(conversationKey, async () => {
       await authStore.reload();
+      const senderJids = inbound.senderJids;
+      const pairingText = isGroup ? stripWhatsAppBotMention(trimmed) : trimmed;
       const authorized =
-        inbound.fromMe || authStore.isAuthorized(inbound.senderJid);
+        inbound.fromMe ||
+        authStore.isAuthorized(senderJids) ||
+        senderJids.some((senderJid) =>
+          isWhatsAppBotAddress(senderJid, inbound.me)
+        );
+
+      if (authorized) {
+        await authStore.rememberIdentities(senderJids);
+      }
 
       if (!authorized) {
         if (isGroup) {
+          if (looksLikePairingCodeAttempt(pairingText)) {
+            await handlePairing(inbound.senderJid, pairingText);
+            return;
+          }
+
           await sendText(jid, LINK_IN_PRIVATE_REPLY);
           return;
         }
@@ -124,8 +142,8 @@ export function createChatHandler(deps: ChatHandlerDeps) {
         return;
       }
 
-      if (isGroup && looksLikePairingCodeAttempt(trimmed)) {
-        await sendText(jid, LINK_IN_PRIVATE_REPLY);
+      if (looksLikePairingCodeAttempt(pairingText)) {
+        await sendText(jid, ALREADY_LINKED_REPLY);
         return;
       }
 
@@ -486,6 +504,7 @@ function normalizeInboundChat(
     mentionedJids: data.mentionedJids ?? [],
     quotedParticipant: data.quotedParticipant ?? null,
     senderJid: data.senderJid ?? data.jid,
+    senderJids: data.senderJids ?? [data.senderJid ?? data.jid],
     text: data.text,
   };
 }

--- a/apps/platform/whatsapp/src/chat-handler.ts
+++ b/apps/platform/whatsapp/src/chat-handler.ts
@@ -24,11 +24,23 @@ import {
   prepareWhatsAppReply,
   splitWhatsAppMessage,
 } from "./format";
+import {
+  explainGroupMessageHandling,
+  resolveChannelOrgKey,
+  stripWhatsAppBotMention,
+} from "./group-message";
+import type { WhatsAppInboundChat } from "./inbound-message";
 import type { SessionStore } from "./session-store";
 import { WhatsAppTodoStatusMessage } from "./todo-status-message";
 import { createTypingLoop } from "./typing-indicator";
 
 const chatLocks = new Map<string, Promise<void>>();
+
+const GROUP_MESSAGE_PREFIX =
+  "[WhatsApp group — your reply is visible to everyone in this group.]\n";
+
+const LINK_IN_PRIVATE_REPLY =
+  "Link your account in a private chat with Nakama first.";
 
 const PAIRING_PROMPT =
   "Welcome to Nakama.\n\n" +
@@ -52,52 +64,92 @@ export interface ChatHandlerDeps {
 export function createChatHandler(deps: ChatHandlerDeps) {
   const { client, config, authStore, sessionStore, orgStore, getSocket } = deps;
 
-  return async function handleMessage(data: {
-    jid: string;
-    text: string;
-  }): Promise<void> {
-    const { jid, text } = data;
+  return async function handleMessage(
+    data: Pick<WhatsAppInboundChat, "jid" | "text"> &
+      Partial<Omit<WhatsAppInboundChat, "jid" | "text">>
+  ): Promise<void> {
+    const inbound = normalizeInboundChat(data);
+    const { jid, text } = inbound;
 
     if (!(text && text.trim())) {
       return;
     }
 
     const trimmed = text.trim();
+    const isGroup = inbound.isGroup;
+    const conversationKey = jid;
+    const channelOrgKey = resolveChannelOrgKey(jid, isGroup);
+    const groupDecision = isGroup
+      ? explainGroupMessageHandling({
+          me: inbound.me,
+          mentionedJids: inbound.mentionedJids,
+          quotedParticipant: inbound.quotedParticipant,
+          text: trimmed,
+        })
+      : null;
+
+    if (groupDecision && !groupDecision.shouldHandle) {
+      console.log(
+        [
+          "Ignored WhatsApp group message",
+          `reason=${groupDecision.reason}`,
+          `jid=${jid}`,
+          `sender=${inbound.senderJid || "-"}`,
+          `text=${JSON.stringify(trimmed)}`,
+        ].join(" ")
+      );
+      return;
+    }
 
     if (isStopCommand(trimmed)) {
-      if (!stopActiveStream(jid)) {
+      if (!stopActiveStream(conversationKey)) {
         await sendText(jid, "Nothing to stop.");
       }
 
       return;
     }
 
-    await withChatLock(jid, async () => {
+    await withChatLock(conversationKey, async () => {
       await authStore.reload();
-      const authorized = authStore.isAuthorized(jid);
+      const authorized =
+        inbound.fromMe || authStore.isAuthorized(inbound.senderJid);
 
       if (!authorized) {
+        if (isGroup) {
+          await sendText(jid, LINK_IN_PRIVATE_REPLY);
+          return;
+        }
+
         await handlePairing(jid, trimmed);
+        return;
+      }
+
+      if (isGroup && looksLikePairingCodeAttempt(trimmed)) {
+        await sendText(jid, LINK_IN_PRIVATE_REPLY);
         return;
       }
 
       const command = trimmed.startsWith("/") ? parseCommand(trimmed) : null;
       const bypassOrgGate =
         command === "/help" || command === "/start" || command === "/org";
+      const orgGateText = isGroup ? stripWhatsAppBotMention(trimmed) : trimmed;
 
       if (!bypassOrgGate) {
-        const orgReady = await ensureOrgReady(jid, trimmed);
+        const orgReady = await ensureOrgReady(channelOrgKey, orgGateText, jid);
         if (!orgReady) {
           return;
         }
       }
 
       if (trimmed.startsWith("/")) {
-        await handleCommand(jid, trimmed);
+        await handleCommand(conversationKey, channelOrgKey, jid, trimmed);
         return;
       }
 
-      await handleChatMessage(jid, { message: trimmed });
+      const messageText = isGroup ? stripWhatsAppBotMention(trimmed) : trimmed;
+      await handleChatMessage(conversationKey, jid, {
+        message: withGroupContext(messageText, isGroup),
+      });
     });
   };
 
@@ -130,7 +182,12 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     await sendText(jid, result.message);
   }
 
-  async function handleCommand(jid: string, text: string): Promise<void> {
+  async function handleCommand(
+    conversationKey: string,
+    channelOrgKey: string,
+    jid: string,
+    text: string
+  ): Promise<void> {
     const command = parseCommand(text);
 
     switch (command) {
@@ -140,14 +197,14 @@ export function createChatHandler(deps: ChatHandlerDeps) {
         return;
 
       case "/clear": {
-        const session = await resolveSession(jid);
+        const session = await resolveSession(conversationKey);
         await session.clear();
         await sendText(jid, "History cleared.");
         return;
       }
 
       case "/compact": {
-        const session = await resolveSession(jid);
+        const session = await resolveSession(conversationKey);
         const result = await session.compact({ force: true });
         await sendText(
           jid,
@@ -157,7 +214,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
       }
 
       case "/new": {
-        await createAndBindSession(jid);
+        await createAndBindSession(conversationKey);
         await sendText(jid, "Started a new conversation.");
         return;
       }
@@ -167,7 +224,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
         return;
 
       case "/org":
-        await handleOrgCommand(jid, text);
+        await handleOrgCommand(conversationKey, channelOrgKey, jid, text);
         return;
 
       default:
@@ -176,40 +233,46 @@ export function createChatHandler(deps: ChatHandlerDeps) {
   }
 
   async function ensureOrgReady(
-    jid: string,
-    messageText: string
+    channelOrgKey: string,
+    messageText: string,
+    replyJid: string
   ): Promise<boolean> {
     const orgContext = await prepareChannelOrgContext({
-      getSelectedOrgId: () => orgStore.get(jid)?.orgId,
+      getSelectedOrgId: () => orgStore.get(channelOrgKey)?.orgId,
       listOrgs: () => client.listUserOrgs(),
       saveSelectedOrgId: async (orgId) => {
-        orgStore.set(jid, orgId);
+        orgStore.set(channelOrgKey, orgId);
         await orgStore.save();
       },
       text: messageText.startsWith("/") ? undefined : messageText,
     });
 
     if (orgContext.status === "empty") {
-      await sendText(jid, "No organizations are configured yet.");
+      await sendText(replyJid, "No organizations are configured yet.");
       return false;
     }
 
     if (orgContext.status === "prompt") {
-      await sendText(jid, orgContext.message);
+      await sendText(replyJid, orgContext.message);
       return false;
     }
 
     client.setOrgId(orgContext.orgId);
 
     if (orgContext.justSelected) {
-      await sendText(jid, formatOrgSwitchConfirmation(orgContext.orgName));
+      await sendText(replyJid, formatOrgSwitchConfirmation(orgContext.orgName));
       return false;
     }
 
     return true;
   }
 
-  async function handleOrgCommand(jid: string, text: string): Promise<void> {
+  async function handleOrgCommand(
+    conversationKey: string,
+    channelOrgKey: string,
+    jid: string,
+    text: string
+  ): Promise<void> {
     const { orgs } = await client.listUserOrgs();
 
     if (orgs.length === 0) {
@@ -221,7 +284,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     if (!arg) {
       await sendText(
         jid,
-        formatOrgSelectionPrompt(orgs, orgStore.get(jid)?.orgId)
+        formatOrgSelectionPrompt(orgs, orgStore.get(channelOrgKey)?.orgId)
       );
       return;
     }
@@ -232,13 +295,13 @@ export function createChatHandler(deps: ChatHandlerDeps) {
       return;
     }
 
-    const previousOrgId = orgStore.get(jid)?.orgId;
-    orgStore.set(jid, picked.id);
+    const previousOrgId = orgStore.get(channelOrgKey)?.orgId;
+    orgStore.set(channelOrgKey, picked.id);
     await orgStore.save();
     client.setOrgId(picked.id);
 
     if (previousOrgId && previousOrgId !== picked.id) {
-      sessionStore.delete(jid);
+      sessionStore.delete(conversationKey);
       await sessionStore.save();
     }
 
@@ -246,13 +309,14 @@ export function createChatHandler(deps: ChatHandlerDeps) {
   }
 
   async function handleChatMessage(
+    conversationKey: string,
     jid: string,
     input: SendMessageInput
   ): Promise<void> {
-    const session = await resolveSession(jid);
+    const session = await resolveSession(conversationKey);
     const typingLoop = createTypingLoop(getSocket(), jid);
     const todoStatus = new WhatsAppTodoStatusMessage(getSocket(), jid);
-    const signal = registerActiveStream(jid);
+    const signal = registerActiveStream(conversationKey);
     let reply = "";
 
     typingLoop.start();
@@ -306,7 +370,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
       await sendText(jid, formatError(error));
       return;
     } finally {
-      clearActiveStream(jid);
+      clearActiveStream(conversationKey);
       typingLoop.stop();
     }
 
@@ -408,6 +472,34 @@ export function createChatHandler(deps: ChatHandlerDeps) {
       await socket.sendMessage(jid, { text: chunk });
     }
   }
+}
+
+function normalizeInboundChat(
+  data: Pick<WhatsAppInboundChat, "jid" | "text"> &
+    Partial<Omit<WhatsAppInboundChat, "jid" | "text">>
+): WhatsAppInboundChat {
+  return {
+    fromMe: data.fromMe ?? false,
+    isGroup: data.isGroup ?? false,
+    jid: data.jid,
+    me: data.me,
+    mentionedJids: data.mentionedJids ?? [],
+    quotedParticipant: data.quotedParticipant ?? null,
+    senderJid: data.senderJid ?? data.jid,
+    text: data.text,
+  };
+}
+
+function withGroupContext(message: string, isGroup: boolean): string {
+  if (!isGroup) {
+    return message;
+  }
+
+  if (message.trim()) {
+    return `${GROUP_MESSAGE_PREFIX}${message}`;
+  }
+
+  return GROUP_MESSAGE_PREFIX.trim();
 }
 
 function parseCommand(text: string): string {

--- a/apps/platform/whatsapp/src/chat-handler.ts
+++ b/apps/platform/whatsapp/src/chat-handler.ts
@@ -166,7 +166,10 @@ export function createChatHandler(deps: ChatHandlerDeps) {
 
       const messageText = isGroup ? stripWhatsAppBotMention(trimmed) : trimmed;
       await handleChatMessage(conversationKey, jid, {
-        message: withGroupContext(messageText, isGroup),
+        message: withGroupContext(
+          withQuotedContext(messageText, inbound.quotedText),
+          isGroup
+        ),
       });
     });
   };
@@ -503,10 +506,24 @@ function normalizeInboundChat(
     me: data.me,
     mentionedJids: data.mentionedJids ?? [],
     quotedParticipant: data.quotedParticipant ?? null,
+    quotedText: data.quotedText ?? null,
     senderJid: data.senderJid ?? data.jid,
     senderJids: data.senderJids ?? [data.senderJid ?? data.jid],
     text: data.text,
   };
+}
+
+function withQuotedContext(message: string, quotedText: string | null): string {
+  const quote = quotedText?.trim();
+  if (!quote) {
+    return message;
+  }
+
+  if (message.trim()) {
+    return `[Quoted message]\n${quote}\n\n${message}`;
+  }
+
+  return `[Quoted message]\n${quote}`;
 }
 
 function withGroupContext(message: string, isGroup: boolean): string {

--- a/apps/platform/whatsapp/src/group-message.test.ts
+++ b/apps/platform/whatsapp/src/group-message.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import {
+  explainGroupMessageHandling,
+  isWhatsAppBotAddress,
+  isWhatsAppGroupChat,
+  resolveChannelOrgKey,
+  stripWhatsAppBotMention,
+  type WhatsAppAccount,
+} from "./group-message";
+
+const me: WhatsAppAccount = {
+  id: "628100000000@s.whatsapp.net",
+  lid: "236283431522503@lid",
+};
+
+describe("group-message helpers", () => {
+  test("isWhatsAppGroupChat detects group JIDs", () => {
+    expect(isWhatsAppGroupChat("120363@g.us")).toBe(true);
+    expect(isWhatsAppGroupChat("628100000000@s.whatsapp.net")).toBe(false);
+    expect(isWhatsAppGroupChat("236283431522503@lid")).toBe(false);
+  });
+
+  test("resolveChannelOrgKey scopes org store by group or private chat", () => {
+    expect(resolveChannelOrgKey("120363@g.us", true)).toBe("g:120363@g.us");
+    expect(resolveChannelOrgKey("628100000000@s.whatsapp.net", false)).toBe(
+      "628100000000@s.whatsapp.net"
+    );
+  });
+
+  test("isWhatsAppBotAddress matches phone and lid identities", () => {
+    expect(isWhatsAppBotAddress("628100000000@s.whatsapp.net", me)).toBe(true);
+    expect(isWhatsAppBotAddress("628100000000:12@s.whatsapp.net", me)).toBe(
+      true
+    );
+    expect(isWhatsAppBotAddress("236283431522503@lid", me)).toBe(true);
+    expect(isWhatsAppBotAddress("9999999999@s.whatsapp.net", me)).toBe(false);
+  });
+
+  test("explainGroupMessageHandling accepts mention, reply, and slash commands", () => {
+    expect(
+      explainGroupMessageHandling({
+        me,
+        mentionedJids: ["628100000000@s.whatsapp.net"],
+        quotedParticipant: null,
+        text: "@Nakama hello",
+      }).shouldHandle
+    ).toBe(true);
+
+    expect(
+      explainGroupMessageHandling({
+        me,
+        mentionedJids: [],
+        quotedParticipant: null,
+        text: "hello",
+      }).shouldHandle
+    ).toBe(false);
+
+    expect(
+      explainGroupMessageHandling({
+        me,
+        mentionedJids: [],
+        quotedParticipant: me.lid ?? null,
+        text: "follow up",
+      }).shouldHandle
+    ).toBe(true);
+
+    expect(
+      explainGroupMessageHandling({
+        me,
+        mentionedJids: [],
+        quotedParticipant: null,
+        text: "/status",
+      }).shouldHandle
+    ).toBe(true);
+  });
+
+  test("explainGroupMessageHandling ignores non-slash messages without bot info", () => {
+    expect(
+      explainGroupMessageHandling({
+        mentionedJids: ["628100000000@s.whatsapp.net"],
+        quotedParticipant: null,
+        text: "hello",
+      })
+    ).toEqual({ reason: "missing-bot-info", shouldHandle: false });
+  });
+
+  test("stripWhatsAppBotMention removes @mention tokens", () => {
+    expect(stripWhatsAppBotMention("hi @Nakama there")).toBe("hi there");
+    expect(stripWhatsAppBotMention("@Nakama")).toBe("");
+  });
+});

--- a/apps/platform/whatsapp/src/group-message.ts
+++ b/apps/platform/whatsapp/src/group-message.ts
@@ -1,0 +1,74 @@
+import { areJidsSameUser, isJidGroup } from "@whiskeysockets/baileys";
+
+export interface WhatsAppAccount {
+  id: string;
+  lid?: string | null;
+}
+
+export interface GroupMessageHandlingDecision {
+  reason:
+    | "slash-command"
+    | "missing-bot-info"
+    | "reply-to-bot"
+    | "bot-mention"
+    | "no-text"
+    | "no-trigger";
+  shouldHandle: boolean;
+}
+
+export function isWhatsAppGroupChat(jid: string): boolean {
+  return Boolean(isJidGroup(jid));
+}
+
+export function resolveChannelOrgKey(jid: string, isGroup: boolean): string {
+  return isGroup ? `g:${jid}` : jid;
+}
+
+export function isWhatsAppBotAddress(
+  jid: string | null | undefined,
+  me: WhatsAppAccount | undefined
+): boolean {
+  if (!(jid && me)) {
+    return false;
+  }
+
+  if (areJidsSameUser(jid, me.id)) {
+    return true;
+  }
+
+  return Boolean(me.lid && areJidsSameUser(jid, me.lid));
+}
+
+export function explainGroupMessageHandling(input: {
+  mentionedJids: string[];
+  quotedParticipant: string | null;
+  text: string;
+  me?: WhatsAppAccount | undefined;
+}): GroupMessageHandlingDecision {
+  const text = input.text.trim();
+
+  if (text.startsWith("/")) {
+    return { reason: "slash-command", shouldHandle: true };
+  }
+
+  if (!input.me) {
+    return { reason: "missing-bot-info", shouldHandle: false };
+  }
+
+  if (isWhatsAppBotAddress(input.quotedParticipant, input.me)) {
+    return { reason: "reply-to-bot", shouldHandle: true };
+  }
+
+  if (input.mentionedJids.some((jid) => isWhatsAppBotAddress(jid, input.me))) {
+    return { reason: "bot-mention", shouldHandle: true };
+  }
+
+  return {
+    reason: text ? "no-trigger" : "no-text",
+    shouldHandle: false,
+  };
+}
+
+export function stripWhatsAppBotMention(text: string): string {
+  return text.replace(/@\S+/g, "").replace(/\s+/g, " ").trim();
+}

--- a/apps/platform/whatsapp/src/inbound-message.test.ts
+++ b/apps/platform/whatsapp/src/inbound-message.test.ts
@@ -171,9 +171,41 @@ describe("inbound message routing", () => {
       me: ME,
       mentionedJids: [ME.lid],
       quotedParticipant: null,
+      quotedText: null,
       senderJid: "9999999999@s.whatsapp.net",
       senderJids: ["9999999999@s.whatsapp.net", "104784384290844@lid"],
       text: "@Nakama hello",
     });
+  });
+
+  test("parseInboundWhatsAppMessage keeps quoted message text", () => {
+    const inbound = parseInboundWhatsAppMessage(
+      {
+        key: {
+          participant: "9999999999@s.whatsapp.net",
+          remoteJid: "120363@g.us",
+        },
+        message: {
+          extendedTextMessage: {
+            contextInfo: {
+              mentionedJid: [ME.id],
+              participant: "6281352311912@s.whatsapp.net",
+              quotedMessage: {
+                conversation:
+                  "Update Daily Well PHSS 20-08-2026\nSFT-01 Unload flow",
+              },
+            },
+            text: "@Nakama ini data laporan hari berikutnya",
+          },
+        },
+      },
+      ME
+    );
+
+    expect(inbound?.quotedParticipant).toBe("6281352311912@s.whatsapp.net");
+    expect(inbound?.quotedText).toBe(
+      "Update Daily Well PHSS 20-08-2026\nSFT-01 Unload flow"
+    );
+    expect(inbound?.text).toBe("@Nakama ini data laporan hari berikutnya");
   });
 });

--- a/apps/platform/whatsapp/src/inbound-message.test.ts
+++ b/apps/platform/whatsapp/src/inbound-message.test.ts
@@ -172,6 +172,7 @@ describe("inbound message routing", () => {
       mentionedJids: [ME.lid],
       quotedParticipant: null,
       senderJid: "9999999999@s.whatsapp.net",
+      senderJids: ["9999999999@s.whatsapp.net", "104784384290844@lid"],
       text: "@Nakama hello",
     });
   });

--- a/apps/platform/whatsapp/src/inbound-message.test.ts
+++ b/apps/platform/whatsapp/src/inbound-message.test.ts
@@ -3,8 +3,14 @@ import {
   extractInboundText,
   isPrivateWhatsAppChat,
   isSelfWhatsAppChat,
+  parseInboundWhatsAppMessage,
   shouldHandleInboundMessage,
 } from "./inbound-message";
+
+const ME = {
+  id: "6281379292556@s.whatsapp.net",
+  lid: "236283431522503@lid",
+};
 
 describe("inbound message routing", () => {
   test("accepts private phone and lid chats", () => {
@@ -75,5 +81,98 @@ describe("inbound message routing", () => {
     };
 
     expect(extractInboundText(payload as any)).toBe("hi from toJSON");
+  });
+
+  test("ignores group messages without a mention, reply, or slash command", () => {
+    expect(
+      shouldHandleInboundMessage(
+        {
+          key: {
+            participant: "9999999999@s.whatsapp.net",
+            remoteJid: "120363@g.us",
+          },
+          message: { conversation: "hello everyone" },
+        },
+        ME
+      )
+    ).toBe(false);
+  });
+
+  test("handles group mentions, replies, and slash commands", () => {
+    expect(
+      shouldHandleInboundMessage(
+        {
+          key: {
+            participant: "9999999999@s.whatsapp.net",
+            remoteJid: "120363@g.us",
+          },
+          message: {
+            extendedTextMessage: {
+              contextInfo: { mentionedJid: [ME.id] },
+              text: "@Nakama hello",
+            },
+          },
+        },
+        ME
+      )
+    ).toBe(true);
+
+    expect(
+      shouldHandleInboundMessage(
+        {
+          key: {
+            participant: "9999999999@s.whatsapp.net",
+            remoteJid: "120363@g.us",
+          },
+          message: {
+            extendedTextMessage: {
+              contextInfo: { participant: ME.lid },
+              text: "follow up",
+            },
+          },
+        },
+        ME
+      )
+    ).toBe(true);
+
+    expect(
+      shouldHandleInboundMessage(
+        {
+          key: { fromMe: true, remoteJid: "120363@g.us" },
+          message: { conversation: "/status" },
+        },
+        ME
+      )
+    ).toBe(true);
+  });
+
+  test("parseInboundWhatsAppMessage keeps group sender and chat JIDs separate", () => {
+    const inbound = parseInboundWhatsAppMessage(
+      {
+        key: {
+          participant: "104784384290844@lid",
+          participantPn: "9999999999@s.whatsapp.net",
+          remoteJid: "120363@g.us",
+        },
+        message: {
+          extendedTextMessage: {
+            contextInfo: { mentionedJid: [ME.lid] },
+            text: "@Nakama hello",
+          },
+        },
+      },
+      ME
+    );
+
+    expect(inbound).toEqual({
+      fromMe: false,
+      isGroup: true,
+      jid: "120363@g.us",
+      me: ME,
+      mentionedJids: [ME.lid],
+      quotedParticipant: null,
+      senderJid: "9999999999@s.whatsapp.net",
+      text: "@Nakama hello",
+    });
   });
 });

--- a/apps/platform/whatsapp/src/inbound-message.ts
+++ b/apps/platform/whatsapp/src/inbound-message.ts
@@ -28,6 +28,7 @@ export interface WhatsAppInboundChat {
   me?: WhatsAppAccount;
   mentionedJids: string[];
   quotedParticipant: string | null;
+  quotedText: string | null;
   senderJid: string;
   senderJids: string[];
   text: string;
@@ -86,6 +87,14 @@ function extractQuotedParticipant(
   return extractContextInfo(message)?.participant ?? null;
 }
 
+function extractQuotedText(
+  message: proto.IMessage | null | undefined
+): string | null {
+  const quotedMessage = extractContextInfo(message)?.quotedMessage;
+  const quotedText = extractInboundText(quotedMessage).trim();
+  return quotedText || null;
+}
+
 export function shouldHandleInboundMessage(
   msg: {
     key: WhatsAppInboundKey;
@@ -114,6 +123,7 @@ export function parseInboundWhatsAppMessage(
   const fromMe = Boolean(msg.key.fromMe);
   const mentionedJids = extractMentionedJids(msg.message);
   const quotedParticipant = extractQuotedParticipant(msg.message);
+  const quotedText = extractQuotedText(msg.message);
 
   if (isGroup) {
     const decision = explainGroupMessageHandling({
@@ -146,6 +156,7 @@ export function parseInboundWhatsAppMessage(
     me,
     mentionedJids,
     quotedParticipant,
+    quotedText,
     senderJid,
     senderJids,
     text,

--- a/apps/platform/whatsapp/src/inbound-message.ts
+++ b/apps/platform/whatsapp/src/inbound-message.ts
@@ -6,6 +6,28 @@ import {
   isLidUser,
   type proto,
 } from "@whiskeysockets/baileys";
+import {
+  explainGroupMessageHandling,
+  type WhatsAppAccount,
+} from "./group-message";
+
+interface WhatsAppInboundKey {
+  fromMe?: boolean | null;
+  participant?: string | null;
+  participantPn?: string | null;
+  remoteJid?: string | null;
+}
+
+export interface WhatsAppInboundChat {
+  fromMe: boolean;
+  isGroup: boolean;
+  jid: string;
+  me?: WhatsAppAccount;
+  mentionedJids: string[];
+  quotedParticipant: string | null;
+  senderJid: string;
+  text: string;
+}
 
 export function isPrivateWhatsAppChat(jid: string): boolean {
   return isJidUser(jid) || isLidUser(jid);
@@ -13,7 +35,7 @@ export function isPrivateWhatsAppChat(jid: string): boolean {
 
 export function isSelfWhatsAppChat(
   remoteJid: string,
-  me: { id: string; lid?: string | null } | undefined
+  me: WhatsAppAccount | undefined
 ): boolean {
   if (!me) {
     return false;
@@ -44,6 +66,120 @@ export function extractInboundText(
   return readTextContent(materialized);
 }
 
+function extractMentionedJids(
+  message: proto.IMessage | null | undefined
+): string[] {
+  return (
+    extractContextInfo(message)?.mentionedJid?.filter((jid): jid is string =>
+      Boolean(jid)
+    ) ?? []
+  );
+}
+
+function extractQuotedParticipant(
+  message: proto.IMessage | null | undefined
+): string | null {
+  return extractContextInfo(message)?.participant ?? null;
+}
+
+export function shouldHandleInboundMessage(
+  msg: {
+    key: WhatsAppInboundKey;
+    message?: proto.IMessage | null;
+  },
+  me: WhatsAppAccount | undefined
+): boolean {
+  return parseInboundWhatsAppMessage(msg, me) !== null;
+}
+
+export function parseInboundWhatsAppMessage(
+  msg: {
+    key: WhatsAppInboundKey;
+    message?: proto.IMessage | null;
+  },
+  me: WhatsAppAccount | undefined
+): WhatsAppInboundChat | null {
+  const remoteJid = msg.key.remoteJid;
+  const text = extractInboundText(msg.message);
+
+  if (!(remoteJid && text)) {
+    return null;
+  }
+
+  const isGroup = Boolean(isJidGroup(remoteJid));
+  const fromMe = Boolean(msg.key.fromMe);
+  const mentionedJids = extractMentionedJids(msg.message);
+  const quotedParticipant = extractQuotedParticipant(msg.message);
+
+  if (isGroup) {
+    const decision = explainGroupMessageHandling({
+      me,
+      mentionedJids,
+      quotedParticipant,
+      text,
+    });
+
+    if (!decision.shouldHandle) {
+      return null;
+    }
+  } else if (!isPrivateWhatsAppChat(remoteJid)) {
+    return null;
+  } else if (fromMe && !isSelfWhatsAppChat(remoteJid, me)) {
+    return null;
+  }
+
+  const senderJid = resolveSenderJid(msg.key, remoteJid, isGroup, me);
+
+  if (isGroup && !senderJid) {
+    return null;
+  }
+
+  return {
+    fromMe,
+    isGroup,
+    jid: remoteJid,
+    me,
+    mentionedJids,
+    quotedParticipant,
+    senderJid,
+    text,
+  };
+}
+
+function resolveSenderJid(
+  key: WhatsAppInboundKey,
+  remoteJid: string,
+  isGroup: boolean,
+  me: WhatsAppAccount | undefined
+): string {
+  if (!isGroup) {
+    return remoteJid;
+  }
+
+  return (
+    key.participantPn ?? key.participant ?? (key.fromMe && me ? me.id : "")
+  );
+}
+
+function extractContextInfo(
+  message: proto.IMessage | null | undefined
+): proto.IContextInfo | undefined {
+  if (!message) {
+    return;
+  }
+
+  const extracted = extractMessageContent(message) ?? message;
+  const materialized = materializeMessage(extracted) ?? extracted;
+
+  return (
+    materialized.extendedTextMessage?.contextInfo ??
+    materialized.imageMessage?.contextInfo ??
+    materialized.videoMessage?.contextInfo ??
+    materialized.documentMessage?.contextInfo ??
+    undefined
+  );
+}
+
 function readTextContent(
   message: Partial<proto.IMessage> | null | undefined
 ): string {
@@ -68,28 +204,4 @@ function materializeMessage(
   } catch {
     return null;
   }
-}
-
-export function shouldHandleInboundMessage(
-  msg: {
-    key: { fromMe?: boolean | null; remoteJid?: string | null };
-    message?: proto.IMessage | null;
-  },
-  me: { id: string; lid?: string | null } | undefined
-): boolean {
-  const remoteJid = msg.key.remoteJid;
-
-  if (
-    !remoteJid ||
-    isJidGroup(remoteJid) ||
-    !isPrivateWhatsAppChat(remoteJid)
-  ) {
-    return false;
-  }
-
-  if (msg.key.fromMe && !isSelfWhatsAppChat(remoteJid, me)) {
-    return false;
-  }
-
-  return Boolean(extractInboundText(msg.message));
 }

--- a/apps/platform/whatsapp/src/inbound-message.ts
+++ b/apps/platform/whatsapp/src/inbound-message.ts
@@ -14,8 +14,11 @@ import {
 interface WhatsAppInboundKey {
   fromMe?: boolean | null;
   participant?: string | null;
+  participantLid?: string | null;
   participantPn?: string | null;
   remoteJid?: string | null;
+  senderLid?: string | null;
+  senderPn?: string | null;
 }
 
 export interface WhatsAppInboundChat {
@@ -26,6 +29,7 @@ export interface WhatsAppInboundChat {
   mentionedJids: string[];
   quotedParticipant: string | null;
   senderJid: string;
+  senderJids: string[];
   text: string;
 }
 
@@ -128,7 +132,8 @@ export function parseInboundWhatsAppMessage(
     return null;
   }
 
-  const senderJid = resolveSenderJid(msg.key, remoteJid, isGroup, me);
+  const senderJids = collectSenderJids(msg.key, remoteJid, isGroup, me);
+  const senderJid = senderJids[0] ?? "";
 
   if (isGroup && !senderJid) {
     return null;
@@ -142,23 +147,37 @@ export function parseInboundWhatsAppMessage(
     mentionedJids,
     quotedParticipant,
     senderJid,
+    senderJids,
     text,
   };
 }
 
-function resolveSenderJid(
+function collectSenderJids(
   key: WhatsAppInboundKey,
   remoteJid: string,
   isGroup: boolean,
   me: WhatsAppAccount | undefined
-): string {
-  if (!isGroup) {
-    return remoteJid;
-  }
+): string[] {
+  const candidates = isGroup
+    ? [
+        key.participantPn,
+        key.senderPn,
+        key.participant,
+        key.participantLid,
+        key.senderLid,
+        key.fromMe && me ? me.id : null,
+        key.fromMe && me?.lid ? me.lid : null,
+      ]
+    : [
+        remoteJid,
+        key.senderPn,
+        key.senderLid,
+        key.participant,
+        key.participantPn,
+        key.participantLid,
+      ];
 
-  return (
-    key.participantPn ?? key.participant ?? (key.fromMe && me ? me.id : "")
-  );
+  return [...new Set(candidates.filter((jid): jid is string => Boolean(jid)))];
 }
 
 function extractContextInfo(

--- a/apps/platform/whatsapp/src/socket.ts
+++ b/apps/platform/whatsapp/src/socket.ts
@@ -11,13 +11,14 @@ import {
 import {
   extractInboundText,
   isPrivateWhatsAppChat,
-  shouldHandleInboundMessage,
+  parseInboundWhatsAppMessage,
+  type WhatsAppInboundChat,
 } from "./inbound-message";
 
 export interface WhatsAppSocketDeps {
   onConnected?: (me: { id: string; lid?: string | null }) => void;
   onDisconnected?: () => void;
-  onMessage: (data: { jid: string; text: string }) => Promise<void>;
+  onMessage: (data: WhatsAppInboundChat) => Promise<void>;
   onQr?: (qr: string) => void;
 }
 
@@ -110,11 +111,11 @@ export async function createWhatsAppSocket(
         for (const msg of m.messages) {
           const remoteJid = msg.key.remoteJid ?? null;
           const text = extractInboundText(msg.message);
-          const shouldHandle = shouldHandleInboundMessage(msg, me);
+          const inbound = parseInboundWhatsAppMessage(msg, me);
 
           if (remoteJid) {
             console.log(
-              `WhatsApp upsert item jid=${remoteJid} fromMe=${msg.key.fromMe ? "yes" : "no"} participant=${msg.key.participant ?? "-"} text=${text ? "yes" : "no"} handle=${shouldHandle ? "yes" : "no"}`
+              `WhatsApp upsert item jid=${remoteJid} fromMe=${msg.key.fromMe ? "yes" : "no"} participant=${msg.key.participant ?? "-"} text=${text ? "yes" : "no"} handle=${inbound ? "yes" : "no"}`
             );
           }
 
@@ -131,21 +132,24 @@ export async function createWhatsAppSocket(
             );
           }
 
-          if (!(shouldHandle && remoteJid)) {
+          if (!inbound) {
             continue;
           }
 
-          const preview = text.length > 120 ? `${text.slice(0, 120)}…` : text;
+          const preview =
+            inbound.text.length > 120
+              ? `${inbound.text.slice(0, 120)}…`
+              : inbound.text;
           console.log(
-            `WhatsApp message received from ${remoteJid}: ${preview}`
+            `WhatsApp message received from ${inbound.jid}: ${preview}`
           );
 
           try {
-            await deps.onMessage({ jid: remoteJid, text });
+            await deps.onMessage(inbound);
           } catch (error) {
             console.error("WhatsApp inbound message handling failed.", {
               error: error instanceof Error ? error.message : String(error),
-              jid: remoteJid,
+              jid: inbound.jid,
             });
           }
         }

--- a/apps/platform/whatsapp/src/test-helpers.ts
+++ b/apps/platform/whatsapp/src/test-helpers.ts
@@ -77,6 +77,7 @@ export function createMockClient(
     profileIds: [] as string[],
     sendStream: 0,
     setOrgId: 0,
+    streamInputs: [] as unknown[],
   };
   const orgIds: string[] = [];
 
@@ -88,6 +89,7 @@ export function createMockClient(
     streamOptions?: { signal?: AbortSignal }
   ) => {
     calls.sendStream += 1;
+    calls.streamInputs.push(_input);
 
     if (!options.streaming) {
       return "Agent reply";

--- a/apps/platform/whatsapp/src/test-helpers.ts
+++ b/apps/platform/whatsapp/src/test-helpers.ts
@@ -263,6 +263,7 @@ export async function writeWhatsAppConfigIni(
     profileId?: string;
     pairingCode?: string | null;
     pairedJid?: string | null;
+    allowedPhones?: string[];
   }
 ): Promise<void> {
   const dir = path.join(homeDir, ".nakama", "whatsapp");
@@ -280,6 +281,10 @@ export async function writeWhatsAppConfigIni(
 
   if (config.pairedJid) {
     lines.push(`paired_jid=${config.pairedJid}`);
+  }
+
+  if (config.allowedPhones?.length) {
+    lines.push(`allowed_phones=${config.allowedPhones.join(",")}`);
   }
 
   lines.push("");

--- a/apps/server/src/services/super-bot-session-state.ts
+++ b/apps/server/src/services/super-bot-session-state.ts
@@ -25,11 +25,11 @@ export class SuperBotSessionState {
   }
 
   canCreateProfile(sessionId: string | undefined): boolean {
-    return this.hasConfirmedTurn(sessionId);
-  }
+    if (!sessionId) {
+      return true;
+    }
 
-  canUpdateProfile(sessionId: string | undefined): boolean {
-    return this.hasConfirmedTurn(sessionId);
+    return (this.turns.get(sessionId)?.turnIndex ?? 0) >= 2;
   }
 
   canAssignTool(sessionId: string | undefined, toolId: string): boolean {
@@ -56,14 +56,6 @@ export class SuperBotSessionState {
 
   clearSession(sessionId: string): void {
     this.turns.delete(sessionId);
-  }
-
-  private hasConfirmedTurn(sessionId: string | undefined): boolean {
-    if (!sessionId) {
-      return true;
-    }
-
-    return (this.turns.get(sessionId)?.turnIndex ?? 0) >= 2;
   }
 
   private turnFor(sessionId: string): TurnState {

--- a/apps/server/src/services/super-bot-session-state.ts
+++ b/apps/server/src/services/super-bot-session-state.ts
@@ -25,11 +25,11 @@ export class SuperBotSessionState {
   }
 
   canCreateProfile(sessionId: string | undefined): boolean {
-    if (!sessionId) {
-      return true;
-    }
+    return this.hasConfirmedTurn(sessionId);
+  }
 
-    return (this.turns.get(sessionId)?.turnIndex ?? 0) >= 2;
+  canUpdateProfile(sessionId: string | undefined): boolean {
+    return this.hasConfirmedTurn(sessionId);
   }
 
   canAssignTool(sessionId: string | undefined, toolId: string): boolean {
@@ -58,6 +58,14 @@ export class SuperBotSessionState {
     this.turns.delete(sessionId);
   }
 
+  private hasConfirmedTurn(sessionId: string | undefined): boolean {
+    if (!sessionId) {
+      return true;
+    }
+
+    return (this.turns.get(sessionId)?.turnIndex ?? 0) >= 2;
+  }
+
   private turnFor(sessionId: string): TurnState {
     let turn = this.turns.get(sessionId);
 
@@ -79,3 +87,6 @@ export const TOOL_ASSIGNMENT_CONFIRMATION_MESSAGE =
 
 export const PROFILE_CREATE_CONFIRMATION_MESSAGE =
   "Wait for the user to confirm the draft in a later message before calling create_profile.";
+
+export const PROFILE_UPDATE_CONFIRMATION_MESSAGE =
+  "Wait for the user to confirm the new system prompt in a later message before calling update_profile.";

--- a/apps/server/src/tools/super-bot-tools.test.ts
+++ b/apps/server/src/tools/super-bot-tools.test.ts
@@ -7,10 +7,12 @@ import type {
   CreateToolRequest,
   ProfileResponse,
   ToolDetail,
+  UpdateProfileRequest,
 } from "@nakama/core";
 import type { ProfileService } from "../services/profile-service";
 import {
   PROFILE_CREATE_CONFIRMATION_MESSAGE,
+  PROFILE_UPDATE_CONFIRMATION_MESSAGE,
   SuperBotSessionState,
   TOOL_ASSIGNMENT_CONFIRMATION_MESSAGE,
 } from "../services/super-bot-session-state";
@@ -574,9 +576,152 @@ describe("super bot create_profile", () => {
   });
 });
 
+describe("super bot update_profile", () => {
+  test("refuses update_profile on the first turn", async () => {
+    let updateProfileCalled = false;
+    const sessionState = new SuperBotSessionState();
+    sessionState.beginTurn(SESSION_ID);
+    const updateProfile = getUpdateProfileTool(
+      {
+        async updateProfile(): Promise<ProfileResponse> {
+          updateProfileCalled = true;
+          throw new Error("should not be called");
+        },
+      },
+      sessionState
+    );
+
+    const error = await captureError(
+      updateProfile.run(
+        { profileId: "support-bot", systemPrompt: "You are support." },
+        { orgId: ORG_ID, sessionId: SESSION_ID }
+      )
+    );
+
+    expect(error?.message).toBe(PROFILE_UPDATE_CONFIRMATION_MESSAGE);
+    expect(updateProfileCalled).toBe(false);
+  });
+
+  test("updates the stored system prompt after a later user turn confirms", async () => {
+    const captured: Array<{
+      orgId: string;
+      profileId: string;
+      request: UpdateProfileRequest;
+    }> = [];
+    const sessionState = new SuperBotSessionState();
+    sessionState.beginTurn(SESSION_ID);
+    sessionState.beginTurn(SESSION_ID);
+    const updateProfile = getUpdateProfileTool(
+      {
+        async updateProfile(
+          orgId: string,
+          profileId: string,
+          request: UpdateProfileRequest
+        ): Promise<ProfileResponse> {
+          captured.push({ orgId, profileId, request });
+          return {
+            profile: {
+              createdAt: "2026-01-01T00:00:00.000Z",
+              hasAvatar: false,
+              id: profileId,
+              isSuper: false,
+              mcpServerCount: 0,
+              mcpServers: [],
+              model: null,
+              name: "Support Bot",
+              skills: [],
+              soulActive: true,
+              systemPrompt: request.systemPrompt ?? "",
+              toolCount: 0,
+              tools: [],
+              updatedAt: "2026-01-01T00:00:00.000Z",
+            },
+          };
+        },
+      },
+      sessionState
+    );
+
+    await expect(
+      updateProfile.run(
+        { profileId: "support-bot", systemPrompt: "You are support." },
+        { orgId: ORG_ID, sessionId: SESSION_ID }
+      )
+    ).resolves.toMatchObject({
+      profile: { id: "support-bot", systemPrompt: "You are support." },
+    });
+    expect(captured[0]).toEqual({
+      orgId: ORG_ID,
+      profileId: "support-bot",
+      request: { systemPrompt: "You are support." },
+    });
+  });
+
+  test("clears the stored system prompt when an empty string is passed", async () => {
+    const captured: UpdateProfileRequest[] = [];
+    const updateProfile = getUpdateProfileTool({
+      async updateProfile(
+        _orgId: string,
+        _profileId: string,
+        request: UpdateProfileRequest
+      ): Promise<ProfileResponse> {
+        captured.push(request);
+        return {
+          profile: {
+            createdAt: "2026-01-01T00:00:00.000Z",
+            hasAvatar: false,
+            id: "support-bot",
+            isSuper: false,
+            mcpServerCount: 0,
+            mcpServers: [],
+            model: null,
+            name: "Support Bot",
+            skills: [],
+            soulActive: true,
+            systemPrompt: request.systemPrompt ?? "",
+            toolCount: 0,
+            tools: [],
+            updatedAt: "2026-01-01T00:00:00.000Z",
+          },
+        };
+      },
+    });
+
+    await updateProfile.run(
+      { profileId: "support-bot", systemPrompt: "" },
+      { orgId: ORG_ID, sessionId: SESSION_ID }
+    );
+
+    expect(captured[0]?.systemPrompt).toBe("");
+  });
+
+  test("rejects a missing profileId", async () => {
+    let updateProfileCalled = false;
+    const updateProfile = getUpdateProfileTool({
+      async updateProfile(): Promise<ProfileResponse> {
+        updateProfileCalled = true;
+        throw new Error("should not be called");
+      },
+    });
+
+    const error = await captureError(
+      updateProfile.run(
+        { systemPrompt: "You are support." },
+        { orgId: ORG_ID, sessionId: SESSION_ID }
+      )
+    );
+
+    expect(error?.message).toBe("profileId is required.");
+    expect(updateProfileCalled).toBe(false);
+  });
+});
+
 function createTestTools(
   profileService: Partial<
-    Pick<ProfileService, "createTool" | "assignTool" | "createProfile">
+    Pick<
+      ProfileService,
+      "createTool" | "assignTool" | "createProfile" | "updateProfile"
+    >
   >
 ) {
   const sessionState = new SuperBotSessionState();
@@ -613,6 +758,28 @@ function getCreateProfileTool(
 
   if (!tool) {
     throw new Error("create_profile was not registered");
+  }
+
+  return tool;
+}
+
+function getUpdateProfileTool(
+  profileService: Pick<ProfileService, "updateProfile">,
+  sessionState?: SuperBotSessionState
+) {
+  const state = sessionState ?? new SuperBotSessionState();
+  if (!sessionState) {
+    state.beginTurn(SESSION_ID);
+    state.beginTurn(SESSION_ID);
+  }
+
+  const tool = createSuperBotTools(
+    profileService as ProfileService,
+    state
+  ).find((candidate) => candidate.name === "update_profile");
+
+  if (!tool) {
+    throw new Error("update_profile was not registered");
   }
 
   return tool;

--- a/apps/server/src/tools/super-bot-tools.ts
+++ b/apps/server/src/tools/super-bot-tools.ts
@@ -160,7 +160,7 @@ export function createSuperBotTools(
           throw new Error("systemPrompt is required.");
         }
 
-        if (!sessionState.canUpdateProfile(context.sessionId)) {
+        if (!sessionState.canCreateProfile(context.sessionId)) {
           throw new Error(PROFILE_UPDATE_CONFIRMATION_MESSAGE);
         }
 

--- a/apps/server/src/tools/super-bot-tools.ts
+++ b/apps/server/src/tools/super-bot-tools.ts
@@ -12,6 +12,7 @@ import {
 import type { ProfileService } from "../services/profile-service";
 import {
   PROFILE_CREATE_CONFIRMATION_MESSAGE,
+  PROFILE_UPDATE_CONFIRMATION_MESSAGE,
   type SuperBotSessionState,
   TOOL_ASSIGNMENT_CONFIRMATION_MESSAGE,
 } from "../services/super-bot-session-state";
@@ -129,6 +130,47 @@ export function createSuperBotTools(
     },
     {
       description:
+        "Update a profile's stored system prompt. Draft the new prompt in chat, wait for explicit user confirmation, then call this. Use get_profile first when you need the current prompt.",
+      name: "update_profile",
+      parameters: {
+        additionalProperties: false,
+        properties: {
+          profileId: {
+            description: "Profile id to update.",
+            type: "string",
+          },
+          systemPrompt: {
+            description:
+              "Replacement system prompt stored on the profile. Pass an empty string to clear it.",
+            type: "string",
+          },
+        },
+        required: ["profileId", "systemPrompt"],
+        type: "object",
+      },
+      async run(input, context: ToolContext) {
+        const profileId = readString(input, "profileId");
+        const systemPrompt = readStringAllowEmpty(input, "systemPrompt");
+
+        if (!profileId) {
+          throw new Error("profileId is required.");
+        }
+
+        if (systemPrompt === null) {
+          throw new Error("systemPrompt is required.");
+        }
+
+        if (!sessionState.canUpdateProfile(context.sessionId)) {
+          throw new Error(PROFILE_UPDATE_CONFIRMATION_MESSAGE);
+        }
+
+        return profileService.updateProfile(requireOrgId(context), profileId, {
+          systemPrompt,
+        });
+      },
+    },
+    {
+      description:
         "Assign an existing tool to a profile. Use only when the user explicitly asks to assign a tool to a profile.",
       name: "assign_tool_to_profile",
       parameters: {
@@ -239,12 +281,17 @@ export function createSuperBotTools(
 }
 
 function readString(input: unknown, key: string): string | null {
+  const value = readStringAllowEmpty(input, key);
+  return value?.trim() ? value.trim() : null;
+}
+
+function readStringAllowEmpty(input: unknown, key: string): string | null {
   if (typeof input !== "object" || input === null || !(key in input)) {
     return null;
   }
 
   const value = (input as Record<string, unknown>)[key];
-  return typeof value === "string" && value.trim() ? value.trim() : null;
+  return typeof value === "string" ? value : null;
 }
 
 function readOptionalString(

--- a/apps/web/src/components/WhatsAppAllowedPhonesDialog.tsx
+++ b/apps/web/src/components/WhatsAppAllowedPhonesDialog.tsx
@@ -1,4 +1,4 @@
-import { parseAllowedWhatsAppPhones } from "@nakama/core/whatsapp-config";
+import { parseAllowedWhatsAppPhones } from "@nakama/core/whatsapp-phones";
 import { Delete02Icon } from "hugeicons-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";

--- a/apps/web/src/components/WhatsAppAllowedPhonesDialog.tsx
+++ b/apps/web/src/components/WhatsAppAllowedPhonesDialog.tsx
@@ -1,0 +1,188 @@
+import { parseAllowedWhatsAppPhones } from "@nakama/core/whatsapp-config";
+import { Delete02Icon } from "hugeicons-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@/components/ui/input-group";
+import { useSaveWhatsAppSettings } from "@/hooks/use-whatsapp-settings";
+import { formatError } from "@/lib/client";
+
+function formatAllowedPhone(digits: string): string {
+  return `+${digits}`;
+}
+
+interface WhatsAppAllowedPhonesDialogProps {
+  allowedPhones: string[];
+  onAllowedPhonesChange: (phones: string[]) => void;
+  onError?: (message: string) => void;
+  onOpenChange: (open: boolean) => void;
+  onSaved?: () => void;
+  open: boolean;
+  profileId: string;
+}
+
+export function WhatsAppAllowedPhonesDialog({
+  allowedPhones,
+  onAllowedPhonesChange,
+  onError,
+  onOpenChange,
+  onSaved,
+  open,
+  profileId,
+}: WhatsAppAllowedPhonesDialogProps) {
+  const saveMutation = useSaveWhatsAppSettings();
+  const [newPhoneInput, setNewPhoneInput] = useState("");
+  const [formError, setFormError] = useState<string | null>(null);
+
+  function saveAllowedPhones(nextPhones: string[], afterSuccess?: () => void) {
+    onAllowedPhonesChange(nextPhones);
+    setFormError(null);
+
+    saveMutation.mutate(
+      {
+        allowedPhones: nextPhones.join(","),
+        profileId: profileId.trim() || "default",
+      },
+      {
+        onError: (error) => {
+          const message = formatError(error);
+          setFormError(message);
+          onError?.(message);
+        },
+        onSuccess: () => {
+          onSaved?.();
+          afterSuccess?.();
+        },
+      }
+    );
+  }
+
+  function addAllowedPhone() {
+    let phones: string[];
+
+    try {
+      phones = parseAllowedWhatsAppPhones(newPhoneInput);
+    } catch (error) {
+      setFormError(error instanceof Error ? error.message : String(error));
+      return;
+    }
+
+    if (phones.length === 0) {
+      return;
+    }
+
+    saveAllowedPhones([...new Set([...allowedPhones, ...phones])], () => {
+      setNewPhoneInput("");
+    });
+  }
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent className="p-6 sm:max-w-lg">
+        <DialogHeader className="gap-2">
+          <DialogTitle>Allowed numbers</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-1.5">
+          <p className="font-medium text-sm">Add number</p>
+          <InputGroup>
+            <InputGroupInput
+              className="font-mono text-sm ring-0 focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0"
+              disabled={saveMutation.isPending}
+              onChange={(event) => {
+                setNewPhoneInput(event.target.value);
+                if (formError) {
+                  setFormError(null);
+                }
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  addAllowedPhone();
+                }
+              }}
+              placeholder="+62812…"
+              value={newPhoneInput}
+            />
+            <InputGroupAddon align="inline-end">
+              <InputGroupButton
+                disabled={saveMutation.isPending || !newPhoneInput.trim()}
+                onClick={addAllowedPhone}
+                size="sm"
+                type="button"
+                variant="ghost"
+              >
+                Add
+              </InputGroupButton>
+            </InputGroupAddon>
+          </InputGroup>
+          {formError ? (
+            <p
+              className="rounded-md bg-destructive/10 px-2.5 py-1 text-destructive text-xs"
+              role="alert"
+            >
+              {formError}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="space-y-2">
+          <p className="font-medium text-sm">Numbers</p>
+          <div className="h-40 space-y-2 overflow-y-auto">
+            {allowedPhones.length > 0 ? (
+              allowedPhones.map((phone) => (
+                <div
+                  className="flex min-h-12 items-center justify-between gap-3 rounded-md bg-muted/40 px-3 py-2"
+                  key={phone}
+                >
+                  <code className="truncate text-sm">
+                    {formatAllowedPhone(phone)}
+                  </code>
+                  <Button
+                    aria-label={`Remove ${formatAllowedPhone(phone)}`}
+                    disabled={saveMutation.isPending}
+                    onClick={() =>
+                      saveAllowedPhones(
+                        allowedPhones.filter((entry) => entry !== phone)
+                      )
+                    }
+                    size="icon-sm"
+                    type="button"
+                    variant="ghost"
+                  >
+                    <Delete02Icon aria-hidden="true" className="size-4" />
+                  </Button>
+                </div>
+              ))
+            ) : (
+              <p className="px-3 py-4 text-center text-muted-foreground text-xs">
+                No numbers added.
+              </p>
+            )}
+          </div>
+        </div>
+
+        <DialogFooter className="gap-3 border-t-0 bg-transparent p-0 sm:justify-end">
+          <Button
+            onClick={() => onOpenChange(false)}
+            type="button"
+            variant="outline"
+          >
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/WhatsAppSettingsCard.tsx
+++ b/apps/web/src/components/WhatsAppSettingsCard.tsx
@@ -1,19 +1,7 @@
-import type { UpdateWhatsAppSettingsRequest } from "@nakama/core/contract";
-import { useQueryClient } from "@tanstack/react-query";
-import { useEffect, useRef, useState } from "react";
 import { SETTINGS_CARD_LOADING_SKELETON } from "@/components/integration-settings.shared";
 import { WhatsAppAllowedPhonesDialog } from "@/components/WhatsAppAllowedPhonesDialog";
 import { WhatsAppSettingsCardContent } from "@/components/whatsapp-settings-card-content";
-import { useProfilesQuery } from "@/hooks/use-app-queries";
-import { useSystemStatusQuery } from "@/hooks/use-system-status";
-import {
-  useReconnectWhatsApp,
-  useRegenerateWhatsAppPairingCode,
-  useSaveWhatsAppSettings,
-  useWhatsAppSettings,
-} from "@/hooks/use-whatsapp-settings";
-import { formatError } from "@/lib/client";
-import { queryKeys } from "@/lib/query-keys";
+import { useWhatsAppSettingsCard } from "@/hooks/use-whatsapp-settings-card";
 
 interface WhatsAppSettingsCardProps {
   embedded?: boolean;
@@ -26,253 +14,9 @@ export function WhatsAppSettingsCard({
   submitLabel,
   onSaveSuccess,
 }: WhatsAppSettingsCardProps) {
-  const queryClient = useQueryClient();
-  const { data: settings, isLoading, error: loadError } = useWhatsAppSettings();
-  const { data: status } = useSystemStatusQuery();
-  const { data: profiles = [] } = useProfilesQuery();
-  const saveMutation = useSaveWhatsAppSettings();
-  const regenerateMutation = useRegenerateWhatsAppPairingCode();
-  const reconnectMutation = useReconnectWhatsApp();
+  const card = useWhatsAppSettingsCard({ onSaveSuccess, submitLabel });
 
-  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [profileId, setProfileId] = useState("default");
-  const [hint, setHint] = useState<string | null>(null);
-  const [formError, setFormError] = useState<string | null>(null);
-  const [qrWasVisible, setQrWasVisible] = useState(false);
-  const [copied, setCopied] = useState(false);
-  const [allowedPhones, setAllowedPhones] = useState<string[]>([]);
-  const [allowedPhonesOpen, setAllowedPhonesOpen] = useState(false);
-
-  const settingsProfileId = settings?.profileId;
-  const settingsAllowedPhones = settings?.allowedPhones;
-
-  useEffect(() => {
-    if (settingsProfileId !== undefined) {
-      setProfileId(settingsProfileId);
-    }
-  }, [settingsProfileId]);
-
-  useEffect(() => {
-    if (settingsAllowedPhones) {
-      setAllowedPhones(settingsAllowedPhones);
-    }
-  }, [settingsAllowedPhones]);
-
-  const configured = settings?.configured === true;
-  const worker = status?.whatsappWorker;
-  const running = worker?.running === true;
-  const connected = worker?.connected === true;
-  const qrCode = worker?.qrCode ?? null;
-  const paired = Boolean(worker?.paired || settings?.pairedJid);
-  const pairingCode = settings?.pairingCode ?? null;
-  const linkedNumber = settings?.phoneNumberMasked ?? null;
-
-  useEffect(() => {
-    if (qrCode) {
-      setQrWasVisible(true);
-    }
-    if (paired) {
-      setQrWasVisible(false);
-    }
-  }, [qrCode, paired]);
-
-  useEffect(() => {
-    if (worker?.paired && !settings?.pairedJid) {
-      void queryClient.invalidateQueries({
-        queryKey: queryKeys.whatsapp.settings,
-      });
-      return;
-    }
-
-    if (worker?.connected && !paired) {
-      void queryClient.invalidateQueries({
-        queryKey: queryKeys.whatsapp.settings,
-      });
-    }
-  }, [
-    worker?.paired,
-    worker?.connected,
-    settings?.pairedJid,
-    paired,
-    queryClient,
-  ]);
-
-  useEffect(() => {
-    setCopied(false);
-  }, [pairingCode]);
-
-  useEffect(
-    () => () => {
-      if (copyTimeoutRef.current) {
-        clearTimeout(copyTimeoutRef.current);
-      }
-    },
-    []
-  );
-
-  const useQrLinking = !pairingCode;
-  const showQr = configured && running && Boolean(qrCode) && useQrLinking;
-  const awaitingQr =
-    configured &&
-    !paired &&
-    running &&
-    !connected &&
-    !qrCode &&
-    !qrWasVisible &&
-    useQrLinking;
-  const bridgeStarting =
-    configured && !paired && running && !connected && Boolean(pairingCode);
-  const linkingAfterScan =
-    configured &&
-    !paired &&
-    running &&
-    !qrCode &&
-    (qrWasVisible || connected) &&
-    useQrLinking;
-  const showReconnect = configured && !showQr && !awaitingQr;
-  const canSave = !configured || profileId !== settings?.profileId;
-  const actionLabel = submitLabel ?? (configured ? "Save" : "Enable WhatsApp");
-
-  const statusLine =
-    hint ??
-    (formError ? formError : null) ??
-    (loadError ? formatError(loadError) : null);
-
-  const headerSubtitle = configured
-    ? paired && running && !showQr
-      ? "WhatsApp is linked and the bridge is running"
-      : paired && !running
-        ? "Linked. Start the WhatsApp bridge to receive messages"
-        : showQr
-          ? "Scan the QR code with WhatsApp to link your device"
-          : linkingAfterScan
-            ? "Linking your WhatsApp account…"
-            : bridgeStarting
-              ? "Bridge starting — enter the pairing code in WhatsApp"
-              : awaitingQr
-                ? "Preparing QR code…"
-                : pairingCode
-                  ? "Enter the pairing code in WhatsApp"
-                  : "Scan the QR code, or generate a pairing code"
-    : "Choose a profile and enable WhatsApp to get started";
-
-  const statusBadge = configured
-    ? paired && running && !showQr
-      ? "Connected"
-      : paired && !running
-        ? "Paired"
-        : linkingAfterScan
-          ? "Linking"
-          : bridgeStarting
-            ? "Starting…"
-            : showQr
-              ? "Awaiting scan"
-              : awaitingQr
-                ? "Starting…"
-                : pairingCode
-                  ? "Awaiting link"
-                  : "Not linked"
-    : "Not set up";
-
-  async function copyPairingCode() {
-    if (!pairingCode) {
-      return;
-    }
-
-    try {
-      await navigator.clipboard.writeText(pairingCode);
-      setCopied(true);
-      if (copyTimeoutRef.current) {
-        clearTimeout(copyTimeoutRef.current);
-      }
-      copyTimeoutRef.current = setTimeout(() => {
-        setCopied(false);
-        copyTimeoutRef.current = null;
-      }, 2000);
-    } catch {
-      setHint("Copy the code manually.");
-    }
-  }
-
-  function handleSave() {
-    setFormError(null);
-    setHint(null);
-
-    const request: UpdateWhatsAppSettingsRequest = {
-      profileId: profileId.trim() || "default",
-    };
-
-    saveMutation.mutate(request, {
-      onError: (error) => {
-        setFormError(formatError(error));
-      },
-      onSuccess: (saved) => {
-        if (saved.pairedJid) {
-          setHint("Saved.");
-        } else if (saved.pairingCode) {
-          setHint("Saved. Use the pairing code in WhatsApp.");
-        } else if (configured) {
-          setHint("Saved.");
-        } else {
-          setHint("Enabled. Start the bridge and scan the QR code.");
-        }
-        onSaveSuccess?.();
-      },
-    });
-  }
-
-  function handleRegeneratePairingCode() {
-    setFormError(null);
-    setHint(null);
-
-    regenerateMutation.mutate(undefined, {
-      onError: (error) => {
-        setFormError(formatError(error));
-      },
-      onSuccess: () => {
-        setHint("New code ready.");
-      },
-    });
-  }
-
-  function handleReconnect() {
-    setFormError(null);
-    setHint(null);
-    setQrWasVisible(false);
-
-    reconnectMutation.mutate(undefined, {
-      onError: (error) => {
-        setFormError(formatError(error));
-      },
-      onSuccess: () => {
-        setHint("Session reset. Scan the QR code when it appears.");
-      },
-    });
-  }
-
-  function handleProfileChange(nextProfileId: string) {
-    setProfileId(nextProfileId);
-    setHint(null);
-    setFormError(null);
-
-    if (!configured || nextProfileId === settings?.profileId) {
-      return;
-    }
-
-    saveMutation.mutate(
-      { profileId: nextProfileId.trim() || "default" },
-      {
-        onError: (error) => {
-          setFormError(formatError(error));
-        },
-        onSuccess: () => {
-          setHint("Reply profile saved.");
-        },
-      }
-    );
-  }
-
-  if (isLoading) {
+  if (card.isLoading) {
     if (embedded) {
       return SETTINGS_CARD_LOADING_SKELETON;
     }
@@ -280,61 +24,53 @@ export function WhatsAppSettingsCard({
     return <div className="py-3">{SETTINGS_CARD_LOADING_SKELETON}</div>;
   }
 
-  const allowedPhoneSummary =
-    allowedPhones.length === 0
-      ? "None"
-      : `${allowedPhones.length} number${allowedPhones.length === 1 ? "" : "s"}`;
-
   const allowedPhonesDialog = (
     <WhatsAppAllowedPhonesDialog
-      allowedPhones={allowedPhones}
-      onAllowedPhonesChange={setAllowedPhones}
-      onError={setFormError}
-      onOpenChange={setAllowedPhonesOpen}
-      onSaved={() => {
-        setHint("Allowed numbers saved.");
-        setFormError(null);
-      }}
-      open={allowedPhonesOpen}
-      profileId={profileId}
+      allowedPhones={card.allowedPhones}
+      onAllowedPhonesChange={card.onAllowedPhonesChange}
+      onError={card.onError}
+      onOpenChange={card.onAllowedPhonesOpenChange}
+      onSaved={card.onSavedAllowedPhones}
+      open={card.allowedPhonesOpen}
+      profileId={card.profileId}
     />
   );
 
   const content = (
     <WhatsAppSettingsCardContent
-      actionLabel={actionLabel}
-      allowedPhoneSummary={allowedPhoneSummary}
-      awaitingQr={awaitingQr}
-      bridgeStarting={bridgeStarting}
-      canSave={canSave}
-      configured={configured}
-      copied={copied}
+      actionLabel={card.actionLabel}
+      allowedPhoneSummary={card.allowedPhoneSummary}
+      awaitingQr={card.awaitingQr}
+      bridgeStarting={card.bridgeStarting}
+      canSave={card.canSave}
+      configured={card.configured}
+      copied={card.copied}
       embedded={embedded}
-      formError={formError}
-      headerSubtitle={headerSubtitle}
-      linkedNumber={linkedNumber}
-      linkingAfterScan={linkingAfterScan}
-      loadError={loadError}
-      onCopyPairingCode={() => void copyPairingCode()}
-      onManageAllowedPhones={() => setAllowedPhonesOpen(true)}
-      onProfileChange={handleProfileChange}
-      onReconnect={handleReconnect}
-      onRegeneratePairingCode={handleRegeneratePairingCode}
-      onSave={handleSave}
-      paired={paired}
-      pairingCode={pairingCode}
-      profileId={profileId}
-      profiles={profiles}
-      qrCode={qrCode}
-      reconnectPending={reconnectMutation.isPending}
-      regeneratePending={regenerateMutation.isPending}
-      running={running}
-      savePending={saveMutation.isPending}
-      showQr={showQr}
-      showReconnect={showReconnect}
-      statusBadge={statusBadge}
-      statusLine={statusLine}
-      worker={worker}
+      formError={card.formError}
+      headerSubtitle={card.headerSubtitle}
+      linkedNumber={card.linkedNumber}
+      linkingAfterScan={card.linkingAfterScan}
+      loadError={card.loadError}
+      onCopyPairingCode={card.onCopyPairingCode}
+      onManageAllowedPhones={card.onManageAllowedPhones}
+      onProfileChange={card.onProfileChange}
+      onReconnect={card.onReconnect}
+      onRegeneratePairingCode={card.onRegeneratePairingCode}
+      onSave={card.onSave}
+      paired={card.paired}
+      pairingCode={card.pairingCode}
+      profileId={card.profileId}
+      profiles={card.profiles}
+      qrCode={card.qrCode}
+      reconnectPending={card.reconnectPending}
+      regeneratePending={card.regeneratePending}
+      running={card.running}
+      savePending={card.savePending}
+      showQr={card.showQr}
+      showReconnect={card.showReconnect}
+      statusBadge={card.statusBadge}
+      statusLine={card.statusLine}
+      worker={card.worker}
     />
   );
 
@@ -342,7 +78,7 @@ export function WhatsAppSettingsCard({
     return (
       <>
         <div className="space-y-2">
-          <p className="text-muted-foreground text-xs">{headerSubtitle}</p>
+          <p className="text-muted-foreground text-xs">{card.headerSubtitle}</p>
           {content}
         </div>
         {allowedPhonesDialog}

--- a/apps/web/src/components/WhatsAppSettingsCard.tsx
+++ b/apps/web/src/components/WhatsAppSettingsCard.tsx
@@ -2,6 +2,7 @@ import type { UpdateWhatsAppSettingsRequest } from "@nakama/core/contract";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 import { SETTINGS_CARD_LOADING_SKELETON } from "@/components/integration-settings.shared";
+import { WhatsAppAllowedPhonesDialog } from "@/components/WhatsAppAllowedPhonesDialog";
 import { WhatsAppSettingsCardContent } from "@/components/whatsapp-settings-card-content";
 import { useProfilesQuery } from "@/hooks/use-app-queries";
 import { useSystemStatusQuery } from "@/hooks/use-system-status";
@@ -39,14 +40,23 @@ export function WhatsAppSettingsCard({
   const [formError, setFormError] = useState<string | null>(null);
   const [qrWasVisible, setQrWasVisible] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [allowedPhones, setAllowedPhones] = useState<string[]>([]);
+  const [allowedPhonesOpen, setAllowedPhonesOpen] = useState(false);
 
   const settingsProfileId = settings?.profileId;
+  const settingsAllowedPhones = settings?.allowedPhones;
 
   useEffect(() => {
     if (settingsProfileId !== undefined) {
       setProfileId(settingsProfileId);
     }
   }, [settingsProfileId]);
+
+  useEffect(() => {
+    if (settingsAllowedPhones) {
+      setAllowedPhones(settingsAllowedPhones);
+    }
+  }, [settingsAllowedPhones]);
 
   const configured = settings?.configured === true;
   const worker = status?.whatsappWorker;
@@ -270,9 +280,30 @@ export function WhatsAppSettingsCard({
     return <div className="py-3">{SETTINGS_CARD_LOADING_SKELETON}</div>;
   }
 
+  const allowedPhoneSummary =
+    allowedPhones.length === 0
+      ? "None"
+      : `${allowedPhones.length} number${allowedPhones.length === 1 ? "" : "s"}`;
+
+  const allowedPhonesDialog = (
+    <WhatsAppAllowedPhonesDialog
+      allowedPhones={allowedPhones}
+      onAllowedPhonesChange={setAllowedPhones}
+      onError={setFormError}
+      onOpenChange={setAllowedPhonesOpen}
+      onSaved={() => {
+        setHint("Allowed numbers saved.");
+        setFormError(null);
+      }}
+      open={allowedPhonesOpen}
+      profileId={profileId}
+    />
+  );
+
   const content = (
     <WhatsAppSettingsCardContent
       actionLabel={actionLabel}
+      allowedPhoneSummary={allowedPhoneSummary}
       awaitingQr={awaitingQr}
       bridgeStarting={bridgeStarting}
       canSave={canSave}
@@ -285,6 +316,7 @@ export function WhatsAppSettingsCard({
       linkingAfterScan={linkingAfterScan}
       loadError={loadError}
       onCopyPairingCode={() => void copyPairingCode()}
+      onManageAllowedPhones={() => setAllowedPhonesOpen(true)}
       onProfileChange={handleProfileChange}
       onReconnect={handleReconnect}
       onRegeneratePairingCode={handleRegeneratePairingCode}
@@ -308,12 +340,20 @@ export function WhatsAppSettingsCard({
 
   if (embedded) {
     return (
-      <div className="space-y-2">
-        <p className="text-muted-foreground text-xs">{headerSubtitle}</p>
-        {content}
-      </div>
+      <>
+        <div className="space-y-2">
+          <p className="text-muted-foreground text-xs">{headerSubtitle}</p>
+          {content}
+        </div>
+        {allowedPhonesDialog}
+      </>
     );
   }
 
-  return content;
+  return (
+    <>
+      {content}
+      {allowedPhonesDialog}
+    </>
+  );
 }

--- a/apps/web/src/components/whatsapp-settings-card-content.tsx
+++ b/apps/web/src/components/whatsapp-settings-card-content.tsx
@@ -5,6 +5,7 @@ import {
   SettingsRow,
 } from "@/components/integration-settings.shared";
 import { ProfileAvatar } from "@/components/ProfileAvatar";
+import { Button } from "@/components/ui/button";
 import {
   Select,
   SelectContent,
@@ -47,6 +48,8 @@ export function WhatsAppSettingsCardContent({
   loadError,
   canSave,
   actionLabel,
+  allowedPhoneSummary,
+  onManageAllowedPhones,
   onSave,
 }: {
   embedded: boolean;
@@ -79,6 +82,8 @@ export function WhatsAppSettingsCardContent({
   loadError: unknown;
   canSave: boolean;
   actionLabel: string;
+  allowedPhoneSummary: string;
+  onManageAllowedPhones: () => void;
   onSave: () => void;
 }) {
   const paneItemClass = embedded ? undefined : "px-0 py-0";
@@ -140,6 +145,25 @@ export function WhatsAppSettingsCardContent({
           </SelectContent>
         </Select>
       </SettingsRow>
+
+      {configured ? (
+        <SettingsRow className={paneItemClass} label="Allowed numbers">
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            <span className="text-muted-foreground text-xs">
+              {allowedPhoneSummary}
+            </span>
+            <Button
+              disabled={savePending}
+              onClick={onManageAllowedPhones}
+              size="sm"
+              type="button"
+              variant="outline"
+            >
+              Manage
+            </Button>
+          </div>
+        </SettingsRow>
+      ) : null}
 
       {configured ? (
         <WhatsAppSettingsLinkingSection

--- a/apps/web/src/hooks/use-whatsapp-settings-card.ts
+++ b/apps/web/src/hooks/use-whatsapp-settings-card.ts
@@ -1,0 +1,361 @@
+import type { UpdateWhatsAppSettingsRequest } from "@nakama/core/contract";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef, useState } from "react";
+import { useProfilesQuery } from "@/hooks/use-app-queries";
+import { useSystemStatusQuery } from "@/hooks/use-system-status";
+import {
+  useReconnectWhatsApp,
+  useRegenerateWhatsAppPairingCode,
+  useSaveWhatsAppSettings,
+  useWhatsAppSettings,
+} from "@/hooks/use-whatsapp-settings";
+import { formatError } from "@/lib/client";
+import { queryKeys } from "@/lib/query-keys";
+
+export function useWhatsAppSettingsCard({
+  onSaveSuccess,
+  submitLabel,
+}: {
+  onSaveSuccess?: () => void;
+  submitLabel?: string;
+}) {
+  const queryClient = useQueryClient();
+  const { data: settings, isLoading, error: loadError } = useWhatsAppSettings();
+  const { data: status } = useSystemStatusQuery();
+  const { data: profiles = [] } = useProfilesQuery();
+  const saveMutation = useSaveWhatsAppSettings();
+  const regenerateMutation = useRegenerateWhatsAppPairingCode();
+  const reconnectMutation = useReconnectWhatsApp();
+
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [profileId, setProfileId] = useState("default");
+  const [hint, setHint] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [qrWasVisible, setQrWasVisible] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [allowedPhones, setAllowedPhones] = useState<string[]>([]);
+  const [allowedPhonesOpen, setAllowedPhonesOpen] = useState(false);
+
+  const settingsProfileId = settings?.profileId;
+  const settingsAllowedPhones = settings?.allowedPhones;
+
+  useEffect(() => {
+    if (settingsProfileId !== undefined) {
+      setProfileId(settingsProfileId);
+    }
+  }, [settingsProfileId]);
+
+  useEffect(() => {
+    if (settingsAllowedPhones) {
+      setAllowedPhones(settingsAllowedPhones);
+    }
+  }, [settingsAllowedPhones]);
+
+  const configured = settings?.configured === true;
+  const worker = status?.whatsappWorker;
+  const running = worker?.running === true;
+  const connected = worker?.connected === true;
+  const qrCode = worker?.qrCode ?? null;
+  const paired = Boolean(worker?.paired || settings?.pairedJid);
+  const pairingCode = settings?.pairingCode ?? null;
+  const linkedNumber = settings?.phoneNumberMasked ?? null;
+
+  useEffect(() => {
+    if (qrCode) {
+      setQrWasVisible(true);
+    }
+    if (paired) {
+      setQrWasVisible(false);
+    }
+  }, [qrCode, paired]);
+
+  useEffect(() => {
+    if (worker?.paired && !settings?.pairedJid) {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.whatsapp.settings,
+      });
+      return;
+    }
+
+    if (worker?.connected && !paired) {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.whatsapp.settings,
+      });
+    }
+  }, [
+    worker?.paired,
+    worker?.connected,
+    settings?.pairedJid,
+    paired,
+    queryClient,
+  ]);
+
+  useEffect(() => {
+    setCopied(false);
+  }, [pairingCode]);
+
+  useEffect(
+    () => () => {
+      if (copyTimeoutRef.current) {
+        clearTimeout(copyTimeoutRef.current);
+      }
+    },
+    []
+  );
+
+  const useQrLinking = !pairingCode;
+  const showQr = configured && running && Boolean(qrCode) && useQrLinking;
+  const awaitingQr =
+    configured &&
+    !paired &&
+    running &&
+    !connected &&
+    !qrCode &&
+    !qrWasVisible &&
+    useQrLinking;
+  const bridgeStarting =
+    configured && !paired && running && !connected && Boolean(pairingCode);
+  const linkingAfterScan =
+    configured &&
+    !paired &&
+    running &&
+    !qrCode &&
+    (qrWasVisible || connected) &&
+    useQrLinking;
+  const showReconnect = configured && !showQr && !awaitingQr;
+  const canSave = !configured || profileId !== settings?.profileId;
+  const actionLabel = submitLabel ?? (configured ? "Save" : "Enable WhatsApp");
+  const { headerSubtitle, statusBadge } = resolveWhatsAppStatusCopy({
+    awaitingQr,
+    bridgeStarting,
+    configured,
+    linkingAfterScan,
+    paired,
+    pairingCode,
+    running,
+    showQr,
+  });
+
+  async function copyPairingCode() {
+    if (!pairingCode) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(pairingCode);
+      setCopied(true);
+      if (copyTimeoutRef.current) {
+        clearTimeout(copyTimeoutRef.current);
+      }
+      copyTimeoutRef.current = setTimeout(() => {
+        setCopied(false);
+        copyTimeoutRef.current = null;
+      }, 2000);
+    } catch {
+      setHint("Copy the code manually.");
+    }
+  }
+
+  function handleSave() {
+    setFormError(null);
+    setHint(null);
+
+    const request: UpdateWhatsAppSettingsRequest = {
+      profileId: profileId.trim() || "default",
+    };
+
+    saveMutation.mutate(request, {
+      onError: (error) => {
+        setFormError(formatError(error));
+      },
+      onSuccess: (saved) => {
+        if (saved.pairedJid) {
+          setHint("Saved.");
+        } else if (saved.pairingCode) {
+          setHint("Saved. Use the pairing code in WhatsApp.");
+        } else if (configured) {
+          setHint("Saved.");
+        } else {
+          setHint("Enabled. Start the bridge and scan the QR code.");
+        }
+        onSaveSuccess?.();
+      },
+    });
+  }
+
+  function handleRegeneratePairingCode() {
+    setFormError(null);
+    setHint(null);
+
+    regenerateMutation.mutate(undefined, {
+      onError: (error) => {
+        setFormError(formatError(error));
+      },
+      onSuccess: () => {
+        setHint("New code ready.");
+      },
+    });
+  }
+
+  function handleReconnect() {
+    setFormError(null);
+    setHint(null);
+    setQrWasVisible(false);
+
+    reconnectMutation.mutate(undefined, {
+      onError: (error) => {
+        setFormError(formatError(error));
+      },
+      onSuccess: () => {
+        setHint("Session reset. Scan the QR code when it appears.");
+      },
+    });
+  }
+
+  function handleProfileChange(nextProfileId: string) {
+    setProfileId(nextProfileId);
+    setHint(null);
+    setFormError(null);
+
+    if (!configured || nextProfileId === settings?.profileId) {
+      return;
+    }
+
+    saveMutation.mutate(
+      { profileId: nextProfileId.trim() || "default" },
+      {
+        onError: (error) => {
+          setFormError(formatError(error));
+        },
+        onSuccess: () => {
+          setHint("Reply profile saved.");
+        },
+      }
+    );
+  }
+
+  return {
+    actionLabel,
+    allowedPhoneSummary:
+      allowedPhones.length === 0
+        ? "None"
+        : `${allowedPhones.length} number${allowedPhones.length === 1 ? "" : "s"}`,
+    allowedPhones,
+    allowedPhonesOpen,
+    awaitingQr,
+    bridgeStarting,
+    canSave,
+    configured,
+    copied,
+    formError,
+    headerSubtitle,
+    isLoading,
+    linkedNumber,
+    linkingAfterScan,
+    loadError,
+    onAllowedPhonesChange: setAllowedPhones,
+    onAllowedPhonesOpenChange: setAllowedPhonesOpen,
+    onCopyPairingCode: () => {
+      void copyPairingCode();
+    },
+    onError: setFormError,
+    onManageAllowedPhones: () => setAllowedPhonesOpen(true),
+    onProfileChange: handleProfileChange,
+    onReconnect: handleReconnect,
+    onRegeneratePairingCode: handleRegeneratePairingCode,
+    onSave: handleSave,
+    onSavedAllowedPhones: () => {
+      setHint("Allowed numbers saved.");
+      setFormError(null);
+    },
+    paired,
+    pairingCode,
+    profileId,
+    profiles,
+    qrCode,
+    reconnectPending: reconnectMutation.isPending,
+    regeneratePending: regenerateMutation.isPending,
+    running,
+    savePending: saveMutation.isPending,
+    showQr,
+    showReconnect,
+    statusBadge,
+    statusLine:
+      hint ??
+      (formError ? formError : null) ??
+      (loadError ? formatError(loadError) : null),
+    worker,
+  };
+}
+
+function resolveWhatsAppStatusCopy(input: {
+  awaitingQr: boolean;
+  bridgeStarting: boolean;
+  configured: boolean;
+  linkingAfterScan: boolean;
+  paired: boolean;
+  pairingCode: string | null;
+  running: boolean;
+  showQr: boolean;
+}): { headerSubtitle: string; statusBadge: string } {
+  if (!input.configured) {
+    return {
+      headerSubtitle: "Choose a profile and enable WhatsApp to get started",
+      statusBadge: "Not set up",
+    };
+  }
+
+  if (input.paired && input.running && !input.showQr) {
+    return {
+      headerSubtitle: "WhatsApp is linked and the bridge is running",
+      statusBadge: "Connected",
+    };
+  }
+
+  if (input.paired && !input.running) {
+    return {
+      headerSubtitle: "Linked. Start the WhatsApp bridge to receive messages",
+      statusBadge: "Paired",
+    };
+  }
+
+  if (input.showQr) {
+    return {
+      headerSubtitle: "Scan the QR code with WhatsApp to link your device",
+      statusBadge: "Awaiting scan",
+    };
+  }
+
+  if (input.linkingAfterScan) {
+    return {
+      headerSubtitle: "Linking your WhatsApp account…",
+      statusBadge: "Linking",
+    };
+  }
+
+  if (input.bridgeStarting) {
+    return {
+      headerSubtitle: "Bridge starting — enter the pairing code in WhatsApp",
+      statusBadge: "Starting…",
+    };
+  }
+
+  if (input.awaitingQr) {
+    return {
+      headerSubtitle: "Preparing QR code…",
+      statusBadge: "Starting…",
+    };
+  }
+
+  if (input.pairingCode) {
+    return {
+      headerSubtitle: "Enter the pairing code in WhatsApp",
+      statusBadge: "Awaiting link",
+    };
+  }
+
+  return {
+    headerSubtitle: "Scan the QR code, or generate a pairing code",
+    statusBadge: "Not linked",
+  };
+}

--- a/docs/website/content/docs/docs.mdx
+++ b/docs/website/content/docs/docs.mdx
@@ -58,7 +58,7 @@ Then open the dashboard, complete the setup wizard, and send your first message.
 
 - [CLI](/cli) — terminal chat and slash commands
 - [Telegram](/telegram) — bot setup, pairing, groups, and troubleshooting
-- [WhatsApp](/whatsapp) — direct chat linking, commands, and troubleshooting
+- [WhatsApp](/whatsapp) — direct chat linking, groups, commands, and troubleshooting
 - [Discord](/discord) — bot setup, pairing, slash commands, and servers
 
 ## Extend

--- a/docs/website/content/docs/profiles.mdx
+++ b/docs/website/content/docs/profiles.mdx
@@ -35,6 +35,8 @@ Platform admins create extra profiles inside the **active org**. Each new profil
 
 Super Bot can also create profiles from chat using a confirm-first factory. For profile-creation requests, it drafts soul files and a tool plan in chat, waits for your explicit OK, then calls `create_profile`. New profiles keep `MEMORY.md` empty and receive basic file/knowledge tools automatically; extra tools still need an explicit ask. On the Profiles page, use **Ask Super Bot** (empty state or create dialog) when a Super Bot profile exists.
 
+Super Bot can also change a profile's stored `systemPrompt` from chat. Ask it to update the prompt, review the draft, then confirm — it calls `update_profile` only after you say OK. That edits the database prompt, not soul files. Edit soul files on the profile **Prompt** tab.
+
 Super Bot can hand coding tasks to a dedicated coding agent via the `coding-agent` skill and `bash`. See [Coding agent](/coding-agent).
 
 ## What a profile contains

--- a/docs/website/content/docs/whatsapp.mdx
+++ b/docs/website/content/docs/whatsapp.mdx
@@ -3,7 +3,7 @@ title: "WhatsApp"
 description: "Set up Nakama on WhatsApp with linking, commands, and troubleshooting."
 ---
 
-Use WhatsApp when you want the same Nakama agent available from your phone in a direct chat.
+Use WhatsApp when you want the same Nakama agent available from your phone in a direct chat or group.
 
 The WhatsApp bridge talks to the same Nakama server as the web app and CLI. It is a chat channel, not a separate agent system.
 
@@ -20,7 +20,7 @@ WhatsApp works well for:
 
 With WhatsApp enabled, users can:
 
-- chat with a Nakama profile in a private WhatsApp chat
+- chat with a Nakama profile in a private WhatsApp chat or a group
 - switch org with commands
 - start a new conversation or clear history
 - stop an in-progress reply
@@ -85,11 +85,15 @@ After linking succeeds, Nakama shows the linked account and the bridge can recei
 
 ## Chat behavior
 
-WhatsApp currently works as a **private chat** channel.
+WhatsApp works in **private chats** and **groups**.
 
-- direct chats are supported
-- group chats are not handled by the current bridge
-- each linked WhatsApp chat keeps its own Nakama session
+- direct chats send every message to the agent
+- group chats reply only to a mention of the linked number, a reply to a Nakama message, or a `/command`
+- each private chat and each group keeps its own Nakama session
+- `/org` in a group is stored for that group, not your private chat
+- pairing still happens in a private chat first
+
+This keeps group chats usable without making Nakama answer every message.
 
 If you change the reply profile, new messages use that profile. Starting a new conversation with `/new` gives you a fresh session.
 
@@ -135,6 +139,16 @@ If QR linking does not finish:
 1. use **Reconnect with QR** in **Integrations → WhatsApp**
 2. wait for a fresh QR code
 3. scan it again from WhatsApp
+
+### The bot does not reply in a group
+
+In a group, Nakama only answers when someone:
+
+1. mentions the linked WhatsApp number
+2. replies to a Nakama message
+3. sends a `/command`
+
+The sender must already be linked in a private chat. Pairing codes sent in a group are ignored.
 
 ### The wrong bot is answering
 

--- a/docs/website/content/docs/whatsapp.mdx
+++ b/docs/website/content/docs/whatsapp.mdx
@@ -93,6 +93,7 @@ WhatsApp works in **private chats** and **groups**.
 - `/org` in a group is stored for that group, not your private chat
 - pairing still happens in a private chat first
 - extra numbers in **Integrations → WhatsApp → Allowed numbers** can also talk to the agent
+- reply to another group message while mentioning Nakama includes that quoted text in the agent turn
 
 This keeps group chats usable without making Nakama answer every message.
 
@@ -149,7 +150,7 @@ In a group, Nakama only answers when someone:
 2. replies to a Nakama message
 3. sends a `/command`
 
-The sender must be the linked WhatsApp number, or a number listed under **Integrations → WhatsApp → Allowed numbers**. Add country code, like `+62812…`.
+The sender must be the linked WhatsApp number, or a number listed under **Integrations → WhatsApp → Allowed numbers**. Add country code, like `+62812…`. Reply to another person's message while mentioning Nakama if the agent should see that text.
 
 ### The wrong bot is answering
 

--- a/docs/website/content/docs/whatsapp.mdx
+++ b/docs/website/content/docs/whatsapp.mdx
@@ -92,6 +92,7 @@ WhatsApp works in **private chats** and **groups**.
 - each private chat and each group keeps its own Nakama session
 - `/org` in a group is stored for that group, not your private chat
 - pairing still happens in a private chat first
+- extra numbers in **Integrations → WhatsApp → Allowed numbers** can also talk to the agent
 
 This keeps group chats usable without making Nakama answer every message.
 
@@ -148,7 +149,7 @@ In a group, Nakama only answers when someone:
 2. replies to a Nakama message
 3. sends a `/command`
 
-The sender must already be linked in a private chat. Pairing codes sent in a group are ignored.
+The sender must be the linked WhatsApp number, or a number listed under **Integrations → WhatsApp → Allowed numbers**. Add country code, like `+62812…`.
 
 ### The wrong bot is answering
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,6 +41,7 @@
     "./discord-attachment": "./src/discord-attachment.ts",
     "./discord-worker": "./src/discord-worker.ts",
     "./whatsapp-config": "./src/whatsapp-config.ts",
+    "./whatsapp-phones": "./src/whatsapp-phones.ts",
     "./whatsapp-worker": "./src/whatsapp-worker.ts",
     "./skills/archive": "./src/skills/archive.ts",
     "./skills/freshness": "./src/skills/freshness.ts",

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -1359,6 +1359,7 @@ export type AgentBrowserInstallEvent =
     };
 
 export interface WhatsAppSettingsResponse {
+  allowedPhones: string[];
   configured: boolean;
   pairedJid: string | null;
   pairingCode: string | null;
@@ -1367,6 +1368,7 @@ export interface WhatsAppSettingsResponse {
 }
 
 export interface UpdateWhatsAppSettingsRequest {
+  allowedPhones?: string;
   phoneNumber?: string;
   profileId?: string;
 }

--- a/packages/core/src/whatsapp-config.test.ts
+++ b/packages/core/src/whatsapp-config.test.ts
@@ -8,6 +8,7 @@ import {
   loadWhatsAppConfigFile,
   maskPhoneNumber,
   normalizePairingCode,
+  parseAllowedWhatsAppPhones,
   resetWhatsAppSessionForReconnect,
   resolveWhatsAppConfigFromSources,
   saveWhatsAppConfig,
@@ -90,6 +91,40 @@ describe("isWhatsAppUserAuthorized", () => {
       })
     ).toBe(false);
   });
+
+  test("returns true when any candidate JID matches", () => {
+    expect(
+      isWhatsAppUserAuthorized(
+        ["104784384290844@lid", "1234567890@s.whatsapp.net"],
+        {
+          pairedJid: "1234567890@s.whatsapp.net",
+          pairedLid: null,
+        }
+      )
+    ).toBe(true);
+  });
+
+  test("returns true when JID matches an allowed phone", () => {
+    expect(
+      isWhatsAppUserAuthorized("628111111111@s.whatsapp.net", {
+        allowedPhones: ["628111111111"],
+        pairedJid: "1234567890@s.whatsapp.net",
+        pairedLid: null,
+      })
+    ).toBe(true);
+  });
+});
+
+describe("parseAllowedWhatsAppPhones", () => {
+  test("normalizes country-code numbers", () => {
+    expect(
+      parseAllowedWhatsAppPhones("+62 811-1111-1111, 628222222222")
+    ).toEqual(["6281111111111", "628222222222"]);
+  });
+
+  test("rejects short numbers", () => {
+    expect(() => parseAllowedWhatsAppPhones("123")).toThrow();
+  });
 });
 
 describe("generatePairingCode", () => {
@@ -161,6 +196,20 @@ describe("saveWhatsAppConfig", () => {
     await withTempHomedir("nakama-core-wa-home-", async () => {
       const result = await saveWhatsAppConfig({ profileId: "default" });
       expect(result.configured).toBe(true);
+    });
+  });
+
+  test("saves allowed phones", async () => {
+    await withTempHomedir("nakama-core-wa-home-", async () => {
+      const result = await saveWhatsAppConfig({
+        allowedPhones: "+62 811-1111-1111, 628222222222",
+        profileId: "default",
+      });
+
+      expect(result.allowedPhones).toEqual(["6281111111111", "628222222222"]);
+
+      const saved = await loadWhatsAppConfigFile();
+      expect(saved?.allowedPhones).toEqual(["6281111111111", "628222222222"]);
     });
   });
 });
@@ -257,6 +306,7 @@ describe("resolveWhatsAppConfigFromSources", () => {
         WHATSAPP_PHONE_NUMBER: "+1234567890",
       },
       file: {
+        allowedPhones: [],
         pairedJid: null,
         pairedLid: null,
         pairingCode: null,
@@ -266,6 +316,7 @@ describe("resolveWhatsAppConfigFromSources", () => {
     });
 
     expect(resolved).toEqual({
+      allowedPhones: [],
       pairedJid: null,
       pairedLid: null,
       pairingCode: null,
@@ -278,6 +329,7 @@ describe("resolveWhatsAppConfigFromSources", () => {
     const resolved = resolveWhatsAppConfigFromSources({
       env: {},
       file: {
+        allowedPhones: ["628111111111"],
         pairedJid: "9876543210@s.whatsapp.net",
         pairedLid: null,
         pairingCode: "ABCD1234",

--- a/packages/core/src/whatsapp-config.ts
+++ b/packages/core/src/whatsapp-config.ts
@@ -19,6 +19,7 @@ export const normalizePairingCode = normalizeHandshakeInput;
 
 export const DEFAULT_WHATSAPP_PROFILE_ID = "default";
 export interface WhatsAppConfigFile {
+  allowedPhones: string[];
   outboundPort?: string | null;
   pairedJid: string | null;
   pairedLid: string | null;
@@ -28,6 +29,7 @@ export interface WhatsAppConfigFile {
 }
 
 export interface WhatsAppSettingsPublic {
+  allowedPhones: string[];
   configured: boolean;
   pairedJid: string | null;
   pairingCode: string | null;
@@ -36,6 +38,7 @@ export interface WhatsAppSettingsPublic {
 }
 
 export interface UpdateWhatsAppSettingsInput {
+  allowedPhones?: string;
   phoneNumber?: string;
   profileId?: string;
 }
@@ -118,22 +121,97 @@ function isSameWhatsAppUserJid(left: string, right: string): boolean {
   return Boolean(leftDigits && leftDigits === rightDigits);
 }
 
-export function isWhatsAppUserAuthorized(
-  jid: string,
-  config: Pick<WhatsAppConfigFile, "pairedJid" | "pairedLid">
-): boolean {
-  if (!config.pairedJid) {
-    return false;
+const MIN_ALLOWED_PHONE_DIGITS = 8;
+
+export function parseAllowedWhatsAppPhones(raw: string): string[] {
+  const phones = new Set<string>();
+
+  for (const part of raw.split(",")) {
+    const digits = phoneDigits(part);
+
+    if (!digits) {
+      continue;
+    }
+
+    if (digits.length < MIN_ALLOWED_PHONE_DIGITS) {
+      throw new Error(`Invalid WhatsApp number: ${part.trim()}`);
+    }
+
+    phones.add(digits);
   }
+
+  return [...phones];
+}
+
+export function isWhatsAppUserAuthorized(
+  jid: string | readonly string[],
+  config: Pick<WhatsAppConfigFile, "pairedJid" | "pairedLid"> & {
+    allowedPhones?: string[];
+  }
+): boolean {
+  const jids = typeof jid === "string" ? [jid] : jid;
+  const allowedPhones = config.allowedPhones ?? [];
+
+  return jids.some((entry) => {
+    if (!entry) {
+      return false;
+    }
+
+    if (
+      config.pairedJid &&
+      (isSameWhatsAppUserJid(entry, config.pairedJid) ||
+        (config.pairedLid
+          ? isSameWhatsAppUserJid(entry, config.pairedLid)
+          : false))
+    ) {
+      return true;
+    }
+
+    const digits = whatsAppUserDigits(entry);
+    return Boolean(digits && allowedPhones.includes(digits));
+  });
+}
+
+export async function rememberWhatsAppPairedIdentities(
+  jids: readonly string[]
+): Promise<void> {
+  const config = await loadWhatsAppConfigFile();
 
   if (
-    isSameWhatsAppUserJid(jid, config.pairedJid) ||
-    (config.pairedLid ? isSameWhatsAppUserJid(jid, config.pairedLid) : false)
+    !(
+      config &&
+      isWhatsAppUserAuthorized(jids, {
+        allowedPhones: [],
+        pairedJid: config.pairedJid,
+        pairedLid: config.pairedLid,
+      })
+    )
   ) {
-    return true;
+    return;
   }
 
-  return false;
+  const phoneJid = jids.find(
+    (jid) => whatsAppJidServer(jid) === "s.whatsapp.net"
+  );
+  const lidJid = jids.find((jid) => whatsAppJidServer(jid) === "lid");
+  const nextPairedJid =
+    phoneJid && isSameWhatsAppUserJid(phoneJid, config.pairedJid)
+      ? phoneJid
+      : config.pairedJid;
+  const nextPairedLid = lidJid ?? config.pairedLid;
+
+  if (
+    nextPairedJid === config.pairedJid &&
+    nextPairedLid === config.pairedLid
+  ) {
+    return;
+  }
+
+  await writeWhatsAppConfigFile({
+    ...config,
+    pairedJid: nextPairedJid,
+    pairedLid: nextPairedLid,
+  });
 }
 
 export async function loadWhatsAppConfigFile(): Promise<WhatsAppConfigFile | null> {
@@ -152,6 +230,7 @@ export async function loadWhatsAppConfigFile(): Promise<WhatsAppConfigFile | nul
   const outboundPort = values.outbound_port?.trim() || null;
 
   return {
+    allowedPhones: parseAllowedWhatsAppPhones(values.allowed_phones ?? ""),
     outboundPort,
     pairedJid,
     pairedLid,
@@ -166,6 +245,7 @@ export function toWhatsAppSettingsPublic(
 ): WhatsAppSettingsPublic {
   if (!file) {
     return {
+      allowedPhones: [],
       configured: false,
       pairedJid: null,
       pairingCode: null,
@@ -175,6 +255,7 @@ export function toWhatsAppSettingsPublic(
   }
 
   return {
+    allowedPhones: file.allowedPhones,
     configured: true,
     pairedJid: file.pairedJid,
     pairingCode: file.pairingCode,
@@ -201,6 +282,9 @@ async function writeWhatsAppConfigFile(
     ...(config.pairingCode ? [`pairing_code=${config.pairingCode}`] : []),
     ...(config.pairedJid ? [`paired_jid=${config.pairedJid}`] : []),
     ...(config.pairedLid ? [`paired_lid=${config.pairedLid}`] : []),
+    ...(config.allowedPhones.length > 0
+      ? [`allowed_phones=${config.allowedPhones.join(",")}`]
+      : []),
     "",
   ];
 
@@ -248,12 +332,22 @@ function buildSavedWhatsAppConfig(
   const pairedJid = existing?.pairedJid ?? null;
 
   return {
+    allowedPhones: resolveAllowedPhones(input, existing),
     pairedJid,
     pairedLid: existing?.pairedLid ?? null,
     pairingCode: resolvePairingCode(existing, pairedJid),
     phoneNumber,
     profileId: resolveProfileId(input, existing),
   };
+}
+
+function resolveAllowedPhones(
+  input: UpdateWhatsAppSettingsInput,
+  existing: WhatsAppConfigFile | null
+): string[] {
+  return input.allowedPhones === undefined
+    ? (existing?.allowedPhones ?? [])
+    : parseAllowedWhatsAppPhones(input.allowedPhones);
 }
 
 export async function saveWhatsAppConfig(
@@ -425,6 +519,7 @@ export function resolveWhatsAppConfigFromSources(options: {
   }
 
   return {
+    allowedPhones: file?.allowedPhones ?? [],
     pairedJid: file?.pairedJid ?? null,
     pairedLid: file?.pairedLid ?? null,
     pairingCode: file?.pairingCode ?? null,

--- a/packages/core/src/whatsapp-config.ts
+++ b/packages/core/src/whatsapp-config.ts
@@ -12,6 +12,9 @@ import {
   writeTextFile,
 } from "./fs";
 import { getUserConfigDir } from "./user-config";
+import { parseAllowedWhatsAppPhones } from "./whatsapp-phones";
+
+export { parseAllowedWhatsAppPhones } from "./whatsapp-phones";
 
 /** WhatsApp name for shared handshake helpers. */
 export const generatePairingCode = generateHandshakeCode;
@@ -119,28 +122,6 @@ function isSameWhatsAppUserJid(left: string, right: string): boolean {
   const leftDigits = whatsAppUserDigits(left);
   const rightDigits = whatsAppUserDigits(right);
   return Boolean(leftDigits && leftDigits === rightDigits);
-}
-
-const MIN_ALLOWED_PHONE_DIGITS = 8;
-
-export function parseAllowedWhatsAppPhones(raw: string): string[] {
-  const phones = new Set<string>();
-
-  for (const part of raw.split(",")) {
-    const digits = phoneDigits(part);
-
-    if (!digits) {
-      continue;
-    }
-
-    if (digits.length < MIN_ALLOWED_PHONE_DIGITS) {
-      throw new Error(`Invalid WhatsApp number: ${part.trim()}`);
-    }
-
-    phones.add(digits);
-  }
-
-  return [...phones];
 }
 
 export function isWhatsAppUserAuthorized(

--- a/packages/core/src/whatsapp-phones.ts
+++ b/packages/core/src/whatsapp-phones.ts
@@ -1,0 +1,21 @@
+const MIN_ALLOWED_PHONE_DIGITS = 8;
+
+export function parseAllowedWhatsAppPhones(raw: string): string[] {
+  const phones = new Set<string>();
+
+  for (const part of raw.split(",")) {
+    const digits = part.replace(/\D/g, "");
+
+    if (!digits) {
+      continue;
+    }
+
+    if (digits.length < MIN_ALLOWED_PHONE_DIGITS) {
+      throw new Error(`Invalid WhatsApp number: ${part.trim()}`);
+    }
+
+    phones.add(digits);
+  }
+
+  return [...phones];
+}

--- a/packages/db/src/constants.ts
+++ b/packages/db/src/constants.ts
@@ -15,18 +15,20 @@ export const SUPER_BOT_SYSTEM_PROMPT = `You are Super Bot, the Nakama orchestrat
 
 ## Routing
 - New bot or agent → draft soul files and a tool plan in chat, wait for explicit OK, then create_profile (no tool calls on the first turn).
+- Change a profile's stored system prompt → get_profile, draft the new prompt in chat, wait for explicit OK, then update_profile.
 - Workflow to remember → skill_manage.
 - Scheduled task → create_automation.
 - New callable tool → list_tools, write JS or Python, create_tool (see tool authoring rules).
 
 ## Tools
-read/write/edit/delete_file, search_files, web_search, bash, create_profile/get_profile/list_profiles, create_tool/list_tools/assign_tool_to_profile, create_automation/list_automations/delete_automation/run_automation. Tool schemas are authoritative; persistent tools use JavaScript or Python (see tool authoring rules).
+read/write/edit/delete_file, search_files, web_search, bash, create_profile/update_profile/get_profile/list_profiles, create_tool/list_tools/assign_tool_to_profile, create_automation/list_automations/delete_automation/run_automation. Tool schemas are authoritative; persistent tools use JavaScript or Python (see tool authoring rules).
 
 ## Automations
 Confirm schedule in the user's timezone, then create_automation (manual, 5-field cron, or runAt ISO one-shot). Prefer runAt for one-time reminders. Set delivery for Telegram/WhatsApp/email/Discord when asked; omit when results only need saving. Test via list_automations → run_automation. Default to Super Bot unless told to target another profile.
 
 ## Profiles
 Prefer the create-profile skill when active. Never call create_profile before the user confirms the draft. Pass name and soulFiles only — the server generates the profile id.
+Never call update_profile before the user confirms the new system prompt. This updates the stored system prompt only — soul files stay on disk.
 
 ## Safety
 - Explain destructive bash/file writes when impact is unclear.


### PR DESCRIPTION
## Summary

Mention, reply, or `/command` Nakama in a WhatsApp group — linked or Allowed numbers. Reply-quotes now reach the model.

**Before:** groups dropped; one paired JID; quotes were trigger-only; Allowed numbers crashed the dashboard.
**After:** group triggers, extra phones, quoted text in the agent turn, phone parse in `whatsapp-phones`.

Why safe:
1. Plain group chatter still ignored
2. Allowlist matches digits only; pairing still one primary
3. Web no longer imports Node `fs`

Only follow up if a quote is media with no caption, or a sender is LID-only.

## Test plan
- [x] `bun test packages/core/src/whatsapp-config.test.ts apps/platform/whatsapp/src/inbound-message.test.ts apps/platform/whatsapp/src/chat-handler.test.ts` (66 pass)
- [x] Quote a group report, `@mention` Nakama, confirm the agent uses that text
