### PR TITLE
fix(whatsapp): stop 408 reconnect storms

### DIFF
--- a/apps/platform/whatsapp/src/socket.test.ts
+++ b/apps/platform/whatsapp/src/socket.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import {
+  createWhatsAppSocket,
+  WHATSAPP_RECONNECT_BASE_MS,
+  whatsappReconnectDelayMs,
+} from "./socket";
+
+const TIMEOUT_CLOSE = {
+  connection: "close" as const,
+  lastDisconnect: {
+    error: {
+      message: "Timed Out",
+      output: { statusCode: 408 },
+    },
+  },
+};
+
+const LOGGED_OUT_CLOSE = {
+  connection: "close" as const,
+  lastDisconnect: {
+    error: {
+      message: "Logged Out",
+      output: { statusCode: 401 },
+    },
+  },
+};
+
+describe("whatsappReconnectDelayMs", () => {
+  test("backs off from 1s and caps at 30s", () => {
+    expect(whatsappReconnectDelayMs(0)).toBe(WHATSAPP_RECONNECT_BASE_MS);
+    expect(whatsappReconnectDelayMs(1)).toBe(2000);
+    expect(whatsappReconnectDelayMs(2)).toBe(4000);
+    expect(whatsappReconnectDelayMs(5)).toBe(30_000);
+    expect(whatsappReconnectDelayMs(8)).toBe(30_000);
+  });
+});
+
+describe("WhatsApp socket reconnect", () => {
+  const logSpies: Array<ReturnType<typeof spyOn>> = [];
+
+  afterEach(() => {
+    for (const spy of logSpies.splice(0)) {
+      spy.mockRestore();
+    }
+  });
+
+  test("ends the previous socket and waits before reconnecting on 408", async () => {
+    const { createSocket, delays, emit, sockets } = createReconnectHarness();
+    logSpies.push(spyOn(console, "log").mockImplementation(() => {}));
+
+    const handle = await createHandle({ createSocket, delays });
+    await handle.start();
+
+    expect(createSocket).toHaveBeenCalledTimes(1);
+
+    emit(0, TIMEOUT_CLOSE);
+    await flush();
+
+    expect(delays).toEqual([WHATSAPP_RECONNECT_BASE_MS]);
+    expect(sockets[0]?.end).toHaveBeenCalled();
+    expect(createSocket).toHaveBeenCalledTimes(2);
+  });
+
+  test("ignores a second close on the same socket so reconnect does not storm", async () => {
+    const { createSocket, delays, emit } = createReconnectHarness();
+    logSpies.push(spyOn(console, "log").mockImplementation(() => {}));
+
+    const handle = await createHandle({ createSocket, delays });
+    await handle.start();
+
+    emit(0, TIMEOUT_CLOSE);
+    emit(0, TIMEOUT_CLOSE);
+    await flush();
+
+    expect(createSocket).toHaveBeenCalledTimes(2);
+    expect(delays).toEqual([WHATSAPP_RECONNECT_BASE_MS]);
+  });
+
+  test("does not reconnect after logout", async () => {
+    const { createSocket, delays, emit } = createReconnectHarness();
+    logSpies.push(spyOn(console, "log").mockImplementation(() => {}));
+
+    const handle = await createHandle({ createSocket, delays });
+    await handle.start();
+
+    emit(0, LOGGED_OUT_CLOSE);
+    await flush();
+
+    expect(createSocket).toHaveBeenCalledTimes(1);
+    expect(delays).toEqual([]);
+  });
+});
+
+function createReconnectHarness() {
+  const sockets: Array<{
+    end: ReturnType<typeof mock>;
+    ev: EventEmitter;
+  }> = [];
+  const delays: number[] = [];
+  const createSocket = mock(() => {
+    const ev = new EventEmitter();
+    const socket = {
+      end: mock(() => {
+        ev.emit("connection.update", {
+          connection: "close",
+          lastDisconnect: {
+            error: { message: "ended", output: { statusCode: 428 } },
+          },
+        });
+      }),
+      ev,
+    };
+    sockets.push(socket);
+    return socket;
+  });
+
+  return {
+    createSocket,
+    delays,
+    emit(index: number, update: object) {
+      sockets[index]?.ev.emit("connection.update", update);
+    },
+    sockets,
+  };
+}
+
+async function createHandle(input: {
+  createSocket: () => { ev: EventEmitter; end: () => void };
+  delays: number[];
+}) {
+  return createWhatsAppSocket({
+    createSocket: input.createSocket as never,
+    delay: async (ms) => {
+      input.delays.push(ms);
+    },
+    fetchVersion: async () => ({ version: [2, 3000, 1_023_223_821] }),
+    loadAuthState: async () => ({
+      saveCreds: async () => {},
+      state: {
+        creds: { me: { id: "123@s.whatsapp.net" } },
+        keys: {},
+      } as never,
+    }),
+    onMessage: async () => {},
+  });
+}
+
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}

