### PR TITLE
fix(cli): validate --org id and slug shape

### DIFF
--- a/apps/cli/src/org.test.ts
+++ b/apps/cli/src/org.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseCliOrgArgs } from "./org";
+import { InvalidOrgArgError, parseCliOrgArgs } from "./org";
 
 describe("parseCliOrgArgs", () => {
   test("parses --org flag", () => {
@@ -7,5 +7,30 @@ describe("parseCliOrgArgs", () => {
       orgId: "org_abc",
     });
     expect(parseCliOrgArgs(["--org=org_xyz"])).toEqual({ orgId: "org_xyz" });
+  });
+
+  test("parses org slugs", () => {
+    expect(parseCliOrgArgs(["--org", "acme-co"])).toEqual({
+      orgId: "acme-co",
+    });
+  });
+
+  test("rejects missing --org value", () => {
+    expect(() => parseCliOrgArgs(["--org"])).toThrow(InvalidOrgArgError);
+    expect(() => parseCliOrgArgs(["--org", "--theme", "dark"])).toThrow(
+      InvalidOrgArgError
+    );
+  });
+
+  test("rejects invalid --org shape", () => {
+    expect(() => parseCliOrgArgs(["--org", "../etc"])).toThrow(
+      InvalidOrgArgError
+    );
+    expect(() => parseCliOrgArgs(["--org=org_abc/../x"])).toThrow(
+      InvalidOrgArgError
+    );
+    expect(() => parseCliOrgArgs([`--org=${"a".repeat(200)}`])).toThrow(
+      InvalidOrgArgError
+    );
   });
 });

--- a/apps/cli/src/org.ts
+++ b/apps/cli/src/org.ts
@@ -17,7 +17,7 @@ const ORG_ID_PATTERN = /^org_[A-Za-z0-9]+$/;
 const ORG_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/i;
 const MAX_ORG_REF_LENGTH = 128;
 
-export function assertOrgRef(value: string): string {
+function assertOrgRef(value: string): string {
   if (value.length > MAX_ORG_REF_LENGTH) {
     throw new InvalidOrgArgError(
       `Invalid --org value: exceeds ${MAX_ORG_REF_LENGTH} characters.`

--- a/apps/cli/src/org.ts
+++ b/apps/cli/src/org.ts
@@ -5,6 +5,34 @@ export interface CliOrgOptions {
   orgId?: string;
 }
 
+export class InvalidOrgArgError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidOrgArgError";
+  }
+}
+
+/** Org ids (`org_…`) plus slugs resolved by `assertOrgMembership`. */
+const ORG_ID_PATTERN = /^org_[A-Za-z0-9]+$/;
+const ORG_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/i;
+const MAX_ORG_REF_LENGTH = 128;
+
+export function assertOrgRef(value: string): string {
+  if (value.length > MAX_ORG_REF_LENGTH) {
+    throw new InvalidOrgArgError(
+      `Invalid --org value: exceeds ${MAX_ORG_REF_LENGTH} characters.`
+    );
+  }
+
+  if (ORG_ID_PATTERN.test(value) || ORG_SLUG_PATTERN.test(value)) {
+    return value;
+  }
+
+  throw new InvalidOrgArgError(
+    `Invalid --org value "${value}". Expected org_<id> or a slug.`
+  );
+}
+
 export function parseCliOrgArgs(argv = process.argv.slice(2)): CliOrgOptions {
   let orgId: string | undefined;
 
@@ -12,13 +40,25 @@ export function parseCliOrgArgs(argv = process.argv.slice(2)): CliOrgOptions {
     const arg = argv[index];
 
     if (arg === "--org" || arg === "-o") {
-      orgId = argv[index + 1]?.trim();
+      const raw = argv[index + 1]?.trim();
+      if (!raw || raw.startsWith("-")) {
+        throw new InvalidOrgArgError(
+          "Missing value for --org. Use --org org_<id> or a slug."
+        );
+      }
+      orgId = assertOrgRef(raw);
       index += 1;
       continue;
     }
 
     if (arg.startsWith("--org=")) {
-      orgId = arg.slice("--org=".length).trim();
+      const raw = arg.slice("--org=".length).trim();
+      if (!raw) {
+        throw new InvalidOrgArgError(
+          "Missing value for --org. Use --org=org_<id> or a slug."
+        );
+      }
+      orgId = assertOrgRef(raw);
     }
   }
 


### PR DESCRIPTION
## Summary

CLI `--org` / `-o` rejects malformed org refs before membership lookup.

**Before:** any trimmed string was accepted (including `../…` and huge values).
**After:** `assertOrgRef` allows `org_[A-Za-z0-9]+` or a slug (`[a-z0-9]+(-[a-z0-9]+)*`), max 128 chars; missing values throw `InvalidOrgArgError`.

Why safe:
1. Existing `org_*` test ids and slug resolution in `assertOrgMembership` still work
2. Invalid args fail closed at parse time (no server round-trip)
3. Unit tests cover accept + reject (closes #616)

Only revisit if product adds a new org-ref format outside id/slug.

## Test plan
- [x] `bun test ./apps/cli/src/org.test.ts` (4 pass)
- [x] `parseCliOrgArgs(["--org","../x"])` → `InvalidOrgArgError`; `--org acme-co` accepted
