### PR TITLE
fix: address #454 review — drop duplicate abortReason, add JS retry test

### DIFF
--- a/apps/server/src/services/custom-tool-handlers.test.ts
+++ b/apps/server/src/services/custom-tool-handlers.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import type { ToolContext } from "@nakama/core";
+import {
+  CUSTOM_TOOL_HANDLERS,
+  getCustomToolHandler,
+  TOOL_RETRY_LIMIT,
+  withToolRetries,
+} from "./custom-tool-handlers";
+
+function ctx(signal?: AbortSignal): ToolContext {
+  return { signal };
+}
+
+describe("withToolRetries", () => {
+  test("succeeds on the first attempt without extra calls", async () => {
+    let attempts = 0;
+    const run = async () => {
+      attempts += 1;
+      return { ok: true };
+    };
+
+    const result = await withToolRetries(run)({}, ctx());
+
+    expect(result).toEqual({ ok: true });
+    expect(attempts).toBe(1);
+  });
+
+  test("retries at most twice and returns success when a later attempt succeeds", async () => {
+    let attempts = 0;
+    const run = async () => {
+      attempts += 1;
+      if (attempts < 3) {
+        throw new Error("transient");
+      }
+      return { ok: true };
+    };
+
+    const result = await withToolRetries(run)({}, ctx());
+
+    expect(result).toEqual({ ok: true });
+    expect(attempts).toBe(3);
+  });
+
+  test("stops after two retries and re-throws the last error unchanged", async () => {
+    let attempts = 0;
+    const message =
+      "Python tool timed out after 8000ms (exit code null): (no stderr)";
+    const run = async () => {
+      attempts += 1;
+      throw new Error(message);
+    };
+
+    await expect(withToolRetries(run)({}, ctx())).rejects.toThrow(message);
+    expect(attempts).toBe(TOOL_RETRY_LIMIT + 1);
+  });
+
+  test("an aborted signal during the run stops immediately and is never retried", async () => {
+    let attempts = 0;
+    const controller = new AbortController();
+    const run = async () => {
+      attempts += 1;
+      controller.abort(new Error("cancelled"));
+      throw new Error("boom");
+    };
+
+    await expect(
+      withToolRetries(run)({}, ctx(controller.signal))
+    ).rejects.toThrow("boom");
+    expect(attempts).toBe(1);
+  });
+
+  test("an already-aborted signal never starts the run", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("cancelled"));
+    let attempts = 0;
+    const run = async () => {
+      attempts += 1;
+      return { ok: true };
+    };
+
+    await expect(
+      withToolRetries(run)({}, ctx(controller.signal))
+    ).rejects.toThrow("cancelled");
+    expect(attempts).toBe(0);
+  });
+
+  test("aborting during the backoff cancels the retry", async () => {
+    let attempts = 0;
+    const controller = new AbortController();
+    const run = async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error("transient");
+      }
+      return { ok: true };
+    };
+
+    const pending = withToolRetries(run)({}, ctx(controller.signal));
+    setTimeout(() => controller.abort(), 25);
+
+    await expect(pending).rejects.toThrow();
+    // Never reached the second attempt.
+    expect(attempts).toBe(1);
+  });
+});
+
+describe("getCustomToolHandler seam", () => {
+  test("applies the retry wrapper to both javascript and python handlers", () => {
+    for (const type of ["javascript", "python"] as const) {
+      const viaSeam = getCustomToolHandler(type);
+      expect(viaSeam).not.toBeNull();
+      // The seam returns a wrapped load, distinct from the raw loader.
+      expect(viaSeam!.load).not.toBe(CUSTOM_TOOL_HANDLERS[type].load);
+    }
+  });
+
+  test("returns null for unknown handler types", () => {
+    expect(getCustomToolHandler("ruby")).toBeNull();
+  });
+});

--- a/apps/server/src/services/custom-tool-handlers.test.ts
+++ b/apps/server/src/services/custom-tool-handlers.test.ts
@@ -198,4 +198,57 @@ if __name__ == "__main__":
       await rm(configDir, { force: true, recursive: true });
     }
   });
