### PR TITLE
fix(chat): allow agent turns to run for 24 hours

### DIFF
--- a/packages/core/src/chat-stream-timeout.test.ts
+++ b/packages/core/src/chat-stream-timeout.test.ts
@@ -1,9 +1,27 @@
 import { describe, expect, test } from "bun:test";
 import {
   DEFAULT_CHAT_FIRST_TOKEN_TIMEOUT_MS,
+  DEFAULT_CHAT_STREAM_TIMEOUT_MS,
+  MAX_CHAT_STREAM_TIMEOUT_MS,
   MIN_CHAT_FIRST_TOKEN_TIMEOUT_MS,
   resolveChatFirstTokenTimeoutMs,
+  resolveChatStreamTimeoutMs,
 } from "./chat-stream-timeout";
+
+describe("resolveChatStreamTimeoutMs", () => {
+  test("defaults to 24 hours and caps explicit values at 24 hours", () => {
+    const twentyFourHoursMs = 24 * 60 * 60 * 1000;
+
+    expect(resolveChatStreamTimeoutMs({})).toBe(twentyFourHoursMs);
+    expect(DEFAULT_CHAT_STREAM_TIMEOUT_MS).toBe(twentyFourHoursMs);
+    expect(MAX_CHAT_STREAM_TIMEOUT_MS).toBe(twentyFourHoursMs);
+    expect(
+      resolveChatStreamTimeoutMs({
+        NAKAMA_CHAT_STREAM_TIMEOUT_MS: String(twentyFourHoursMs + 1),
+      })
+    ).toBe(twentyFourHoursMs);
+  });
+});
 
 describe("resolveChatFirstTokenTimeoutMs", () => {
   test("falls back to the default when unset or unparseable", () => {

--- a/packages/core/src/chat-stream-timeout.ts
+++ b/packages/core/src/chat-stream-timeout.ts
@@ -1,8 +1,8 @@
 import { readEnvValue } from "./config";
 
-export const DEFAULT_CHAT_STREAM_TIMEOUT_MS = 1_800_000;
+export const DEFAULT_CHAT_STREAM_TIMEOUT_MS = 86_400_000;
 export const MIN_CHAT_STREAM_TIMEOUT_MS = 60_000;
-export const MAX_CHAT_STREAM_TIMEOUT_MS = 3_600_000;
+export const MAX_CHAT_STREAM_TIMEOUT_MS = 86_400_000;
 
 export function resolveChatStreamTimeoutMs(
   env: Record<string, string | undefined> = process.env
@@ -26,8 +26,8 @@ export function resolveChatStreamTimeoutMs(
 /**
  * A separate, much shorter budget for the provider's *first* output of a turn.
  *
- * The stream timeout has to stay long because a healthy turn can spend half an
- * hour in a tool loop. That same budget is far too generous for a provider that
+ * The stream timeout has to stay long because a healthy turn can spend hours
+ * in a tool loop. That same budget is far too generous for a provider that
  * accepted the connection and then said nothing at all, which is the case that
  * holds a session hostage with no way to reach it. Anything the provider emits
  * (a chunk, a thinking delta, a tool call) satisfies this deadline; the 4s


### PR DESCRIPTION
## Summary

Long-running agents can keep one chat turn open for up to 24 hours.

**Before:** Chat turns timed out after 30 minutes and could not be configured beyond 1 hour.
**After:** The default and configurable ceiling are both 24 hours.

Why safe:
1. Shorter environment overrides and the 1-minute minimum still work
2. Silent providers retain the separate 2-minute first-token deadline
3. Resolver coverage locks both the new default and maximum

Only follow up if abandoned turns hold server resources for too long.

## Test plan
- [x] `bun test packages/core/src/chat-stream-timeout.test.ts` (4 pass)
- [x] `bun x ultracite check packages/core/src/chat-stream-timeout.ts packages/core/src/chat-stream-timeout.test.ts`
- [ ] Restart Nakama and send one normal chat message
