### PR TITLE
fix(cli): restore stdin encoding and strip cursor probes in one pass

### DIFF
--- a/apps/cli/src/terminal-encoding.test.ts
+++ b/apps/cli/src/terminal-encoding.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { Readable } from "node:stream";
+import { restoreReadableEncoding } from "./terminal-input";
+
+describe("restoreReadableEncoding", () => {
+  test("restores a prior named encoding", async () => {
+    const stream = new Readable({
+      read() {
+        this.push(Buffer.from([0x61]));
+        this.push(null);
+      },
+    });
+    stream.setEncoding("utf8");
+    restoreReadableEncoding(stream, "hex");
+
+    const chunk = await new Promise<unknown>((resolve) => {
+      stream.once("data", resolve);
+    });
+
+    expect(chunk).toBe("61");
+  });
+
+  test("restores buffer mode after utf8 when previous was unset", async () => {
+    const stream = new Readable({
+      read() {
+        this.push(Buffer.from([0xc3, 0xa9]));
+        this.push(null);
+      },
+    });
+    stream.setEncoding("utf8");
+    restoreReadableEncoding(stream, null);
+
+    const chunk = await new Promise<unknown>((resolve) => {
+      stream.once("data", resolve);
+    });
+
+    expect(Buffer.isBuffer(chunk)).toBe(true);
+  });
+});

