### PR TITLE
Review asserts: remove meaningless, add meaningful

### DIFF
--- a/apps/cli/src/org.ts
+++ b/apps/cli/src/org.ts
@@ -50,15 +50,16 @@ export async function resolveCliOrgId(
   }
 
   const { orgs } = await client.listUserOrgs();
+  const [onlyOrg] = orgs;
 
-  if (orgs.length === 0) {
+  if (!onlyOrg) {
     throw new Error("No organizations found.");
   }
 
   if (orgs.length === 1) {
-    client.setOrgId(orgs[0]!.id);
-    await saveCliOrgId(orgs[0]!.id);
-    return orgs[0]!.id;
+    client.setOrgId(onlyOrg.id);
+    await saveCliOrgId(onlyOrg.id);
+    return onlyOrg.id;
   }
 
   throw new Error(

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -3378,8 +3378,9 @@ export class AgentService {
       profileModel: profile?.model ?? null,
       userConfig: this.userConfig,
     };
+    const [firstInstalled, secondInstalled] = installed;
 
-    if (installed.length === 0) {
+    if (!firstInstalled) {
       const installLines = [
         "# Coding Agent Harness",
         "No coding agent CLI is installed on this host.",
@@ -3395,7 +3396,7 @@ export class AgentService {
       return installLines.join("\n");
     }
 
-    if (installed.length > 1) {
+    if (secondInstalled) {
       const names = installed
         .map((harness) => `- ${harness.name} (\`${harness.command}\`)`)
         .join("\n");
@@ -3411,9 +3412,8 @@ export class AgentService {
       ].join("\n");
     }
 
-    const harness = installed[0]!;
     return this.formatSingleCodingHarnessContext(
-      harness,
+      firstInstalled,
       workspaceRoot,
       probeContext
     );

--- a/apps/server/src/services/coding-agent-harness-service.ts
+++ b/apps/server/src/services/coding-agent-harness-service.ts
@@ -458,12 +458,13 @@ export async function resolveCodingAgentHarness(
   }
 
   const installed = enabled.filter((harness) => harness.installed);
+  const [firstInstalled, secondInstalled] = installed;
 
-  if (installed.length === 1) {
-    return ensureReady(installed[0]!);
+  if (firstInstalled && !secondInstalled) {
+    return ensureReady(firstInstalled);
   }
 
-  if (installed.length > 1) {
+  if (secondInstalled) {
     throw new Error(
       "Multiple coding agents are installed. Ask the user which one to use, then run that CLI via bash."
     );

--- a/apps/server/src/services/session-turn-registry.ts
+++ b/apps/server/src/services/session-turn-registry.ts
@@ -65,7 +65,11 @@ function rebuildSnapshotIndexes(turn: ActiveTurn): void {
 }
 
 function removeEventAt(turn: ActiveTurn, index: number): StreamEvent {
-  const removed = turn.events[index]!;
+  const removed = turn.events[index];
+  if (!removed) {
+    throw new Error("Snapshot index must reference a buffered event.");
+  }
+
   const lastIndex = turn.events.length - 1;
 
   if (index !== lastIndex) {

--- a/apps/server/src/services/skill-curator-service.ts
+++ b/apps/server/src/services/skill-curator-service.ts
@@ -147,6 +147,11 @@ export class SkillCuratorService {
       restoreMisses: [],
     };
     const profiles = await this.db.listProfilesForOrg(orgId);
+    for (const profile of profiles) {
+      if (profile.orgId !== orgId) {
+        throw new Error("Curator profile must belong to the requested org.");
+      }
+    }
     const enabledAutomationProfileIds = new Set(
       (await this.db.listAutomationsForOrg(orgId))
         .filter((automation) => automation.enabled)
@@ -363,6 +368,11 @@ export class SkillCuratorService {
     profileId: string;
     winner: ConsolidateCandidateSkill;
   }): Promise<"staged" | "applied" | "skipped"> {
+    const hasLosers = input.losers.length > 0;
+    if ((input.mode === "merge") !== hasLosers) {
+      throw new Error("Merge requires losers; deslopify requires none.");
+    }
+
     const winnerBody: SkillConsolidateBodyInput = {
       body: input.winner.body,
       description: input.winner.description,

--- a/packages/core/src/provider-setup-prompt.ts
+++ b/packages/core/src/provider-setup-prompt.ts
@@ -195,13 +195,15 @@ function resolveProviderChoice(input: string): UserProviderName | null {
   }
 
   const numeric = Number(input);
-
-  if (
+  const choice =
     Number.isInteger(numeric) &&
     numeric >= 1 &&
     numeric <= PROVIDER_CHOICES.length
-  ) {
-    return PROVIDER_CHOICES[numeric - 1]!.id;
+      ? PROVIDER_CHOICES[numeric - 1]
+      : undefined;
+
+  if (choice) {
+    return choice.id;
   }
 
   return null;
@@ -231,9 +233,13 @@ function resolveModelChoice(
 
   const numeric = Number(input);
   const models = options.getModelsForProvider(provider);
+  const choice =
+    Number.isInteger(numeric) && numeric >= 1 && numeric <= models.length
+      ? models[numeric - 1]
+      : undefined;
 
-  if (Number.isInteger(numeric) && numeric >= 1 && numeric <= models.length) {
-    return models[numeric - 1]!.id;
+  if (choice) {
+    return choice.id;
   }
 
   return options.getDefaultModel(provider);

--- a/packages/core/src/skills/consolidate.ts
+++ b/packages/core/src/skills/consolidate.ts
@@ -160,6 +160,11 @@ function contentLength(candidate: ConsolidateCandidateSkill): number {
 export function buildConsolidatePlan(
   input: BuildConsolidatePlanInput
 ): ConsolidatePlan {
+  const skillNames = new Set(input.skills.map((skill) => skill.name));
+  if (skillNames.size !== input.skills.length) {
+    throw new Error("Consolidation candidates must have unique names.");
+  }
+
   let skippedCount = 0;
   const eligible: ConsolidateCandidateSkill[] = [];
 

--- a/packages/db/src/database-url.ts
+++ b/packages/db/src/database-url.ts
@@ -34,6 +34,9 @@ export function ensureDatabaseDirectory(databasePath: string): void {
   if (databasePath === ":memory:") {
     return;
   }
+  if (!isAbsolute(databasePath)) {
+    throw new Error("Database path must be absolute.");
+  }
 
   const directory = dirname(databasePath);
   mkdirSync(directory, { mode: PRIVATE_DIR_MODE, recursive: true });


### PR DESCRIPTION
## What changed

Review of asserts across the codebase. Two kinds of edits, all assert/guard-level only:

**Removed meaningless (redundant non-null assertions + guaranteed length checks)**

- `apps/cli/src/org.ts` — dropped `orgs[0]!`, replaced with destructuring + explicit empty guard.
- `apps/server/src/services/agent-service.ts` — dropped `installed[0]!`, destructured `[firstInstalled, secondInstalled]`.
- `apps/server/src/services/coding-agent-harness-service.ts` — same pattern, `installed[0]!` removed.
- `packages/core/src/provider-setup-prompt.ts` — replaced `[n-1]!.id` indexing with a narrowed `choice` lookup.

**Added meaningful (negative-space contracts)**

- `apps/server/src/services/skill-curator-service.ts` — curator profiles must belong to the requested org; merge requires losers / deslopify requires none.
- `packages/core/src/skills/consolidate.ts` — consolidation candidates must have unique names.
- `apps/server/src/services/session-turn-registry.ts` — snapshot index must reference a buffered event.
- `packages/db/src/database-url.ts` — database path must be absolute.

## What was verified

Ran the relevant test subsets locally (bun test), all green:

- `apps/cli/src/org.test.ts`
- `packages/core/src/provider-setup-prompt.test.ts`
- `packages/core/src/skills/consolidate.test.ts`
- `packages/core/src/skills/curator-consolidate.test.ts`
- `apps/server/src/services/session-turn-registry.test.ts`
- `apps/server/src/services/coding-agent-harness-service.test.ts`
- `apps/server/src/services/skill-curator-service.test.ts`
- `apps/server/src/services/agent-service.test.ts`
- `packages/db/src/database-permissions.test.ts`

68 tests pass, 0 fail. No new TypeScript errors introduced in the changed files (remaining `tsc --noEmit` errors are pre-existing in unrelated files).

## Remaining risks

- Did not run the full monorepo test suite, only the subsets covering the touched files.
- The new contract guards throw on conditions current callers never hit; a caller elsewhere violating one (e.g. merge with empty losers) surfaces as a runtime throw rather than a silent no-op.