### PR TITLE
fix(client): set Content-Type only when request has a body

### DIFF
--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -108,6 +108,7 @@ test("non-browser clients send local auth as a bearer token", async () => {
 
   const headers = new Headers(fetchCalls[0]!.init?.headers);
   expect(headers.get("Authorization")).toBe("Bearer local-auth-token");
+  expect(headers.get("Content-Type")).toBeNull();
 });
 
 test("data export downloads zip bytes with filename metadata", async () => {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -2368,7 +2368,9 @@ export class NakamaClient {
     retried = false
   ): Promise<T> {
     const method = (init?.method ?? "GET").toUpperCase();
-    const headers = this.buildHeaders(method, init?.headers);
+    const headers = this.buildHeaders(method, init?.headers, {
+      hasBody: init?.body != null,
+    });
 
     const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
       ...init,
@@ -2406,8 +2408,9 @@ export class NakamaClient {
     retried = false
   ): Promise<Response> {
     const method = (init?.method ?? "GET").toUpperCase();
-    const headers = this.buildHeaders(method, init?.headers);
-    delete headers["Content-Type"];
+    const headers = this.buildHeaders(method, init?.headers, {
+      hasBody: false,
+    });
 
     const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
       ...init,
@@ -2432,12 +2435,16 @@ export class NakamaClient {
 
   private buildHeaders(
     method: string,
-    headers?: HeadersInit
+    headers?: HeadersInit,
+    options: { hasBody?: boolean } = {}
   ): Record<string, string> {
     const merged: Record<string, string> = {
-      "Content-Type": "application/json",
       ...((headers as Record<string, string>) ?? {}),
     };
+
+    if (options.hasBody && merged["Content-Type"] == null) {
+      merged["Content-Type"] = "application/json";
+    }
 
     if (this.authToken) {
       merged["Authorization"] = `Bearer ${this.authToken}`;


### PR DESCRIPTION
## Summary

`NakamaClient` sends `Content-Type: application/json` only when the request has a body.

**Before:** `buildHeaders` always seeded `Content-Type: application/json` (including GET).
**After:** default JSON content-type only when `hasBody` is true (`init.body != null`); `fetchRaw` never sets it.

Why safe:
1. JSON POST/PUT callers that pass `body` still get the header
2. Call sites that set `Content-Type` explicitly (chat stream) unchanged
3. Client tests assert GET has no Content-Type (closes #603)

Only revisit if a bodyless POST endpoint requires a content-type for CSRF/proxy quirks.

## Test plan
- [x] `bun test ./packages/client/src/client.test.ts` (12 pass)
- [x] Bearer/GET case asserts `Content-Type` is null
