### PR TITLE
feat(providers): let openai-compatible endpoints speak the Responses API

### DIFF
--- a/apps/server/src/providers/create.ts
+++ b/apps/server/src/providers/create.ts
@@ -142,6 +142,9 @@ function createProvider(options: CreateProviderOptions): ProviderClient {
           model,
           options.instance?.customModels
         ),
+        ...(options.instance?.wireApi
+          ? { wireApi: options.instance.wireApi }
+          : {}),
       });
     }
   }

--- a/apps/server/src/providers/create.ts
+++ b/apps/server/src/providers/create.ts
@@ -142,9 +142,7 @@ function createProvider(options: CreateProviderOptions): ProviderClient {
           model,
           options.instance?.customModels
         ),
-        ...(options.instance?.wireApi
-          ? { wireApi: options.instance.wireApi }
-          : {}),
+        wireApi: options.instance?.wireApi,
       });
     }
   }

--- a/apps/server/src/providers/openai-compatible-wire-api.test.ts
+++ b/apps/server/src/providers/openai-compatible-wire-api.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { createOpenAICompatibleProvider } from "./openai-compatible";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+const RESPONSE_PAYLOAD = {
+  output: [
+    {
+      content: [{ text: "ok", type: "output_text" }],
+      id: "msg_1",
+      role: "assistant",
+      status: "completed",
+      type: "message",
+    },
+  ],
+  usage: { input_tokens: 1, output_tokens: 1 },
+};
+
+function stubFetch(payload: unknown) {
+  const calls: Array<{ body: Record<string, unknown>; url: string }> = [];
+
+  globalThis.fetch = mock(async (url: unknown, init?: RequestInit) => {
+    calls.push({
+      body: JSON.parse(String(init?.body ?? "{}")),
+      url: String(url),
+    });
+
+    return new Response(JSON.stringify(payload), {
+      headers: { "Content-Type": "application/json" },
+      status: 200,
+    });
+  }) as unknown as typeof fetch;
+
+  return calls;
+}
+
+function stubSseFetch(events: unknown[]) {
+  const calls: Array<{ body: Record<string, unknown>; url: string }> = [];
+  const sse = events
+    .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+    .join("");
+
+  globalThis.fetch = mock(async (url: unknown, init?: RequestInit) => {
+    calls.push({
+      body: JSON.parse(String(init?.body ?? "{}")),
+      url: String(url),
+    });
+
+    return new Response(sse, {
+      headers: { "Content-Type": "text/event-stream" },
+      status: 200,
+    });
+  }) as unknown as typeof fetch;
+
+  return calls;
+}
+
+const CHAT_INPUT = {
+  messages: [{ content: "hi", role: "user" as const }],
+  providerOptions: { thinking: { effort: "medium" as const, enabled: true } },
+  system: "s",
+  tools: [
+    {
+      description: "d",
+      name: "search",
+      parameters: { type: "object" as const },
+    },
+  ],
+};
+
+describe("openai-compatible wire API", () => {
+  test("wireApi responses posts to /responses and keeps reasoning next to tools", async () => {
+    const calls = stubFetch(RESPONSE_PAYLOAD);
+    const provider = createOpenAICompatibleProvider({
+      apiKey: "k",
+      baseUrl: "https://endpoint.test/v1",
+      displayName: "Endpoint",
+      model: "gpt-5.4",
+      supportsThinking: true,
+      wireApi: "responses",
+    });
+
+    await provider.generateChat(CHAT_INPUT);
+
+    expect(calls[0]?.url).toBe("https://endpoint.test/v1/responses");
+    // chat/completions rejects this pair on gpt-5.4+, so the provider forces
+    // reasoning_effort to "none" there. The Responses API accepts both.
+    expect(calls[0]?.body.reasoning).toEqual({
+      effort: "medium",
+      summary: "auto",
+    });
+    expect(calls[0]?.body.reasoning_effort).toBeUndefined();
+  });
+
+  test("wireApi responses streams from the same endpoint", async () => {
+    const calls = stubSseFetch([
+      { delta: "ok", type: "response.output_text.delta" },
+      {
+        item: {
+          content: [{ text: "ok", type: "output_text" }],
+          role: "assistant",
+          type: "message",
+        },
+        type: "response.output_item.done",
+      },
+    ]);
+    const provider = createOpenAICompatibleProvider({
+      apiKey: "k",
+      baseUrl: "https://endpoint.test/v1",
+      displayName: "Endpoint",
+      model: "gpt-5.4",
+      supportsThinking: true,
+      wireApi: "responses",
+    });
+
+    await provider.streamChat(CHAT_INPUT, {
+      onChunk: () => undefined,
+    });
+
+    expect(calls[0]?.url).toBe("https://endpoint.test/v1/responses");
+    expect(calls[0]?.body.stream).toBe(true);
+  });
+
+  test("without wireApi the endpoint stays on chat/completions", async () => {
+    const calls = stubFetch({
+      choices: [{ message: { content: "ok", role: "assistant" } }],
+      usage: { completion_tokens: 1, prompt_tokens: 1, total_tokens: 2 },
+    });
+    const provider = createOpenAICompatibleProvider({
+      apiKey: "k",
+      baseUrl: "https://endpoint.test/v1",
+      displayName: "Endpoint",
+      model: "gpt-5.4",
+      supportsThinking: true,
+    });
+
+    await provider.generateChat(CHAT_INPUT);
+
+    expect(calls[0]?.url).toContain("/chat/completions");
+    expect(calls[0]?.body.reasoning).toBeUndefined();
+  });
+});