+
+  test("javascript handler failures are actually retried through the seam", async () => {
+    const configDir = await mkdtemp(path.join(os.tmpdir(), "nakama-config-"));
+    process.env.NAKAMA_CONFIG_DIR = configDir;
+    const toolsDir = path.join(configDir, "tools");
+    await mkdir(toolsDir, { recursive: true });
+
+    // The loader caches module instances, so a module-level counter persists
+    // across the retried run() calls — fail twice, succeed on the third.
+    await writeFile(
+      path.join(toolsDir, "flaky.js"),
+      `let attempts = 0;
+export async function run(input, context) {
+  attempts += 1;
+  if (attempts < 3) {
+    throw new Error("flaky");
+  }
+  return { ok: true, attempts };
+}
+`,
+      "utf8"
+    );
+
+    try {
+      const handler = getCustomToolHandler("javascript");
+      expect(handler).not.toBeNull();
+      const tool = await handler!.load(
+        makeRecord({
+          handlerConfig: { modulePath: "flaky.js" },
+          handlerType: "javascript",
+          name: "flaky",
+        })
+      );
+      expect(tool).not.toBeNull();
+
+      const result = (await tool!.run({}, {})) as {
+        ok: boolean;
+        attempts: number;
+      };
+
+      // Succeeded on attempt 3 after two thrown failures — proves the retry
+      // policy reaches the javascript loader through the seam.
+      expect(result.ok).toBe(true);
+      expect(result.attempts).toBe(3);
+    } finally {
+      if (originalConfigDir === undefined) {
+        delete process.env.NAKAMA_CONFIG_DIR;
+      } else {
+        process.env.NAKAMA_CONFIG_DIR = originalConfigDir;
+      }
+      await rm(configDir, { force: true, recursive: true });
+    }
+  });
 });

