### PR TITLE
fix(server): stop POST /v1/automations answering with a raw TypeError

### DIFF
--- a/apps/server/src/services/automation-service.ts
+++ b/apps/server/src/services/automation-service.ts
@@ -118,7 +118,7 @@ export class AutomationService {
 
     const now = new Date().toISOString();
     const automation: StoredAutomation = {
-      description: input.description.trim() || input.prompt.trim(),
+      description: input.description?.trim() || input.prompt.trim(),
       enabled: input.enabled ?? true,
       id: createId("automation"),
       name: input.name.trim(),

--- a/apps/server/src/services/automation.test.ts
+++ b/apps/server/src/services/automation.test.ts
@@ -106,6 +106,27 @@ describe("AutomationService", () => {
     });
   });
 
+  test("falls back to the prompt when description is omitted", async () => {
+    const db = await createTestDb();
+    const service = new AutomationService(db, {
+      getUserTimezone: async () => "UTC",
+    });
+
+    // The HTTP route casts the body with readJson, so an absent field reaches
+    // create() as undefined however the type is declared.
+    const automation = await service.create(
+      ORG_ID,
+      {
+        name: "Nightly pull",
+        prompt: "run the tool",
+        trigger: { type: "manual" },
+      } as Parameters<typeof service.create>[1],
+      PROFILE_ID
+    );
+
+    expect(automation.description).toBe("run the tool");
+  });
+
   test("defaults schedule timezone from user config", async () => {
     const db = await createTestDb();
     const service = new AutomationService(db, {

--- a/packages/core/src/automation-validate.test.ts
+++ b/packages/core/src/automation-validate.test.ts
@@ -18,6 +18,26 @@ describe("validateAutomationInput", () => {
     ).not.toThrow();
   });
 
+  test("names the missing field when name is absent", () => {
+    expect(() =>
+      validateAutomationInput({
+        name: undefined,
+        prompt: "Summarize news",
+        trigger: { type: "manual" },
+      })
+    ).toThrow("Automation name is required.");
+  });
+
+  test("names the missing field when prompt is absent", () => {
+    expect(() =>
+      validateAutomationInput({
+        name: "Daily digest",
+        prompt: undefined,
+        trigger: { type: "manual" },
+      })
+    ).toThrow("Automation prompt is required.");
+  });
+
   test("rejects invalid cron", () => {
     expect(() =>
       validateAutomationInput({

--- a/packages/core/src/automation-validate.ts
+++ b/packages/core/src/automation-validate.ts
@@ -68,12 +68,14 @@ export function computeAutomationNextRunAt(
 }
 
 export function validateAutomationInput(input: {
-  name: string;
-  prompt: string;
+  // Undefined, not just empty: request bodies reach this unvalidated, so an
+  // absent field has to name itself here rather than throw a TypeError.
+  name: string | undefined;
+  prompt: string | undefined;
   trigger: AutomationTrigger;
 }): void {
-  const name = input.name.trim();
-  const prompt = input.prompt.trim();
+  const name = input.name?.trim() ?? "";
+  const prompt = input.prompt?.trim() ?? "";
 
   if (!name) {
     throw new Error("Automation name is required.");


### PR DESCRIPTION
## Summary

`POST /v1/automations` now accepts a body with no `description` and reuses the prompt for it, instead of answering with a JavaScript TypeError string.

**Before:** an omitted `description` returned `{"error":"undefined is not an object (evaluating 'input.description.trim')"}`, and an omitted `name` or `prompt` threw the same way one line earlier.
**After:** `description` falls back to the prompt; a missing `name` or `prompt` returns the message that names it.

Why safe:
1. Falling back to the prompt is what that expression already spelled out. It only ever fired for an empty string, so an absent field was the one case it could not reach.
2. The guard sits in `validateAutomationInput` and `AutomationService.create`, so both callers of `create()` go through it rather than the HTTP route alone.
3. Three tests added. Two of them fail on `827d2b9d` with the exact TypeError from the issue, which is how the fix was checked.

Only follow up if something depended on the old status: a missing `name` answers `{"error":"Automation name is required."}` with 500, not 400. That predates this bug and is not what #448 reports, so it stays out of this diff.

## Test plan
- [x] `bun run test`, 11 workspaces, 2429 pass, 0 fail
- [x] Live instance on a throwaway config dir, the issue's exact body with `description` removed:

```
827d2b9d      HTTP 500  {"error":"undefined is not an object (evaluating 'input.description.trim')"}
this branch   HTTP 201  description "run the tool", equal to the prompt
```

Closes #448
