### PR TITLE
fix(db): create the database file and its directory private

### DIFF
--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -1,6 +1,7 @@
 import { Database } from "bun:sqlite";
+import { chmodSync } from "node:fs";
 import type { AgentQuestionnaire, ChatMessage } from "@nakama/core";
-import { getUserMessageText } from "@nakama/core";
+import { getUserMessageText, PRIVATE_FILE_MODE } from "@nakama/core";
 import { LOCAL_CLIENT_USER_ID } from "@nakama/core/local-auth";
 import { LLM_USAGE_STATS_ID, WORKSPACE_SETTINGS_ID } from "../constants";
 import { ensureDatabaseDirectory, resolveDatabasePath } from "../database-url";
@@ -401,13 +402,28 @@ interface ArtifactShareRow {
   token_hash: string;
 }
 
+/**
+ * The file holds plaintext MCP credentials and every transcript, so it carries
+ * the same 0600 the rest of ~/.nakama already uses. bun:sqlite takes no mode, and
+ * an existing loose file keeps its own, so chmod after open rather than at create.
+ */
+function openPrivateDatabase(databasePath: string): Database {
+  ensureDatabaseDirectory(databasePath);
+  const db = new Database(databasePath, { create: true });
+
+  if (databasePath !== ":memory:") {
+    chmodSync(databasePath, PRIVATE_FILE_MODE);
+  }
+
+  return db;
+}
+
 export async function createSqliteDatabase(
   databaseUrl: string
 ): Promise<SqliteDatabase> {
   const databasePath = resolveDatabasePath(databaseUrl);
-  ensureDatabaseDirectory(databasePath);
 
-  let db = new Database(databasePath, { create: true });
+  let db = openPrivateDatabase(databasePath);
   migrateDatabase(db);
   let adapter = createSqliteDatabaseAdapter(db);
 
@@ -427,8 +443,7 @@ export async function createSqliteDatabase(
       db.close();
     },
     async reopen() {
-      ensureDatabaseDirectory(databasePath);
-      const nextDb = new Database(databasePath, { create: true });
+      const nextDb = openPrivateDatabase(databasePath);
       migrateDatabase(nextDb);
       const nextAdapter = createSqliteDatabaseAdapter(nextDb);
       const previousDb = db;

--- a/packages/db/src/database-permissions.test.ts
+++ b/packages/db/src/database-permissions.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { createSqliteDatabase } from "./adapters/sqlite";
+
+// Windows has no POSIX mode bits, so the assertions below cannot mean anything
+// there. Everything else under ~/.nakama is 0600/0700; the database holds
+// plaintext MCP credentials and every transcript, so it follows the same rule.
+const posix = process.platform !== "win32";
+
+function modeOf(path: string): number {
+  // biome-ignore lint/suspicious/noBitwiseOperators: masking the permission bits out of st_mode is what the operator is for.
+  return statSync(path).mode & 0o777;
+}
+
+describe("database permissions", () => {
+  test.skipIf(!posix)("a fresh database is private", async () => {
+    const root = mkdtempSync(join(tmpdir(), "nakama-db-perms-"));
+    const databasePath = join(root, "data", "sqlite", "nakama.sqlite");
+
+    const db = await createSqliteDatabase(`file:${databasePath}`);
+    db.close();
+
+    expect(modeOf(databasePath)).toBe(0o600);
+    expect(modeOf(dirname(databasePath))).toBe(0o700);
+    rmSync(root, { force: true, recursive: true });
+  });
+
+  test.skipIf(!posix)(
+    "startup tightens a world-readable database",
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), "nakama-db-perms-"));
+      const databasePath = join(root, "data", "sqlite", "nakama.sqlite");
+      mkdirSync(dirname(databasePath), { recursive: true });
+      chmodSync(dirname(databasePath), 0o755);
+      writeFileSync(databasePath, "");
+      chmodSync(databasePath, 0o644);
+
+      const db = await createSqliteDatabase(`file:${databasePath}`);
+      db.close();
+
+      expect(modeOf(databasePath)).toBe(0o600);
+      expect(modeOf(dirname(databasePath))).toBe(0o700);
+      rmSync(root, { force: true, recursive: true });
+    }
+  );
+});

--- a/packages/db/src/database-url.ts
+++ b/packages/db/src/database-url.ts
@@ -1,6 +1,6 @@
-import { mkdirSync } from "node:fs";
+import { chmodSync, mkdirSync } from "node:fs";
 import { dirname, isAbsolute, resolve } from "node:path";
-import { getUserConfigDir } from "@nakama/core";
+import { getUserConfigDir, PRIVATE_DIR_MODE } from "@nakama/core";
 
 export interface ResolveDatabasePathOptions {
   /** Anchor relative file: paths (defaults to ~/.nakama). */
@@ -35,5 +35,9 @@ export function ensureDatabaseDirectory(databasePath: string): void {
     return;
   }
 
-  mkdirSync(dirname(databasePath), { recursive: true });
+  const directory = dirname(databasePath);
+  mkdirSync(directory, { mode: PRIVATE_DIR_MODE, recursive: true });
+  // mkdir masks a new directory's mode with the umask and leaves an existing
+  // one alone, so re-tighten instead of trusting creation.
+  chmodSync(directory, PRIVATE_DIR_MODE);
 }


### PR DESCRIPTION
## Summary

The sqlite database and the directories holding it are created private, so the file carrying plaintext MCP credentials, every transcript, org memory and task output is no longer readable by other users on the host.

**Before:** `data/sqlite/nakama.sqlite` at 0644 under 0755 directories, while everything else in `~/.nakama` already went through `PRIVATE_FILE_MODE` / `PRIVATE_DIR_MODE`.
**After:** 0600 file, 0700 directories, applied on every open rather than only at creation, so an install already carrying loose modes is tightened on its next start.

Why safe:
1. It reuses the two constants the rest of the repo already enforces instead of introducing a second convention next to them.
2. Both open sites, the first open and `reopen()`, now route through one helper, so they cannot drift apart later.
3. The chmod is skipped for `:memory:`, which is what almost every test in the suite uses.

Only follow up if WAL is ever switched on: `journal_mode` is never set today, so sqlite writes no `-wal` or `-shm` sidecars to tighten, and that helper is where they would go.

## Test plan
- [x] `bun run test`, 11 workspaces, 2428 pass, 0 fail. The two new tests fail on `8cc04d7b` with `Expected: 384, Received: 420`.
- [x] Fresh init, real server start on a throwaway `NAKAMA_CONFIG_DIR`:

```
8cc04d7b      -rw-r--r--  nakama.sqlite    drwxr-xr-x  data    drwxr-xr-x  data/sqlite
this branch   -rw-------  nakama.sqlite    drwx------  data    drwx------  data/sqlite
```

- [x] Upgrade path, the same config dir created by `8cc04d7b` then started once on this branch:

```
before   -rw-r--r--  nakama.sqlite    drwxr-xr-x  data/sqlite
after    -rw-------  nakama.sqlite    drwx------  data/sqlite
```

Windows has no POSIX mode bits, so both tests are `skipIf(!posix)` and the assertions were only ever run on macOS here.

Closes #428
