### PR TITLE
fix(cli): detect clipboard media type and bail on oversized images

### DIFF
--- a/apps/cli/src/clipboard-image.test.ts
+++ b/apps/cli/src/clipboard-image.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { detectClipboardImageMediaType } from "./clipboard-image";
+
+describe("detectClipboardImageMediaType", () => {
+  test("detects png/jpeg/gif/webp magic bytes", () => {
+    expect(
+      detectClipboardImageMediaType(
+        Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+      )
+    ).toBe("image/png");
+
+    expect(
+      detectClipboardImageMediaType(Buffer.from([0xff, 0xd8, 0xff, 0xe0]))
+    ).toBe("image/jpeg");
+
+    expect(detectClipboardImageMediaType(Buffer.from("GIF89a", "ascii"))).toBe(
+      "image/gif"
+    );
+
+    const webp = Buffer.alloc(12);
+    webp.write("RIFF", 0, "ascii");
+    webp.write("WEBP", 8, "ascii");
+    expect(detectClipboardImageMediaType(webp)).toBe("image/webp");
+  });
+
+  test("rejects unknown signatures", () => {
+    expect(() =>
+      detectClipboardImageMediaType(Buffer.from("not-an-image"))
+    ).toThrow(/Unsupported clipboard image type/);
+  });
+});

--- a/apps/cli/src/clipboard-image.test.ts
+++ b/apps/cli/src/clipboard-image.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { detectClipboardImageMediaType } from "./clipboard-image";
+import { MAX_IMAGE_BYTES } from "@nakama/core";
+import {
+  attachmentFromClipboardBytes,
+  detectClipboardImageMediaType,
+} from "./clipboard-image";
 
 describe("detectClipboardImageMediaType", () => {
   test("detects png/jpeg/gif/webp magic bytes", () => {
@@ -27,5 +31,23 @@ describe("detectClipboardImageMediaType", () => {
     expect(() =>
       detectClipboardImageMediaType(Buffer.from("not-an-image"))
     ).toThrow(/Unsupported clipboard image type/);
+  });
+});
+
+describe("attachmentFromClipboardBytes", () => {
+  test("encodes small images with detected media type", () => {
+    const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const attachment = attachmentFromClipboardBytes(bytes);
+
+    expect(attachment.mediaType).toBe("image/png");
+    expect(attachment.data).toBe(bytes.toString("base64"));
+  });
+
+  test("rejects oversized clipboard payloads before base64 encode", () => {
+    const bytes = Buffer.alloc(MAX_IMAGE_BYTES + 1);
+
+    expect(() => attachmentFromClipboardBytes(bytes)).toThrow(
+      /Clipboard image is too large/
+    );
   });
 });

--- a/apps/cli/src/clipboard-image.ts
+++ b/apps/cli/src/clipboard-image.ts
@@ -1,6 +1,58 @@
 import { getImageBinary, hasImage } from "@crosscopy/clipboard";
 import { type ImageAttachment, validateImageAttachments } from "@nakama/core";
 
+export function detectClipboardImageMediaType(
+  bytes: Uint8Array | Buffer
+): ImageAttachment["mediaType"] {
+  if (
+    bytes.length >= 8 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47
+  ) {
+    return "image/png";
+  }
+
+  if (
+    bytes.length >= 3 &&
+    bytes[0] === 0xff &&
+    bytes[1] === 0xd8 &&
+    bytes[2] === 0xff
+  ) {
+    return "image/jpeg";
+  }
+
+  if (
+    bytes.length >= 6 &&
+    bytes[0] === 0x47 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x38 &&
+    (bytes[4] === 0x37 || bytes[4] === 0x39)
+  ) {
+    return "image/gif";
+  }
+
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  ) {
+    return "image/webp";
+  }
+
+  throw new Error(
+    "Unsupported clipboard image type. Allowed: jpeg, png, gif, webp."
+  );
+}
+
 export async function readClipboardImage(): Promise<ImageAttachment | null> {
   if (!hasImage()) {
     return null;
@@ -14,7 +66,7 @@ export async function readClipboardImage(): Promise<ImageAttachment | null> {
 
   const attachment: ImageAttachment = {
     data: Buffer.from(bytes).toString("base64"),
-    mediaType: "image/png",
+    mediaType: detectClipboardImageMediaType(bytes),
   };
 
   validateImageAttachments([attachment]);

--- a/apps/cli/src/clipboard-image.ts
+++ b/apps/cli/src/clipboard-image.ts
@@ -1,5 +1,9 @@
 import { getImageBinary, hasImage } from "@crosscopy/clipboard";
-import { type ImageAttachment, validateImageAttachments } from "@nakama/core";
+import {
+  type ImageAttachment,
+  MAX_IMAGE_BYTES,
+  validateImageAttachments,
+} from "@nakama/core";
 
 export function detectClipboardImageMediaType(
   bytes: Uint8Array | Buffer
@@ -53,6 +57,21 @@ export function detectClipboardImageMediaType(
   );
 }
 
+export function attachmentFromClipboardBytes(
+  bytes: Uint8Array | Buffer
+): ImageAttachment {
+  if (bytes.length > MAX_IMAGE_BYTES) {
+    throw new Error(
+      `Clipboard image is too large (${bytes.length} bytes). Maximum is ${MAX_IMAGE_BYTES / (1024 * 1024)} MB.`
+    );
+  }
+
+  return {
+    data: Buffer.from(bytes).toString("base64"),
+    mediaType: detectClipboardImageMediaType(bytes),
+  };
+}
+
 export async function readClipboardImage(): Promise<ImageAttachment | null> {
   if (!hasImage()) {
     return null;
@@ -64,11 +83,7 @@ export async function readClipboardImage(): Promise<ImageAttachment | null> {
     return null;
   }
 
-  const attachment: ImageAttachment = {
-    data: Buffer.from(bytes).toString("base64"),
-    mediaType: detectClipboardImageMediaType(bytes),
-  };
-
+  const attachment = attachmentFromClipboardBytes(bytes);
   validateImageAttachments([attachment]);
   return attachment;
 }


### PR DESCRIPTION
## Summary

Clipboard images get `mediaType` from magic bytes and reject oversized payloads before base64.

**Before:** every clipboard payload was labeled `image/png`; huge buffers were base64-encoded first.
**After:** `attachmentFromClipboardBytes` checks `MAX_IMAGE_BYTES`, then `detectClipboardImageMediaType` (PNG/JPEG/GIF/WebP).

Why safe:
1. Allowed types match `validateImageAttachments` (jpeg/png/gif/webp)
2. Same 5 MB limit as other image paths
3. Unit tests cover signatures, reject, and oversize (closes #609 and #610)

Only revisit if clipboard APIs expose size without loading full bytes.

## Test plan
- [x] `bun test ./apps/cli/src/clipboard-image.test.ts` (4 pass)
- [x] PNG/JPEG/GIF/WebP signatures + oversize reject covered in unit tests