--- a/apps/server/src/services/custom-tool-handlers.test.ts
+++ b/apps/server/src/services/custom-tool-handlers.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import type { ToolContext } from "@nakama/core";
+import type { StoredToolRecord } from "@nakama/db";
 import {
   CUSTOM_TOOL_HANDLERS,
   getCustomToolHandler,
@@ -9,6 +13,23 @@ import {
 
 function ctx(signal?: AbortSignal): ToolContext {
   return { signal };
+}
+
+const originalConfigDir = process.env.NAKAMA_CONFIG_DIR;
+
+function makeRecord(
+  overrides: Partial<StoredToolRecord> = {}
+): StoredToolRecord {
+  return {
+    createdAt: new Date().toISOString(),
+    description: "Retry probe",
+    handlerConfig: { modulePath: "flaky.py" },
+    handlerType: "python",
+    id: "tool_flaky",
+    name: "flaky",
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
 }
 
 describe("withToolRetries", () => {
@@ -116,5 +137,65 @@ describe("getCustomToolHandler seam", () => {
 
   test("returns null for unknown handler types", () => {
     expect(getCustomToolHandler("ruby")).toBeNull();
+  });
+
+  test("python handler failures are actually retried through the seam", async () => {
+    const configDir = await mkdtemp(path.join(os.tmpdir(), "nakama-config-"));
+    process.env.NAKAMA_CONFIG_DIR = configDir;
+    const toolsDir = path.join(configDir, "tools");
+    const wsDir = path.join(configDir, "ws");
+    await mkdir(toolsDir, { recursive: true });
+    await mkdir(wsDir, { recursive: true });
+
+    // The module persists an attempt counter in the workspace, fails while the
+    // count is below 3, then succeeds — so the test can assert the actual
+    // number of spawns, not just the final result.
+    await writeFile(
+      path.join(toolsDir, "flaky.py"),
+      `import json, os, sys
+
+def run(input, context):
+    root = os.environ.get("NAKAMA_WORKSPACE_ROOT", "/tmp")
+    counter = os.path.join(root, "attempts.txt")
+    n = 0
+    if os.path.exists(counter):
+        n = int(open(counter).read().strip() or "0")
+    n += 1
+    open(counter, "w").write(str(n))
+    if n < 3:
+        sys.stderr.write("flaky\\n")
+        sys.exit(3)
+    return {"ok": True, "attempts": n}
+
+if __name__ == "__main__":
+    payload = json.loads(sys.stdin.read() or "{}")
+    sys.stdout.write(json.dumps(run(payload, {})))
+`,
+      "utf8"
+    );
+
+    try {
+      const handler = getCustomToolHandler("python");
+      expect(handler).not.toBeNull();
+      const tool = await handler!.load(makeRecord());
+      expect(tool).not.toBeNull();
+
+      const result = (await tool!.run({}, { workspaceRoot: wsDir })) as {
+        ok: boolean;
+        attempts: number;
+      };
+
+      // Succeeded on attempt 3 after two failed spawns — proves the retry
+      // policy reaches the python loader, not just the seam wrapper.
+      expect(result.ok).toBe(true);
+      expect(result.attempts).toBe(3);
+    } finally {
+      if (originalConfigDir === undefined) {
+        delete process.env.NAKAMA_CONFIG_DIR;
+      } else {
+        process.env.NAKAMA_CONFIG_DIR = originalConfigDir;
+      }
+      await rm(configDir, { force: true, recursive: true });
+    }
   });
 });

--- a/apps/server/src/services/custom-tool-handlers.ts
+++ b/apps/server/src/services/custom-tool-handlers.ts
@@ -1,4 +1,8 @@
-import type { ToolDefinition, ToolSourceResponse } from "@nakama/core";
+import type {
+  ToolContext,
+  ToolDefinition,
+  ToolSourceResponse,
+} from "@nakama/core";
 import type { StoredToolRecord } from "@nakama/db";
 import {
   loadJavascriptTool,
@@ -42,13 +46,93 @@ export const CUSTOM_TOOL_HANDLERS = {
 
 export type CustomToolType = keyof typeof CUSTOM_TOOL_HANDLERS;
 
+/**
+ * How many times a failed custom tool run is retried after the first attempt
+ * (up to 3 attempts total) before the last error is surfaced unchanged.
+ */
+export const TOOL_RETRY_LIMIT = 2;
+
+/** Base backoff between attempts; each retry doubles it: 500ms, then 1s. */
+export const TOOL_RETRY_BASE_DELAY_MS = 500;
+
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new Error("Tool execution aborted");
+}
+
+/** Resolves after `ms`, or rejects immediately when the signal aborts. */
+function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) {
+    return Promise.reject(abortReason(signal));
+  }
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(abortReason(signal as AbortSignal));
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * Wraps a custom tool run with at-most-two retries and exponential backoff.
+ *
+ * Thrown errors (including timeouts) are transient by default and get
+ * retried; an aborted `context.signal` stops immediately and is never
+ * retried, including mid-backoff. The final failure is re-thrown unchanged
+ * so callers keep the current error message shape.
+ */
+export function withToolRetries(
+  run: (input: unknown, context: ToolContext) => Promise<unknown>
+): (input: unknown, context: ToolContext) => Promise<unknown> {
+  return async (input, context) => {
+    let attempts = 0;
+    for (;;) {
+      if (context.signal?.aborted) {
+        throw abortReason(context.signal);
+      }
+      try {
+        return await run(input, context);
+      } catch (error) {
+        attempts += 1;
+        if (attempts > TOOL_RETRY_LIMIT || context.signal?.aborted) {
+          throw error;
+        }
+        await abortableDelay(
+          TOOL_RETRY_BASE_DELAY_MS * 2 ** (attempts - 1),
+          context.signal
+        );
+      }
+    }
+  };
+}
+
 export function getCustomToolHandler(
   handlerType: string
 ): CustomToolHandler | null {
-  return (
+  const handler =
     (CUSTOM_TOOL_HANDLERS as Record<string, CustomToolHandler>)[handlerType] ??
-    null
-  );
+    null;
+  if (!handler) {
+    return null;
+  }
+  return {
+    ...handler,
+    // Both loader types resolve through this seam, so wrapping load here
+    // applies the retry policy to JavaScript and Python in one place.
+    load: async (record) => {
+      const definition = await handler.load(record);
+      if (!definition) {
+        return null;
+      }
+      return { ...definition, run: withToolRetries(definition.run) };
+    },
+  };
 }
 
 export function isCustomToolType(

--- a/apps/server/src/services/custom-tool-handlers.ts
+++ b/apps/server/src/services/custom-tool-handlers.ts
@@ -1,10 +1,10 @@
+import { setTimeout as delay } from "node:timers/promises";
 import type {
   ToolContext,
   ToolDefinition,
   ToolSourceResponse,
 } from "@nakama/core";
 import type { StoredToolRecord } from "@nakama/db";
-import { setTimeout as delay } from "node:timers/promises";
 import {
   loadJavascriptTool,
   resolveJavascriptModulePath,
@@ -64,12 +64,6 @@ function abortReason(signal: AbortSignal): unknown {
     : new Error("Tool execution aborted");
 }
 
-function abortReason(signal: AbortSignal): unknown {
-  return signal.reason instanceof Error
-    ? signal.reason
-    : new Error("Tool execution aborted");
-}
-
 /**
  * Wraps a custom tool run with at-most-two retries and exponential backoff.
  *
@@ -96,11 +90,9 @@ export function withToolRetries(
         }
         // Rejects immediately if the signal aborts mid-backoff (including an
         // already-aborted signal), so a cancelled turn never waits out the delay.
-        await delay(
-          TOOL_RETRY_BASE_DELAY_MS * 2 ** (attempts - 1),
-          undefined,
-          { signal: context.signal }
-        );
+        await delay(TOOL_RETRY_BASE_DELAY_MS * 2 ** (attempts - 1), undefined, {
+          signal: context.signal,
+        });
       }
     }
   };

--- a/apps/server/src/services/custom-tool-handlers.ts
+++ b/apps/server/src/services/custom-tool-handlers.ts
@@ -4,6 +4,7 @@ import type {
   ToolSourceResponse,
 } from "@nakama/core";
 import type { StoredToolRecord } from "@nakama/db";
+import { setTimeout as delay } from "node:timers/promises";
 import {
   loadJavascriptTool,
   resolveJavascriptModulePath,
@@ -63,22 +64,10 @@ function abortReason(signal: AbortSignal): unknown {
     : new Error("Tool execution aborted");
 }
 
-/** Resolves after `ms`, or rejects immediately when the signal aborts. */
-function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
-  if (signal?.aborted) {
-    return Promise.reject(abortReason(signal));
-  }
-  return new Promise((resolve, reject) => {
-    const onAbort = () => {
-      clearTimeout(timer);
-      reject(abortReason(signal as AbortSignal));
-    };
-    const timer = setTimeout(() => {
-      signal?.removeEventListener("abort", onAbort);
-      resolve();
-    }, ms);
-    signal?.addEventListener("abort", onAbort, { once: true });
-  });
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new Error("Tool execution aborted");
 }
 
 /**
@@ -105,9 +94,12 @@ export function withToolRetries(
         if (attempts > TOOL_RETRY_LIMIT || context.signal?.aborted) {
           throw error;
         }
-        await abortableDelay(
+        // Rejects immediately if the signal aborts mid-backoff (including an
+        // already-aborted signal), so a cancelled turn never waits out the delay.
+        await delay(
           TOOL_RETRY_BASE_DELAY_MS * 2 ** (attempts - 1),
-          context.signal
+          undefined,
+          { signal: context.signal }
         );
       }
     }

--- a/apps/server/src/services/custom-tool-handlers.ts
+++ b/apps/server/src/services/custom-tool-handlers.ts
@@ -52,8 +52,10 @@ export type CustomToolType = keyof typeof CUSTOM_TOOL_HANDLERS;
  */
 export const TOOL_RETRY_LIMIT = 2;
 
-/** Base backoff between attempts; each retry doubles it: 500ms, then 1s. */
-export const TOOL_RETRY_BASE_DELAY_MS = 500;
+/**
+ * Base backoff between attempts; each retry doubles it: 500ms, then 1s.
+ */
+const TOOL_RETRY_BASE_DELAY_MS = 500;
 
 function abortReason(signal: AbortSignal): unknown {
   return signal.reason instanceof Error

--- a/apps/server/src/services/python-tool-loader.test.ts
+++ b/apps/server/src/services/python-tool-loader.test.ts
@@ -157,10 +157,14 @@ if __name__ == "__main__":
     const tool = await loadPythonTool(
       makeRecord({ handlerConfig: { modulePath: "boom.py" }, name: "boom" })
     );
-    const result = (await tool!.run({}, {})) as { error: string };
 
-    expect(result.error).toMatch(/exit code/i);
-    expect(result.error).toContain("kaboom");
+    // A failed spawn must reject so the retry policy can retry transient
+    // failures; executeToolCall turns the throw into `{ error }` for callers.
+    const err = await tool!.run({}, {}).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/exit code/i);
+    expect((err as Error).message).toContain("kaboom");
   });
 
   test("returns an error tool when stdout is not valid JSON", async () => {
@@ -187,9 +191,8 @@ if __name__ == "__main__":
         name: "badjson",
       })
     );
-    const result = (await tool!.run({}, {})) as { error: string };
 
-    expect(result.error).toMatch(/non-json/i);
+    await expect(tool!.run({}, {})).rejects.toThrow(/non-json/i);
   });
 
   test("returns an error tool when the module prints nothing to stdout", async () => {
@@ -217,10 +220,8 @@ if __name__ == "__main__":
         name: "silent",
       })
     );
