### PR TITLE
fix(server): clean up custom tool retry seam after #454

### DIFF
--- a/apps/server/src/services/custom-tool-handlers.test.ts
+++ b/apps/server/src/services/custom-tool-handlers.test.ts
@@ -203,30 +203,16 @@ if __name__ == "__main__":
     const configDir = await mkdtemp(path.join(os.tmpdir(), "nakama-config-"));
     process.env.NAKAMA_CONFIG_DIR = configDir;
     const toolsDir = path.join(configDir, "tools");
-    const wsDir = path.join(configDir, "ws");
     await mkdir(toolsDir, { recursive: true });
-    await mkdir(wsDir, { recursive: true });
 
-    // Persist attempt count in the workspace so retries are observable across
-    // in-process module calls (mirrors the python seam test).
+    // In-process module counter — JS retries share the cached module.
     await writeFile(
       path.join(toolsDir, "flaky.js"),
-      `import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import path from "node:path";
-
-export async function run(_input, context) {
-  const root = context.workspaceRoot ?? "/tmp";
-  const counter = path.join(root, "attempts.txt");
-  let n = 0;
-  if (existsSync(counter)) {
-    n = Number.parseInt(readFileSync(counter, "utf8").trim() || "0", 10);
-  }
-  n += 1;
-  writeFileSync(counter, String(n));
-  if (n < 3) {
-    throw new Error("flaky");
-  }
-  return { ok: true, attempts: n };
+      `let attempts = 0;
+export async function run() {
+  attempts += 1;
+  if (attempts < 3) throw new Error("flaky");
+  return { ok: true, attempts };
 }
 `,
       "utf8"
@@ -239,13 +225,11 @@ export async function run(_input, context) {
         makeRecord({
           handlerConfig: { modulePath: "flaky.js" },
           handlerType: "javascript",
-          id: "tool_flaky_js",
-          name: "flaky_js",
         })
       );
       expect(tool).not.toBeNull();
 
-      const result = (await tool!.run({}, { workspaceRoot: wsDir })) as {
+      const result = (await tool!.run({}, {})) as {
         ok: boolean;
         attempts: number;
       };

--- a/apps/server/src/services/custom-tool-handlers.test.ts
+++ b/apps/server/src/services/custom-tool-handlers.test.ts
@@ -198,4 +198,67 @@ if __name__ == "__main__":
       await rm(configDir, { force: true, recursive: true });
     }
   });
+
+  test("javascript handler failures are actually retried through the seam", async () => {
+    const configDir = await mkdtemp(path.join(os.tmpdir(), "nakama-config-"));
+    process.env.NAKAMA_CONFIG_DIR = configDir;
+    const toolsDir = path.join(configDir, "tools");
+    const wsDir = path.join(configDir, "ws");
+    await mkdir(toolsDir, { recursive: true });
+    await mkdir(wsDir, { recursive: true });
+
+    // Persist attempt count in the workspace so retries are observable across
+    // in-process module calls (mirrors the python seam test).
+    await writeFile(
+      path.join(toolsDir, "flaky.js"),
+      `import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+export async function run(_input, context) {
+  const root = context.workspaceRoot ?? "/tmp";
+  const counter = path.join(root, "attempts.txt");
+  let n = 0;
+  if (existsSync(counter)) {
+    n = Number.parseInt(readFileSync(counter, "utf8").trim() || "0", 10);
+  }
+  n += 1;
+  writeFileSync(counter, String(n));
+  if (n < 3) {
+    throw new Error("flaky");
+  }
+  return { ok: true, attempts: n };
+}
+`,
+      "utf8"
+    );
+
+    try {
+      const handler = getCustomToolHandler("javascript");
+      expect(handler).not.toBeNull();
+      const tool = await handler!.load(
+        makeRecord({
+          handlerConfig: { modulePath: "flaky.js" },
+          handlerType: "javascript",
+          id: "tool_flaky_js",
+          name: "flaky_js",
+        })
+      );
+      expect(tool).not.toBeNull();
+
+      const result = (await tool!.run({}, { workspaceRoot: wsDir })) as {
+        ok: boolean;
+        attempts: number;
+      };
+
+      expect(result.ok).toBe(true);
+      expect(result.attempts).toBe(3);
+    } finally {
+      if (originalConfigDir === undefined) {
+        delete process.env.NAKAMA_CONFIG_DIR;
+      } else {
+        process.env.NAKAMA_CONFIG_DIR = originalConfigDir;
+      }
+      await rm(configDir, { force: true, recursive: true });
+    }
+  });
 });

--- a/apps/server/src/services/custom-tool-handlers.ts
+++ b/apps/server/src/services/custom-tool-handlers.ts
@@ -1,10 +1,10 @@
+import { setTimeout as delay } from "node:timers/promises";
 import type {
   ToolContext,
   ToolDefinition,
   ToolSourceResponse,
 } from "@nakama/core";
 import type { StoredToolRecord } from "@nakama/db";
-import { setTimeout as delay } from "node:timers/promises";
 import {
   loadJavascriptTool,
   resolveJavascriptModulePath,
@@ -58,13 +58,7 @@ export const TOOL_RETRY_LIMIT = 2;
  */
 const TOOL_RETRY_BASE_DELAY_MS = 500;
 
-function abortReason(signal: AbortSignal): unknown {
-  return signal.reason instanceof Error
-    ? signal.reason
-    : new Error("Tool execution aborted");
-}
-
-function abortReason(signal: AbortSignal): unknown {
+function abortReason(signal: AbortSignal): Error {
   return signal.reason instanceof Error
     ? signal.reason
     : new Error("Tool execution aborted");
@@ -96,11 +90,9 @@ export function withToolRetries(
         }
         // Rejects immediately if the signal aborts mid-backoff (including an
         // already-aborted signal), so a cancelled turn never waits out the delay.
-        await delay(
-          TOOL_RETRY_BASE_DELAY_MS * 2 ** (attempts - 1),
-          undefined,
-          { signal: context.signal }
-        );
+        await delay(TOOL_RETRY_BASE_DELAY_MS * 2 ** (attempts - 1), undefined, {
+          signal: context.signal,
+        });
       }
     }
   };


### PR DESCRIPTION
## Summary

Custom tool retry seam from #454 is lint-clean, and JavaScript failures retry end-to-end like Python.

**Before:** Duplicate `abortReason` broke ultracite; JS only had a structural “load wrapped” check.
**After:** One `abortReason`, imports/format clean; `flaky.js` asserts attempt count 3 through the seam.

Why safe:
1. Behavior unchanged — only deletes dead paste + adds a proving test
2. Existing python seam test still passes; new JS test mirrors it
3. `bun x ultracite check` clean on the touched files

Only follow up if timeout retries (3× budget) should become errors-only or shared-deadline — still open from #454.

## Test plan
- [x] `bun test apps/server/src/services/custom-tool-handlers.test.ts` (10 pass)
- [x] `bun x ultracite check` on touched files
- [ ] Spot-check one flaky custom JS tool in playground — second/third attempt succeeds
