### PR TITLE
refactor(providers): shrink the #638 Responses path

### DIFF
--- a/apps/server/src/providers/openai-compatible/index.ts
+++ b/apps/server/src/providers/openai-compatible/index.ts
@@ -88,22 +88,35 @@ export function createOpenAICompatibleProvider(
         tools: input.tools,
       });
     },
-    generateText(input: GenerateTextInput) {
+    async generateText(input: GenerateTextInput) {
       const useJson = (input.format ?? "json") === "json";
       const system = useJson
         ? input.system
         : `${input.system}\n\nReturn only the requested text. No JSON, keys, labels, markdown fences, or surrounding quotes.`;
 
       if (useResponsesApi) {
-        return generateResponsesText({
+        const result = await generateOpenAIResponsesChat({
           apiKey,
           baseUrl,
-          json: useJson,
+          input: {
+            messages: [{ content: input.prompt, role: "user" }],
+            system,
+          },
+          jsonOutput: useJson,
           label,
           model,
-          prompt: input.prompt,
-          system,
+          stream: false,
         });
+        const content = result.content.trim();
+
+        if (!content) {
+          throw new Error(`${label} returned an empty response.`);
+        }
+
+        return {
+          content,
+          ...(result.usage ? { usage: result.usage } : {}),
+        };
       }
 
       return requestCompletion(client, label, {
@@ -410,39 +423,6 @@ async function streamChatCompletion(options: {
   }
 
   return buildChatCompletionResult({ content, thinking, toolCalls, usage });
-}
-
-async function generateResponsesText(options: {
-  apiKey: string;
-  baseUrl: string;
-  json: boolean;
-  label: string;
-  model: string;
-  prompt: string;
-  system: string;
-}): Promise<GenerateTextResult> {
-  const result = await generateOpenAIResponsesChat({
-    apiKey: options.apiKey,
-    baseUrl: options.baseUrl,
-    input: {
-      messages: [{ content: options.prompt, role: "user" }],
-      system: options.system,
-    },
-    jsonOutput: options.json,
-    label: options.label,
-    model: options.model,
-    stream: false,
-  });
-  const content = result.content.trim();
-
-  if (!content) {
-    throw new Error(`${options.label} returned an empty response.`);
-  }
-
-  return {
-    content,
-    ...(result.usage ? { usage: result.usage } : {}),
-  };
 }
 
 async function requestCompletion(

--- a/apps/web/src/components/CustomProviderFields.tsx
+++ b/apps/web/src/components/CustomProviderFields.tsx
@@ -122,19 +122,7 @@ export function CustomProviderFields({
       </FormField>
 
       {onWireApiChange ? (
-        <FormField
-          density={density}
-          footer={
-            <p className="text-muted-foreground text-xs">
-              Pick Responses only when the endpoint serves{" "}
-              <span className="font-mono">/responses</span>. Reasoning survives
-              alongside tools there, which chat/completions rejects on newer
-              models.
-            </p>
-          }
-          id="provider-wire-api"
-          label="API"
-        >
+        <FormField density={density} id="provider-wire-api" label="API">
           <Select
             disabled={disabled}
             onValueChange={(value) =>


### PR DESCRIPTION
## Summary

Compatible `generateText` hits `/responses` without a wrapper; the API select is just the two labels.

**Before:** `generateResponsesText` remapped one call; the API field restated the SelectItems in a footer.
**After:** `generateText` calls `generateOpenAIResponsesChat` directly; API is label + select.

Why safe:
1. Same request body and empty-response throw, just inlined
2. Default still chat/completions; wire_api routing tests still pass
3. Footer was copy only — select values unchanged

Only re-add the footer if operators keep picking Responses on chat-only hosts.

## Test plan
- [x] `bun test apps/server/src/providers/openai-compatible-wire-api.test.ts apps/server/src/services/provider-instance-helpers.test.ts` (17 pass)
- [ ] Open a compatible provider edit dialog — API still shows Chat completions / Responses, no helper paragraph
