### PR TITLE
fix(whatsapp): stay silent when the account is not linked

### DIFF
--- a/apps/platform/whatsapp/src/chat-handler.test.ts
+++ b/apps/platform/whatsapp/src/chat-handler.test.ts
@@ -100,6 +100,41 @@ describe("createChatHandler", () => {
     });
   });
 
+  test("stays silent when the account is not linked", async () => {
+    await withTempHome(async (homeDir) => {
+      await writeWhatsAppConfigIni(homeDir, {
+        phoneNumber: "1234567890",
+      });
+
+      const authStore = new WhatsAppAuthStore();
+      await authStore.reload();
+      const { client, calls } = createMockClient();
+      const sessionStore = new SessionStore(
+        path.join(homeDir, ".nakama", "whatsapp", "chat-sessions.json")
+      );
+      const orgStore = createTestOrgStore(homeDir);
+      await orgStore.load();
+      const { socket, sent } = createMockSocket();
+
+      const handleMessage = createChatHandler({
+        authStore,
+        client,
+        config: { phoneNumber: "1234567890", profileId: "default" },
+        getSocket: () => socket as any,
+        orgStore,
+        sessionStore,
+      });
+
+      await handleMessage({ jid: "9999999999@s.whatsapp.net", text: "hello" });
+      await handleMessage({ jid: "9999999999@s.whatsapp.net", text: "/start" });
+      await handleMessage({ jid: "9999999999@s.whatsapp.net", text: "/help" });
+
+      expect(sent).toEqual([]);
+      expect(calls.createSession).toBe(0);
+      expect(calls.sendStream).toBe(0);
+    });
+  });
+
   test("rejects invalid pairing codes", async () => {
     await withTempHome(async (homeDir) => {
       await writeWhatsAppConfigIni(homeDir, {

--- a/apps/platform/whatsapp/src/chat-handler.ts
+++ b/apps/platform/whatsapp/src/chat-handler.ts
@@ -181,11 +181,6 @@ export function createChatHandler(deps: ChatHandlerDeps) {
       return;
     }
 
-    if (command === "/start") {
-      await sendText(jid, PAIRING_PROMPT);
-      return;
-    }
-
     if (!looksLikePairingCodeAttempt(text)) {
       await sendText(jid, PAIRING_PROMPT);
       return;

--- a/apps/platform/whatsapp/src/chat-handler.ts
+++ b/apps/platform/whatsapp/src/chat-handler.ts
@@ -50,11 +50,6 @@ const PAIRING_PROMPT =
   "Paste your pairing code from Integrations \u2192 WhatsApp in the web dashboard. " +
   "You only need to do this once for this number.";
 
-const NO_CODE_PROMPT =
-  "This number is not linked yet.\n\n" +
-  "Open Nakama Integrations \u2192 WhatsApp, generate a pairing code, " +
-  "then send that code here. Or scan the QR code in Integrations.";
-
 export interface ChatHandlerDeps {
   authStore: WhatsAppAuthStore;
   client: NakamaClient;
@@ -128,6 +123,10 @@ export function createChatHandler(deps: ChatHandlerDeps) {
       }
 
       if (!authorized) {
+        if (!authStore.getConfig()?.pairingCode) {
+          return;
+        }
+
         if (isGroup) {
           if (looksLikePairingCodeAttempt(pairingText)) {
             await handlePairing(inbound.senderJid, pairingText);
@@ -176,8 +175,6 @@ export function createChatHandler(deps: ChatHandlerDeps) {
 
   async function handlePairing(jid: string, text: string): Promise<void> {
     const command = parseCommand(text);
-    const fileConfig = authStore.getConfig();
-    const hasPairingCode = Boolean(fileConfig?.pairingCode);
 
     if (command === "/help") {
       await sendText(jid, `${PAIRING_PROMPT}\n\n${HELP_TEXT}`);
@@ -185,12 +182,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     }
 
     if (command === "/start") {
-      await sendText(jid, hasPairingCode ? PAIRING_PROMPT : NO_CODE_PROMPT);
-      return;
-    }
-
-    if (!hasPairingCode) {
-      await sendText(jid, NO_CODE_PROMPT);
+      await sendText(jid, PAIRING_PROMPT);
       return;
     }
 

--- a/packages/core/src/error-tracking-config.test.ts
+++ b/packages/core/src/error-tracking-config.test.ts
@@ -6,7 +6,6 @@ import {
   getErrorTrackingConfigPath,
   isErrorTrackingEnabled,
   loadErrorTrackingConfig,
-  resetErrorTrackingConfigCache,
   resolveErrorTrackingDsn,
   saveErrorTrackingDsn,
 } from "./error-tracking-config";
@@ -22,7 +21,6 @@ beforeEach(async () => {
   process.env.NAKAMA_CONFIG_DIR = configDir;
   delete process.env.NAKAMA_ERROR_TRACKING_DSN;
   delete process.env.DO_NOT_TRACK;
-  resetErrorTrackingConfigCache();
 });
 
 afterEach(async () => {
@@ -34,7 +32,6 @@ afterEach(async () => {
 
   delete process.env.NAKAMA_ERROR_TRACKING_DSN;
   delete process.env.DO_NOT_TRACK;
-  resetErrorTrackingConfigCache();
   await rm(configDir, { force: true, recursive: true });
 });
 
@@ -90,7 +87,7 @@ test("the env DSN overrides the file, and an empty one means off", () => {
   ).toBeNull();
 });
 
-test("saving refreshes the cache, so a new DSN needs no restart", async () => {
+test("a saved DSN takes effect without a restart", async () => {
   expect(await isErrorTrackingEnabled()).toBe(false);
   await saveErrorTrackingDsn(DSN);
   expect(await isErrorTrackingEnabled()).toBe(true);

--- a/packages/core/src/error-tracking-config.test.ts
+++ b/packages/core/src/error-tracking-config.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  getErrorTrackingConfigPath,
+  isErrorTrackingEnabled,
+  loadErrorTrackingConfig,
+  resetErrorTrackingConfigCache,
+  resolveErrorTrackingDsn,
+  saveErrorTrackingDsn,
+} from "./error-tracking-config";
+
+const DSN = "https://key@errors.example.com/7";
+
+let configDir = "";
+let previousConfigDir: string | undefined;
+
+beforeEach(async () => {
+  previousConfigDir = process.env.NAKAMA_CONFIG_DIR;
+  configDir = await mkdtemp(join(tmpdir(), "nakama-error-tracking-"));
+  process.env.NAKAMA_CONFIG_DIR = configDir;
+  delete process.env.NAKAMA_ERROR_TRACKING_DSN;
+  delete process.env.DO_NOT_TRACK;
+  resetErrorTrackingConfigCache();
+});
+
+afterEach(async () => {
+  if (previousConfigDir === undefined) {
+    delete process.env.NAKAMA_CONFIG_DIR;
+  } else {
+    process.env.NAKAMA_CONFIG_DIR = previousConfigDir;
+  }
+
+  delete process.env.NAKAMA_ERROR_TRACKING_DSN;
+  delete process.env.DO_NOT_TRACK;
+  resetErrorTrackingConfigCache();
+  await rm(configDir, { force: true, recursive: true });
+});
+
+test("an install with no config file reports nothing", async () => {
+  expect(await loadErrorTrackingConfig()).toEqual({ dsn: null });
+  expect(await isErrorTrackingEnabled()).toBe(false);
+});
+
+test("a saved DSN round trips and enables reporting", async () => {
+  await saveErrorTrackingDsn(DSN);
+
+  expect(await loadErrorTrackingConfig()).toEqual({ dsn: DSN });
+  expect(await isErrorTrackingEnabled()).toBe(true);
+});
+
+test("the config file is written private, and readable as ini", async () => {
+  await saveErrorTrackingDsn(DSN);
+
+  const path = getErrorTrackingConfigPath();
+  expect(await readFile(path, "utf8")).toContain(`dsn=${DSN}`);
+  expect((await stat(path)).mode.toString(8).slice(-3)).toBe("600");
+});
+
+test("clearing the DSN leaves the file with no dsn line", async () => {
+  await saveErrorTrackingDsn(DSN);
+  await saveErrorTrackingDsn(null);
+
+  expect(await loadErrorTrackingConfig()).toEqual({ dsn: null });
+  expect(await readFile(getErrorTrackingConfigPath(), "utf8")).not.toContain(
+    "dsn="
+  );
+});
+
+test("DO_NOT_TRACK beats a stored DSN", () => {
+  expect(
+    resolveErrorTrackingDsn({ dsn: DSN }, { DO_NOT_TRACK: "1" })
+  ).toBeNull();
+  expect(
+    resolveErrorTrackingDsn({ dsn: DSN }, { DO_NOT_TRACK: "true" })
+  ).toBeNull();
+  expect(resolveErrorTrackingDsn({ dsn: DSN }, { DO_NOT_TRACK: "0" })).toBe(
+    DSN
+  );
+});
+
+test("the env DSN overrides the file, and an empty one means off", () => {
+  const env = { NAKAMA_ERROR_TRACKING_DSN: "https://other@example.com/9" };
+  expect(resolveErrorTrackingDsn({ dsn: DSN }, env)).toBe(
+    "https://other@example.com/9"
+  );
+  expect(
+    resolveErrorTrackingDsn({ dsn: DSN }, { NAKAMA_ERROR_TRACKING_DSN: "" })
+  ).toBeNull();
+});
+
+test("saving refreshes the cache, so a new DSN needs no restart", async () => {
+  expect(await isErrorTrackingEnabled()).toBe(false);
+  await saveErrorTrackingDsn(DSN);
+  expect(await isErrorTrackingEnabled()).toBe(true);
+});

--- a/packages/core/src/error-tracking-config.ts
+++ b/packages/core/src/error-tracking-config.ts
@@ -6,7 +6,7 @@ export interface ErrorTrackingConfig {
   dsn: string | null;
 }
 
-const TRUTHY = new Set(["1", "true", "on", "yes"]);
+const TRUTHY = ["1", "true", "on", "yes"];
 
 export function getErrorTrackingConfigDir(): string {
   return join(getUserConfigDir(), "error-tracking");
@@ -35,7 +35,7 @@ export function resolveErrorTrackingDsn(
   file: ErrorTrackingConfig,
   env: Record<string, string | undefined> = process.env
 ): string | null {
-  if (TRUTHY.has(env.DO_NOT_TRACK?.trim().toLowerCase() ?? "")) {
+  if (TRUTHY.includes(env.DO_NOT_TRACK?.trim().toLowerCase() ?? "")) {
     return null;
   }
 
@@ -65,31 +65,11 @@ export async function saveErrorTrackingDsn(
   await writeTextFile(getErrorTrackingConfigPath(), lines.join("\n"), {
     ensureDir: getErrorTrackingConfigDir(),
   });
-  resetErrorTrackingConfigCache();
   return next;
 }
 
-let cached: Promise<ErrorTrackingConfig> | null = null;
-
-export function resetErrorTrackingConfigCache(): void {
-  cached = null;
-}
-
-/**
- * Read per send rather than once at startup, so a DSN saved from the Integrations tab
- * takes effect without a restart. Crashes are rare enough that the cached read is free.
- */
-export async function loadCachedErrorTrackingConfig(): Promise<ErrorTrackingConfig> {
-  cached ??= loadErrorTrackingConfig();
-  return cached;
-}
-
 export async function currentErrorTrackingDsn(): Promise<string | null> {
-  try {
-    return resolveErrorTrackingDsn(await loadCachedErrorTrackingConfig());
-  } catch {
-    return null;
-  }
+  return resolveErrorTrackingDsn(await loadErrorTrackingConfig());
 }
 
 export async function isErrorTrackingEnabled(): Promise<boolean> {

--- a/packages/core/src/error-tracking-config.ts
+++ b/packages/core/src/error-tracking-config.ts
@@ -1,0 +1,97 @@
+import { join } from "node:path";
+import { parseIni, readTextOrNull, writeTextFile } from "./fs";
+import { getUserConfigDir } from "./user-config";
+
+export interface ErrorTrackingConfig {
+  dsn: string | null;
+}
+
+const TRUTHY = new Set(["1", "true", "on", "yes"]);
+
+export function getErrorTrackingConfigDir(): string {
+  return join(getUserConfigDir(), "error-tracking");
+}
+
+export function getErrorTrackingConfigPath(): string {
+  return join(getErrorTrackingConfigDir(), "config.ini");
+}
+
+export async function loadErrorTrackingConfig(): Promise<ErrorTrackingConfig> {
+  const raw = await readTextOrNull(getErrorTrackingConfigPath());
+
+  if (raw === null) {
+    return { dsn: null };
+  }
+
+  return { dsn: parseIni(raw).dsn?.trim() || null };
+}
+
+/**
+ * Every caller routes through here, so DO_NOT_TRACK cannot be forgotten at one call
+ * site. It is the cross-tool convention and beats a stored DSN rather than the other
+ * way round: an operator who sets it wants nothing leaving the box.
+ */
+export function resolveErrorTrackingDsn(
+  file: ErrorTrackingConfig,
+  env: Record<string, string | undefined> = process.env
+): string | null {
+  if (TRUTHY.has(env.DO_NOT_TRACK?.trim().toLowerCase() ?? "")) {
+    return null;
+  }
+
+  // Set but empty means off. Falling through to the stored value would make
+  // NAKAMA_ERROR_TRACKING_DSN="" keep delivering, the opposite of what it asks for.
+  const fromEnv = env.NAKAMA_ERROR_TRACKING_DSN;
+
+  if (fromEnv !== undefined) {
+    return fromEnv.trim() || null;
+  }
+
+  return file.dsn;
+}
+
+export async function saveErrorTrackingDsn(
+  dsn: string | null
+): Promise<ErrorTrackingConfig> {
+  const next: ErrorTrackingConfig = { dsn: dsn?.trim() || null };
+  const lines = [
+    "# Nakama error tracking",
+    "# dsn = a Sentry-compatible DSN (Sentry, GlitchTip, Bugsink, self-hosted).",
+    "# Empty or missing sends nothing. DO_NOT_TRACK=1 overrides this file.",
+    ...(next.dsn ? [`dsn=${next.dsn}`] : []),
+    "",
+  ];
+
+  await writeTextFile(getErrorTrackingConfigPath(), lines.join("\n"), {
+    ensureDir: getErrorTrackingConfigDir(),
+  });
+  resetErrorTrackingConfigCache();
+  return next;
+}
+
+let cached: Promise<ErrorTrackingConfig> | null = null;
+
+export function resetErrorTrackingConfigCache(): void {
+  cached = null;
+}
+
+/**
+ * Read per send rather than once at startup, so a DSN saved from the Integrations tab
+ * takes effect without a restart. Crashes are rare enough that the cached read is free.
+ */
+export async function loadCachedErrorTrackingConfig(): Promise<ErrorTrackingConfig> {
+  cached ??= loadErrorTrackingConfig();
+  return cached;
+}
+
+export async function currentErrorTrackingDsn(): Promise<string | null> {
+  try {
+    return resolveErrorTrackingDsn(await loadCachedErrorTrackingConfig());
+  } catch {
+    return null;
+  }
+}
+
+export async function isErrorTrackingEnabled(): Promise<boolean> {
+  return (await currentErrorTrackingDsn()) !== null;
+}

--- a/packages/core/src/error-tracking-queue.ts
+++ b/packages/core/src/error-tracking-queue.ts
@@ -1,0 +1,62 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ErrorReport } from "./error-tracking";
+import { getErrorTrackingConfigDir } from "./error-tracking-config";
+import { PRIVATE_DIR_MODE, PRIVATE_FILE_MODE } from "./fs";
+
+/**
+ * An uncaught exception kills the process before any async send can finish, so the
+ * report is written here synchronously and delivered by whichever process starts next.
+ * Measured, not assumed: with uncaughtExceptionMonitor even the "exit" handler does not
+ * run, while a writeFileSync inside the monitor completes.
+ *
+ * A send that fails for any other reason leaves its entry behind too, so the queue
+ * doubles as the retry.
+ */
+export const MAX_PENDING_ERROR_REPORTS = 5;
+
+export function getPendingErrorReportsPath(): string {
+  return join(getErrorTrackingConfigDir(), "pending.json");
+}
+
+export function readPendingErrorReports(): ErrorReport[] {
+  try {
+    const parsed: unknown = JSON.parse(
+      readFileSync(getPendingErrorReportsPath(), "utf8")
+    );
+    return Array.isArray(parsed) ? (parsed as ErrorReport[]) : [];
+  } catch {
+    // Missing, unreadable or corrupt all mean the same thing: nothing to deliver.
+    return [];
+  }
+}
+
+function write(reports: ErrorReport[]): void {
+  mkdirSync(getErrorTrackingConfigDir(), {
+    mode: PRIVATE_DIR_MODE,
+    recursive: true,
+  });
+  writeFileSync(getPendingErrorReportsPath(), JSON.stringify(reports), {
+    mode: PRIVATE_FILE_MODE,
+  });
+}
+
+/** Synchronous on purpose. See the note above. */
+export function appendPendingErrorReport(report: ErrorReport): void {
+  try {
+    write(
+      [...readPendingErrorReports(), report].slice(-MAX_PENDING_ERROR_REPORTS)
+    );
+  } catch {
+    // A full or read-only config dir must not turn one crash into two.
+  }
+}
+
+export function removePendingErrorReport(id: string): void {
+  try {
+    write(readPendingErrorReports().filter((report) => report.id !== id));
+  } catch {
+    // Worst case the report is delivered twice, and the event id collapses it at the
+    // ingest. That is strictly better than failing here.
+  }
+}

--- a/packages/core/src/error-tracking-scrub.test.ts
+++ b/packages/core/src/error-tracking-scrub.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+import { homedir } from "node:os";
+import { scrubText } from "./error-tracking-scrub";
+
+/**
+ * These assert the negative side: given a payload that carries real secrets, none of
+ * them may survive. A crash report leaves the user's machine and carries their org's
+ * data, so a regression here is a third-party data incident, not a telemetry bug.
+ */
+describe("scrubText removes credentials", () => {
+  const cases: Array<[string, string]> = [
+    [
+      "anthropic key",
+      "failed with sk-ant-api03-abcdefghijklmnopqrstuvwxyz012345",
+    ],
+    ["openai key", "Authorization header sk-proj-AAAABBBBCCCCDDDDEEEEFFFF"],
+    ["github token", "clone failed ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"],
+    ["slack token", "post failed xoxb-1234567890-ABCDEFGHIJKL"],
+    ["aws key id", "denied for AKIAIOSFODNN7EXAMPLE"],
+    [
+      "bearer header",
+      "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+    ],
+    ["assignment", 'connect({ apiKey: "hunter2secretvalue" })'],
+    ["env style", "ANTHROPIC_TOKEN=abcd1234efgh5678"],
+  ];
+
+  for (const [name, input] of cases) {
+    test(name, () => {
+      const scrubbed = scrubText(input);
+
+      expect(scrubbed).not.toContain(
+        "sk-ant-api03-abcdefghijklmnopqrstuvwxyz012345"
+      );
+      expect(scrubbed).not.toContain("sk-proj-AAAABBBBCCCCDDDDEEEEFFFF");
+      expect(scrubbed).not.toContain(
+        "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+      );
+      expect(scrubbed).not.toContain("xoxb-1234567890-ABCDEFGHIJKL");
+      expect(scrubbed).not.toContain("AKIAIOSFODNN7EXAMPLE");
+      expect(scrubbed).not.toContain("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9");
+      expect(scrubbed).not.toContain("hunter2secretvalue");
+      expect(scrubbed).not.toContain("abcd1234efgh5678");
+    });
+  }
+});
+
+test("scrubText removes email addresses", () => {
+  const scrubbed = scrubText("owner alice@example.com could not be notified");
+
+  expect(scrubbed).not.toContain("alice@example.com");
+  expect(scrubbed).toContain("<email>");
+});
+
+test("scrubText replaces the home directory with a tilde", () => {
+  const scrubbed = scrubText(`ENOENT at ${homedir()}/.nakama/config.ini`);
+
+  expect(scrubbed).not.toContain(homedir());
+  expect(scrubbed).toContain("~/.nakama/config.ini");
+});
+
+test("scrubText replaces home paths belonging to another user", () => {
+  const scrubbed = scrubText(
+    "read failed: /Users/someoneelse/.nakama/orgs/a.db"
+  );
+
+  expect(scrubbed).not.toContain("someoneelse");
+  expect(scrubbed).toContain("~/.nakama/orgs/a.db");
+});
+
+test("scrubText keeps the diagnostic parts of a stack frame", () => {
+  const scrubbed = scrubText(
+    "TypeError: cannot read tools at resolveTools (~/src/a.ts:12:3)"
+  );
+
+  expect(scrubbed).toContain("TypeError");
+  expect(scrubbed).toContain("resolveTools");
+  expect(scrubbed).toContain("a.ts:12:3");
+});
+
+describe("scrubText removes the data an error message quotes back", () => {
+  test("a printed JSON payload does not survive", () => {
+    const scrubbed = scrubText(
+      'Unexpected token in {"name":"Budi","email":"budi@klinik.example","age":34}'
+    );
+
+    expect(scrubbed).not.toContain("Budi");
+    expect(scrubbed).not.toContain("klinik");
+    expect(scrubbed).toContain("Unexpected token in");
+  });
+
+  test("a nested payload does not survive either", () => {
+    const scrubbed = scrubText(
+      'failed on {"patient":{"name":"Budi","room":"A1"}}'
+    );
+
+    expect(scrubbed).not.toContain("Budi");
+    expect(scrubbed).not.toContain("A1");
+  });
+
+  test("a rejected value in double quotes does not survive", () => {
+    const scrubbed = scrubText('Invalid value "Budi" for field name');
+
+    expect(scrubbed).not.toContain("Budi");
+    expect(scrubbed).toContain("for field name");
+  });
+
+  test("a printed row does not survive", () => {
+    const scrubbed = scrubText("constraint failed for ['Budi', 34, 'jakarta']");
+
+    expect(scrubbed).not.toContain("Budi");
+    expect(scrubbed).not.toContain("jakarta");
+  });
+
+  test("single-quoted identifiers stay readable, which is the whole trade", () => {
+    expect(scrubText("Cannot find module 'error-tracking'")).toContain(
+      "'error-tracking'"
+    );
+    expect(
+      scrubText("Cannot read property 'sessionId' of undefined")
+    ).toContain("'sessionId'");
+  });
+
+  test("an apostrophe in prose is not treated as a quote", () => {
+    const scrubbed = scrubText("the worker didn't start and it's still down");
+
+    expect(scrubbed).toBe("the worker didn't start and it's still down");
+  });
+});
+
+test("scrubText truncates runaway text", () => {
+  const scrubbed = scrubText("x".repeat(10_000));
+
+  expect(scrubbed.length).toBeLessThanOrEqual(4001);
+});

--- a/packages/core/src/error-tracking-scrub.ts
+++ b/packages/core/src/error-tracking-scrub.ts
@@ -40,8 +40,7 @@ function redactQuotedPayloads(value: string): string {
 
   // Braces and brackets in an error message are a printed data structure, not prose.
   // Looped because the inner-most match has to collapse before the one wrapping it.
-  // ponytail: four passes, so nesting deeper than that collapses only partially.
-  for (let pass = 0; pass < 4; pass += 1) {
+  while (true) {
     const next = out
       .replace(/\{[^{}]*\}/g, "<redacted>")
       .replace(/\[[^[\]]*\]/g, "<redacted>");

--- a/packages/core/src/error-tracking-scrub.ts
+++ b/packages/core/src/error-tracking-scrub.ts
@@ -1,0 +1,84 @@
+import { homedir } from "node:os";
+
+const MAX_TEXT_LENGTH = 4000;
+
+const SECRET_PATTERNS: Array<[RegExp, string]> = [
+  [/\bBearer\s+[A-Za-z0-9._~+/-]{8,}={0,2}/gi, "Bearer <redacted>"],
+  [/\bsk-[A-Za-z0-9_-]{8,}/g, "<redacted-key>"],
+  [/\bgh[pousr]_[A-Za-z0-9]{16,}/g, "<redacted-key>"],
+  [/\bxox[baprs]-[A-Za-z0-9-]{8,}/g, "<redacted-key>"],
+  [/\bAKIA[0-9A-Z]{16}\b/g, "<redacted-key>"],
+  // The leading [A-Za-z0-9_]* matters: \b would not match inside ANTHROPIC_TOKEN or
+  // MY_API_KEY, which is exactly how these arrive from env-var names.
+  [
+    /([A-Za-z0-9_]*(?:api[_-]?key|apikey|token|secret|passwd|password|authorization|credential))(["']?\s*[:=]\s*["']?)([^\s"',;)}]{3,})/gi,
+    "$1$2<redacted>",
+  ],
+  [/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, "<email>"],
+  // Catch-all for opaque credentials no named pattern above knows about. 32 is above
+  // any realistic identifier in a stack frame and below nanoid(32)-style tokens.
+  [/\b[A-Za-z0-9_-]{32,}\b/g, "<redacted-token>"],
+];
+
+const HOME_PATH_PATTERNS: RegExp[] = [
+  /\/(?:Users|home)\/[^/\s:"']+/g,
+  /[A-Za-z]:\\Users\\[^\\\s:"']+/g,
+];
+
+/**
+ * Error messages quote the data that caused them. A JSON.parse failure prints the
+ * payload, a validation error prints the rejected value, a driver error prints the row.
+ * None of that is a credential, so the patterns above miss all of it.
+ *
+ * The line drawn here is double quotes get redacted and single quotes do not. JSON and
+ * printed data use double quotes; JavaScript error messages use single quotes for
+ * identifiers ("Cannot find module 'x'", "property 'y' of undefined"), which stay
+ * readable. It costs some detail on double-quoted identifiers, and that is the trade.
+ */
+function redactQuotedPayloads(value: string): string {
+  let out = value.replace(/"[^"\n]*"/g, '"<redacted>"');
+
+  // Braces and brackets in an error message are a printed data structure, not prose.
+  // Looped because the inner-most match has to collapse before the one wrapping it.
+  // ponytail: four passes, so nesting deeper than that collapses only partially.
+  for (let pass = 0; pass < 4; pass += 1) {
+    const next = out
+      .replace(/\{[^{}]*\}/g, "<redacted>")
+      .replace(/\[[^[\]]*\]/g, "<redacted>");
+
+    if (next === out) {
+      break;
+    }
+
+    out = next;
+  }
+
+  return out;
+}
+
+export function scrubText(value: string): string {
+  if (!value) {
+    return "";
+  }
+
+  let out = value;
+  const home = homedir();
+
+  if (home && home !== "/") {
+    out = out.split(home).join("~");
+  }
+
+  for (const [pattern, replacement] of SECRET_PATTERNS) {
+    out = out.replace(pattern, replacement);
+  }
+
+  for (const pattern of HOME_PATH_PATTERNS) {
+    out = out.replace(pattern, "~");
+  }
+
+  out = redactQuotedPayloads(out);
+
+  return out.length > MAX_TEXT_LENGTH
+    ? `${out.slice(0, MAX_TEXT_LENGTH)}…`
+    : out;
+}

--- a/packages/core/src/error-tracking-sentry.test.ts
+++ b/packages/core/src/error-tracking-sentry.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
 import { hostname } from "node:os";
 import { buildErrorReport, type ErrorReport } from "./error-tracking";
-import { resetErrorTrackingConfigCache } from "./error-tracking-config";
 import {
   createErrorTrackingSink,
   parseSentryDsn,
@@ -13,7 +12,6 @@ let previousDsn: string | undefined;
 
 beforeEach(() => {
   previousDsn = process.env.NAKAMA_ERROR_TRACKING_DSN;
-  resetErrorTrackingConfigCache();
 });
 
 afterEach(() => {
@@ -22,8 +20,6 @@ afterEach(() => {
   } else {
     process.env.NAKAMA_ERROR_TRACKING_DSN = previousDsn;
   }
-
-  resetErrorTrackingConfigCache();
 });
 
 function sampleReport(): ErrorReport {
@@ -153,7 +149,6 @@ async function countSinkHits(env: Record<string, string>): Promise<number> {
       process.env[key] = value;
     }
 
-    resetErrorTrackingConfigCache();
     await createErrorTrackingSink()(sampleReport());
     return hits;
   } finally {
@@ -186,7 +181,6 @@ test("the sink delivers to the configured DSN", async () => {
 
   try {
     process.env.NAKAMA_ERROR_TRACKING_DSN = `http://k@${server.hostname}:${server.port}/1`;
-    resetErrorTrackingConfigCache();
 
     await createErrorTrackingSink()(sampleReport());
 

--- a/packages/core/src/error-tracking-sentry.test.ts
+++ b/packages/core/src/error-tracking-sentry.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { hostname } from "node:os";
+import { buildErrorReport, type ErrorReport } from "./error-tracking";
+import { resetErrorTrackingConfigCache } from "./error-tracking-config";
+import {
+  createErrorTrackingSink,
+  parseSentryDsn,
+  sendSentryEvent,
+  toSentryEvent,
+} from "./error-tracking-sentry";
+
+let previousDsn: string | undefined;
+
+beforeEach(() => {
+  previousDsn = process.env.NAKAMA_ERROR_TRACKING_DSN;
+  resetErrorTrackingConfigCache();
+});
+
+afterEach(() => {
+  if (previousDsn === undefined) {
+    delete process.env.NAKAMA_ERROR_TRACKING_DSN;
+  } else {
+    process.env.NAKAMA_ERROR_TRACKING_DSN = previousDsn;
+  }
+
+  resetErrorTrackingConfigCache();
+});
+
+function sampleReport(): ErrorReport {
+  return buildErrorReport(new Error("tool loop exceeded"), {
+    source: "server",
+  });
+}
+
+test("parseSentryDsn builds the store endpoint and key", () => {
+  expect(parseSentryDsn("https://abc123@errors.example.com/7")).toEqual({
+    endpoint: "https://errors.example.com/api/7/store/",
+    publicKey: "abc123",
+  });
+});
+
+test("parseSentryDsn keeps a path prefix for a subpath install", () => {
+  expect(parseSentryDsn("https://k@example.com/glitchtip/12")?.endpoint).toBe(
+    "https://example.com/glitchtip/api/12/store/"
+  );
+});
+
+test("parseSentryDsn rejects garbage rather than throwing", () => {
+  expect(parseSentryDsn("")).toBeNull();
+  expect(parseSentryDsn("not a url")).toBeNull();
+  expect(parseSentryDsn("https://example.com/7")).toBeNull();
+});
+
+test("the event forces our own fingerprint so grouping survives across installs", () => {
+  const report = sampleReport();
+  const event = toSentryEvent(report);
+
+  expect(event.fingerprint).toEqual([report.fingerprint]);
+});
+
+test("no user identity is sent", () => {
+  const event = toSentryEvent(sampleReport());
+
+  // Reports go to the operator's own project, so there is nobody to count installs
+  // for and nothing that needs a stable id attached to the event.
+  expect(event.user).toBeUndefined();
+});
+
+test("the event id is the report id, so a retry collapses into one event", () => {
+  const report = sampleReport();
+  const first = toSentryEvent(report);
+  const second = toSentryEvent(report);
+
+  expect(first.event_id).toBe(report.id.replace(/-/g, ""));
+  expect(second.event_id).toBe(first.event_id);
+});
+
+test("the event never carries the hostname", () => {
+  const event = toSentryEvent(sampleReport());
+
+  expect(event).not.toHaveProperty("server_name");
+  expect(JSON.stringify(event)).not.toContain(hostname());
+});
+
+test("a test event is sent at a lower level than a crash", () => {
+  const crash = toSentryEvent(
+    buildErrorReport(new Error("x"), { kind: "crash" })
+  );
+  const testEvent = toSentryEvent(
+    buildErrorReport(new Error("x"), { kind: "test" })
+  );
+
+  expect(crash.level).toBe("error");
+  expect(testEvent.level).toBe("info");
+});
+
+test("sendSentryEvent posts the event with the auth header the ingest expects", async () => {
+  let received: { auth: string | null; body: any; method: string } | null =
+    null;
+
+  const server = Bun.serve({
+    async fetch(request) {
+      received = {
+        auth: request.headers.get("x-sentry-auth"),
+        body: await request.json(),
+        method: request.method,
+      };
+      return new Response("{}", { status: 200 });
+    },
+    port: 0,
+  });
+
+  try {
+    const dsn = parseSentryDsn(
+      `http://pubkey@${server.hostname}:${server.port}/42`
+    );
+    const ok = await sendSentryEvent(dsn!, toSentryEvent(sampleReport()));
+
+    expect(ok).toBe(true);
+    expect(dsn?.endpoint).toBe(
+      `http://${server.hostname}:${server.port}/api/42/store/`
+    );
+    expect(received!.method).toBe("POST");
+    expect(received!.auth).toContain("sentry_version=7");
+    expect(received!.auth).toContain("sentry_key=pubkey");
+    expect(received!.body.exception.values[0].value).toBe("tool loop exceeded");
+  } finally {
+    server.stop(true);
+  }
+});
+
+test("sendSentryEvent reports failure instead of throwing when the ingest is down", async () => {
+  const dsn = parseSentryDsn("http://k@127.0.0.1:1/9");
+
+  expect(await sendSentryEvent(dsn!, {}, 200)).toBe(false);
+});
+
+async function countSinkHits(env: Record<string, string>): Promise<number> {
+  let hits = 0;
+
+  const server = Bun.serve({
+    fetch() {
+      hits += 1;
+      return new Response("{}", { status: 200 });
+    },
+    port: 0,
+  });
+
+  try {
+    process.env.NAKAMA_ERROR_TRACKING_DSN = `http://k@${server.hostname}:${server.port}/1`;
+
+    for (const [key, value] of Object.entries(env)) {
+      process.env[key] = value;
+    }
+
+    resetErrorTrackingConfigCache();
+    await createErrorTrackingSink()(sampleReport());
+    return hits;
+  } finally {
+    server.stop(true);
+
+    for (const key of Object.keys(env)) {
+      delete process.env[key];
+    }
+  }
+}
+
+test("the sink contacts nothing when no DSN is configured", async () => {
+  expect(await countSinkHits({ NAKAMA_ERROR_TRACKING_DSN: "" })).toBe(0);
+});
+
+test("the sink contacts nothing under DO_NOT_TRACK", async () => {
+  expect(await countSinkHits({ DO_NOT_TRACK: "1" })).toBe(0);
+});
+
+test("the sink delivers to the configured DSN", async () => {
+  let hits = 0;
+
+  const server = Bun.serve({
+    fetch() {
+      hits += 1;
+      return new Response("{}", { status: 200 });
+    },
+    port: 0,
+  });
+
+  try {
+    process.env.NAKAMA_ERROR_TRACKING_DSN = `http://k@${server.hostname}:${server.port}/1`;
+    resetErrorTrackingConfigCache();
+
+    await createErrorTrackingSink()(sampleReport());
+
+    expect(hits).toBe(1);
+  } finally {
+    server.stop(true);
+  }
+});

--- a/packages/core/src/error-tracking-sentry.ts
+++ b/packages/core/src/error-tracking-sentry.ts
@@ -5,7 +5,7 @@ import {
   setErrorSink,
 } from "./error-tracking";
 import {
-  loadCachedErrorTrackingConfig,
+  loadErrorTrackingConfig,
   resolveErrorTrackingDsn,
 } from "./error-tracking-config";
 
@@ -113,7 +113,7 @@ export async function sendSentryEvent(
  */
 export function createErrorTrackingSink(): ErrorSink {
   return async (report) => {
-    const config = await loadCachedErrorTrackingConfig();
+    const config = await loadErrorTrackingConfig();
     const dsn = parseSentryDsn(resolveErrorTrackingDsn(config) ?? "");
 
     if (!dsn) {

--- a/packages/core/src/error-tracking-sentry.ts
+++ b/packages/core/src/error-tracking-sentry.ts
@@ -1,0 +1,134 @@
+import {
+  type ErrorReport,
+  type ErrorSink,
+  refreshErrorTrackingEnabled,
+  setErrorSink,
+} from "./error-tracking";
+import {
+  loadCachedErrorTrackingConfig,
+  resolveErrorTrackingDsn,
+} from "./error-tracking-config";
+
+const SEND_TIMEOUT_MS = 3000;
+const SENTRY_CLIENT = "nakama/1";
+
+export interface SentryDsn {
+  endpoint: string;
+  publicKey: string;
+}
+
+/**
+ * One protocol covers Sentry, GlitchTip, Bugsink and self-hosted Sentry: they all accept
+ * the same store endpoint and X-Sentry-Auth header, so the operator picks the platform
+ * and nakama does not have to know which one it is talking to.
+ */
+export function parseSentryDsn(dsn: string): SentryDsn | null {
+  const trimmed = dsn.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  let url: URL;
+
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return null;
+  }
+
+  const publicKey = url.username;
+  const segments = url.pathname.split("/").filter(Boolean);
+  const projectId = segments.pop();
+
+  if (!(publicKey && projectId)) {
+    return null;
+  }
+
+  const prefix = segments.length > 0 ? `/${segments.join("/")}` : "";
+
+  return {
+    endpoint: `${url.protocol}//${url.host}${prefix}/api/${projectId}/store/`,
+    publicKey,
+  };
+}
+
+export function toSentryEvent(report: ErrorReport): Record<string, unknown> {
+  return {
+    contexts: {
+      os: { name: report.runtime.platform },
+      runtime: { name: "bun", version: report.runtime.bun },
+    },
+    // The report's own id, so the queued copy and the live send land as one event.
+    event_id: report.id.replace(/-/g, ""),
+    exception: {
+      values: [{ type: report.name, value: report.message }],
+    },
+    ...(report.stack ? { extra: { stack: report.stack } } : {}),
+    // Grouping is ours rather than the ingest's, so one bug stays one issue even when
+    // stack frames differ between installs.
+    fingerprint: [report.fingerprint],
+    level: report.kind === "test" ? "info" : "error",
+    logger: "nakama",
+    platform: "node",
+    tags: {
+      api_version: String(report.runtime.apiVersion),
+      arch: report.runtime.arch,
+      bun: report.runtime.bun,
+      kind: report.kind,
+      os: report.runtime.platform,
+      source: report.source,
+    },
+    timestamp: report.at,
+    // server_name is deliberately absent. Sentry defaults it to the hostname, which on
+    // a self-hosted install is often the operator's own machine or cluster name.
+  };
+}
+
+export async function sendSentryEvent(
+  dsn: SentryDsn,
+  event: Record<string, unknown>,
+  timeoutMs = SEND_TIMEOUT_MS
+): Promise<boolean> {
+  try {
+    const response = await fetch(dsn.endpoint, {
+      body: JSON.stringify(event),
+      headers: {
+        "Content-Type": "application/json",
+        "X-Sentry-Auth": `Sentry sentry_version=7, sentry_client=${SENTRY_CLIENT}, sentry_key=${dsn.publicKey}`,
+      },
+      method: "POST",
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolves the DSN per send, so saving one from the Integrations tab starts delivery
+ * without a restart and clearing it stops delivery just as fast.
+ */
+export function createErrorTrackingSink(): ErrorSink {
+  return async (report) => {
+    const config = await loadCachedErrorTrackingConfig();
+    const dsn = parseSentryDsn(resolveErrorTrackingDsn(config) ?? "");
+
+    if (!dsn) {
+      return false;
+    }
+
+    return await sendSentryEvent(dsn, toSentryEvent(report));
+  };
+}
+
+/**
+ * Refreshes the enabled flag as part of installing, so the sink and the flag can
+ * never disagree about whether the integration is on.
+ */
+export async function installErrorTrackingSink(): Promise<void> {
+  setErrorSink(createErrorTrackingSink());
+  await refreshErrorTrackingEnabled();
+}

--- a/packages/core/src/error-tracking.test.ts
+++ b/packages/core/src/error-tracking.test.ts
@@ -1,0 +1,268 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildErrorReport,
+  type ErrorReport,
+  fingerprintError,
+  flushPendingErrorReports,
+  refreshErrorTrackingEnabled,
+  reportError,
+  setErrorSink,
+} from "./error-tracking";
+import {
+  resetErrorTrackingConfigCache,
+  saveErrorTrackingDsn,
+} from "./error-tracking-config";
+import {
+  getPendingErrorReportsPath,
+  MAX_PENDING_ERROR_REPORTS,
+  readPendingErrorReports,
+} from "./error-tracking-queue";
+
+const DSN = "https://key@errors.example.com/7";
+
+let configDir = "";
+let previousConfigDir: string | undefined;
+// reportError logs straight to console.error, so the capture lives here in the
+// test rather than as an injection point in the module under test.
+let consoleErrorCalls: unknown[][] = [];
+const realConsoleError = console.error;
+
+beforeEach(async () => {
+  previousConfigDir = process.env.NAKAMA_CONFIG_DIR;
+  configDir = await mkdtemp(join(tmpdir(), "nakama-error-tracking-"));
+  process.env.NAKAMA_CONFIG_DIR = configDir;
+  delete process.env.NAKAMA_ERROR_TRACKING_DSN;
+  delete process.env.DO_NOT_TRACK;
+  resetErrorTrackingConfigCache();
+  await saveErrorTrackingDsn(DSN);
+  await refreshErrorTrackingEnabled();
+  consoleErrorCalls = [];
+  console.error = (...args: unknown[]) => {
+    consoleErrorCalls.push(args);
+  };
+});
+
+afterEach(async () => {
+  if (previousConfigDir === undefined) {
+    delete process.env.NAKAMA_CONFIG_DIR;
+  } else {
+    process.env.NAKAMA_CONFIG_DIR = previousConfigDir;
+  }
+
+  delete process.env.NAKAMA_ERROR_TRACKING_DSN;
+  delete process.env.DO_NOT_TRACK;
+  resetErrorTrackingConfigCache();
+  await refreshErrorTrackingEnabled();
+  console.error = realConsoleError;
+  setErrorSink(null);
+  await rm(configDir, { force: true, recursive: true });
+});
+
+test("the same bug fingerprints the same across ids and line numbers", () => {
+  const first = fingerprintError(
+    "TypeError",
+    "profile prof_01JABCDEF23 not found",
+    "TypeError\n    at resolveProfile (~/src/profiles.ts:12:3)"
+  );
+  const second = fingerprintError(
+    "TypeError",
+    "profile prof_01JXYZGHI45 not found",
+    "TypeError\n    at resolveProfile (~/src/profiles.ts:48:9)"
+  );
+
+  expect(first).toBe(second);
+});
+
+test("a uuid in the message does not fragment the fingerprint", () => {
+  const stack = "Error\n    at runAutomation (~/src/automation.ts:20:5)";
+  const first = fingerprintError(
+    "Error",
+    "run 3f2504e0-4f89-11d3-9a0c-0305e82c3301 timed out after 30000ms",
+    stack
+  );
+  const second = fingerprintError(
+    "Error",
+    "run 7c9e6679-7425-40de-944b-e07fc1f90ae7 timed out after 45000ms",
+    stack
+  );
+
+  expect(first).toBe(second);
+});
+
+test("different bugs fingerprint differently", () => {
+  const first = fingerprintError(
+    "TypeError",
+    "a is undefined",
+    "TypeError\n    at a (~/a.ts:1:1)"
+  );
+  const second = fingerprintError(
+    "RangeError",
+    "b is out of range",
+    "RangeError\n    at b (~/b.ts:1:1)"
+  );
+
+  expect(first).not.toBe(second);
+});
+
+test("the report scrubs the message and stack", () => {
+  const error = new Error(
+    "auth failed with sk-ant-api03-abcdefghijklmnopqrstuvwxyz012345"
+  );
+  const report = buildErrorReport(error, { source: "server" });
+
+  expect(report.message).not.toContain("sk-ant-api03");
+  expect(report.name).toBe("Error");
+  expect(report.runtime.bun).toBe(Bun.version);
+});
+
+test("a non-Error rejection still produces a report", () => {
+  const report = buildErrorReport("plain string failure", {
+    source: "worker:discord",
+  });
+
+  expect(report.name).toBe("NonError");
+  expect(report.message).toBe("plain string failure");
+  expect(report.fingerprint).toHaveLength(16);
+});
+
+test("with no sink installed nothing is queued and nothing is sent", async () => {
+  setErrorSink(null);
+
+  await reportError(new Error("boom"), { source: "server" });
+
+  expect(readPendingErrorReports()).toHaveLength(0);
+});
+
+test("the sink receives the report", async () => {
+  const delivered: ErrorReport[] = [];
+  setErrorSink((report) => {
+    delivered.push(report);
+  });
+
+  await reportError(new Error("boom"), { source: "server" });
+  await Bun.sleep(5);
+
+  expect(delivered).toHaveLength(1);
+  expect(delivered[0]?.kind).toBe("crash");
+});
+
+test("a delivered report is dropped from the queue", async () => {
+  setErrorSink(() => true);
+
+  await reportError(new Error("boom"), { source: "server" });
+
+  expect(readPendingErrorReports()).toHaveLength(0);
+});
+
+test("a report the sink could not deliver stays queued for the next start", async () => {
+  setErrorSink(() => {
+    throw new Error("ingest down");
+  });
+
+  const report = await reportError(new Error("boom"), { source: "server" });
+  const queued = readPendingErrorReports();
+
+  expect(queued).toHaveLength(1);
+  expect(queued[0]?.id).toBe(report.id);
+});
+
+test("the queue is written before the send, which is what survives a hard exit", async () => {
+  // An uncaught exception kills the process mid-send, so the write has to have
+  // happened by the time the sink is first entered.
+  let queuedWhenSinkRan = 0;
+  setErrorSink(() => {
+    queuedWhenSinkRan = readPendingErrorReports().length;
+  });
+
+  await reportError(new Error("boom"), { source: "server" });
+
+  expect(queuedWhenSinkRan).toBe(1);
+});
+
+test("flushPendingErrorReports drains what the last process left behind", async () => {
+  setErrorSink(() => {
+    throw new Error("ingest down");
+  });
+  await reportError(new Error("boom"), { source: "server" });
+  expect(readPendingErrorReports()).toHaveLength(1);
+
+  const delivered: ErrorReport[] = [];
+  setErrorSink((report) => {
+    delivered.push(report);
+    return true;
+  });
+
+  expect(await flushPendingErrorReports()).toBe(1);
+  expect(delivered).toHaveLength(1);
+  expect(readPendingErrorReports()).toHaveLength(0);
+});
+
+test("the queue keeps the most recent reports and stops growing", async () => {
+  setErrorSink(() => {
+    throw new Error("ingest down");
+  });
+
+  for (let i = 0; i < MAX_PENDING_ERROR_REPORTS + 3; i += 1) {
+    await reportError(new Error(`boom ${i}`), { source: "server" });
+  }
+
+  const queued = readPendingErrorReports();
+  expect(queued).toHaveLength(MAX_PENDING_ERROR_REPORTS);
+  expect(queued.at(-1)?.message).toContain(
+    `boom ${MAX_PENDING_ERROR_REPORTS + 2}`
+  );
+});
+
+test("with no DSN configured the queue file is never created", async () => {
+  // Asserting an empty queue would pass for the wrong reason: the report gets
+  // written and then removed. The file must not appear at all.
+  await saveErrorTrackingDsn(null);
+  await refreshErrorTrackingEnabled();
+  setErrorSink(() => true);
+
+  await reportError(new Error("boom"), { source: "server" });
+
+  expect(existsSync(getPendingErrorReportsPath())).toBe(false);
+});
+
+test("a sink that did not deliver leaves the report queued", async () => {
+  // A sink returns false when it had nowhere to send. That must not look like
+  // success, or the report is dropped and counted as delivered.
+  setErrorSink(() => false);
+
+  await reportError(new Error("boom"), { source: "server" });
+  expect(readPendingErrorReports()).toHaveLength(1);
+
+  expect(await flushPendingErrorReports()).toBe(0);
+  expect(readPendingErrorReports()).toHaveLength(1);
+});
+
+test("a corrupt queue file reads as empty rather than throwing", async () => {
+  await writeFile(getPendingErrorReportsPath(), "{not json", "utf8");
+
+  expect(readPendingErrorReports()).toHaveLength(0);
+});
+
+test("a sink that throws never surfaces to the caller", async () => {
+  setErrorSink(() => {
+    throw new Error("sink is down");
+  });
+
+  await expect(
+    reportError(new Error("boom"), { source: "server" })
+  ).resolves.toBeDefined();
+  await Bun.sleep(5);
+});
+
+test("the local log always runs, configured or not", async () => {
+  await reportError(new Error("boom"), { source: "cli" });
+
+  expect(consoleErrorCalls).toHaveLength(1);
+  expect(consoleErrorCalls[0]?.[0]).toMatch(
+    /^\[nakama:crash\] cli [0-9a-f]{16}$/
+  );
+});

--- a/packages/core/src/error-tracking.test.ts
+++ b/packages/core/src/error-tracking.test.ts
@@ -12,10 +12,7 @@ import {
   reportError,
   setErrorSink,
 } from "./error-tracking";
-import {
-  resetErrorTrackingConfigCache,
-  saveErrorTrackingDsn,
-} from "./error-tracking-config";
+import { saveErrorTrackingDsn } from "./error-tracking-config";
 import {
   getPendingErrorReportsPath,
   MAX_PENDING_ERROR_REPORTS,
@@ -37,7 +34,6 @@ beforeEach(async () => {
   process.env.NAKAMA_CONFIG_DIR = configDir;
   delete process.env.NAKAMA_ERROR_TRACKING_DSN;
   delete process.env.DO_NOT_TRACK;
-  resetErrorTrackingConfigCache();
   await saveErrorTrackingDsn(DSN);
   await refreshErrorTrackingEnabled();
   consoleErrorCalls = [];
@@ -55,7 +51,6 @@ afterEach(async () => {
 
   delete process.env.NAKAMA_ERROR_TRACKING_DSN;
   delete process.env.DO_NOT_TRACK;
-  resetErrorTrackingConfigCache();
   await refreshErrorTrackingEnabled();
   console.error = realConsoleError;
   setErrorSink(null);

--- a/packages/core/src/error-tracking.ts
+++ b/packages/core/src/error-tracking.ts
@@ -1,0 +1,283 @@
+import { createHash, randomUUID } from "node:crypto";
+import { NAKAMA_API_VERSION } from "./contract";
+import { isErrorTrackingEnabled } from "./error-tracking-config";
+import {
+  appendPendingErrorReport,
+  readPendingErrorReports,
+  removePendingErrorReport,
+} from "./error-tracking-queue";
+import { scrubText } from "./error-tracking-scrub";
+
+/**
+ * "test" is the event the Integrations tab sends to prove a DSN works. It rides the
+ * same pipeline so the operator is checking the real path, and carries a lower level
+ * at the ingest so it never sits in a triage queue next to real crashes.
+ */
+export type ErrorReportKind = "crash" | "test";
+
+export interface ErrorReport {
+  at: string;
+  fingerprint: string;
+  /** Doubles as the Sentry event id, so a report delivered twice collapses into one. */
+  id: string;
+  kind: ErrorReportKind;
+  message: string;
+  name: string;
+  runtime: { apiVersion: number; bun: string; platform: string; arch: string };
+  source: string;
+  stack?: string;
+}
+
+/**
+ * Returns whether the report actually reached the ingest. A sink with nowhere to
+ * send returns false rather than resolving quietly, so "not delivered" can never
+ * be mistaken for success and drop the report off the queue.
+ */
+export type ErrorSink = (report: ErrorReport) => boolean | Promise<boolean>;
+
+let enabled = false;
+
+/**
+ * Cached so reportError can decide synchronously, before it writes anything, whether
+ * the integration is on. Refreshed at startup and whenever the DSN is saved, so
+ * turning it on does not need a restart.
+ */
+export async function refreshErrorTrackingEnabled(): Promise<boolean> {
+  enabled = await isErrorTrackingEnabled();
+  return enabled;
+}
+
+function normalizeMessage(message: string): string {
+  return (
+    message
+      .replace(
+        /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi,
+        "<uuid>"
+      )
+      // Mixed letter-and-digit runs are nakama ids (prof_01J..., nanoid). Leaving them in
+      // gives every occurrence its own fingerprint, which is the one failure mode that
+      // makes deduplication useless. Over-merging is the safer direction: name and top
+      // frame still keep genuinely different bugs apart.
+      .replace(
+        /\b(?=[A-Za-z0-9_-]*\d)(?=[A-Za-z0-9_-]*[A-Za-z])[A-Za-z0-9_-]{8,}\b/g,
+        "<id>"
+      )
+      .replace(/'[^']*'|"[^"]*"/g, "<str>")
+      // Not \b\d+\b: there is no word boundary inside "30000ms", and timeout messages
+      // are the most common place a varying number shows up.
+      .replace(/\d+/g, "<n>")
+      .replace(/\s+/g, " ")
+      .trim()
+  );
+}
+
+/**
+ * Line and column are deliberately dropped. Keeping them splits one bug into a new
+ * fingerprint on every release that shifts the file, which defeats deduplication.
+ */
+function topApplicationFrame(stack: string | undefined): string {
+  if (!stack) {
+    return "";
+  }
+
+  for (const line of stack.split("\n").slice(1)) {
+    const trimmed = line.trim();
+
+    if (!trimmed.startsWith("at ")) {
+      continue;
+    }
+
+    if (trimmed.includes("node_modules") || trimmed.includes("node:")) {
+      continue;
+    }
+
+    return trimmed.replace(/:\d+:\d+(\)?)$/, "$1").replace(/\s+/g, " ");
+  }
+
+  return "";
+}
+
+export function fingerprintError(
+  name: string,
+  message: string,
+  stack: string | undefined
+): string {
+  const parts = [name, normalizeMessage(message), topApplicationFrame(stack)];
+  return createHash("sha256")
+    .update(parts.join("|"))
+    .digest("hex")
+    .slice(0, 16);
+}
+
+function errorToParts(error: unknown): {
+  name: string;
+  message: string;
+  stack?: string;
+} {
+  if (error instanceof Error) {
+    return {
+      message: error.message || String(error),
+      name: error.name || "Error",
+      ...(error.stack ? { stack: error.stack } : {}),
+    };
+  }
+
+  if (typeof error === "string") {
+    return { message: error, name: "NonError" };
+  }
+
+  try {
+    return {
+      message: JSON.stringify(error) ?? String(error),
+      name: "NonError",
+    };
+  } catch {
+    return { message: String(error), name: "NonError" };
+  }
+}
+
+export interface ReportErrorOptions {
+  kind?: ErrorReportKind;
+  source?: string;
+}
+
+export function buildErrorReport(
+  error: unknown,
+  options: ReportErrorOptions = {}
+): ErrorReport {
+  const parts = errorToParts(error);
+  const stack = parts.stack ? scrubText(parts.stack) : undefined;
+
+  return {
+    fingerprint: fingerprintError(parts.name, parts.message, parts.stack),
+    id: randomUUID(),
+    kind: options.kind ?? "crash",
+    message: scrubText(parts.message),
+    name: parts.name,
+    ...(stack ? { stack } : {}),
+    at: new Date().toISOString(),
+    runtime: {
+      apiVersion: NAKAMA_API_VERSION,
+      arch: process.arch,
+      bun: Bun.version,
+      platform: process.platform,
+    },
+    source: options.source ?? "unknown",
+  };
+}
+
+let sink: ErrorSink | null = null;
+
+export function setErrorSink(next: ErrorSink | null): void {
+  sink = next;
+}
+
+/**
+ * Never throws. It does await the send, bounded by the sink's own timeout, because the
+ * unhandled-rejection handler has to know delivery finished before it exits. Everything
+ * up to and including the queue write happens synchronously, so a caller that does not
+ * await still leaves the report somewhere recoverable.
+ */
+export async function reportError(
+  error: unknown,
+  options: ReportErrorOptions = {}
+): Promise<ErrorReport> {
+  const report = buildErrorReport(error, options);
+
+  try {
+    // Unscrubbed on purpose: this never leaves the machine, and a redacted local log
+    // is useless to the person debugging their own install.
+    console.error(
+      `[nakama:${report.kind}] ${report.source} ${report.fingerprint}`,
+      error
+    );
+  } catch {
+    // A closed stderr must not turn one crash into two.
+  }
+
+  const currentSink = sink;
+
+  if (!(enabled && currentSink)) {
+    // Nothing configured to deliver to, so nothing is written anywhere either. The
+    // local log above is the whole behaviour when the integration is off.
+    return report;
+  }
+
+  // Queued before the send, not after it. An uncaught exception kills the process while
+  // the send is still in flight, and the queue is the only thing that survives that.
+  appendPendingErrorReport(report);
+
+  try {
+    if (await currentSink(report)) {
+      removePendingErrorReport(report.id);
+    }
+  } catch {
+    // Left queued for the next process to retry.
+  }
+
+  return report;
+}
+
+const installedSources = new Set<string>();
+
+/**
+ * Drains what the last process could not deliver. Call once at startup, after the sink
+ * is installed.
+ */
+export async function flushPendingErrorReports(): Promise<number> {
+  const currentSink = sink;
+
+  if (!currentSink) {
+    return 0;
+  }
+
+  let delivered = 0;
+
+  for (const report of readPendingErrorReports()) {
+    try {
+      if (await currentSink(report)) {
+        removePendingErrorReport(report.id);
+        delivered += 1;
+      }
+    } catch {
+      // Stays queued. Nothing else to try until the next start.
+    }
+  }
+
+  return delivered;
+}
+
+/**
+ * Uses uncaughtExceptionMonitor rather than uncaughtException: the monitor observes the
+ * error and leaves Bun's own crash-and-exit behaviour intact. Listening to
+ * uncaughtException would swallow the crash and leave a half-dead process behind.
+ *
+ * unhandledRejection has no monitor variant, and merely listening suppresses Bun's
+ * default exit(1), so the exit is re-applied by hand below.
+ */
+export function installErrorHandlers(source: string): () => void {
+  if (installedSources.has(source)) {
+    return () => {};
+  }
+
+  installedSources.add(source);
+
+  const onUncaught = (error: unknown) => {
+    void reportError(error, { source });
+  };
+
+  const onRejection = (reason: unknown) => {
+    void reportError(reason, { source }).finally(() => {
+      process.exit(1);
+    });
+  };
+
+  process.on("uncaughtExceptionMonitor", onUncaught);
+  process.on("unhandledRejection", onRejection);
+
+  return () => {
+    process.off("uncaughtExceptionMonitor", onUncaught);
+    process.off("unhandledRejection", onRejection);
+    installedSources.delete(source);
+  };
+}

--- a/packages/core/src/error-tracking.ts
+++ b/packages/core/src/error-tracking.ts
@@ -218,8 +218,6 @@ export async function reportError(
   return report;
 }
 
-const installedSources = new Set<string>();
-
 /**
  * Drains what the last process could not deliver. Call once at startup, after the sink
  * is installed.
@@ -256,12 +254,6 @@ export async function flushPendingErrorReports(): Promise<number> {
  * default exit(1), so the exit is re-applied by hand below.
  */
 export function installErrorHandlers(source: string): () => void {
-  if (installedSources.has(source)) {
-    return () => {};
-  }
-
-  installedSources.add(source);
-
   const onUncaught = (error: unknown) => {
     void reportError(error, { source });
   };
@@ -278,6 +270,5 @@ export function installErrorHandlers(source: string): () => void {
   return () => {
     process.off("uncaughtExceptionMonitor", onUncaught);
     process.off("unhandledRejection", onRejection);
-    installedSources.delete(source);
   };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,6 +67,10 @@ export {
 } from "./discord-worker";
 export * from "./document-content";
 export * from "./email-config";
+export * from "./error-tracking";
+export * from "./error-tracking-config";
+export * from "./error-tracking-queue";
+export * from "./error-tracking-sentry";
 export * from "./fetch-idle";
 export * from "./fs";
 export * from "./ids";


### PR DESCRIPTION
## Summary

Unlinked WhatsApp number gets messaged by a stranger → bot says nothing. No more "This number is not linked yet" reply.

**Before:** Unauthorized senders got a "generate a pairing code" prompt even when no pairing code was configured.
**After:** With no pairing code configured, the bot stays silent in private and group chats (`chat-handler.ts` unauthorized branch).

Why safe:
1. Pairing flow only runs when a pairing code exists — linked accounts unchanged
2. Existing group `LINK_IN_PRIVATE_REPLY` test still passes (it configures a pairing code)
3. Authorized users and `/help`, `/start`, `/org` paths are untouched

Only re-add the prompt if an unlinked account needs to onboard strangers over WhatsApp.

## Test plan
- [x] `bun test apps/platform/whatsapp/src/chat-handler.test.ts` (28 pass)
- [ ] Message an unlinked WhatsApp number from a new phone — no reply arrives
