### PR TITLE
fix(server): keep the agent-browser install stream terminal once it ends

### DIFF
--- a/apps/server/src/http/coding-harness-install-stream.test.ts
+++ b/apps/server/src/http/coding-harness-install-stream.test.ts
@@ -3,6 +3,9 @@ import { streamInstallEvents } from "./coding-harness-install-stream";
 
 type TestEvent = { type: string; message?: string; error?: string };
 
+const TIMEOUT_MS = 10;
+const OUTLIVES_TIMEOUT_MS = 30;
+
 function deferred<T>(): {
   promise: Promise<T>;
   resolve: (value: T) => void;
@@ -67,15 +70,16 @@ describe("streamInstallEvents", () => {
       Promise.reject(new Error("installer exited with code 1"))
     );
 
-    expect(await readEvents(response)).toEqual([
-      { error: "installer exited with code 1", type: "error" },
-    ]);
+    const events = await readEvents(response);
+
+    expect(events.map((event) => event.type)).toEqual(["error"]);
+    expect(events[0]?.error).toContain("installer exited with code 1");
   });
 
   test("ends the stream with a timeout error when the installer stalls", async () => {
     const response = streamInstallEvents<TestEvent>(
       () => new Promise<void>(() => undefined),
-      { timeoutMessage: "Install timed out.", timeoutMs: 10 }
+      { timeoutMessage: "Install timed out.", timeoutMs: TIMEOUT_MS }
     );
 
     expect(await readEvents(response)).toEqual([
@@ -89,7 +93,9 @@ describe("streamInstallEvents", () => {
 
     const response = streamInstallEvents<TestEvent>(
       async (send) => {
-        await new Promise((settle) => setTimeout(settle, 40));
+        await new Promise((settle) =>
+          setTimeout(settle, TIMEOUT_MS + OUTLIVES_TIMEOUT_MS)
+        );
         try {
           send({ message: "still unpacking", type: "progress" });
         } catch (error) {
@@ -97,7 +103,7 @@ describe("streamInstallEvents", () => {
         }
         executorDone.resolve();
       },
-      { timeoutMessage: "Install timed out.", timeoutMs: 10 }
+      { timeoutMessage: "Install timed out.", timeoutMs: TIMEOUT_MS }
     );
 
     await readEvents(response);

--- a/apps/server/src/http/coding-harness-install-stream.test.ts
+++ b/apps/server/src/http/coding-harness-install-stream.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import { streamInstallEvents } from "./coding-harness-install-stream";
+
+type TestEvent = { type: string; message?: string; error?: string };
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+async function readEvents(response: Response): Promise<TestEvent[]> {
+  const body = await response.text();
+  return body
+    .split("\n\n")
+    .filter((chunk) => chunk.startsWith("data: "))
+    .map((chunk) => JSON.parse(chunk.slice("data: ".length)) as TestEvent);
+}
+
+describe("streamInstallEvents", () => {
+  test("send after the client disconnects does not throw at the executor", async () => {
+    const clientGone = deferred<void>();
+    const executorDone = deferred<void>();
+    const thrown: unknown[] = [];
+
+    const response = streamInstallEvents<TestEvent>(async (send) => {
+      await clientGone.promise;
+      try {
+        send({ message: "unpacking", type: "progress" });
+      } catch (error) {
+        thrown.push(error);
+      }
+      executorDone.resolve();
+    });
+
+    await response.body?.getReader().cancel();
+    clientGone.resolve();
+    await executorDone.promise;
+
+    expect(thrown).toEqual([]);
+  });
+
+  test("delivers every executor event to the client", async () => {
+    const response = streamInstallEvents<TestEvent>((send) => {
+      send({ message: "unpacking", type: "progress" });
+      send({ type: "done" });
+      return Promise.resolve();
+    });
+
+    expect(await readEvents(response)).toEqual([
+      { message: "unpacking", type: "progress" },
+      { type: "done" },
+    ]);
+  });
+
+  test("reports an executor failure as an error event", async () => {
+    const response = streamInstallEvents<TestEvent>(() =>
+      Promise.reject(new Error("installer exited with code 1"))
+    );
+
+    expect(await readEvents(response)).toEqual([
+      { error: "installer exited with code 1", type: "error" },
+    ]);
+  });
+
+  test("ends the stream with a timeout error when the installer stalls", async () => {
+    const response = streamInstallEvents<TestEvent>(
+      () => new Promise<void>(() => undefined),
+      { timeoutMessage: "Install timed out.", timeoutMs: 10 }
+    );
+
+    expect(await readEvents(response)).toEqual([
+      { error: "Install timed out.", type: "error" },
+    ]);
+  });
+
+  test("send after the timeout does not throw at the executor", async () => {
+    const executorDone = deferred<void>();
+    const thrown: unknown[] = [];
+
+    const response = streamInstallEvents<TestEvent>(
+      async (send) => {
+        await new Promise((settle) => setTimeout(settle, 40));
+        try {
+          send({ message: "still unpacking", type: "progress" });
+        } catch (error) {
+          thrown.push(error);
+        }
+        executorDone.resolve();
+      },
+      { timeoutMessage: "Install timed out.", timeoutMs: 10 }
+    );
+
+    await readEvents(response);
+    await executorDone.promise;
+
+    expect(thrown).toEqual([]);
+  });
+});

--- a/apps/server/src/http/coding-harness-install-stream.test.ts
+++ b/apps/server/src/http/coding-harness-install-stream.test.ts
@@ -38,7 +38,11 @@ describe("streamInstallEvents", () => {
       executorDone.resolve();
     });
 
-    await response.body?.getReader().cancel();
+    const body = response.body;
+    if (!body) {
+      throw new Error("the install stream response has no body");
+    }
+    await body.getReader().cancel();
     clientGone.resolve();
     await executorDone.promise;
 

--- a/apps/server/src/http/coding-harness-install-stream.ts
+++ b/apps/server/src/http/coding-harness-install-stream.ts
@@ -5,42 +5,76 @@ const INSTALL_STREAM_TIMEOUT_MS = 120_000;
 
 type InstallStreamErrorEvent = { type: "error"; error: string };
 
+type InstallStreamOptions = {
+  timeoutMessage?: string;
+  timeoutMs?: number;
+};
+
 export function streamInstallEvents<TEvent extends { type: string }>(
   executor: (send: (event: TEvent) => void) => Promise<void>,
-  options: {
-    timeoutMessage?: string;
-  } = {}
+  options: InstallStreamOptions = {}
 ): Response {
   const encoder = new TextEncoder();
   const keepaliveIntervalMs = 4000;
+  const timeoutMs = options.timeoutMs ?? INSTALL_STREAM_TIMEOUT_MS;
   const timeoutMessage =
     options.timeoutMessage ??
-    `Install timed out after ${Math.round(INSTALL_STREAM_TIMEOUT_MS / 1000)}s waiting for the installer.`;
+    `Install timed out after ${Math.round(timeoutMs / 1000)}s waiting for the installer.`;
+
+  let terminated = false;
+  let keepalive: ReturnType<typeof setInterval> | undefined;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  const clearTimers = () => {
+    clearInterval(keepalive);
+    clearTimeout(timeoutId);
+  };
 
   const stream = new ReadableStream<Uint8Array>({
+    cancel() {
+      terminated = true;
+      clearTimers();
+    },
     async start(controller) {
       const send = (event: TEvent) => {
+        if (terminated) {
+          return;
+        }
         controller.enqueue(
           encoder.encode(`data: ${JSON.stringify(event)}\n\n`)
         );
       };
 
-      const keepalive = setInterval(() => {
+      const finish = () => {
+        clearTimers();
+
+        if (terminated) {
+          return;
+        }
+
+        terminated = true;
+        controller.close();
+      };
+
+      keepalive = setInterval(() => {
+        if (terminated) {
+          clearTimers();
+          return;
+        }
         try {
           controller.enqueue(encoder.encode(": ping\n\n"));
         } catch {
-          clearInterval(keepalive);
+          clearTimers();
         }
       }, keepaliveIntervalMs);
 
-      const timeoutId = setTimeout(() => {
+      timeoutId = setTimeout(() => {
         send({
           error: timeoutMessage,
           type: "error",
         } as Extract<TEvent, InstallStreamErrorEvent>);
-        clearInterval(keepalive);
-        controller.close();
-      }, INSTALL_STREAM_TIMEOUT_MS);
+        finish();
+      }, timeoutMs);
 
       try {
         await executor(send);
@@ -50,9 +84,7 @@ export function streamInstallEvents<TEvent extends { type: string }>(
           type: "error",
         } as Extract<TEvent, InstallStreamErrorEvent>);
       } finally {
-        clearTimeout(timeoutId);
-        clearInterval(keepalive);
-        controller.close();
+        finish();
       }
     },
   });
@@ -68,9 +100,7 @@ export function streamInstallEvents<TEvent extends { type: string }>(
 
 export function streamAgentBrowserInstall(
   executor: (send: (event: AgentBrowserInstallEvent) => void) => Promise<void>,
-  options: {
-    timeoutMessage?: string;
-  } = {}
+  options: InstallStreamOptions = {}
 ): Response {
   return streamInstallEvents<AgentBrowserInstallEvent>(executor, options);
 }

--- a/apps/server/src/services/cli-package-install.test.ts
+++ b/apps/server/src/services/cli-package-install.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { runTimedInstallCommand } from "./cli-package-install";
+
+const SLOW_PLAN = {
+  args: ["-c", "printf partial; exec sleep 5"],
+  command: "sh",
+  displayCommand: "sh -c 'printf partial; exec sleep 5'",
+};
+
+describe("runTimedInstallCommand", () => {
+  test("gives up on an installer that outlives the timeout", async () => {
+    const result = await runTimedInstallCommand(SLOW_PLAN, undefined, {
+      timeoutMs: 50,
+    });
+
+    expect(result.timedOut).toBe(true);
+  });
+
+  test("stops reporting progress once the timeout has resolved", async () => {
+    const late: string[] = [];
+    let settled = false;
+
+    await runTimedInstallCommand(
+      SLOW_PLAN,
+      (message) => {
+        if (settled) {
+          late.push(message);
+        }
+      },
+      { timeoutMs: 50 }
+    );
+    settled = true;
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    expect(late).toEqual([]);
+  });
+
+  test("reports every progress line from an installer that finishes in time", async () => {
+    const progress: string[] = [];
+
+    const result = await runTimedInstallCommand(
+      {
+        args: ["-c", "printf 'one\\ntwo'"],
+        command: "sh",
+        displayCommand: "sh -c \"printf 'one\\ntwo'\"",
+      },
+      (message) => progress.push(message),
+      { timeoutMs: 5000 }
+    );
+
+    expect({
+      exitCode: result.exitCode,
+      progress,
+      timedOut: result.timedOut,
+    }).toEqual({
+      exitCode: 0,
+      progress: ["stdout: one", "stdout: two"],
+      timedOut: false,
+    });
+  });
+});

--- a/apps/server/src/services/cli-package-install.test.ts
+++ b/apps/server/src/services/cli-package-install.test.ts
@@ -1,15 +1,25 @@
 import { describe, expect, test } from "bun:test";
 import { runTimedInstallCommand } from "./cli-package-install";
 
-const SLOW_PLAN = {
+const STALLING_PLAN = {
   args: ["-c", "printf partial; exec sleep 5"],
   command: "sh",
   displayCommand: "sh -c 'printf partial; exec sleep 5'",
 };
 
+/**
+ * Exits on its own inside the window the late-progress test waits out, so that
+ * test still sees the late flush if SIGTERM is ever lost or slow.
+ */
+const SELF_EXITING_PLAN = {
+  args: ["-c", "printf partial; exec sleep 1"],
+  command: "sh",
+  displayCommand: "sh -c 'printf partial; exec sleep 1'",
+};
+
 describe("runTimedInstallCommand", () => {
   test("gives up on an installer that outlives the timeout", async () => {
-    const result = await runTimedInstallCommand(SLOW_PLAN, undefined, {
+    const result = await runTimedInstallCommand(STALLING_PLAN, undefined, {
       timeoutMs: 50,
     });
 
@@ -21,7 +31,7 @@ describe("runTimedInstallCommand", () => {
     let settled = false;
 
     await runTimedInstallCommand(
-      SLOW_PLAN,
+      SELF_EXITING_PLAN,
       (message) => {
         if (settled) {
           late.push(message);
@@ -31,7 +41,7 @@ describe("runTimedInstallCommand", () => {
     );
     settled = true;
 
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await new Promise((resolve) => setTimeout(resolve, 1500));
 
     expect(late).toEqual([]);
   });

--- a/apps/server/src/services/cli-package-install.ts
+++ b/apps/server/src/services/cli-package-install.ts
@@ -2,6 +2,8 @@ import { getToolExecutionEnv } from "../lib/ensure-process-path";
 
 export const CLI_SIGTERM_GRACE_MS = 2000;
 
+const CLI_INSTALL_TIMEOUT_MS = 120_000;
+
 export interface GlobalPackageInstallPlan {
   args: string[];
   command: string;
@@ -133,7 +135,8 @@ export async function probeCliVersion(command: string): Promise<{
 
 export async function runTimedInstallCommand(
   plan: GlobalPackageInstallPlan,
-  onProgress?: (message: string) => void
+  onProgress?: (message: string) => void,
+  options: { timeoutMs?: number } = {}
 ): Promise<{
   exitCode: number | null;
   stdout: string;
@@ -141,7 +144,7 @@ export async function runTimedInstallCommand(
   timedOut: boolean;
 }> {
   const { spawn } = await import("node:child_process");
-  const timeoutMs = 120_000;
+  const timeoutMs = options.timeoutMs ?? CLI_INSTALL_TIMEOUT_MS;
 
   return new Promise((resolve) => {
     const child = spawn(plan.command, plan.args, {
@@ -154,6 +157,17 @@ export async function runTimedInstallCommand(
     let stdoutBuffer = "";
     let stderrBuffer = "";
     let killTimeoutId: ReturnType<typeof setTimeout> | undefined;
+    let settled = false;
+
+    const settle = (value: {
+      exitCode: number | null;
+      stdout: string;
+      stderr: string;
+      timedOut: boolean;
+    }) => {
+      settled = true;
+      resolve(value);
+    };
 
     const timeoutId = setTimeout(() => {
       timedOut = true;
@@ -162,7 +176,7 @@ export async function runTimedInstallCommand(
         () => child.kill("SIGKILL"),
         CLI_SIGTERM_GRACE_MS
       );
-      resolve({
+      settle({
         exitCode: null,
         stderr: stderr.trim(),
         stdout: stdout.trim(),
@@ -171,6 +185,10 @@ export async function runTimedInstallCommand(
     }, timeoutMs);
 
     const emitLine = (prefix: "stdout" | "stderr", line: string) => {
+      if (settled) {
+        return;
+      }
+
       onProgress?.(`${prefix}: ${line}`);
     };
 
@@ -220,7 +238,7 @@ export async function runTimedInstallCommand(
         emitLine("stderr", stderrBuffer.trim());
       }
 
-      resolve({
+      settle({
         exitCode: null,
         stderr: `${stderr}\n${String(error)}`.trim(),
         stdout,
@@ -239,7 +257,7 @@ export async function runTimedInstallCommand(
         emitLine("stderr", stderrBuffer.trim());
       }
 
-      resolve({
+      settle({
         exitCode,
         stderr: stderr.trim(),
         stdout: stdout.trim(),


### PR DESCRIPTION
## Summary

The agent-browser install stream reaches a terminal state once, and nothing writes to it after that.

**Before:** a client disconnect mid-install left the controller closed while the installer ran on, so the next progress line threw `Invalid state: Controller is already closed` from inside the child process stdout handler.
**After:** `streamInstallEvents` ignores sends once the stream is terminal and closes exactly once, and `runTimedInstallCommand` stops flushing buffered output through `onProgress` after it has resolved.

Why safe:
1. Both files unmodified, wired the way `models.ts` wires them, four runs on `1441fb13` and four on this branch: one unhandled rejection every run and `runTimedInstallCommand` never resolving, against none and resolving. The probe is below.
2. Two positive controls pin the normal path: every executor event still reaches the client, and an executor failure still arrives as an `error` event carrying its cause. Turning `send` into a no-op fails 3 of the 8 new tests.
3. No call site changes. `timeoutMs` is a new optional third parameter on `runTimedInstallCommand`, whose three production callers all pass two arguments, and a new optional property on the options object `streamAgentBrowserInstall` already accepted, whose one caller sets `timeoutMessage` alone.

Only follow up if the stream timeout should also abort the installer. The two 120s timers stay independent here, so a stalled install still runs on after the client has been told it timed out, which leaves the second of the five acceptance criteria open.

Two guards carry no test, and I would rather say so than imply coverage: closing twice, and clearing the timers when the client disconnects. Removing either leaves all 8 tests green, because both fail entirely inside the stream and on Bun 1.3.14 a second close raises neither an `unhandledRejection` nor an `uncaughtException`.

My earlier comment on this issue said no unhandled rejection surfaces. That holds for the simplified reproduction I ran there, and not for the installer path, where it does.

<details>
<summary>Probe used for Before and After</summary>

```ts
// save at the repository root, then: bun run probe.ts
import { streamInstallEvents } from "./apps/server/src/http/coding-harness-install-stream";
import { runTimedInstallCommand } from "./apps/server/src/services/cli-package-install";

let unhandled = 0;
const reasons: string[] = [];
process.on("unhandledRejection", (reason) => {
  unhandled++;
  reasons.push(String(reason));
});

let settled = false;
const plan = {
  args: ["-c", "sleep 0.2; echo late-progress-line; sleep 0.2"],
  command: "sh",
  displayCommand: "sh -c '...'",
};

const response = streamInstallEvents<{ type: string }>(async (send) => {
  await runTimedInstallCommand(plan, (message) => {
    send({ message, type: "progress" } as never);
  });
  settled = true;
});

await response.body?.getReader().cancel(); // the browser tab closes mid install
await new Promise((r) => setTimeout(r, 1500));
console.log(JSON.stringify({ reasons, settled, unhandled }));
process.exit(0);
```

Every run on `1441fb13` prints:

```
{"reasons":["TypeError [ERR_INVALID_STATE]: Invalid state: Controller is already closed"],"settled":false,"unhandled":1}
```

Every run on this branch prints:

```
{"reasons":[],"settled":true,"unhandled":0}
```

</details>

## Test plan
- [x] `bun test` gives 2532 pass and 0 fail, against 2524 on `1441fb13` in a separate worktree; `bun run check` and `bun run knip` are clean. Run on macOS, so ubuntu is CI's word rather than mine
- [ ] Start an agent-browser install from Settings, close the tab while it runs, and confirm the server prints no `Invalid state: Controller is already closed`

Refs #439
