### PR TITLE
fix(settings): confirm before removing LLM provider

### DIFF
--- a/apps/web/src/components/settings/ProviderSettingsCard.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsCard.tsx
@@ -104,6 +104,10 @@ export function ProviderSettingsCard({
                     <ProviderInstanceCard
                       catalog={catalog}
                       instance={instance}
+                      isDefaultProvider={
+                        providersResponse?.defaultProviderId === instance.id
+                      }
+                      isLastProvider={providers.length === 1}
                       key={instance.id}
                       onDelete={async (providerId) => {
                         await deleteProviderMutation.mutateAsync(providerId);

--- a/apps/web/src/components/settings/provider-instance-card.tsx
+++ b/apps/web/src/components/settings/provider-instance-card.tsx
@@ -74,6 +74,8 @@ export function ProviderInstanceCard({
   onUpdate,
   onDelete,
   onError,
+  isDefaultProvider = false,
+  isLastProvider = false,
 }: {
   instance: ProviderInstanceSummary;
   catalog: ProviderModelOption[];
@@ -83,10 +85,14 @@ export function ProviderInstanceCard({
   ) => Promise<void>;
   onDelete: (providerId: string) => Promise<void>;
   onError: (error: string | null) => void;
+  isDefaultProvider?: boolean;
+  isLastProvider?: boolean;
 }) {
   const card = useProviderInstanceCard({
     catalog,
     instance,
+    isDefaultProvider,
+    isLastProvider,
     onDelete,
     onError,
     onUpdate,

--- a/apps/web/src/components/settings/use-provider-instance-card.ts
+++ b/apps/web/src/components/settings/use-provider-instance-card.ts
@@ -35,6 +35,8 @@ export function useProviderInstanceCard({
   onUpdate,
   onDelete,
   onError,
+  isDefaultProvider = false,
+  isLastProvider = false,
 }: {
   instance: ProviderInstanceSummary;
   catalog: ProviderModelOption[];
@@ -44,6 +46,8 @@ export function useProviderInstanceCard({
   ) => Promise<void>;
   onDelete: (providerId: string) => Promise<void>;
   onError: (error: string | null) => void;
+  isDefaultProvider?: boolean;
+  isLastProvider?: boolean;
 }) {
   const [replaceKeyOpen, setReplaceKeyOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
@@ -157,6 +161,18 @@ export function useProviderInstanceCard({
   };
 
   const handleDelete = async () => {
+    const soleWarning =
+      isLastProvider || isDefaultProvider
+        ? "This is your only/default LLM provider. "
+        : "";
+    const confirmed = window.confirm(
+      `${soleWarning}Remove ${instance.label} (${instance.type})? Models using this provider will stop working. This cannot be undone.`
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
     setBusy(true);
     onError(null);
 


### PR DESCRIPTION
## Summary

Remove an LLM provider from Settings → confirm dialog first; warn extra when it is your only/default provider. Fixes #625

**Before:** one click on Remove deleted the provider instantly — sole-provider removal silently dropped its stored API key.
**After:** `handleDelete()` in `use-provider-instance-card.ts` guards with a confirm that names label/type and prepends "This is your only/default LLM provider." when applicable.

Why safe:
1. Same pattern already ships in `McpTab.tsx` deletes
2. UI-only — server `DELETE /v1/providers/:id` and all auth paths untouched (3 files, +26 LOC)
3. Dismiss/cancel keeps the row exactly as before, verified live

Only re-add / follow up if product wants an in-app dialog instead of `window.confirm` for a11y consistency.

## Test plan
- [x] `bun x tsc --noEmit -p apps/web` clean; `bun run knip` no findings
- [x] Playwright: Remove → dialog appears → dismiss → row intact; Update-key & Manage-models dialogs unaffected (`qa-evidence/F-011/verify/`)
- [ ] Settings → Remove on any provider → Cancel keeps it; message warns when it is the last one

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/ox--alpha-000000)
