### PR TITLE
fix(cli): bail early on oversized clipboard images

### DIFF
--- a/apps/cli/src/clipboard-image.test.ts
+++ b/apps/cli/src/clipboard-image.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { MAX_IMAGE_BYTES } from "@nakama/core";
+import { attachmentFromClipboardBytes } from "./clipboard-image";
+
+describe("attachmentFromClipboardBytes", () => {
+  test("encodes small images without base64 ballooning first", () => {
+    const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const attachment = attachmentFromClipboardBytes(bytes);
+
+    expect(attachment.mediaType).toBe("image/png");
+    expect(attachment.data).toBe(bytes.toString("base64"));
+  });
+
+  test("rejects oversized clipboard payloads before base64 encode", () => {
+    const bytes = Buffer.alloc(MAX_IMAGE_BYTES + 1);
+
+    expect(() => attachmentFromClipboardBytes(bytes)).toThrow(
+      /Clipboard image is too large/
+    );
+  });
+});

--- a/apps/cli/src/clipboard-image.ts
+++ b/apps/cli/src/clipboard-image.ts
@@ -1,5 +1,24 @@
 import { getImageBinary, hasImage } from "@crosscopy/clipboard";
-import { type ImageAttachment, validateImageAttachments } from "@nakama/core";
+import {
+  type ImageAttachment,
+  MAX_IMAGE_BYTES,
+  validateImageAttachments,
+} from "@nakama/core";
+
+export function attachmentFromClipboardBytes(
+  bytes: Uint8Array | Buffer
+): ImageAttachment {
+  if (bytes.length > MAX_IMAGE_BYTES) {
+    throw new Error(
+      `Clipboard image is too large (${bytes.length} bytes). Maximum is ${MAX_IMAGE_BYTES / (1024 * 1024)} MB.`
+    );
+  }
+
+  return {
+    data: Buffer.from(bytes).toString("base64"),
+    mediaType: "image/png",
+  };
+}
 
 export async function readClipboardImage(): Promise<ImageAttachment | null> {
   if (!hasImage()) {
@@ -12,11 +31,7 @@ export async function readClipboardImage(): Promise<ImageAttachment | null> {
     return null;
   }
 
-  const attachment: ImageAttachment = {
-    data: Buffer.from(bytes).toString("base64"),
-    mediaType: "image/png",
-  };
-
+  const attachment = attachmentFromClipboardBytes(bytes);
   validateImageAttachments([attachment]);
   return attachment;
 }


### PR DESCRIPTION
## Summary

Clipboard paste rejects oversized images on raw bytes before base64 encoding.

**Before:** full clipboard buffer → base64 string → `validateImageAttachments` reject (large memory spike).
**After:** `attachmentFromClipboardBytes` checks `bytes.length > MAX_IMAGE_BYTES` first, then encodes.

Why safe:
1. Same `MAX_IMAGE_BYTES` (5 MB) as file/`validateImageAttachments` paths
2. Small images still validate via existing `validateImageAttachments`
3. Unit tests cover under/over limit (closes #610)

Only revisit if clipboard APIs expose size without loading full bytes (further optimization).

## Test plan
- [x] `bun test apps/cli/src/clipboard-image.test.ts` (2 pass)
- [ ] Paste a normal PNG in CLI chat; oversized paste errors without hanging

Closes #610
