### PR TITLE
fix(cli): restore prior stdin pause after password prompt

### DIFF
--- a/apps/cli/src/setup.ts
+++ b/apps/cli/src/setup.ts
@@ -19,30 +19,34 @@ function readPassword(prompt: string): Promise<string> {
 
     stdout.write(prompt);
 
+    const wasPaused = stdin.isPaused();
     stdin.setRawMode(true);
     stdin.resume();
     stdin.setEncoding("utf8");
 
     let password = "";
 
+    const restoreStdin = () => {
+      stdin.setRawMode(false);
+      if (wasPaused) {
+        stdin.pause();
+      }
+      stdin.removeListener("data", onData);
+      stdout.write("\n");
+    };
+
     const onData = (chunk: string) => {
       for (const char of chunk) {
         if (char === "\n" || char === "\r" || char === "\u0004") {
           // Enter or EOF
-          stdin.setRawMode(false);
-          stdin.pause();
-          stdin.removeListener("data", onData);
-          stdout.write("\n");
+          restoreStdin();
           resolve(password);
           return;
         }
 
         if (char === "\u0003") {
           // Ctrl+C
-          stdin.setRawMode(false);
-          stdin.pause();
-          stdin.removeListener("data", onData);
-          stdout.write("\n");
+          restoreStdin();
           process.exit(130);
         }
 


### PR DESCRIPTION
## Summary

CLI admin password prompt restores stdin’s prior paused/flowing state after Enter or Ctrl+C.

**Before:** `readPassword` always `resume()` then always `pause()` on exit — flowing stdin stayed paused.
**After:** snapshot `stdin.isPaused()` before resume; `restoreStdin()` only pauses when it was paused.

Why safe:
1. Raw mode still cleared on every exit path
2. Listener still removed; newline still written
3. Closes #619

Only revisit if a caller needed the old “always pause” side effect after setup.

## Test plan
- [x] Code review: `wasPaused` + `restoreStdin()` on Enter and Ctrl+C paths
- [ ] Fresh CLI setup password prompts → subsequent readline questions still accept input