--- a/apps/platform/whatsapp/src/socket.test.ts
+++ b/apps/platform/whatsapp/src/socket.test.ts
@@ -1,10 +1,49 @@
-import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
-import { EventEmitter } from "node:events";
 import {
-  createWhatsAppSocket,
-  WHATSAPP_RECONNECT_BASE_MS,
-  whatsappReconnectDelayMs,
-} from "./socket";
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+import { EventEmitter } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as baileys from "@whiskeysockets/baileys";
+
+const sockets: Array<{
+  end: ReturnType<typeof mock>;
+  ev: EventEmitter;
+}> = [];
+const delays: number[] = [];
+const createSocket = mock(() => {
+  const ev = new EventEmitter();
+  const socket = {
+    end: mock(() => {
+      ev.emit("connection.update", {
+        connection: "close",
+        lastDisconnect: {
+          error: { message: "ended", output: { statusCode: 428 } },
+        },
+      });
+    }),
+    ev,
+  };
+  sockets.push(socket);
+  return socket;
+});
+
+mock.module("@whiskeysockets/baileys", () => ({
+  ...baileys,
+  fetchLatestBaileysVersion: async () => ({
+    version: [2, 3000, 1_023_223_821],
+  }),
+  makeWASocket: createSocket,
+}));
+
+const { createWhatsAppSocket } = await import("./socket");
 
 const TIMEOUT_CLOSE = {
   connection: "close" as const,
@@ -26,30 +65,42 @@ const LOGGED_OUT_CLOSE = {
   },
 };
 
