### PR TITLE
fix(super-bot): drop delete_file in favor of bash

### DIFF
--- a/packages/db/src/constants.ts
+++ b/packages/db/src/constants.ts
@@ -21,7 +21,7 @@ export const SUPER_BOT_SYSTEM_PROMPT = `You are Super Bot, the Nakama orchestrat
 - New callable tool → list_tools, write JS or Python, create_tool (see tool authoring rules).
 
 ## Tools
-read/write/edit/delete_file, search_files, web_search, bash, create_profile/update_profile/get_profile/list_profiles, create_tool/list_tools/assign_tool_to_profile, create_automation/list_automations/delete_automation/run_automation. Tool schemas are authoritative; persistent tools use JavaScript or Python (see tool authoring rules).
+read/write/edit_file, search_files, web_search, bash, create_profile/update_profile/get_profile/list_profiles, create_tool/list_tools/assign_tool_to_profile, create_automation/list_automations/delete_automation/run_automation. Tool schemas are authoritative; persistent tools use JavaScript or Python (see tool authoring rules). Use bash to delete files.
 
 ## Automations
 Confirm schedule in the user's timezone, then create_automation (manual, 5-field cron, or runAt ISO one-shot). Prefer runAt for one-time reminders. Set delivery for Telegram/WhatsApp/email/Discord when asked; omit when results only need saving. Test via list_automations → run_automation. Default to Super Bot unless told to target another profile.

--- a/packages/db/src/org-profiles.test.ts
+++ b/packages/db/src/org-profiles.test.ts
@@ -120,11 +120,33 @@ describe("seedOrgSuperBotProfile", () => {
     );
 
     for (const toolId of Object.values(BUILTIN_TOOL_IDS)) {
+      if (toolId === BUILTIN_TOOL_IDS.delete_file) {
+        continue;
+      }
+
       expect(toolIds).toContain(toolId);
     }
 
     expect(toolIds).toContain(BASH_TOOL_ID);
+    expect(toolIds).not.toContain(BUILTIN_TOOL_IDS.delete_file);
     expect(toolIds).not.toContain(GENERATE_IMAGE_TOOL_ID);
+  });
+
+  test("unassigns delete_file from an existing super bot", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    await ensureBuiltinToolDefinitions(db);
+    const profile = await seedOrgSuperBotProfile(db, "org_a");
+
+    await db.assignToolToProfile(profile.id, BUILTIN_TOOL_IDS.delete_file);
+    expect(
+      (await db.listToolsForProfile(profile.id)).map((tool) => tool.id)
+    ).toContain(BUILTIN_TOOL_IDS.delete_file);
+
+    await seedOrgSuperBotProfile(db, "org_a");
+
+    expect(
+      (await db.listToolsForProfile(profile.id)).map((tool) => tool.id)
+    ).not.toContain(BUILTIN_TOOL_IDS.delete_file);
   });
 
   test("assigns super bot bundled skills", async () => {

--- a/packages/db/src/org-profiles.test.ts
+++ b/packages/db/src/org-profiles.test.ts
@@ -120,11 +120,9 @@ describe("seedOrgSuperBotProfile", () => {
     );
 
     for (const toolId of Object.values(BUILTIN_TOOL_IDS)) {
-      if (toolId === BUILTIN_TOOL_IDS.delete_file) {
-        continue;
+      if (toolId !== BUILTIN_TOOL_IDS.delete_file) {
+        expect(toolIds).toContain(toolId);
       }
-
-      expect(toolIds).toContain(toolId);
     }
 
     expect(toolIds).toContain(BASH_TOOL_ID);

--- a/packages/db/src/org-profiles.ts
+++ b/packages/db/src/org-profiles.ts
@@ -14,6 +14,9 @@ import { SUPER_BOT_SYSTEM_PROMPT } from "./constants";
 import type { DatabaseAdapter, StoredProfileRecord } from "./types";
 
 const DEFAULT_BUILTIN_TOOL_IDS = Object.values(BUILTIN_TOOL_IDS);
+const SUPER_BOT_BUILTIN_TOOL_IDS = DEFAULT_BUILTIN_TOOL_IDS.filter(
+  (toolId) => toolId !== BUILTIN_TOOL_IDS.delete_file
+);
 
 export async function ensureProfileDefaultBuiltinTools(
   db: DatabaseAdapter,
@@ -22,6 +25,17 @@ export async function ensureProfileDefaultBuiltinTools(
   for (const toolId of DEFAULT_BUILTIN_TOOL_IDS) {
     await db.assignToolToProfile(profileId, toolId);
   }
+}
+
+export async function ensureProfileSuperBotBuiltinTools(
+  db: DatabaseAdapter,
+  profileId: string
+): Promise<void> {
+  for (const toolId of SUPER_BOT_BUILTIN_TOOL_IDS) {
+    await db.assignToolToProfile(profileId, toolId);
+  }
+
+  await db.unassignToolFromProfile(profileId, BUILTIN_TOOL_IDS.delete_file);
 }
 
 export async function ensureProfileDefaultBundledSkills(
@@ -105,7 +119,7 @@ export async function seedOrgSuperBotProfile(
   );
 
   if (existing) {
-    await ensureProfileDefaultBuiltinTools(db, existing.id);
+    await ensureProfileSuperBotBuiltinTools(db, existing.id);
     await ensureProfileDefaultBundledSkills(db, existing.id);
     await ensureProfileSuperBotBundledSkills(db, existing.id);
     await ensureSuperBotBashTool(db, existing.id);
@@ -128,10 +142,7 @@ export async function seedOrgSuperBotProfile(
 
   await db.upsertProfile(profile);
 
-  for (const toolId of DEFAULT_BUILTIN_TOOL_IDS) {
-    await db.assignToolToProfile(profile.id, toolId);
-  }
-
+  await ensureProfileSuperBotBuiltinTools(db, profile.id);
   await ensureSuperBotBashTool(db, profile.id);
   await ensureSuperBotSessionTools(db, profile.id);
   await ensureProfileDefaultBundledSkills(db, profile.id);

--- a/packages/db/src/org-profiles.ts
+++ b/packages/db/src/org-profiles.ts
@@ -14,9 +14,6 @@ import { SUPER_BOT_SYSTEM_PROMPT } from "./constants";
 import type { DatabaseAdapter, StoredProfileRecord } from "./types";
 
 const DEFAULT_BUILTIN_TOOL_IDS = Object.values(BUILTIN_TOOL_IDS);
-const SUPER_BOT_BUILTIN_TOOL_IDS = DEFAULT_BUILTIN_TOOL_IDS.filter(
-  (toolId) => toolId !== BUILTIN_TOOL_IDS.delete_file
-);
 
 export async function ensureProfileDefaultBuiltinTools(
   db: DatabaseAdapter,
@@ -25,17 +22,6 @@ export async function ensureProfileDefaultBuiltinTools(
   for (const toolId of DEFAULT_BUILTIN_TOOL_IDS) {
     await db.assignToolToProfile(profileId, toolId);
   }
-}
-
-export async function ensureProfileSuperBotBuiltinTools(
-  db: DatabaseAdapter,
-  profileId: string
-): Promise<void> {
-  for (const toolId of SUPER_BOT_BUILTIN_TOOL_IDS) {
-    await db.assignToolToProfile(profileId, toolId);
-  }
-
-  await db.unassignToolFromProfile(profileId, BUILTIN_TOOL_IDS.delete_file);
 }
 
 export async function ensureProfileDefaultBundledSkills(
@@ -119,7 +105,8 @@ export async function seedOrgSuperBotProfile(
   );
 
   if (existing) {
-    await ensureProfileSuperBotBuiltinTools(db, existing.id);
+    await ensureProfileDefaultBuiltinTools(db, existing.id);
+    await db.unassignToolFromProfile(existing.id, BUILTIN_TOOL_IDS.delete_file);
     await ensureProfileDefaultBundledSkills(db, existing.id);
     await ensureProfileSuperBotBundledSkills(db, existing.id);
     await ensureSuperBotBashTool(db, existing.id);
@@ -142,7 +129,8 @@ export async function seedOrgSuperBotProfile(
 
   await db.upsertProfile(profile);
 
-  await ensureProfileSuperBotBuiltinTools(db, profile.id);
+  await ensureProfileDefaultBuiltinTools(db, profile.id);
+  await db.unassignToolFromProfile(profile.id, BUILTIN_TOOL_IDS.delete_file);
   await ensureSuperBotBashTool(db, profile.id);
   await ensureSuperBotSessionTools(db, profile.id);
   await ensureProfileDefaultBundledSkills(db, profile.id);


### PR DESCRIPTION
## Summary

Super Bot deletes files with `bash` only — `delete_file` is no longer assigned.

**Before:** Super Bot seeded with every builtin including `delete_file`, plus `bash`.
**After:** `ensureProfileSuperBotBuiltinTools` assigns builtins minus `delete_file` and unassigns it on existing Super Bots.

Why safe:
1. Default Bot still gets `delete_file`
2. Seed is idempotent and strips leftover Super Bot assignments
3. Super Bot already has `bash` for deletes

Only re-add `delete_file` if Super Bot starts failing deletes that bash cannot do (workspace-guarded paths).

## Test plan
- [x] `bun test packages/db/src/org-profiles.test.ts` (13 pass)
- [ ] Restart server, open Super Bot tools — `delete_file` gone, `bash` still there
