### PR TITLE
fix(cli): strip cursor probes in a single pass

### DIFF
--- a/apps/cli/src/terminal-input.ts
+++ b/apps/cli/src/terminal-input.ts
@@ -1,5 +1,24 @@
 const CURSOR_POSITION_REPORT = /^\x1b\[(\d+);(\d+)R$/;
+const CURSOR_POSITION_REPORT_GLOBAL = /\x1b\[(\d+);(\d+)R/g;
 const MOUSE_EVENT_REPORT = /^\x1b\[<\d+;\d+;\d+[mM]$/;
+
+/** Strip all CPR sequences in one pass; return the first report's row. */
+export function stripCursorPositionReports(pending: string): {
+  pending: string;
+  row: number | null;
+} {
+  let row: number | null = null;
+  const cleaned = pending.replace(
+    CURSOR_POSITION_REPORT_GLOBAL,
+    (_match, rowText: string) => {
+      if (row === null) {
+        row = Number(rowText);
+      }
+      return "";
+    }
+  );
+  return { pending: cleaned, row };
+}
 
 export function isTerminalResponse(chunk: string): boolean {
   if (CURSOR_POSITION_REPORT.test(chunk)) {
@@ -163,17 +182,14 @@ export class TerminalInput {
   private handleData = (chunk: Buffer | string): void => {
     this.pending += String(chunk);
 
-    const cursorMatch = this.pending.match(/\x1b\[(\d+);(\d+)R/);
+    const stripped = stripCursorPositionReports(this.pending);
+    this.pending = stripped.pending;
 
-    if (cursorMatch) {
-      const row = Number(cursorMatch[1]);
-
+    if (stripped.row !== null) {
       for (const waiter of this.cursorWaiters) {
-        waiter(row);
+        waiter(stripped.row);
       }
-
       this.cursorWaiters.clear();
-      this.pending = this.pending.replace(/\x1b\[\d+;\d+R/g, "");
     }
 
     const consumed = consumeTerminalInput(this.pending);

--- a/apps/cli/src/terminal-screen.test.ts
+++ b/apps/cli/src/terminal-screen.test.ts
@@ -3,6 +3,7 @@ import {
   consumeTerminalInput,
   isMouseEventReport,
   isTerminalResponse,
+  stripCursorPositionReports,
 } from "./terminal-input";
 
 describe("isTerminalResponse", () => {
@@ -13,6 +14,22 @@ describe("isTerminalResponse", () => {
 
   test("detects mouse tracking reports", () => {
     expect(isMouseEventReport("\x1b[<64;12;8M")).toBe(true);
+  });
+});
+
+describe("stripCursorPositionReports", () => {
+  test("strips multiple reports in one pass and keeps the first row", () => {
+    const result = stripCursorPositionReports("a\x1b[12;1R\x1b[99;2Rb");
+
+    expect(result.row).toBe(12);
+    expect(result.pending).toBe("ab");
+  });
+
+  test("returns null row when no report is present", () => {
+    expect(stripCursorPositionReports("hello")).toEqual({
+      pending: "hello",
+      row: null,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Multiple cursor-position reports in one stdin chunk are stripped in a single pass; waiters still get the first row.

**Before:** `match` then a separate global `replace` could drop later CPRs without a deterministic strip/extract pairing.
**After:** `stripCursorPositionReports()` removes every `\x1b[row;colR` in one `replace` and returns the first row for `cursorWaiters`.

Why safe:
1. First-row semantics match the previous `match()` behavior
2. Key/paste/mouse consumption still runs on the cleaned buffer
3. Unit tests cover multi-CPR + no-CPR (closes #623)

Only revisit if a waiter ever needs the *latest* CPR in a burst instead of the first.

## Test plan
- [x] `bun test apps/cli/src/terminal-screen.test.ts` (7 pass)
- [ ] In CLI chat, trigger layout that probes cursor (resize / redraw) — input still accepts keys

Closes #623
