### PR TITLE
fix(cli): reject invalid --theme values

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -17,6 +17,7 @@ import {
   ensureUserConfiguredViaCli,
 } from "./setup";
 import { detectTheme, setTheme, type Theme } from "./styled-text";
+import { InvalidThemeArgError, parseThemeArg } from "./theme-arg";
 
 if (isRotateTokenCommand()) {
   try {
@@ -28,34 +29,18 @@ if (isRotateTokenCommand()) {
   }
 }
 
-function parseThemeArg(argv = process.argv.slice(2)): Theme | null {
-  for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index];
-
-    if (arg === "--theme") {
-      const value = argv[index + 1]?.trim();
-      if (value === "light" || value === "dark") {
-        return value;
-      }
-      index += 1;
-      continue;
-    }
-
-    if (arg === "--theme=light") {
-      return "light";
-    }
-    if (arg === "--theme=dark") {
-      return "dark";
-    }
-  }
-
-  return null;
-}
-
 async function resolveTheme(): Promise<Theme> {
-  const explicit = parseThemeArg();
-  if (explicit) {
-    return explicit;
+  try {
+    const explicit = parseThemeArg();
+    if (explicit) {
+      return explicit;
+    }
+  } catch (error) {
+    if (error instanceof InvalidThemeArgError) {
+      console.error(error.message);
+      process.exit(1);
+    }
+    throw error;
   }
   if (process.env.NAKAMA_THEME === "light") {
     return "light";

--- a/apps/cli/src/theme-arg.test.ts
+++ b/apps/cli/src/theme-arg.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { InvalidThemeArgError, parseThemeArg } from "./theme-arg";
+
+describe("parseThemeArg", () => {
+  test("parses --theme light/dark", () => {
+    expect(parseThemeArg(["--theme", "light"])).toBe("light");
+    expect(parseThemeArg(["chat", "--theme", "dark"])).toBe("dark");
+  });
+
+  test("parses --theme=light/dark", () => {
+    expect(parseThemeArg(["--theme=light"])).toBe("light");
+    expect(parseThemeArg(["--theme=dark"])).toBe("dark");
+  });
+
+  test("returns null when flag is absent", () => {
+    expect(parseThemeArg(["chat"])).toBeNull();
+    expect(parseThemeArg([])).toBeNull();
+  });
+
+  test("rejects unknown --theme values", () => {
+    expect(() => parseThemeArg(["--theme", "sepia"])).toThrow(
+      InvalidThemeArgError
+    );
+    expect(() => parseThemeArg(["--theme=neon"])).toThrow(InvalidThemeArgError);
+  });
+
+  test("rejects missing --theme value", () => {
+    expect(() => parseThemeArg(["--theme"])).toThrow(InvalidThemeArgError);
+  });
+});

--- a/apps/cli/src/theme-arg.ts
+++ b/apps/cli/src/theme-arg.ts
@@ -1,0 +1,40 @@
+import type { Theme } from "./styled-text";
+
+export class InvalidThemeArgError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidThemeArgError";
+  }
+}
+
+function assertThemeValue(value: string | undefined): Theme {
+  if (value === "light" || value === "dark") {
+    return value;
+  }
+
+  if (value === undefined || value.length === 0) {
+    throw new InvalidThemeArgError(
+      "Missing value for --theme. Use --theme light or --theme dark."
+    );
+  }
+
+  throw new InvalidThemeArgError(
+    `Invalid --theme value "${value}". Use light or dark.`
+  );
+}
+
+export function parseThemeArg(argv = process.argv.slice(2)): Theme | null {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--theme") {
+      return assertThemeValue(argv[index + 1]?.trim());
+    }
+
+    if (arg?.startsWith("--theme=")) {
+      return assertThemeValue(arg.slice("--theme=".length).trim());
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Invalid or missing `--theme` now exits non-zero with a clear error instead of swallowing the next argv token.

**Before:** `--theme sepia` / `--theme` / `--theme=neon` fell through; the next arg could be consumed as a “value” and ignored.
**After:** `parseThemeArg` (`theme-arg.ts`) validates `light`|`dark` and throws `InvalidThemeArgError`; CLI prints the message and `process.exit(1)`.

Why safe:
1. Valid `--theme light|dark` and `--theme=…` paths unchanged
2. Absent `--theme` still returns `null` → env / auto-detect as before
3. Unit tests cover accept + reject cases (closes #618)

Only revisit if scripts relied on the old silent swallow (they should not).

## Test plan
- [x] `bun test ./apps/cli/src/theme-arg.test.ts` (5 pass)
- [x] `parseThemeArg(["--theme","sepia"])` / missing value → `InvalidThemeArgError`; `--theme dark` → `dark`