-describe("whatsappReconnectDelayMs", () => {
-  test("backs off from 1s and caps at 30s", () => {
-    expect(whatsappReconnectDelayMs(0)).toBe(WHATSAPP_RECONNECT_BASE_MS);
-    expect(whatsappReconnectDelayMs(1)).toBe(2000);
-    expect(whatsappReconnectDelayMs(2)).toBe(4000);
-    expect(whatsappReconnectDelayMs(5)).toBe(30_000);
-    expect(whatsappReconnectDelayMs(8)).toBe(30_000);
-  });
-});
-
 describe("WhatsApp socket reconnect", () => {
-  const logSpies: Array<ReturnType<typeof spyOn>> = [];
+  let logSpy: ReturnType<typeof spyOn>;
+  let timeoutSpy: ReturnType<typeof spyOn>;
+  let previousConfigDir: string | undefined;
+  let tempConfigDir: string;
 
-  afterEach(() => {
-    for (const spy of logSpies.splice(0)) {
-      spy.mockRestore();
+  beforeEach(async () => {
+    sockets.length = 0;
+    delays.length = 0;
+    createSocket.mockClear();
+    previousConfigDir = process.env.NAKAMA_CONFIG_DIR;
+    tempConfigDir = await mkdtemp(join(tmpdir(), "nakama-wa-socket-"));
+    process.env.NAKAMA_CONFIG_DIR = tempConfigDir;
+    logSpy = spyOn(console, "log").mockImplementation(() => {});
+    timeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(
+      (fn, ms) => {
+        delays.push(Number(ms));
+        queueMicrotask(() => (fn as () => void)());
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }
+    );
+  });
+
+  afterEach(async () => {
+    logSpy.mockRestore();
+    timeoutSpy.mockRestore();
+    if (previousConfigDir === undefined) {
+      delete process.env.NAKAMA_CONFIG_DIR;
+    } else {
+      process.env.NAKAMA_CONFIG_DIR = previousConfigDir;
     }
+    await rm(tempConfigDir, { force: true, recursive: true });
   });
 
   test("ends the previous socket and waits before reconnecting on 408", async () => {
-    const { createSocket, delays, emit, sockets } = createReconnectHarness();
-    logSpies.push(spyOn(console, "log").mockImplementation(() => {}));
-
-    const handle = await createHandle({ createSocket, delays });
+    const handle = await createWhatsAppSocket({ onMessage: async () => {} });
     await handle.start();
 
     expect(createSocket).toHaveBeenCalledTimes(1);
@@ -57,16 +108,13 @@ describe("WhatsApp socket reconnect", () => {
     emit(0, TIMEOUT_CLOSE);
     await flush();
 
-    expect(delays).toEqual([WHATSAPP_RECONNECT_BASE_MS]);
+    expect(delays).toEqual([1000]);
     expect(sockets[0]?.end).toHaveBeenCalled();
     expect(createSocket).toHaveBeenCalledTimes(2);
   });
 
   test("ignores a second close on the same socket so reconnect does not storm", async () => {
-    const { createSocket, delays, emit } = createReconnectHarness();
-    logSpies.push(spyOn(console, "log").mockImplementation(() => {}));
-
-    const handle = await createHandle({ createSocket, delays });
+    const handle = await createWhatsAppSocket({ onMessage: async () => {} });
     await handle.start();
 
     emit(0, TIMEOUT_CLOSE);
@@ -74,14 +122,11 @@ describe("WhatsApp socket reconnect", () => {
     await flush();
 
     expect(createSocket).toHaveBeenCalledTimes(2);
-    expect(delays).toEqual([WHATSAPP_RECONNECT_BASE_MS]);
+    expect(delays).toEqual([1000]);
   });
 
   test("does not reconnect after logout", async () => {
-    const { createSocket, delays, emit } = createReconnectHarness();
-    logSpies.push(spyOn(console, "log").mockImplementation(() => {}));
-
-    const handle = await createHandle({ createSocket, delays });
+    const handle = await createWhatsAppSocket({ onMessage: async () => {} });
     await handle.start();
 
     emit(0, LOGGED_OUT_CLOSE);
@@ -92,58 +137,8 @@ describe("WhatsApp socket reconnect", () => {
   });
 });
 
-function createReconnectHarness() {
-  const sockets: Array<{
-    end: ReturnType<typeof mock>;
-    ev: EventEmitter;
-  }> = [];
-  const delays: number[] = [];
-  const createSocket = mock(() => {
-    const ev = new EventEmitter();
-    const socket = {
-      end: mock(() => {
-        ev.emit("connection.update", {
-          connection: "close",
-          lastDisconnect: {
-            error: { message: "ended", output: { statusCode: 428 } },
-          },
-        });
-      }),
-      ev,
-    };
-    sockets.push(socket);
-    return socket;
-  });
-
-  return {
-    createSocket,
-    delays,
-    emit(index: number, update: object) {
-      sockets[index]?.ev.emit("connection.update", update);
-    },
-    sockets,
-  };
-}
-
-async function createHandle(input: {
-  createSocket: () => { ev: EventEmitter; end: () => void };
-  delays: number[];
-}) {
-  return createWhatsAppSocket({
-    createSocket: input.createSocket as never,
-    delay: async (ms) => {
-      input.delays.push(ms);
-    },
-    fetchVersion: async () => ({ version: [2, 3000, 1_023_223_821] }),
-    loadAuthState: async () => ({
-      saveCreds: async () => {},
-      state: {
-        creds: { me: { id: "123@s.whatsapp.net" } },
-        keys: {},
-      } as never,
-    }),
-    onMessage: async () => {},
-  });
+function emit(index: number, update: object) {
+  sockets[index]?.ev.emit("connection.update", update);
 }
 
 async function flush(): Promise<void> {

--- a/apps/platform/whatsapp/src/socket.ts
+++ b/apps/platform/whatsapp/src/socket.ts
@@ -16,22 +16,7 @@ import {
   type WhatsAppInboundChat,
 } from "./inbound-message";
 
-export const WHATSAPP_RECONNECT_BASE_MS = 1000;
-const WHATSAPP_RECONNECT_MAX_MS = 30_000;
-
-export function whatsappReconnectDelayMs(attempt: number): number {
-  const exp = Math.min(Math.max(attempt, 0), 5);
-  return Math.min(
-    WHATSAPP_RECONNECT_MAX_MS,
-    WHATSAPP_RECONNECT_BASE_MS * 2 ** exp
-  );
-}
-
 export interface WhatsAppSocketDeps {
-  createSocket?: typeof makeWASocket;
-  delay?: (ms: number) => Promise<void>;
-  fetchVersion?: () => ReturnType<typeof fetchLatestBaileysVersion>;
-  loadAuthState?: () => ReturnType<typeof usePrivateMultiFileAuthState>;
   onConnected?: (me: { id: string; lid?: string | null }) => void;
   onDisconnected?: () => void;
   onMessage: (data: WhatsAppInboundChat) => Promise<void>;
@@ -48,23 +33,11 @@ export async function createWhatsAppSocket(
   deps: WhatsAppSocketDeps
 ): Promise<WhatsAppSocketHandle> {
   const authDir = getWhatsAppConfigDir() + "/auth";
-  const { state, saveCreds } = deps.loadAuthState
-    ? await deps.loadAuthState()
-    : await usePrivateMultiFileAuthState(authDir);
-  const { version } = deps.fetchVersion
-    ? await deps.fetchVersion()
-    : await fetchLatestBaileysVersion();
-  const createSocket = deps.createSocket ?? makeWASocket;
-  const delay =
-    deps.delay ??
-    ((ms: number) =>
-      new Promise<void>((resolve) => {
-        setTimeout(resolve, ms);
-      }));
+  const { state, saveCreds } = await usePrivateMultiFileAuthState(authDir);
+  const { version } = await fetchLatestBaileysVersion();
 
   let socket: WASocket | null = null;
   let stopped = false;
-  let starting = false;
   let generation = 0;
   let reconnectAttempt = 0;
   let loggedMissingTextPayload = false;
@@ -75,150 +48,148 @@ export async function createWhatsAppSocket(
       return socket;
     },
     async start() {
-      if (stopped || starting) {
+      if (stopped) {
         return;
       }
 
-      starting = true;
       const myGen = ++generation;
+      const previous = socket;
+      socket = null;
+      previous?.end(undefined);
 
-      try {
-        const previous = socket;
-        socket = null;
-        previous?.end(undefined);
+      const next = makeWASocket({
+        auth: state,
+        browser: ["Nakama", "Chrome", "4.0.0"] as [string, string, string],
+        connectTimeoutMs: 30_000,
+        logger: baileysLogger,
+        markOnlineOnConnect: false,
+        printQRInTerminal: false,
+        retryRequestDelayMs: 2000,
+        // Keep history sync disabled, but allow Baileys init queries so the
+        // socket fully subscribes after reconnect/restart.
+        shouldSyncHistoryMessage: () => false,
+        version,
+      });
 
-        const next = createSocket({
-          auth: state,
-          browser: ["Nakama", "Chrome", "4.0.0"] as [string, string, string],
-          connectTimeoutMs: 30_000,
-          logger: baileysLogger,
-          markOnlineOnConnect: false,
-          printQRInTerminal: false,
-          retryRequestDelayMs: 2000,
-          // Keep history sync disabled, but allow Baileys init queries so the
-          // socket fully subscribes after reconnect/restart.
-          shouldSyncHistoryMessage: () => false,
-          version,
-        });
+      if (myGen !== generation || stopped) {
+        next.end(undefined);
+        return;
+      }
 
-        if (myGen !== generation || stopped) {
-          next.end(undefined);
+      socket = next;
+
+      next.ev.on("connection.update", async (update) => {
+        if (myGen !== generation) {
           return;
         }
 
-        socket = next;
+        const { connection, lastDisconnect, qr } = update;
 
-        next.ev.on("connection.update", async (update) => {
-          if (myGen !== generation) {
-            return;
+        if (qr) {
+          deps.onQr?.(qr);
+        }
+
+        if (connection === "open") {
+          reconnectAttempt = 0;
+          const me = state.creds.me;
+          if (me?.id) {
+            deps.onConnected?.({ id: me.id, lid: me.lid ?? null });
           }
+        }
 
-          const { connection, lastDisconnect, qr } = update;
+        if (connection === "close") {
+          generation += 1;
+          deps.onDisconnected?.();
+          const statusCode = lastDisconnect?.error?.message
+            ? (lastDisconnect.error as { output?: { statusCode?: number } })
+                .output?.statusCode
+            : lastDisconnect?.statusCode;
+          const shouldReconnect =
+            statusCode !== DisconnectReason.loggedOut && !stopped;
 
-          if (qr) {
-            deps.onQr?.(qr);
-          }
-
-          if (connection === "open") {
-            reconnectAttempt = 0;
-            const me = state.creds.me;
-            if (me?.id) {
-              deps.onConnected?.({ id: me.id, lid: me.lid ?? null });
-            }
-          }
-
-          if (connection === "close") {
-            if (myGen !== generation) {
-              return;
-            }
-
-            generation += 1;
-            deps.onDisconnected?.();
-            const statusCode = disconnectStatusCode(lastDisconnect);
-            const shouldReconnect =
-              statusCode !== DisconnectReason.loggedOut && !stopped;
-
-            console.log(
-              `WhatsApp disconnected (code: ${statusCode}).${shouldReconnect ? " Reconnecting..." : ""}`
-            );
-
-            if (!shouldReconnect) {
-              return;
-            }
-
-            const waitMs = whatsappReconnectDelayMs(reconnectAttempt);
-            reconnectAttempt += 1;
-            await delay(waitMs);
-            if (stopped) {
-              return;
-            }
-
-            await handle.start();
-          }
-        });
-
-        next.ev.on("creds.update", saveCreds);
-
-        next.ev.on("messages.upsert", async (m) => {
           console.log(
-            `WhatsApp messages.upsert type=${m.type} count=${m.messages.length}`
+            `WhatsApp disconnected (code: ${statusCode}).${shouldReconnect ? " Reconnecting..." : ""}`
           );
 
-          if (!isSupportedUpsertType(m.type)) {
+          if (!shouldReconnect) {
             return;
           }
 
-          const me = state.creds.me;
-
-          for (const msg of m.messages) {
-            const remoteJid = msg.key.remoteJid ?? null;
-            const text = extractInboundText(msg.message);
-            const inbound = parseInboundWhatsAppMessage(msg, me);
-
-            if (remoteJid) {
-              console.log(
-                `WhatsApp upsert item jid=${remoteJid} fromMe=${msg.key.fromMe ? "yes" : "no"} participant=${msg.key.participant ?? "-"} text=${text ? "yes" : "no"} handle=${inbound ? "yes" : "no"}`
-              );
-            }
-
-            if (
-              remoteJid &&
-              !text &&
-              !loggedMissingTextPayload &&
-              isPrivateWhatsAppChat(remoteJid)
-            ) {
-              loggedMissingTextPayload = true;
-              console.log(
-                "WhatsApp missing-text payload:",
-                summarizeMissingTextPayload(msg)
-              );
-            }
-
-            if (!inbound) {
-              continue;
-            }
-
-            const preview =
-              inbound.text.length > 120
-                ? `${inbound.text.slice(0, 120)}…`
-                : inbound.text;
-            console.log(
-              `WhatsApp message received from ${inbound.jid}: ${preview}`
-            );
-
-            try {
-              await deps.onMessage(inbound);
-            } catch (error) {
-              console.error("WhatsApp inbound message handling failed.", {
-                error: error instanceof Error ? error.message : String(error),
-                jid: inbound.jid,
-              });
-            }
+          const waitMs = Math.min(
+            30_000,
+            1000 * 2 ** Math.min(reconnectAttempt, 5)
+          );
+          reconnectAttempt += 1;
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, waitMs);
+          });
+          if (stopped) {
+            return;
           }
-        });
-      } finally {
-        starting = false;
-      }
+
+          await handle.start();
+        }
+      });
+
+      next.ev.on("creds.update", saveCreds);
+
+      next.ev.on("messages.upsert", async (m) => {
+        console.log(
+          `WhatsApp messages.upsert type=${m.type} count=${m.messages.length}`
+        );
+
+        if (!isSupportedUpsertType(m.type)) {
+          return;
+        }
+
+        const me = state.creds.me;
+
+        for (const msg of m.messages) {
+          const remoteJid = msg.key.remoteJid ?? null;
+          const text = extractInboundText(msg.message);
+          const inbound = parseInboundWhatsAppMessage(msg, me);
+
+          if (remoteJid) {
+            console.log(
+              `WhatsApp upsert item jid=${remoteJid} fromMe=${msg.key.fromMe ? "yes" : "no"} participant=${msg.key.participant ?? "-"} text=${text ? "yes" : "no"} handle=${inbound ? "yes" : "no"}`
+            );
+          }
+
+          if (
+            remoteJid &&
+            !text &&
+            !loggedMissingTextPayload &&
+            isPrivateWhatsAppChat(remoteJid)
+          ) {
+            loggedMissingTextPayload = true;
+            console.log(
+              "WhatsApp missing-text payload:",
+              summarizeMissingTextPayload(msg)
+            );
+          }
+
+          if (!inbound) {
+            continue;
+          }
+
+          const preview =
+            inbound.text.length > 120
+              ? `${inbound.text.slice(0, 120)}…`
+              : inbound.text;
+          console.log(
+            `WhatsApp message received from ${inbound.jid}: ${preview}`
+          );
+
+          try {
+            await deps.onMessage(inbound);
+          } catch (error) {
+            console.error("WhatsApp inbound message handling failed.", {
+              error: error instanceof Error ? error.message : String(error),
+              jid: inbound.jid,
+            });
+          }
+        }
+      });
     },
     stop() {
       stopped = true;
@@ -231,21 +202,6 @@ export async function createWhatsAppSocket(
   };
 
   return handle;
-}
-
-function disconnectStatusCode(
-  lastDisconnect:
-    | {
-        error?: { message?: string; output?: { statusCode?: number } };
-        statusCode?: number;
-      }
-    | undefined
-): number | undefined {
-  if (lastDisconnect?.error?.message) {
-    return lastDisconnect.error.output?.statusCode;
-  }
-
-  return lastDisconnect?.statusCode;
 }
 
 function isSupportedUpsertType(type: string): boolean {

--- a/apps/platform/whatsapp/src/socket.ts
+++ b/apps/platform/whatsapp/src/socket.ts
@@ -16,7 +16,22 @@ import {
   type WhatsAppInboundChat,
 } from "./inbound-message";
 
+export const WHATSAPP_RECONNECT_BASE_MS = 1000;
+export const WHATSAPP_RECONNECT_MAX_MS = 30_000;
+
+export function whatsappReconnectDelayMs(attempt: number): number {
+  const exp = Math.min(Math.max(attempt, 0), 5);
+  return Math.min(
+    WHATSAPP_RECONNECT_MAX_MS,
+    WHATSAPP_RECONNECT_BASE_MS * 2 ** exp
+  );
+}
+
 export interface WhatsAppSocketDeps {
+  createSocket?: typeof makeWASocket;
+  delay?: (ms: number) => Promise<void>;
+  fetchVersion?: () => ReturnType<typeof fetchLatestBaileysVersion>;
+  loadAuthState?: () => ReturnType<typeof usePrivateMultiFileAuthState>;
   onConnected?: (me: { id: string; lid?: string | null }) => void;
   onDisconnected?: () => void;
   onMessage: (data: WhatsAppInboundChat) => Promise<void>;
@@ -33,11 +48,25 @@ export async function createWhatsAppSocket(
   deps: WhatsAppSocketDeps
 ): Promise<WhatsAppSocketHandle> {
   const authDir = getWhatsAppConfigDir() + "/auth";
-  const { state, saveCreds } = await usePrivateMultiFileAuthState(authDir);
-  const { version } = await fetchLatestBaileysVersion();
+  const { state, saveCreds } = deps.loadAuthState
+    ? await deps.loadAuthState()
+    : await usePrivateMultiFileAuthState(authDir);
+  const { version } = deps.fetchVersion
+    ? await deps.fetchVersion()
+    : await fetchLatestBaileysVersion();
+  const createSocket = deps.createSocket ?? makeWASocket;
+  const delay =
+    deps.delay ??
+    ((ms: number) =>
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, ms);
+      }));
 
   let socket: WASocket | null = null;
   let stopped = false;
+  let starting = false;
+  let generation = 0;
+  let reconnectAttempt = 0;
   let loggedMissingTextPayload = false;
   const baileysLogger = createBaileysLogger();
 
@@ -46,118 +75,154 @@ export async function createWhatsAppSocket(
       return socket;
     },
     async start() {
-      if (stopped) {
+      if (stopped || starting) {
         return;
       }
 
-      socket = makeWASocket({
-        auth: state,
-        browser: ["Nakama", "Chrome", "4.0.0"] as [string, string, string],
-        connectTimeoutMs: 30_000,
-        logger: baileysLogger,
-        markOnlineOnConnect: false,
-        printQRInTerminal: false,
-        retryRequestDelayMs: 2000,
-        // Keep history sync disabled, but allow Baileys init queries so the
-        // socket fully subscribes after reconnect/restart.
-        shouldSyncHistoryMessage: () => false,
-        version,
-      });
+      starting = true;
+      const myGen = ++generation;
 
-      socket.ev.on("connection.update", async (update) => {
-        const { connection, lastDisconnect, qr } = update;
+      try {
+        const previous = socket;
+        socket = null;
+        previous?.end(undefined);
 
-        if (qr) {
-          deps.onQr?.(qr);
-        }
+        const next = createSocket({
+          auth: state,
+          browser: ["Nakama", "Chrome", "4.0.0"] as [string, string, string],
+          connectTimeoutMs: 30_000,
+          logger: baileysLogger,
+          markOnlineOnConnect: false,
+          printQRInTerminal: false,
+          retryRequestDelayMs: 2000,
+          // Keep history sync disabled, but allow Baileys init queries so the
+          // socket fully subscribes after reconnect/restart.
+          shouldSyncHistoryMessage: () => false,
+          version,
+        });
 
-        if (connection === "open") {
-          const me = state.creds.me;
-          if (me?.id) {
-            deps.onConnected?.({ id: me.id, lid: me.lid ?? null });
-          }
-        }
-
-        if (connection === "close") {
-          deps.onDisconnected?.();
-          const statusCode = lastDisconnect?.error?.message
-            ? (lastDisconnect.error as any)?.output?.statusCode
-            : lastDisconnect?.statusCode;
-          const shouldReconnect =
-            statusCode !== DisconnectReason.loggedOut && !stopped;
-
-          console.log(
-            `WhatsApp disconnected (code: ${statusCode}).${shouldReconnect ? " Reconnecting..." : ""}`
-          );
-
-          if (shouldReconnect) {
-            await handle.start();
-          }
-        }
-      });
-
-      socket.ev.on("creds.update", saveCreds);
-
-      socket.ev.on("messages.upsert", async (m) => {
-        console.log(
-          `WhatsApp messages.upsert type=${m.type} count=${m.messages.length}`
-        );
-
-        if (!isSupportedUpsertType(m.type)) {
+        if (myGen !== generation || stopped) {
+          next.end(undefined);
           return;
         }
 
-        const me = state.creds.me;
+        socket = next;
 
-        for (const msg of m.messages) {
-          const remoteJid = msg.key.remoteJid ?? null;
-          const text = extractInboundText(msg.message);
-          const inbound = parseInboundWhatsAppMessage(msg, me);
+        next.ev.on("connection.update", async (update) => {
+          if (myGen !== generation) {
+            return;
+          }
 
-          if (remoteJid) {
+          const { connection, lastDisconnect, qr } = update;
+
+          if (qr) {
+            deps.onQr?.(qr);
+          }
+
+          if (connection === "open") {
+            reconnectAttempt = 0;
+            const me = state.creds.me;
+            if (me?.id) {
+              deps.onConnected?.({ id: me.id, lid: me.lid ?? null });
+            }
+          }
+
+          if (connection === "close") {
+            if (myGen !== generation) {
+              return;
+            }
+
+            generation += 1;
+            deps.onDisconnected?.();
+            const statusCode = disconnectStatusCode(lastDisconnect);
+            const shouldReconnect =
+              statusCode !== DisconnectReason.loggedOut && !stopped;
+
             console.log(
-              `WhatsApp upsert item jid=${remoteJid} fromMe=${msg.key.fromMe ? "yes" : "no"} participant=${msg.key.participant ?? "-"} text=${text ? "yes" : "no"} handle=${inbound ? "yes" : "no"}`
+              `WhatsApp disconnected (code: ${statusCode}).${shouldReconnect ? " Reconnecting..." : ""}`
             );
-          }
 
-          if (
-            remoteJid &&
-            !text &&
-            !loggedMissingTextPayload &&
-            isPrivateWhatsAppChat(remoteJid)
-          ) {
-            loggedMissingTextPayload = true;
-            console.log(
-              "WhatsApp missing-text payload:",
-              summarizeMissingTextPayload(msg)
-            );
-          }
+            if (!shouldReconnect) {
+              return;
+            }
 
-          if (!inbound) {
-            continue;
-          }
+            const waitMs = whatsappReconnectDelayMs(reconnectAttempt);
+            reconnectAttempt += 1;
+            await delay(waitMs);
+            if (stopped) {
+              return;
+            }
 
-          const preview =
-            inbound.text.length > 120
-              ? `${inbound.text.slice(0, 120)}…`
-              : inbound.text;
+            await handle.start();
+          }
+        });
+
+        next.ev.on("creds.update", saveCreds);
+
+        next.ev.on("messages.upsert", async (m) => {
           console.log(
-            `WhatsApp message received from ${inbound.jid}: ${preview}`
+            `WhatsApp messages.upsert type=${m.type} count=${m.messages.length}`
           );
 
-          try {
-            await deps.onMessage(inbound);
-          } catch (error) {
-            console.error("WhatsApp inbound message handling failed.", {
-              error: error instanceof Error ? error.message : String(error),
-              jid: inbound.jid,
-            });
+          if (!isSupportedUpsertType(m.type)) {
+            return;
           }
-        }
-      });
+
+          const me = state.creds.me;
+
+          for (const msg of m.messages) {
+            const remoteJid = msg.key.remoteJid ?? null;
+            const text = extractInboundText(msg.message);
+            const inbound = parseInboundWhatsAppMessage(msg, me);
+
+            if (remoteJid) {
+              console.log(
+                `WhatsApp upsert item jid=${remoteJid} fromMe=${msg.key.fromMe ? "yes" : "no"} participant=${msg.key.participant ?? "-"} text=${text ? "yes" : "no"} handle=${inbound ? "yes" : "no"}`
+              );
+            }
+
+            if (
+              remoteJid &&
+              !text &&
+              !loggedMissingTextPayload &&
+              isPrivateWhatsAppChat(remoteJid)
+            ) {
+              loggedMissingTextPayload = true;
+              console.log(
+                "WhatsApp missing-text payload:",
+                summarizeMissingTextPayload(msg)
+              );
+            }
+
+            if (!inbound) {
+              continue;
+            }
+
+            const preview =
+              inbound.text.length > 120
+                ? `${inbound.text.slice(0, 120)}…`
+                : inbound.text;
+            console.log(
+              `WhatsApp message received from ${inbound.jid}: ${preview}`
+            );
+
+            try {
+              await deps.onMessage(inbound);
+            } catch (error) {
+              console.error("WhatsApp inbound message handling failed.", {
+                error: error instanceof Error ? error.message : String(error),
+                jid: inbound.jid,
+              });
+            }
+          }
+        });
+      } finally {
+        starting = false;
+      }
     },
     stop() {
       stopped = true;
+      generation += 1;
       if (socket) {
         socket.end(undefined);
         socket = null;
@@ -166,6 +231,21 @@ export async function createWhatsAppSocket(
   };
 
   return handle;
+}
+
+function disconnectStatusCode(
+  lastDisconnect:
+    | {
+        error?: { message?: string; output?: { statusCode?: number } };
+        statusCode?: number;
+      }
+    | undefined
+): number | undefined {
+  if (lastDisconnect?.error?.message) {
+    return lastDisconnect.error.output?.statusCode;
+  }
+
+  return lastDisconnect?.statusCode;
 }
 
 function isSupportedUpsertType(type: string): boolean {

--- a/apps/platform/whatsapp/src/socket.ts
+++ b/apps/platform/whatsapp/src/socket.ts
@@ -17,7 +17,7 @@ import {
 } from "./inbound-message";
 
 export const WHATSAPP_RECONNECT_BASE_MS = 1000;
-export const WHATSAPP_RECONNECT_MAX_MS = 30_000;
+const WHATSAPP_RECONNECT_MAX_MS = 30_000;
 
 export function whatsappReconnectDelayMs(attempt: number): number {
   const exp = Math.min(Math.max(attempt, 0), 5);


### PR DESCRIPTION
## Summary

WhatsApp reconnects once, after a backoff, instead of stacking sockets on every 408.

**Before:** A 408 close immediately called `start()` without ending the old socket, so one blip became ~35 connect/close loops and 41 init-query timeouts.
**After:** `createWhatsAppSocket` ends the previous socket, ignores stale close events, and waits 1s–30s before the next `start()`.

Why safe:
1. Logout (401) still does not reconnect
2. Double-close on the same socket now opens only one replacement
3. Message, QR, and creds handlers are unchanged

Only re-add instant reconnect if a single 408 starts taking minutes to recover.

Related: #476

## Test plan
- [x] `bun test apps/platform/whatsapp/src` (79 pass)
- [ ] Restart the WhatsApp worker, then confirm logs do not burst `disconnected (code: 408)`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