-    const result = (await tool!.run({}, {})) as { error?: unknown };
 
-    expect(result.error).toBeTruthy();
-    expect(result.error).toMatch(/no output/i);
+    await expect(tool!.run({}, {})).rejects.toThrow(/no output/i);
   });
 
   test("rejects on timeout even when the module exits 0", async () => {
@@ -261,9 +262,7 @@ if __name__ == "__main__":
 
     process.env.NAKAMA_PYTHON_TOOL_TIMEOUT_MS = "200";
     try {
-      const result = (await tool!.run({}, {})) as { error?: unknown };
-      expect(result.error).toBeTruthy();
-      expect(result.error).toMatch(/timed out/i);
+      await expect(tool!.run({}, {})).rejects.toThrow(/timed out/i);
     } finally {
       delete process.env.NAKAMA_PYTHON_TOOL_TIMEOUT_MS;
     }

--- a/apps/server/src/services/python-tool-loader.ts
+++ b/apps/server/src/services/python-tool-loader.ts
@@ -119,13 +119,11 @@ async function runPythonTool(
     env.NAKAMA_WORKSPACE_ROOT = workspaceRoot;
   }
 
-  try {
-    return await spawnAndParse(modulePath, input, context, env);
-  } catch (error) {
-    return {
-      error: error instanceof Error ? error.message : String(error),
-    };
-  }
+  // No try/catch here on purpose: a failed spawn must reject so the retry
+  // policy in withToolRetries can retry transient failures. executeToolCall
+  // (packages/agent/src/tool-loop.ts) converts the throw into the same
+  // `{ error: message }` shape callers already expect.
+  return spawnAndParse(modulePath, input, context, env);
 }
 
 async function spawnAndParse(


### PR DESCRIPTION
Follow-up to #454 (merged) addressing the review points from @vincentri.

## Fixes

1. **Duplicate `abortReason` removed** — the backoff refactor left two identical declarations (lines 61 & 67) in `custom-tool-handlers.ts`; Biome flags `lint/suspicious/noRedeclare` and `bun x ultracite check` fails. Deleted the second (dead) copy.

2. **JavaScript end-to-end retry test added** — the seam now has symmetric coverage for both handler types: a `flaky.js` module with a module-level attempt counter fails twice and succeeds on the third run, asserting `attempts === 3` through `getCustomToolHandler("javascript").load(...)`.

## Verification

```
bun test apps/server/src/services/custom-tool-handlers.test.ts  → 10 pass / 0 fail
bun x ultracite check (both files)                            → clean, no fixes applied
```

Note: the timeout-retry open question from #449 was left as implemented (retry both errors and timeouts); the merge of #454 is taken as acceptance of that behavior.