### PR TITLE
fix(settings): stop the provider and timezone routes answering with a TypeError

### DIFF
--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -558,14 +558,16 @@ export class AgentService {
     return this.userConfig;
   }
 
-  async setUserTimezone(timezone: string): Promise<string> {
-    await saveUserTimezone(timezone);
+  // Widened to match saveUserTimezone: the route hands this straight from an
+  // unvalidated request body.
+  async setUserTimezone(timezone: string | undefined): Promise<string> {
+    const saved = await saveUserTimezone(timezone);
 
     if (this.userConfig) {
-      this.userConfig = { ...this.userConfig, timezone };
+      this.userConfig = { ...this.userConfig, timezone: saved };
     }
 
-    return timezone;
+    return saved;
   }
 
   async getThinkingSettings(): Promise<ThinkingSettingsResponse> {

--- a/apps/server/src/services/provider-instance-helpers.test.ts
+++ b/apps/server/src/services/provider-instance-helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { ProviderInstance } from "@nakama/core";
+import { NakamaApiError } from "@nakama/core";
 import {
   applyProviderInstanceUpdate,
   buildProviderInstanceFromCreateRequest,
@@ -339,5 +340,25 @@ describe("buildProviderInstanceFromCreateRequest", () => {
     expect(instance.baseUrl).toBe(
       "https://api.cloudflare.com/client/v4/accounts/abc123/ai/v1"
     );
+  });
+
+  // readJson casts the body without validating it, so both fields can arrive
+  // undefined however the contract types them.
+  test("names the missing field and answers 400, not a TypeError at 500", () => {
+    const cases = [
+      [{}, "Provider type is required."],
+      [{ type: "openai" }, "API key is required."],
+    ] as const;
+
+    for (const [request, message] of cases) {
+      try {
+        buildProviderInstanceFromCreateRequest(request, []);
+        throw new Error("expected a rejection");
+      } catch (error) {
+        expect(error).toBeInstanceOf(NakamaApiError);
+        expect((error as NakamaApiError).message).toBe(message);
+        expect((error as NakamaApiError).status).toBe(400);
+      }
+    }
   });
 });

--- a/apps/server/src/services/provider-instance-helpers.ts
+++ b/apps/server/src/services/provider-instance-helpers.ts
@@ -155,15 +155,25 @@ export function resolveDefaultModelForInstance(
 }
 
 export function buildProviderInstanceFromCreateRequest(
-  request: CreateProviderRequest,
+  // apiKey and type are widened here on purpose: request bodies reach this
+  // unvalidated, so an absent field has to name itself rather than throw a
+  // TypeError, and the type is what stops the guard being deleted later.
+  request: Omit<CreateProviderRequest, "apiKey" | "type"> & {
+    apiKey?: string;
+    type?: CreateProviderRequest["type"];
+  },
   existing: ProviderInstance[]
 ): ProviderInstance {
   const type = request.type;
-  const trimmedKey = request.apiKey.trim();
-  const apiKey = trimmedKey;
+
+  if (!type) {
+    throw new NakamaApiError("Provider type is required.", 400);
+  }
+
+  const apiKey = request.apiKey?.trim() ?? "";
 
   if (!apiKey && type !== "openai_compatible" && type !== "ollama") {
-    throw new Error("API key is required.");
+    throw new NakamaApiError("API key is required.", 400);
   }
 
   if (type === "ollama") {
@@ -173,11 +183,11 @@ export function buildProviderInstanceFromCreateRequest(
     });
 
     if (ollamaRequiresApiKey(hostMode) && !apiKey) {
-      throw new Error("API key is required for Ollama Cloud.");
+      throw new NakamaApiError("API key is required for Ollama Cloud.", 400);
     }
   }
 
-  const fields = buildProviderFieldsFromRequest(request);
+  const fields = buildProviderFieldsFromRequest({ ...request, apiKey, type });
   const rawLabel = request.label?.trim()
     ? validateProviderInstanceLabel(request.label, type)
     : fields.label;

--- a/packages/core/src/user-config.test.ts
+++ b/packages/core/src/user-config.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { NakamaApiError } from "./api-error";
 import { pathExists } from "./fs";
 import {
   createProviderInstanceId,
@@ -11,8 +12,32 @@ import {
   loadUserWebPublicUrl,
   normalizeProviderInstanceLabel,
   saveUserConfig,
+  saveUserTimezone,
   saveUserWebPublicUrl,
 } from "./user-config";
+
+describe("saveUserTimezone", () => {
+  // readJson casts the body without validating it, so timezone can arrive
+  // undefined however the contract types it.
+  test("names the missing field and answers 400, not a TypeError at 500", async () => {
+    const cases = [
+      [undefined, "Timezone is required."],
+      ["  ", "Timezone is required."],
+      ["Not/AZone", "Invalid timezone: Not/AZone"],
+    ] as const;
+
+    for (const [value, message] of cases) {
+      try {
+        await saveUserTimezone(value);
+        throw new Error("expected a rejection");
+      } catch (error) {
+        expect(error).toBeInstanceOf(NakamaApiError);
+        expect((error as NakamaApiError).message).toBe(message);
+        expect((error as NakamaApiError).status).toBe(400);
+      }
+    }
+  });
+});
 
 describe("ensureUserConfigDir", () => {
   let configDir = "";

--- a/packages/core/src/user-config.ts
+++ b/packages/core/src/user-config.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, join } from "node:path";
+import { NakamaApiError } from "./api-error";
 import {
   isValidBaseUrl,
   normalizeBaseUrl,
@@ -397,18 +398,26 @@ export function buildThinkingProviderOptions(
   };
 }
 
-export async function saveUserTimezone(timezone: string): Promise<void> {
-  const trimmed = timezone.trim();
+export async function saveUserTimezone(
+  // Undefined, not just empty: request bodies reach this unvalidated, so an
+  // absent field has to name itself here rather than throw a TypeError.
+  timezone: string | undefined
+): Promise<string> {
+  const trimmed = timezone?.trim() ?? "";
 
-  if (!(trimmed && isValidTimezone(trimmed))) {
-    throw new Error(`Invalid timezone: ${timezone}`);
+  if (!trimmed) {
+    throw new NakamaApiError("Timezone is required.", 400);
+  }
+
+  if (!isValidTimezone(trimmed)) {
+    throw new NakamaApiError(`Invalid timezone: ${trimmed}`, 400);
   }
 
   const existing = await loadUserConfig();
 
   if (existing) {
     await saveUserConfig({ ...existing, timezone: trimmed });
-    return;
+    return trimmed;
   }
 
   const raw = await readTextOrNull(getUserConfigPath());
@@ -421,6 +430,8 @@ export async function saveUserTimezone(timezone: string): Promise<void> {
   await writeTextFile(getUserConfigPath(), lines.join("\n"), {
     ensureDir: getUserConfigDir(),
   });
+
+  return trimmed;
 }
 
 function readWebPublicUrl(values: Record<string, string>): string | undefined {


### PR DESCRIPTION
## Summary

An omitted field on `PUT /v1/settings/provider` or `PUT /v1/settings/timezone` now answers 400 naming the field, instead of a 500 carrying a TypeError string.

**Before:** `readJson` casts the body without validating it, so the value reached `.trim()` and `.replace()` and the stack trace came back as the error message.
**After:** the guard sits where the value is dereferenced, so the provider one covers `PUT /v1/settings/provider` and `POST /v1/providers` through the single builder they share.

Same throwaway instance, curl against both:

| request | before | after |
| --- | --- | --- |
| `provider {}` | 500 `undefined is not an object (evaluating 'request.apiKey.trim')` | 400 `Provider type is required.` |
| `provider {"apiKey":"k"}` | 500 `undefined is not an object (evaluating 'type.replace')` | 400 `Provider type is required.` |
| `timezone {}` | 500 `undefined is not an object (evaluating 'timezone.trim')` | 400 `Timezone is required.` |
| `timezone {"timezone":"Not/AZone"}` | 500 `Invalid timezone: Not/AZone` | 400 `Invalid timezone: Not/AZone` |
| `timezone {"timezone":"  Asia/Jakarta  "}` | 200 `{"timezone":"  Asia/Jakarta  "}` | 200 `{"timezone":"Asia/Jakarta"}` |
| a valid provider save | 200 | 200, unchanged |

The last two rows ride along because they share the cause. `Invalid timezone:` and `API key is required.` were 500s too and move to 400 now that both throw `NakamaApiError`, and `saveUserTimezone` returns the trimmed value so the response echoes what was saved.

Why safe:
1. Both parameters are widened to `| undefined` rather than guarded at runtime alone, so nobody deletes the check later as unnecessary. Same shape as #451.
2. No route changes and no new try/catch. `app.onError` maps `NakamaApiError` to its status already, which is how the 13 sibling settings routes answer 400.
3. Typecheck unchanged: 7929 errors before, 7929 after, all pre-existing.

Only follow up if the provider type should be checked against the known names. `{"provider":"nope","apiKey":"k"}` still returns 200 and stores it, which is today's behaviour and a separate question.

One test per module, not two. Asserting the message of a call in one case and its status in the next is the split #458 collapses, so each one covers both fields of the same call.

## Test plan
- [x] `bun run test` across all workspaces: 2437 pass, 0 fail, 11 workspaces exit 0.
- [x] The two new tests run against the unfixed source first: both fail with the exact TypeErrors above, then pass with the fix.
- [x] The table above, driven by curl against a throwaway instance. Server restart confirmed by pid start time against the source mtime.
- [x] `bun run check` and `bun run knip` clean.

Closes #456