--- a/apps/cli/src/terminal-input.ts
+++ b/apps/cli/src/terminal-input.ts
@@ -1,6 +1,35 @@
 const CURSOR_POSITION_REPORT = /^\x1b\[(\d+);(\d+)R$/;
 const MOUSE_EVENT_REPORT = /^\x1b\[<\d+;\d+;\d+[mM]$/;
 
+type ReadableEncodingState = {
+  decoder?: unknown;
+  encoding?: string | null;
+};
+
+/**
+ * Restore a Readable stream's prior encoding.
+ * `setEncoding(null)` does not clear encoding in Node/Bun (nodejs/node#51083),
+ * so buffer mode is restored by clearing `_readableState` when needed.
+ */
+export function restoreReadableEncoding(
+  stream: NodeJS.ReadableStream,
+  previous: BufferEncoding | null | undefined
+): void {
+  if (previous) {
+    stream.setEncoding(previous);
+    return;
+  }
+
+  const state = (stream as { _readableState?: ReadableEncodingState })
+    ._readableState;
+  if (!state) {
+    return;
+  }
+
+  state.encoding = null;
+  state.decoder = null;
+}
+
 export function isTerminalResponse(chunk: string): boolean {
   if (CURSOR_POSITION_REPORT.test(chunk)) {
     return true;
@@ -75,7 +104,7 @@ export class TerminalInput {
   private pending = "";
   private listeners = new Set<(chunk: string) => void>();
   private cursorWaiters = new Set<(row: number) => void>();
-  private previousEncoding: BufferEncoding | null = null;
+  private previousEncoding: BufferEncoding | null | undefined;
 
   start(): void {
     if (this.active) {
@@ -103,7 +132,8 @@ export class TerminalInput {
     this.active = false;
     process.stdin.off("data", this.handleData);
     process.stdin.setRawMode(false);
-    process.stdin.setEncoding(this.previousEncoding);
+    restoreReadableEncoding(process.stdin, this.previousEncoding);
+    this.previousEncoding = undefined;
 
     if (this.mouseTracking) {
       process.stdout.write("\x1b[?1000l\x1b[?1006l");

--- a/apps/cli/src/terminal-input.ts
+++ b/apps/cli/src/terminal-input.ts
@@ -1,5 +1,24 @@
 const CURSOR_POSITION_REPORT = /^\x1b\[(\d+);(\d+)R$/;
+const CURSOR_POSITION_REPORT_GLOBAL = /\x1b\[(\d+);(\d+)R/g;
 const MOUSE_EVENT_REPORT = /^\x1b\[<\d+;\d+;\d+[mM]$/;
+
+/** Strip all CPR sequences in one pass; return the first report's row. */
+export function stripCursorPositionReports(pending: string): {
+  pending: string;
+  row: number | null;
+} {
+  let row: number | null = null;
+  const cleaned = pending.replace(
+    CURSOR_POSITION_REPORT_GLOBAL,
+    (_match, rowText: string) => {
+      if (row === null) {
+        row = Number(rowText);
+      }
+      return "";
+    }
+  );
+  return { pending: cleaned, row };
+}
 
 export function isTerminalResponse(chunk: string): boolean {
   if (CURSOR_POSITION_REPORT.test(chunk)) {
@@ -163,17 +182,14 @@ export class TerminalInput {
   private handleData = (chunk: Buffer | string): void => {
     this.pending += String(chunk);
 
-    const cursorMatch = this.pending.match(/\x1b\[(\d+);(\d+)R/);
+    const stripped = stripCursorPositionReports(this.pending);
+    this.pending = stripped.pending;
 
-    if (cursorMatch) {
-      const row = Number(cursorMatch[1]);
-
+    if (stripped.row !== null) {
       for (const waiter of this.cursorWaiters) {
-        waiter(row);
+        waiter(stripped.row);
       }
-
       this.cursorWaiters.clear();
-      this.pending = this.pending.replace(/\x1b\[\d+;\d+R/g, "");
     }
 
     const consumed = consumeTerminalInput(this.pending);

--- a/apps/cli/src/terminal-input.ts
+++ b/apps/cli/src/terminal-input.ts
@@ -75,6 +75,7 @@ export class TerminalInput {
   private pending = "";
   private listeners = new Set<(chunk: string) => void>();
   private cursorWaiters = new Set<(row: number) => void>();
+  private previousEncoding: BufferEncoding | null = null;
 
   start(): void {
     if (this.active) {
@@ -82,6 +83,7 @@ export class TerminalInput {
     }
 
     this.active = true;
+    this.previousEncoding = process.stdin.readableEncoding;
     process.stdin.setEncoding("utf8");
     process.stdin.setRawMode(true);
     process.stdin.resume();
@@ -101,6 +103,7 @@ export class TerminalInput {
     this.active = false;
     process.stdin.off("data", this.handleData);
     process.stdin.setRawMode(false);
+    process.stdin.setEncoding(this.previousEncoding);
 
     if (this.mouseTracking) {
       process.stdout.write("\x1b[?1000l\x1b[?1006l");

--- a/apps/cli/src/terminal-screen.test.ts
+++ b/apps/cli/src/terminal-screen.test.ts
@@ -3,6 +3,7 @@ import {
   consumeTerminalInput,
   isMouseEventReport,
   isTerminalResponse,
+  stripCursorPositionReports,
 } from "./terminal-input";
 
 describe("isTerminalResponse", () => {
@@ -13,6 +14,22 @@ describe("isTerminalResponse", () => {
 
   test("detects mouse tracking reports", () => {
     expect(isMouseEventReport("\x1b[<64;12;8M")).toBe(true);
+  });
+});
+
+describe("stripCursorPositionReports", () => {
+  test("strips multiple reports in one pass and keeps the first row", () => {
+    const result = stripCursorPositionReports("a\x1b[12;1R\x1b[99;2Rb");
+
+    expect(result.row).toBe(12);
+    expect(result.pending).toBe("ab");
+  });
+
+  test("returns null row when no report is present", () => {
+    expect(stripCursorPositionReports("hello")).toEqual({
+      pending: "hello",
+      row: null,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Leaving CLI chat restores the prior stdin encoding for real, and multi-CPR bursts strip in one pass.

**Before:** `stop()` left `utf8` set (`setEncoding(null)` is a no-op in Node/Bun); multi-CPR chunks used match-then-replace.
**After:** `restoreReadableEncoding()` restores a named encoding or clears `_readableState` for buffer mode; `stripCursorPositionReports()` strips every CPR and keeps the first row.

Why safe:
1. Named-encoding restore still uses `setEncoding`
2. Buffer-mode restore covered by unit tests on Bun Readable streams
3. First-row CPR semantics match the previous `match()` behavior (also closes #623)

Only revisit if a runtime without `_readableState` needs a different buffer-mode restore.

## Test plan
- [x] `bun test ./apps/cli/src/terminal-encoding.test.ts ./apps/cli/src/terminal-screen.test.ts` (9 pass)
- [ ] Enter CLI chat, exit cleanly, then use a readline path — input still readable
