### PR TITLE
fix(cli): resolve chat exit without abort polling

### DIFF
--- a/apps/cli/src/chat.ts
+++ b/apps/cli/src/chat.ts
@@ -730,6 +730,13 @@ async function runStickyChat(
   }
 
   let exiting = false;
+  let resolveExit: (() => void) | null = null;
+
+  const requestExit = (): void => {
+    exiting = true;
+    resolveExit?.();
+    resolveExit = null;
+  };
 
   prompt = new PersistentPrompt({
     getSuggestions: (input) => {
@@ -755,7 +762,7 @@ async function runStickyChat(
         return;
       }
 
-      exiting = true;
+      requestExit();
     },
     onScrollHistory: (event) => {
       if (event === "line_up") {
@@ -797,7 +804,7 @@ async function runStickyChat(
         const outcome = await handleSlashCommand(line);
 
         if (outcome === "exit") {
-          exiting = true;
+          requestExit();
           return;
         }
 
@@ -822,18 +829,17 @@ async function runStickyChat(
   }
 
   function onAbortSignal(): void {
-    exiting = true;
+    requestExit();
   }
 
   options.signal?.addEventListener("abort", onAbortSignal);
 
   await new Promise<void>((resolve) => {
-    const check = setInterval(() => {
-      if (exiting) {
-        clearInterval(check);
-        resolve();
-      }
-    }, 50);
+    resolveExit = resolve;
+    if (exiting || options.signal?.aborted) {
+      resolveExit = null;
+      resolve();
+    }
   });
 
   options.signal?.removeEventListener("abort", onAbortSignal);


### PR DESCRIPTION
## Summary

Interactive CLI chat ends as soon as exit/cancel/AbortSignal fires — no 50ms poll.

**Before:** `addEventListener("abort")` only set `exiting`; a `setInterval(50)` waited to notice.
**After:** `requestExit()` sets `exiting` and resolves the wait promise; abort/cancel/`/exit` all call it; listener still removed before `cleanupChat`.

Why safe:
1. Same cleanup order: remove listener → `cleanupChat`
2. Already-aborted signals resolve immediately (`signal.aborted`)
3. No behavioral change for slash/cancel paths beyond lower exit latency (closes #622)

Only revisit if a future exit path sets `exiting` without calling `requestExit`.

## Test plan
- [x] `bun test ./apps/cli/src/chat.test.ts ./apps/cli/src/commands.test.ts` (16 pass)
- [x] Code review: `/exit`, cancel, and abort all call `requestExit()`; pre-abort resolves immediately
