### PR TITLE
fix(server): reject MCP server creation with 4xx when initial connect fails

### DIFF
--- a/apps/server/src/services/mcp-service.test.ts
+++ b/apps/server/src/services/mcp-service.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { nanoid } from "@nakama/core";
+import { NakamaApiError, nanoid } from "@nakama/core";
 import { PREINSTALLED_MCP_SERVER_IDS } from "@nakama/core/mcp/preinstalled";
 import {
   createInMemoryDatabaseAdapter,
@@ -142,6 +142,25 @@ describe("McpService", () => {
         transport: "stdio",
       })
     ).rejects.toThrow("stdio MCP servers require config.command.");
+  });
+
+  test("does not persist a stdio server whose command fails to connect", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const service = new McpService(db, new McpClientManager());
+
+    const error = await service
+      .createServer({
+        config: { command: "qa-nonexistent-cmd-xyz" },
+        name: "broken",
+        transport: "stdio",
+      })
+      .catch((caught: unknown) => caught);
+
+    expect(error instanceof NakamaApiError).toBe(true);
+    expect((error as NakamaApiError).status).toBe(422);
+
+    const listed = await service.listServers();
+    expect(listed.servers).toHaveLength(0);
   });
 
   test("updates stdio MCP server config while preserving blank env values", async () => {

--- a/apps/server/src/services/mcp-service.ts
+++ b/apps/server/src/services/mcp-service.ts
@@ -54,7 +54,7 @@ export class McpService {
     const name = request.name.trim();
 
     if (!name) {
-      throw new Error("MCP server name is required.");
+      throw invalidMcpServerRequest("MCP server name is required.");
     }
 
     const transport = normalizeTransport(request.transport);
@@ -63,11 +63,11 @@ export class McpService {
     const existing = await this.db.getMcpServerByName(name);
 
     if (existing) {
-      throw new Error(`MCP server already exists: ${name}`);
+      throw new NakamaApiError(`MCP server already exists: ${name}`, 409);
     }
 
     const now = new Date().toISOString();
-    const record: StoredMcpServerRecord = {
+    let record: StoredMcpServerRecord = {
       cachedTools: [],
       config: request.config,
       createdAt: now,
@@ -80,12 +80,22 @@ export class McpService {
       updatedAt: now,
     };
 
-    await this.db.upsertMcpServer(record);
-
+    // Connect before persisting so a failed initial connection is a client
+    // error (4xx) and never leaves a broken server row behind.
     if (request.connect !== false && record.enabled) {
-      await this.connectServer(record.id);
-      return this.getServer(record.id);
+      try {
+        const cachedTools = await this.manager.connect(record);
+        record = { ...record, cachedTools, status: "connected" };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new NakamaApiError(
+          `Could not connect MCP server "${name}": ${message}`,
+          422
+        );
+      }
     }
+
+    await this.db.upsertMcpServer(record);
 
     return { server: toMcpServerDetail(record) };
   }
@@ -567,6 +577,10 @@ function redactStringRecord(
   return redacted;
 }
 
+function invalidMcpServerRequest(message: string): NakamaApiError {
+  return new NakamaApiError(message, 400);
+}
+
 function normalizeTransport(transport: string | undefined): McpTransport {
   const value = transport?.trim().toLowerCase();
 
@@ -578,7 +592,7 @@ function normalizeTransport(transport: string | undefined): McpTransport {
     return "stdio";
   }
 
-  throw new Error('MCP transport must be "http" or "stdio".');
+  throw invalidMcpServerRequest('MCP transport must be "http" or "stdio".');
 }
 
 function validateTransport(
@@ -589,7 +603,7 @@ function validateTransport(
 
 function validateConfig(transport: McpTransport, config: unknown): void {
   if (typeof config !== "object" || config === null) {
-    throw new Error("MCP server config is required.");
+    throw invalidMcpServerRequest("MCP server config is required.");
   }
 
   const record = config as Record<string, unknown>;
@@ -598,13 +612,13 @@ function validateConfig(transport: McpTransport, config: unknown): void {
     const url = record.url;
 
     if (typeof url !== "string" || !url.trim()) {
-      throw new Error("HTTP MCP servers require config.url.");
+      throw invalidMcpServerRequest("HTTP MCP servers require config.url.");
     }
 
     try {
       new URL(url);
     } catch {
-      throw new Error(`Invalid MCP server URL: ${url}`);
+      throw invalidMcpServerRequest(`Invalid MCP server URL: ${url}`);
     }
 
     return;
@@ -613,7 +627,7 @@ function validateConfig(transport: McpTransport, config: unknown): void {
   const command = record.command;
 
   if (typeof command !== "string" || !command.trim()) {
-    throw new Error("stdio MCP servers require config.command.");
+    throw invalidMcpServerRequest("stdio MCP servers require config.command.");
   }
 }
 


### PR DESCRIPTION
## Summary

Add an MCP server whose initial connect fails → typed 4xx and nothing persisted, instead of HTTP 500 plus a broken saved row. Fixes #626

**Before:** `McpService.createServer` upserted first, then connected; connect failure answered 500 and left a status=error row in the list.
**After:** connect runs before persist in `createServer` — failed connect → 422 `NakamaApiError`, invalid config → 400, duplicate name → 409; `connect:false` offline saves still return 201 unchanged.

Why safe:
1. Regression test asserts 422 + zero rows persisted on failure (`mcp-service.test.ts`)
2. Existing save-while-offline semantics preserved (verified: `connect:false` → 201)
3. Only error mapping/ordering changed — response shapes untouched

Only re-add / follow up if some flow depends on persisting unreachable servers created *without* `connect:false`.

## Test plan
- [x] `bun test apps/server/src/services/mcp-service.test.ts mcp-tool-bridge.test.ts` (19 pass)
- [x] Live probe: bogus stdio command → 422, list unchanged; flat bad body → 400 (`qa-evidence/F-019/verify/`)
- [ ] System → MCP → Add with a nonexistent command → inline error, list count unchanged

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/ox--alpha-000000)
