### PR TITLE
fix(whatsapp): silence nonfatal init query timeouts

### DIFF
--- a/apps/platform/whatsapp/src/baileys-logger.test.ts
+++ b/apps/platform/whatsapp/src/baileys-logger.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, mock, test } from "bun:test";
+import { createBaileysLogger } from "./baileys-logger";
+
+describe("Baileys logger", () => {
+  test("suppresses nonfatal init query timeouts", () => {
+    const writeError = mock(() => {});
+    const logger = createBaileysLogger(writeError);
+
+    logger.error(
+      {
+        err: {
+          isBoom: true,
+          message: "Timed Out",
+        },
+      },
+      "unexpected error in 'init queries'"
+    );
+
+    expect(writeError).not.toHaveBeenCalled();
+  });
+
+  test("reports other Baileys errors", () => {
+    const writeError = mock(() => {});
+    const logger = createBaileysLogger(writeError);
+    const context = { err: new Error("Connection Closed") };
+
+    logger.error(context, "error in validating connection");
+
+    expect(writeError).toHaveBeenCalledWith(
+      context,
+      "error in validating connection"
+    );
+  });
+});

--- a/apps/platform/whatsapp/src/baileys-logger.ts
+++ b/apps/platform/whatsapp/src/baileys-logger.ts
@@ -1,0 +1,49 @@
+type ErrorWriter = (...args: unknown[]) => void;
+
+const INIT_QUERY_ERROR = "unexpected error in 'init queries'";
+
+export function createBaileysLogger(
+  writeError: ErrorWriter = console.error.bind(console)
+) {
+  const noop = () => {};
+  const logger = {
+    child: () => logger,
+    debug: noop,
+    error: (...args: unknown[]) => {
+      const [context, message] = args;
+      if (isInitQueryTimeout(context, message)) {
+        return;
+      }
+
+      writeError(...args);
+    },
+    fatal: writeError,
+    info: noop,
+    level: "silent",
+    trace: noop,
+    warn: console.warn.bind(console),
+  };
+
+  return logger;
+}
+
+function isInitQueryTimeout(context: unknown, message: unknown): boolean {
+  if (
+    message !== INIT_QUERY_ERROR ||
+    typeof context !== "object" ||
+    context === null ||
+    !("err" in context)
+  ) {
+    return false;
+  }
+
+  const error = context.err;
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "isBoom" in error &&
+    error.isBoom === true &&
+    "message" in error &&
+    error.message === "Timed Out"
+  );
+}

--- a/apps/platform/whatsapp/src/socket.ts
+++ b/apps/platform/whatsapp/src/socket.ts
@@ -8,6 +8,7 @@ import {
   type WASocket,
 } from "@whiskeysockets/baileys";
 import { usePrivateMultiFileAuthState } from "./auth-state";
+import { createBaileysLogger } from "./baileys-logger";
 import {
   extractInboundText,
   isPrivateWhatsAppChat,
@@ -198,21 +199,4 @@ function summarizeMissingTextPayload(msg: {
   };
 
   return JSON.stringify(summary);
-}
-
-// ponytail: keep Baileys on silent; worker logs what matters itself
-function createBaileysLogger() {
-  const noop = () => {};
-  const logger = {
-    child: () => logger,
-    debug: noop,
-    error: console.error.bind(console),
-    fatal: console.error.bind(console),
-    info: noop,
-    level: "silent",
-    trace: noop,
-    warn: console.warn.bind(console),
-  };
-
-  return logger;
 }


### PR DESCRIPTION
## Summary

WhatsApp workers stay quiet when an optional Baileys startup query times out, while real connection errors remain visible.

**Before:** A nonfatal init-query timeout printed an alarming Boom stack trace after connection.
**After:** Only that exact timeout is suppressed; init queries and other Baileys errors continue unchanged.

Why safe:
1. Matching requires the init-query log message plus a Boom `Timed Out` error
2. Startup queries still run, preserving reconnect and restart subscriptions
3. Regression coverage proves unrelated errors still reach the logger

Only re-add this error if init-query timeouts begin correlating with failed message delivery.

## Test plan
- [x] `bun test apps/platform/whatsapp/src` (76 pass)
- [x] `bun x ultracite check apps/platform/whatsapp/src/baileys-logger.ts apps/platform/whatsapp/src/baileys-logger.test.ts apps/platform/whatsapp/src/socket.ts`
- [ ] Restart a linked WhatsApp worker and confirm no init-query timeout stack appears

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
