### PR TITLE
refactor(server): shrink the #637 install stream guards

### DIFF
--- a/apps/server/src/http/coding-harness-install-stream.test.ts
+++ b/apps/server/src/http/coding-harness-install-stream.test.ts
@@ -6,17 +6,6 @@ type TestEvent = { type: string; message?: string; error?: string };
 const TIMEOUT_MS = 10;
 const OUTLIVES_TIMEOUT_MS = 30;
 
-function deferred<T>(): {
-  promise: Promise<T>;
-  resolve: (value: T) => void;
-} {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((settle) => {
-    resolve = settle;
-  });
-  return { promise, resolve };
-}
-
 async function readEvents(response: Response): Promise<TestEvent[]> {
   const body = await response.text();
   return body
@@ -27,8 +16,8 @@ async function readEvents(response: Response): Promise<TestEvent[]> {
 
 describe("streamInstallEvents", () => {
   test("send after the client disconnects does not throw at the executor", async () => {
-    const clientGone = deferred<void>();
-    const executorDone = deferred<void>();
+    const clientGone = Promise.withResolvers<void>();
+    const executorDone = Promise.withResolvers<void>();
     const thrown: unknown[] = [];
 
     const response = streamInstallEvents<TestEvent>(async (send) => {
@@ -88,7 +77,7 @@ describe("streamInstallEvents", () => {
   });
 
   test("send after the timeout does not throw at the executor", async () => {
-    const executorDone = deferred<void>();
+    const executorDone = Promise.withResolvers<void>();
     const thrown: unknown[] = [];
 
     const response = streamInstallEvents<TestEvent>(

--- a/apps/server/src/http/coding-harness-install-stream.ts
+++ b/apps/server/src/http/coding-harness-install-stream.ts
@@ -61,11 +61,7 @@ export function streamInstallEvents<TEvent extends { type: string }>(
           clearTimers();
           return;
         }
-        try {
-          controller.enqueue(encoder.encode(": ping\n\n"));
-        } catch {
-          clearTimers();
-        }
+        controller.enqueue(encoder.encode(": ping\n\n"));
       }, keepaliveIntervalMs);
 
       timeoutId = setTimeout(() => {

--- a/apps/server/src/services/cli-package-install.ts
+++ b/apps/server/src/services/cli-package-install.ts
@@ -157,17 +157,6 @@ export async function runTimedInstallCommand(
     let stdoutBuffer = "";
     let stderrBuffer = "";
     let killTimeoutId: ReturnType<typeof setTimeout> | undefined;
-    let settled = false;
-
-    const settle = (value: {
-      exitCode: number | null;
-      stdout: string;
-      stderr: string;
-      timedOut: boolean;
-    }) => {
-      settled = true;
-      resolve(value);
-    };
 
     const timeoutId = setTimeout(() => {
       timedOut = true;
@@ -176,7 +165,7 @@ export async function runTimedInstallCommand(
         () => child.kill("SIGKILL"),
         CLI_SIGTERM_GRACE_MS
       );
-      settle({
+      resolve({
         exitCode: null,
         stderr: stderr.trim(),
         stdout: stdout.trim(),
@@ -185,7 +174,7 @@ export async function runTimedInstallCommand(
     }, timeoutMs);
 
     const emitLine = (prefix: "stdout" | "stderr", line: string) => {
-      if (settled) {
+      if (timedOut) {
         return;
       }
 
@@ -238,7 +227,7 @@ export async function runTimedInstallCommand(
         emitLine("stderr", stderrBuffer.trim());
       }
 
-      settle({
+      resolve({
         exitCode: null,
         stderr: `${stderr}\n${String(error)}`.trim(),
         stdout,
@@ -257,7 +246,7 @@ export async function runTimedInstallCommand(
         emitLine("stderr", stderrBuffer.trim());
       }
 
-      settle({
+      resolve({
         exitCode,
         stderr: stderr.trim(),
         stdout: stdout.trim(),


### PR DESCRIPTION
## Summary

Late installer progress still no-ops after timeout, with 26 fewer lines.

**Before:** `settle()` wrapper, a hand-rolled `deferred`, and a keepalive `try/catch` around `terminated`.
**After:** `emitLine` checks `timedOut`; tests use `Promise.withResolvers()`; keepalive trusts `terminated`.

Why safe:
1. Same 8 tests still pass — disconnect and post-timeout `send` still do not throw
2. `timedOut` is set before `resolve` on the path the late-progress test covers
3. Bun leaves `desiredSize` non-null after close, so `terminated` stays

Only re-add `settle()` if late progress after a successful close (not a timeout) starts reaching callers.

## Test plan
- [x] `bun test apps/server/src/http/coding-harness-install-stream.test.ts apps/server/src/services/cli-package-install.test.ts` (8 pass)
- [ ] Start an agent-browser install from Settings, close the tab mid-run — no `Controller is already closed`

Follows #637.
