### PR TITLE
refactor(core): derive AgentChannel from a single AGENT_CHANNELS array

### DIFF
--- a/apps/server/src/http/routes/sessions.ts
+++ b/apps/server/src/http/routes/sessions.ts
@@ -12,6 +12,7 @@ import type {
   SessionMessagesResponse,
   SessionStatusResponse,
 } from "@nakama/core";
+import { AGENT_CHANNELS } from "@nakama/core";
 import { resolveRequestClientOrigin } from "../../services/composio-callback-url";
 import { sessionTurnRegistry } from "../../services/session-turn-registry";
 import type { ServerOptions } from "../context";
@@ -37,18 +38,7 @@ export function registerSessionRoutes(
   const errorSchema = z
     .object({ error: z.string() })
     .openapi("ApiErrorResponse");
-  const agentChannelSchema = z
-    .enum([
-      "web",
-      "cli",
-      "telegram",
-      "whatsapp",
-      "discord",
-      "automation",
-      "task",
-      "subagent",
-    ])
-    .openapi("AgentChannel");
+  const agentChannelSchema = z.enum(AGENT_CHANNELS).openapi("AgentChannel");
   const createSessionRequestSchema = z
     .object({
       channel: agentChannelSchema,

--- a/apps/server/src/http/shared.ts
+++ b/apps/server/src/http/shared.ts
@@ -1,6 +1,7 @@
 import type { AgentChatSession } from "@nakama/agent";
 import type { OrgRole } from "@nakama/core";
 import {
+  AGENT_CHANNELS,
   type AgentChannel,
   type AgentQuestionnaire,
   type AgentTodo,
@@ -380,24 +381,16 @@ export function errorResponse(
   );
 }
 
+const CHANNEL_LIST = `${AGENT_CHANNELS.slice(0, -1).join(", ")}, or ${
+  AGENT_CHANNELS[AGENT_CHANNELS.length - 1]
+}`;
+
 export function parseChannel(value: string | undefined): AgentChannel {
-  if (
-    value === "cli" ||
-    value === "web" ||
-    value === "telegram" ||
-    value === "whatsapp" ||
-    value === "discord" ||
-    value === "automation" ||
-    value === "task" ||
-    value === "subagent"
-  ) {
-    return value;
+  if (value !== undefined && AGENT_CHANNELS.includes(value as AgentChannel)) {
+    return value as AgentChannel;
   }
 
-  throw new NakamaApiError(
-    "Invalid channel. Expected cli, web, telegram, whatsapp, discord, automation, task, or subagent.",
-    400
-  );
+  throw new NakamaApiError(`Invalid channel. Expected ${CHANNEL_LIST}.`, 400);
 }
 
 const STREAM_TIMEOUT_MS = resolveChatStreamTimeoutMs();

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -96,6 +96,7 @@ import type {
   WhatsAppSettingsResponse,
 } from "@nakama/core";
 import {
+  AGENT_CHANNELS,
   apiKeyEnvVarForProvider,
   appendOrgMemorySection,
   buildThinkingProviderOptions,
@@ -3612,20 +3613,9 @@ export class AgentService {
 }
 
 function parseAgentChannel(value: string): AgentChannel | null {
-  if (
-    value === "cli" ||
-    value === "web" ||
-    value === "telegram" ||
-    value === "whatsapp" ||
-    value === "discord" ||
-    value === "automation" ||
-    value === "task" ||
-    value === "subagent"
-  ) {
-    return value;
-  }
-
-  return null;
+  return AGENT_CHANNELS.includes(value as AgentChannel)
+    ? (value as AgentChannel)
+    : null;
 }
 
 function clampSubAgentTimeout(timeoutMs: number | undefined): number {

--- a/apps/server/src/tools/session-tools.ts
+++ b/apps/server/src/tools/session-tools.ts
@@ -1,16 +1,10 @@
-import type { AgentChannel, ToolContext, ToolDefinition } from "@nakama/core";
+import {
+  AGENT_CHANNELS,
+  type AgentChannel,
+  type ToolContext,
+  type ToolDefinition,
+} from "@nakama/core";
 import type { AgentService } from "../services/agent-service";
-
-const AGENT_CHANNELS: AgentChannel[] = [
-  "web",
-  "cli",
-  "telegram",
-  "whatsapp",
-  "discord",
-  "automation",
-  "task",
-  "subagent",
-];
 
 /** Matches `GET /v1/sessions` — optional channel, default web. */
 const DEFAULT_CHANNEL: AgentChannel = "web";
@@ -82,7 +76,7 @@ export function createSessionTools(agent: AgentService): ToolDefinition[] {
           channel: {
             description:
               "Which channel's sessions to list. Defaults to web, the same default the sessions API uses.",
-            enum: AGENT_CHANNELS,
+            enum: [...AGENT_CHANNELS],
             type: "string",
           },
           profileId: {

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -74,15 +74,18 @@ export interface AutomationUnreadSummary {
   totalUnread: number;
 }
 
-export type AgentChannel =
-  | "web"
-  | "cli"
-  | "telegram"
-  | "whatsapp"
-  | "discord"
-  | "automation"
-  | "task"
-  | "subagent";
+export const AGENT_CHANNELS = [
+  "web",
+  "cli",
+  "telegram",
+  "whatsapp",
+  "discord",
+  "automation",
+  "task",
+  "subagent",
+] as const;
+
+export type AgentChannel = (typeof AGENT_CHANNELS)[number];
 
 export const NAKAMA_API_VERSION = 1;
 


### PR DESCRIPTION
## Summary

Adding an agent channel is one edit to `AGENT_CHANNELS`, and the 400 sentence, the published OpenAPI enum and the tool schema all follow from it.

**Before:** eight channel names hand-copied into seven places with the union enforcing none of them, so a ninth member typechecked clean and the copies drifted apart in silence. One of those drifts shipped as #213.
**After:** `AGENT_CHANNELS` in `packages/core/src/contract.ts` is the source, `AgentChannel` is `(typeof AGENT_CHANNELS)[number]`, and `parseChannel`, `parseAgentChannel`, `agentChannelSchema` and the `list_profile_sessions` schema each read that array.

Built at runtime, not argued from the source, twice on each side:

| | before | after |
| --- | --- | --- |
| `buildHttpOpenApiSpec()` document | sha256 `2e91240c...`, 180676 bytes | identical |
| `AgentChannel` in it | 8 channels, referenced from 4 places | same |
| add a ninth member, rebuild | document unchanged | exactly one enum entry added |
| channels `parseChannel` accepts | 8 | same 8 |
| the 400 sentence | `Expected cli, web, ...` | `Expected web, cli, ...` |

Row three is the whole point: the union could grow without the published spec noticing.

Why safe:
1. The document, the tool schema enum and the accepted channel set are unchanged, so no client sees a different API.
2. Typecheck is unchanged: 7928 pre-existing errors on both sides, 0 new and 0 removed once line and column are normalised. That total moves with whatever `bun install` resolved, so the delta is the portable part. Removing a member now raises TS2345 at a call site, which the union never did.
3. The 400 copy is the only difference anywhere. `Invalid channel` occurs nowhere else in the repository, and CONTRIBUTING asks tests to assert behaviour rather than error copy.

Only follow up if the channel table in `builtin-tools.mdx` should be generated too. This leaves it hand maintained.

## Test plan
- [x] `bun test` in `apps/server`: 964 pass, 0 fail, twice with the patch and twice without.
- [x] `bun run knip` exits 0, `bun x ultracite check` on the five files applies no fixes.
- [x] The table above, from `buildHttpOpenApiSpec()` and `parseChannel` called directly.
- [ ] `GET /openapi.json` on a local `bun run dev:server`: `AgentChannel` still lists the eight channels.

Closes #461
