### PR TITLE
fix(cli): hoist child_process import in styled-text

### DIFF
--- a/apps/cli/src/styled-text.ts
+++ b/apps/cli/src/styled-text.ts
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import { visibleLength } from "./text-measure";
 
 export type NamedColor = "default" | "cyan" | "yellow" | "red" | "green";
@@ -48,7 +49,6 @@ export async function detectTheme(): Promise<Theme | null> {
   // macOS system appearance — most reliable for Apple terminals
   if (process.platform === "darwin") {
     try {
-      const { execSync } = require("node:child_process");
       execSync("defaults read -g AppleInterfaceStyle 2>/dev/null", {
         encoding: "utf8",
         timeout: 500,


### PR DESCRIPTION
## Summary

CLI theme detection on macOS uses a top-level `execSync` import → no mid-function `require()`.

**Before:** `require("node:child_process")` ran synchronously inside `detectTheme()` on every macOS call.
**After:** `import { execSync } from "node:child_process"` at module scope (`styled-text.ts`).

Why safe:
1. Same `execSync` API and timeout behavior
2. Import-only change; no control-flow edits
3. Closes #624

Only re-add a dynamic import if a bundler starts pulling `child_process` into non-CLI builds of this module.

## Test plan
- [x] Pre-commit Ultracite format/check on commit (pass)
- [x] `detectTheme()` smoke on macOS → returned `dark`/`light` without throw