--- a/apps/server/src/providers/openai-compatible/index.ts
+++ b/apps/server/src/providers/openai-compatible/index.ts
@@ -9,6 +9,7 @@ import type {
   ProviderClient,
   StreamChatHandlers,
   ToolCall,
+  WireApi,
 } from "@nakama/core";
 import { fetchWithoutIdleTimeout, normalizeBaseUrl } from "@nakama/core";
 import OpenAI from "openai";
@@ -17,6 +18,7 @@ import {
   toOpenAIMessages,
   toOpenAITools,
 } from "../openai";
+import { generateOpenAIResponsesChat } from "../openai/responses";
 import { openAIModelRejectsChatToolsWithReasoning } from "../openai/thinking";
 import {
   buildChatCompletionResult,
@@ -35,6 +37,8 @@ export interface OpenAICompatibleProviderOptions {
   model: string;
   providerName?: ProviderClient["name"];
   supportsThinking: boolean;
+  /** `responses` targets `/responses`; anything else stays on `/chat/completions`. */
+  wireApi?: WireApi;
 }
 
 interface PendingToolCall {
@@ -57,9 +61,22 @@ export function createOpenAICompatibleProvider(
     maxRetries: 0,
     timeout: 600_000,
   });
+  const useResponsesApi = options.wireApi === "responses";
 
   return {
     generateChat(input: GenerateChatInput) {
+      if (useResponsesApi) {
+        return generateOpenAIResponsesChat({
+          apiKey,
+          baseUrl,
+          input,
+          label,
+          model,
+          stream: false,
+          supportsThinking: options.supportsThinking,
+        });
+      }
+
       return requestChatCompletion(client, label, {
         messages: input.messages,
         model,
@@ -77,6 +94,18 @@ export function createOpenAICompatibleProvider(
         ? input.system
         : `${input.system}\n\nReturn only the requested text. No JSON, keys, labels, markdown fences, or surrounding quotes.`;
 
+      if (useResponsesApi) {
+        return generateResponsesText({
+          apiKey,
+          baseUrl,
+          json: useJson,
+          label,
+          model,
+          prompt: input.prompt,
+          system,
+        });
+      }
+
       return requestCompletion(client, label, {
         messages: [
           { content: system, role: "system" },
@@ -88,6 +117,19 @@ export function createOpenAICompatibleProvider(
     },
     name: options.providerName ?? "openai_compatible",
     streamChat(input: GenerateChatInput, handlers: StreamChatHandlers) {
+      if (useResponsesApi) {
+        return generateOpenAIResponsesChat({
+          apiKey,
+          baseUrl,
+          handlers,
+          input,
+          label,
+          model,
+          stream: true,
+          supportsThinking: options.supportsThinking,
+        });
+      }
+
       return streamChatCompletion({
         apiKey,
         baseUrl,
@@ -368,6 +410,39 @@ async function streamChatCompletion(options: {
   }
 
   return buildChatCompletionResult({ content, thinking, toolCalls, usage });
+}
+
+async function generateResponsesText(options: {
+  apiKey: string;
+  baseUrl: string;
+  json: boolean;
+  label: string;
+  model: string;
+  prompt: string;
+  system: string;
+}): Promise<GenerateTextResult> {
+  const result = await generateOpenAIResponsesChat({
+    apiKey: options.apiKey,
+    baseUrl: options.baseUrl,
+    input: {
+      messages: [{ content: options.prompt, role: "user" }],
+      system: options.system,
+    },
+    jsonOutput: options.json,
+    label: options.label,
+    model: options.model,
+    stream: false,
+  });
+  const content = result.content.trim();
+
+  if (!content) {
+    throw new Error(`${options.label} returned an empty response.`);
+  }
+
+  return {
+    content,
+    ...(result.usage ? { usage: result.usage } : {}),
+  };
 }
 
 async function requestCompletion(

--- a/apps/server/src/providers/openai/responses.ts
+++ b/apps/server/src/providers/openai/responses.ts
@@ -24,42 +24,56 @@ import { openAIModelSupportsThinking } from "./thinking";
 
 type ResponseItem = Record<string, unknown>;
 
+export const DEFAULT_OPENAI_RESPONSES_BASE_URL = "https://api.openai.com/v1";
+
 export async function generateOpenAIResponsesChat(options: {
   apiKey: string;
+  /** Endpoint root, without `/responses`. Defaults to the OpenAI API. */
+  baseUrl?: string;
   model: string;
   input: GenerateChatInput;
+  /** Prefixes request errors. Defaults to the OpenAI provider label. */
+  label?: string;
   stream: boolean;
   handlers?: StreamChatHandlers;
   customModels?: CustomModelEntry[];
+  /** Asks the model for a JSON object, mirroring chat `response_format`. */
+  jsonOutput?: boolean;
+  /**
+   * Overrides the OpenAI model-id heuristic. Compatible endpoints serve model
+   * ids the heuristic has never seen, and it answers false for those.
+   */
+  supportsThinking?: boolean;
 }): Promise<ChatCompletionResult> {
+  const label = options.label ?? "OpenAI";
+  const baseUrl = options.baseUrl ?? DEFAULT_OPENAI_RESPONSES_BASE_URL;
   const body = await buildResponsesRequestBody(
     options.model,
     options.input,
     options.stream,
-    options.customModels
+    options.customModels,
+    options.supportsThinking,
+    options.jsonOutput
   );
-  const response = await fetchWithoutIdleTimeout(
-    "https://api.openai.com/v1/responses",
-    {
-      body: JSON.stringify(body),
-      headers: {
-        Authorization: `Bearer ${options.apiKey}`,
-        "Content-Type": "application/json",
-      },
-      method: "POST",
-      signal: options.input.signal,
-    }
-  );
+  const response = await fetchWithoutIdleTimeout(`${baseUrl}/responses`, {
+    body: JSON.stringify(body),
+    headers: {
+      Authorization: `Bearer ${options.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+    signal: options.input.signal,
+  });
 
   if (!response.ok) {
     throw new Error(
-      `OpenAI request failed (${response.status}): ${await response.text()}`
+      `${label} request failed (${response.status}): ${await response.text()}`
     );
   }
 
   if (options.stream) {
     if (!response.body) {
-      throw new Error("OpenAI returned an empty stream.");
+      throw new Error(`${label} returned an empty stream.`);
     }
 
     return readOpenAIResponsesStream(response.body, options.handlers);
@@ -84,7 +98,9 @@ async function buildResponsesRequestBody(
   model: string,
   input: GenerateChatInput,
   stream: boolean,
-  customModels?: CustomModelEntry[]
+  customModels?: CustomModelEntry[],
+  supportsThinking?: boolean,
+  jsonOutput?: boolean
 ) {
   const tools = buildResponsesTools(
     input.tools,
@@ -96,7 +112,13 @@ async function buildResponsesRequestBody(
     instructions: input.system,
     model,
     ...(tools.length > 0 ? { tools } : {}),
-    ...buildOpenAIReasoningRequest(model, input, customModels),
+    ...buildOpenAIReasoningRequest(
+      model,
+      input,
+      customModels,
+      supportsThinking
+    ),
+    ...(jsonOutput ? { text: { format: { type: "json_object" } } } : {}),
     ...(stream ? { stream: true } : {}),
   };
 }
@@ -104,14 +126,13 @@ async function buildResponsesRequestBody(
 function buildOpenAIReasoningRequest(
   model: string,
   input: GenerateChatInput,
-  customModels?: CustomModelEntry[]
+  customModels?: CustomModelEntry[],
+  supportsThinking?: boolean
 ): Record<string, unknown> {
-  if (
-    !(
-      input.providerOptions?.thinking?.enabled &&
-      openAIModelSupportsThinking(model, customModels)
-    )
-  ) {
+  const modelSupportsThinking =
+    supportsThinking ?? openAIModelSupportsThinking(model, customModels);
+
+  if (!(input.providerOptions?.thinking?.enabled && modelSupportsThinking)) {
     return {};
   }
 

--- a/apps/server/src/providers/openai/responses.ts
+++ b/apps/server/src/providers/openai/responses.ts
@@ -24,7 +24,7 @@ import { openAIModelSupportsThinking } from "./thinking";
 
 type ResponseItem = Record<string, unknown>;
 
-export const DEFAULT_OPENAI_RESPONSES_BASE_URL = "https://api.openai.com/v1";
+const DEFAULT_OPENAI_RESPONSES_BASE_URL = "https://api.openai.com/v1";
 
 export async function generateOpenAIResponsesChat(options: {
   apiKey: string;

--- a/apps/server/src/services/provider-instance-helpers.test.ts
+++ b/apps/server/src/services/provider-instance-helpers.test.ts
@@ -208,6 +208,33 @@ describe("resolveProfileProviderSelection", () => {
 });
 
 describe("applyProviderInstanceUpdate", () => {
+  test("stores wireApi only for a recognised value on a compatible instance", () => {
+    const instance = createProviderInstance({
+      baseUrl: "https://endpoint.test/v1",
+      id: "compat-1",
+      label: "Endpoint",
+      type: "openai_compatible",
+      wireApi: "responses",
+    });
+
+    // The request body is passthrough JSON, so anything can arrive here. An
+    // unrecognised value falls back to chat rather than being persisted.
+    expect(
+      applyProviderInstanceUpdate(instance, {
+        wireApi: "nonsense" as never,
+      }).wireApi
+    ).toBeUndefined();
+    expect(
+      applyProviderInstanceUpdate(instance, { wireApi: "responses" }).wireApi
+    ).toBe("responses");
+    expect(
+      applyProviderInstanceUpdate(
+        createProviderInstance({ id: "o-1", label: "OpenAI", type: "openai" }),
+        { wireApi: "responses" }
+      ).wireApi
+    ).toBeUndefined();
+  });
+
   test("preserves supportsThinking on compatible custom models", () => {
     const instance = createProviderInstance({
       apiKey: "",

--- a/apps/server/src/services/provider-instance-helpers.ts
+++ b/apps/server/src/services/provider-instance-helpers.ts
@@ -55,10 +55,7 @@ export function toProviderInstanceSummary(
     id: instance.id,
     label: normalizeProviderInstanceLabel(instance.type, instance.label, []),
     type: instance.type,
-    wireApi:
-      instance.type === "openai_compatible"
-        ? (instance.wireApi ?? "chat")
-        : null,
+    wireApi: instance.wireApi ?? null,
     ...(instance.customModels?.length
       ? { customModels: instance.customModels }
       : {}),
@@ -361,9 +358,7 @@ function buildProviderFieldsFromRequest(
       baseUrl,
       customModels,
       label,
-      ...(parseWireApi(request.wireApi)
-        ? { wireApi: "responses" as const }
-        : {}),
+      wireApi: parseWireApi(request.wireApi),
     };
   }
 

--- a/apps/server/src/services/provider-instance-helpers.ts
+++ b/apps/server/src/services/provider-instance-helpers.ts
@@ -12,6 +12,7 @@ import {
   type OllamaHostMode,
   ollamaRequiresApiKey,
   type ProviderInstance,
+  parseWireApi,
   resolveOllamaHostMode,
   type UserConfig,
   validateCustomModels,
@@ -54,6 +55,10 @@ export function toProviderInstanceSummary(
     id: instance.id,
     label: normalizeProviderInstanceLabel(instance.type, instance.label, []),
     type: instance.type,
+    wireApi:
+      instance.type === "openai_compatible"
+        ? (instance.wireApi ?? "chat")
+        : null,
     ...(instance.customModels?.length
       ? { customModels: instance.customModels }
       : {}),
@@ -234,6 +239,10 @@ export function applyProviderInstanceUpdate(
     next.hostMode = request.hostMode;
   }
 
+  if (request.wireApi !== undefined && instance.type === "openai_compatible") {
+    next.wireApi = parseWireApi(request.wireApi);
+  }
+
   if (request.customModels !== undefined) {
     if (instance.type === "openai_compatible") {
       next.customModels = validateCustomModels(request.customModels);
@@ -275,7 +284,10 @@ export function applyProviderInstanceUpdate(
 
 function buildProviderFieldsFromRequest(
   request: CreateProviderRequest
-): Pick<ProviderInstance, "baseUrl" | "customModels" | "label" | "hostMode"> {
+): Pick<
+  ProviderInstance,
+  "baseUrl" | "customModels" | "label" | "hostMode" | "wireApi"
+> {
   const type = request.type;
 
   if (type === "ollama") {
@@ -345,7 +357,14 @@ function buildProviderFieldsFromRequest(
       throw new Error("At least one model is required.");
     }
 
-    return { baseUrl, customModels, label };
+    return {
+      baseUrl,
+      customModels,
+      label,
+      ...(parseWireApi(request.wireApi)
+        ? { wireApi: "responses" as const }
+        : {}),
+    };
   }
 
   if (type === "openrouter") {

--- a/apps/web/src/components/CustomProviderFields.tsx
+++ b/apps/web/src/components/CustomProviderFields.tsx
@@ -143,7 +143,9 @@ export function CustomProviderFields({
             value={wireApi}
           >
             <SelectTrigger className="w-full" id="provider-wire-api">
-              <SelectValue />
+              <SelectValue>
+                {wireApi === "responses" ? "Responses" : "Chat completions"}
+              </SelectValue>
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="chat">Chat completions</SelectItem>

--- a/apps/web/src/components/CustomProviderFields.tsx
+++ b/apps/web/src/components/CustomProviderFields.tsx
@@ -1,9 +1,17 @@
+import type { WireApi } from "@nakama/core/contract";
 import { BrowsableModelFields } from "@/components/BrowsableModelFields";
 import type { ModelListRow } from "@/components/ModelListEditor";
 import { ModelsBrowseList } from "@/components/ModelsBrowseList";
 import { RemoteModelsBrowseList } from "@/components/RemoteModelsBrowseList";
 import { FormField } from "@/components/ui/form-field";
 import { InputGroup, InputGroupInput } from "@/components/ui/input-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 interface CustomProviderFieldsProps {
   apiKey: string;
@@ -26,9 +34,12 @@ interface CustomProviderFieldsProps {
   onBaseUrlChange: (value: string) => void;
   onCustomModelsChange: (models: ModelListRow[]) => void;
   onDisplayNameChange: (value: string) => void;
+  /** Omitted for endpoints that are known to speak chat/completions, like Ollama. */
+  onWireApiChange?: (value: WireApi) => void;
   providerInstanceId?: string;
   remoteProvider?: "ollama" | "openai_compatible";
   showModelsEditor?: boolean;
+  wireApi?: WireApi;
 }
 
 export function CustomProviderFields({
@@ -48,9 +59,11 @@ export function CustomProviderFields({
   providerInstanceId,
   hostMode,
   browseLabel,
+  wireApi = "chat",
   onDisplayNameChange,
   onBaseUrlChange,
   onCustomModelsChange,
+  onWireApiChange,
 }: CustomProviderFieldsProps) {
   const identityDisabled = disabled || identityReadOnly;
   const resolvedBrowseLabel =
@@ -107,6 +120,38 @@ export function CustomProviderFields({
           />
         </InputGroup>
       </FormField>
+
+      {onWireApiChange ? (
+        <FormField
+          density={density}
+          footer={
+            <p className="text-muted-foreground text-xs">
+              Pick Responses only when the endpoint serves{" "}
+              <span className="font-mono">/responses</span>. Reasoning survives
+              alongside tools there, which chat/completions rejects on newer
+              models.
+            </p>
+          }
+          id="provider-wire-api"
+          label="API"
+        >
+          <Select
+            disabled={disabled}
+            onValueChange={(value) =>
+              onWireApiChange(value === "responses" ? "responses" : "chat")
+            }
+            value={wireApi}
+          >
+            <SelectTrigger className="w-full" id="provider-wire-api">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="chat">Chat completions</SelectItem>
+              <SelectItem value="responses">Responses</SelectItem>
+            </SelectContent>
+          </Select>
+        </FormField>
+      ) : null}
 
       {showModelsEditor ? (
         <BrowsableModelFields

--- a/apps/web/src/components/ProviderSetupForm.tsx
+++ b/apps/web/src/components/ProviderSetupForm.tsx
@@ -205,7 +205,9 @@ export function ProviderSetupForm({
               onBaseUrlChange={form.setBaseUrl}
               onCustomModelsChange={form.setCustomModels}
               onDisplayNameChange={form.setDisplayName}
+              onWireApiChange={form.setWireApi}
               showModelsEditor={canPickModels}
+              wireApi={form.wireApi}
             />
           ) : null}
 

--- a/apps/web/src/components/settings/provider-instance-card.tsx
+++ b/apps/web/src/components/settings/provider-instance-card.tsx
@@ -186,9 +186,11 @@ export function ProviderInstanceCard({
           onDisplayNameChange={card.setEditLabel}
           onOpenChange={card.setEditOpen}
           onSave={() => void card.saveCompatible()}
+          onWireApiChange={card.isOllama ? undefined : card.setEditWireApi}
           open={card.editOpen}
           providerInstanceId={instance.id}
           remoteProvider={card.isOllama ? "ollama" : "openai_compatible"}
+          wireApi={card.editWireApi}
         />
       ) : null}
 

--- a/apps/web/src/components/settings/provider-instance-dialogs.tsx
+++ b/apps/web/src/components/settings/provider-instance-dialogs.tsx
@@ -1,4 +1,4 @@
-import type { ProviderInstanceSummary } from "@nakama/core/contract";
+import type { ProviderInstanceSummary, WireApi } from "@nakama/core/contract";
 import { ViewIcon, ViewOffIcon } from "hugeicons-react";
 import type { ReactNode } from "react";
 import { CustomProviderFields } from "@/components/CustomProviderFields";
@@ -171,7 +171,9 @@ export function ProviderCompatibleEditDialog({
   onDisplayNameChange,
   onBaseUrlChange,
   onCustomModelsChange,
+  onWireApiChange,
   onSave,
+  wireApi,
 }: {
   open: boolean;
   busy: boolean;
@@ -189,7 +191,9 @@ export function ProviderCompatibleEditDialog({
   onDisplayNameChange: (value: string) => void;
   onBaseUrlChange: (value: string) => void;
   onCustomModelsChange: (rows: ModelListRow[]) => void;
+  onWireApiChange?: (value: WireApi) => void;
   onSave: () => void;
+  wireApi?: WireApi;
 }) {
   return (
     <ProviderModelsDialogShell
@@ -215,8 +219,10 @@ export function ProviderCompatibleEditDialog({
         onBaseUrlChange={onBaseUrlChange}
         onCustomModelsChange={onCustomModelsChange}
         onDisplayNameChange={onDisplayNameChange}
+        onWireApiChange={onWireApiChange}
         providerInstanceId={providerInstanceId}
         remoteProvider={remoteProvider}
+        wireApi={wireApi}
       />
     </ProviderModelsDialogShell>
   );

--- a/apps/web/src/components/settings/use-provider-instance-card.ts
+++ b/apps/web/src/components/settings/use-provider-instance-card.ts
@@ -2,6 +2,7 @@ import type {
   ProviderInstanceSummary,
   ProviderModelOption,
   UpdateProviderRequest,
+  WireApi,
 } from "@nakama/core/contract";
 import {
   defaultDiscoveryBaseUrl,
@@ -54,6 +55,7 @@ export function useProviderInstanceCard({
   const [showApiKey, setShowApiKey] = useState(false);
   const [editLabel, setEditLabel] = useState("");
   const [editBaseUrl, setEditBaseUrl] = useState("");
+  const [editWireApi, setEditWireApi] = useState<WireApi>("chat");
   const [manageModels, setManageModels] = useState<ModelListRow[]>([]);
 
   const providerType = instance.type as SelectedProvider;
@@ -115,6 +117,7 @@ export function useProviderInstanceCard({
             ? (defaultDiscoveryBaseUrl(providerType) ?? "")
             : "")
     );
+    setEditWireApi(instance.wireApi ?? "chat");
     setManageModels(seedManageModelRows(instance.customModels, instanceModels));
     setEditOpen(true);
   };
@@ -191,6 +194,7 @@ export function useProviderInstanceCard({
             }
           : {}),
         customModels: normalizeModelListRows(manageModels),
+        ...(isOllama ? {} : { wireApi: editWireApi }),
       },
       () => setEditOpen(false)
     );
@@ -236,6 +240,7 @@ export function useProviderInstanceCard({
     editLabel,
     editManageModels,
     editOpen,
+    editWireApi,
     handleDelete,
     handleManageModelsChange,
     handleReplaceKey,
@@ -256,6 +261,7 @@ export function useProviderInstanceCard({
     setEditBaseUrl,
     setEditLabel,
     setEditOpen,
+    setEditWireApi,
     setManageModels,
     setManageOpen,
     setReplaceKeyOpen,

--- a/apps/web/src/hooks/use-provider-setup-form.ts
+++ b/apps/web/src/hooks/use-provider-setup-form.ts
@@ -3,6 +3,7 @@ import type {
   CreateProviderResponse,
   OllamaHostMode,
   ProviderModelOption,
+  WireApi,
 } from "@nakama/core/contract";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { ModelListRow } from "@/components/ModelListEditor";
@@ -87,6 +88,7 @@ export function useProviderSetupForm(
   const [ollamaHostMode, setOllamaHostMode] = useState<OllamaHostMode>("local");
   const [displayName, setDisplayName] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
+  const [wireApi, setWireApi] = useState<WireApi>("chat");
   const [customModels, setCustomModels] = useState<ModelListRow[]>([]);
   const [extraModels, setExtraModels] = useState<ProviderModelOption[]>([]);
   const [displayNameError, setDisplayNameError] = useState<string | null>(null);
@@ -488,6 +490,8 @@ export function useProviderSetupForm(
               selectedProvider === "ollama" ? ollamaHostMode : undefined,
             model: modelToSave || undefined,
             provider: selectedProvider,
+            wireApi:
+              selectedProvider === "openai_compatible" ? wireApi : undefined,
           })
         );
         setApiKey("");
@@ -519,6 +523,7 @@ export function useProviderSetupForm(
       createProvider,
       onSuccess,
       filteredModels,
+      wireApi,
     ]
   );
 
@@ -557,8 +562,10 @@ export function useProviderSetupForm(
     setDisplayName,
     setSelectedModel,
     setShowApiKey,
+    setWireApi,
     shortlistModels,
     shortlistModelsError,
     showApiKey,
+    wireApi,
   };
 }

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -3,6 +3,7 @@ import type {
   CreateProviderRequest,
   OllamaHostMode,
   ProviderModelOption,
+  WireApi,
 } from "@nakama/core/contract";
 import {
   OLLAMA_CLOUD_DEFAULT_BASE_URL,
@@ -576,6 +577,7 @@ export function buildCreateProviderRequest(options: {
   baseUrl?: string;
   hostMode?: OllamaHostMode;
   customModels?: ConfigureProviderRequest["customModels"];
+  wireApi?: WireApi;
 }): CreateProviderRequest {
   const request = buildConfigureProviderRequest(options);
 
@@ -589,6 +591,7 @@ export function buildCreateProviderRequest(options: {
     ...(options.baseUrl?.trim() ? { baseUrl: options.baseUrl.trim() } : {}),
     ...(options.hostMode ? { hostMode: options.hostMode } : {}),
     ...(request.customModels ? { customModels: request.customModels } : {}),
+    ...(options.wireApi === "responses" ? { wireApi: options.wireApi } : {}),
   };
 }
 

--- a/docs/website/content/docs/providers.mdx
+++ b/docs/website/content/docs/providers.mdx
@@ -46,6 +46,7 @@ Some capabilities depend on the active provider:
 - **Web search** (`web_search` tool) — OpenAI or Anthropic with a valid API key; not available on OpenRouter
 - **Audio transcription** (Telegram voice notes) — requires an OpenAI provider and a transcription model in **Settings → Audio transcription model**
 - **Image parsing** — used when the chat model cannot see images. Set **Settings → Image parsing model**. The list only includes models marked as vision-capable. For a custom endpoint, turn **Vision** on for that model under **Settings → LLM providers**
+- **Responses API endpoints**: a custom endpoint that serves `/responses` rather than `/chat/completions`. Set **API** to Responses under **Settings → LLM providers**, or answer `responses` in the CLI setup wizard. Required for endpoints that do not serve chat/completions at all, and it keeps reasoning available alongside tools on models that reject the pair on chat/completions
 - **Coding agent provider passthrough** — spawn-time credentials for Claude Code / Codex / OpenCode; see [Coding agent](/coding-agent)
 
 ## Per-profile models

--- a/packages/core/src/compatible-provider-config.ts
+++ b/packages/core/src/compatible-provider-config.ts
@@ -1,6 +1,18 @@
-import type { CustomModelEntry, ProviderName } from "./contract";
+import type { CustomModelEntry, ProviderName, WireApi } from "./contract";
 
 export const DISPLAY_NAME_MAX_LENGTH = 64;
+
+/**
+ * Endpoints that serve `/responses` have to be told apart from the ones that
+ * serve `/chat/completions`, and the model id does not say which is which.
+ * Anything unrecognised stays on chat, so a bad value cannot take an endpoint
+ * offline.
+ */
+export function parseWireApi(value: unknown): WireApi | undefined {
+  return typeof value === "string" && value.trim() === "responses"
+    ? "responses"
+    : undefined;
+}
 
 export function normalizeBaseUrl(baseUrl: string): string {
   return baseUrl.trim().replace(/\/+$/, "");

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -1513,6 +1513,7 @@ export interface ProviderInstanceSummary {
   label: string;
   modelCount: number;
   type: ProviderName;
+  wireApi?: WireApi | null;
 }
 
 export interface ListProvidersResponse {
@@ -1528,6 +1529,7 @@ export interface CreateProviderRequest {
   label?: string;
   model?: string;
   type: ProviderName;
+  wireApi?: WireApi;
 }
 
 export interface CreateProviderResponse {
@@ -1542,6 +1544,7 @@ export interface UpdateProviderRequest {
   customModels?: CustomModelEntry[];
   hostMode?: OllamaHostMode;
   label?: string;
+  wireApi?: WireApi;
 }
 
 export interface UpdateProviderResponse {
@@ -2039,6 +2042,12 @@ export type ProviderName =
   | "xai";
 
 export type OllamaHostMode = "local" | "cloud";
+
+/**
+ * Which OpenAI API an endpoint speaks. Some hosts serve `/responses` only, so
+ * this is a property of the endpoint and cannot be inferred from the model id.
+ */
+export type WireApi = "chat" | "responses";
 
 export type GenerateTextFormat = "json" | "text";
 

--- a/packages/core/src/provider-setup-prompt.test.ts
+++ b/packages/core/src/provider-setup-prompt.test.ts
@@ -27,6 +27,26 @@ describe("promptForProviderConfig", () => {
     );
   });
 
+  test("stores wireApi when the custom endpoint answers responses", async () => {
+    const answers = [
+      "openai_compatible",
+      "Responses Only",
+      "https://endpoint.test/v1",
+      "",
+      "responses",
+      "demo-thinker",
+    ];
+    const config = await promptForProviderConfig(scriptedPrompt(answers));
+
+    expect(config.providers[0]?.wireApi).toBe("responses");
+
+    const chat = await promptForProviderConfig(
+      scriptedPrompt(answers.map((a) => (a === "responses" ? "" : a)))
+    );
+
+    expect(chat.providers[0]?.wireApi).toBeUndefined();
+  });
+
   test("accepts a pasted Workers AI URL for Cloudflare", async () => {
     const config = await promptForProviderConfig(
       scriptedPrompt([

--- a/packages/core/src/provider-setup-prompt.ts
+++ b/packages/core/src/provider-setup-prompt.ts
@@ -2,6 +2,7 @@ import { resolveCloudflareAccountInput } from "./cloudflare-provider-config";
 import {
   isValidBaseUrl,
   normalizeBaseUrl,
+  parseWireApi,
   validateCustomModels,
   validateDisplayName,
 } from "./compatible-provider-config";
@@ -319,6 +320,9 @@ async function promptForCompatibleProviderInstance(
 
     const baseUrl = normalizeBaseUrl(baseUrlInput);
     const apiKey = (await question("API key (optional): ")).trim();
+    const wireApi = parseWireApi(
+      await question("API, chat or responses (default chat): ")
+    );
     const modelIds = (await question("Model IDs (comma-separated): "))
       .split(",")
       .map((value) => value.trim())
@@ -344,6 +348,7 @@ async function promptForCompatibleProviderInstance(
       id: createProviderInstanceId(),
       label: displayName,
       type: "openai_compatible",
+      ...(wireApi ? { wireApi } : {}),
     };
   }
 }

--- a/packages/core/src/user-config.test.ts
+++ b/packages/core/src/user-config.test.ts
@@ -105,6 +105,7 @@ describe("user config multi-provider", () => {
           id: compatibleId,
           label: "Ollama",
           type: "openai_compatible",
+          wireApi: "responses",
         },
       ],
       thinkingEffort: "medium",
@@ -125,6 +126,7 @@ describe("user config multi-provider", () => {
     expect(loaded?.providers[1]?.customModels?.[0]?.supportsThinking).toBe(
       true
     );
+    expect(loaded?.providers[1]?.wireApi).toBe("responses");
   });
 
   test("round-trips cerebras models_json with capability flags", async () => {

--- a/packages/core/src/user-config.ts
+++ b/packages/core/src/user-config.ts
@@ -6,6 +6,7 @@ import {
   isValidBaseUrl,
   normalizeBaseUrl,
   parseCustomModelsJson,
+  parseWireApi,
   serializeCustomModels,
   validateDisplayName,
 } from "./compatible-provider-config";
@@ -48,6 +49,7 @@ export interface ProviderInstance {
   id: string;
   label: string;
   type: UserProviderName;
+  wireApi?: import("./contract").WireApi;
 }
 
 export interface UserConfig {
@@ -632,6 +634,8 @@ function loadProvidersFromSections(
       type === "ollama"
         ? (parseOllamaHostMode(values.host_mode) ?? undefined)
         : undefined;
+    const wireApi =
+      type === "openai_compatible" ? parseWireApi(values.wire_api) : undefined;
     const createdAt = values.created_at?.trim() || new Date(0).toISOString();
 
     providers.push({
@@ -641,6 +645,7 @@ function loadProvidersFromSections(
       type,
       ...(baseUrl ? { baseUrl } : {}),
       ...(hostMode ? { hostMode } : {}),
+      ...(wireApi ? { wireApi } : {}),
       ...(customModels ? { customModels } : {}),
       createdAt,
     });
@@ -667,6 +672,10 @@ function buildProviderSectionValues(
 
   if (provider.type === "ollama" && provider.hostMode) {
     values.host_mode = provider.hostMode;
+  }
+
+  if (provider.type === "openai_compatible" && provider.wireApi) {
+    values.wire_api = provider.wireApi;
   }
 
   if (provider.customModels?.length) {


### PR DESCRIPTION
## Summary

An operator points an openai-compatible provider at an endpoint that serves `/v1/responses`, and nakama talks to it.

**Before:** every compatible provider posted to `/chat/completions` only. An endpoint serving `/responses` and nothing else could not be registered, and on gpt-5.4+ models the provider forced `reasoning_effort: "none"` whenever tools were present, because chat/completions rejects that pair.
**After:** `wire_api` on the provider instance picks the path. `generateOpenAIResponsesChat` takes a base URL, an error label and a `supportsThinking` override, so `openai-compatible` reuses it instead of getting a second implementation.

Why safe:
1. Default is chat/completions. With no `wire_api`, the endpoint and request body are what they were, covered by a test that asserts the URL.
2. The `openai` provider is untouched: base URL and label default to the old constants, so its requests and error strings are unchanged.
3. `wireApi` arrives in a passthrough JSON body, so it goes through `parseWireApi`; anything unrecognised falls back to chat rather than being stored.

Closes #635

## Evidence

One throwaway instance, one fake endpoint that serves `/v1/responses` and 404s everything else. Same provider, same session, `wire_api` flipped between the two runs.

```
wire_api=responses  → {"reply":"Responses-only endpoint answered.", ...}
                      endpoint saw: POST /v1/responses
                      reasoning={"effort":"medium","summary":"auto"}

wire_api=chat       → {"error":"Responses Only request failed (404):
                       /v1/chat/completions is not served here; use /v1/responses"}
                      endpoint saw: POST /v1/chat/completions
```

The reasoning line is the second half of the fix: that same turn on chat/completions ships `reasoning_effort: "none"`.

Switching it in the UI writes through to disk. `wire_api` was absent before Save and `wire_api=responses` after.

![API select in the provider edit dialog](https://raw.githubusercontent.com/fajarhide/tinyclaw/4f3dab50302935d19a9f229ed8107802046e3510/wire-api-select.png)

The CLI setup wizard asks the same question, since a headless install pointed at a Responses-only endpoint would otherwise need `config.ini` edited by hand. Documented in `providers.mdx` under provider-specific features.

## Test plan
- [x] `bun run test` across all workspaces: 996 server, 286 web, 0 fail
- [x] Each new test watched failing with the change reverted: routing tests fail on `useResponsesApi = false`, the update guard fails on `next.wireApi = request.wireApi`, the config round-trip fails without the `wire_api` write
- [x] Manual: registered a Responses-only endpoint, sent a turn, flipped the setting in Settings and confirmed `config.ini`
- [x] `extraHeaders` was dropped from the issue's criteria on purpose: nothing in the tree sets it, so the parameter would have had no caller

