### PR TITLE
fix(tools): isolate custom tool handlers in an allowlisted subprocess

### DIFF
--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -248,10 +248,6 @@ import {
   resolveVisionProviderSelection,
   VISION_MODEL_REQUIRED_MESSAGE,
 } from "./image-vision-fallback";
-import {
-  invalidateJavascriptModuleCache,
-  resolveJavascriptModulePath,
-} from "./javascript-tool-loader";
 import type { LlmUsageTracker } from "./llm-usage-tracker";
 import type { McpClientManager } from "./mcp-client-manager";
 import type { McpService } from "./mcp-service";
@@ -2528,24 +2524,6 @@ export class AgentService {
       context.orgId,
       toolId
     );
-
-    if (tool.handlerType === "javascript") {
-      const handlerConfig =
-        typeof record.handlerConfig === "object" &&
-        record.handlerConfig !== null
-          ? (record.handlerConfig as { modulePath?: string })
-          : null;
-
-      if (handlerConfig?.modulePath) {
-        try {
-          invalidateJavascriptModuleCache(
-            resolveJavascriptModulePath(handlerConfig.modulePath)
-          );
-        } catch {
-          // Invalid module paths fail when loading the tool.
-        }
-      }
-    }
 
     const loaded = await handler.load(record);
 

--- a/apps/server/src/services/custom-tool-handlers.test.ts
+++ b/apps/server/src/services/custom-tool-handlers.test.ts
@@ -203,16 +203,35 @@ if __name__ == "__main__":
     const configDir = await mkdtemp(path.join(os.tmpdir(), "nakama-config-"));
     process.env.NAKAMA_CONFIG_DIR = configDir;
     const toolsDir = path.join(configDir, "tools");
+    const wsDir = path.join(configDir, "ws");
     await mkdir(toolsDir, { recursive: true });
+    await mkdir(wsDir, { recursive: true });
 
-    // In-process module counter — JS retries share the cached module.
+    // Each retry is its own subprocess with no shared memory, so the counter
+    // persists in the workspace instead — mirrors the python "flaky" fixture
+    // above, and proves the retry policy reaches the js loader, not just a
+    // cached in-process module.
     await writeFile(
       path.join(toolsDir, "flaky.js"),
-      `let attempts = 0;
-export async function run() {
-  attempts += 1;
-  if (attempts < 3) throw new Error("flaky");
-  return { ok: true, attempts };
+      `import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+async function run(input, context) {
+  const root = process.env.NAKAMA_WORKSPACE_ROOT ?? "/tmp";
+  const counter = path.join(root, "attempts.txt");
+  let n = existsSync(counter) ? Number(readFileSync(counter, "utf8").trim() || "0") : 0;
+  n += 1;
+  writeFileSync(counter, String(n));
+  if (n < 3) {
+    console.error("flaky");
+    process.exit(3);
+  }
+  return { ok: true, attempts: n };
+}
+
+if (import.meta.main) {
+  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
+  process.stdout.write(JSON.stringify(await run(payload, {})));
 }
 `,
       "utf8"
@@ -229,11 +248,13 @@ export async function run() {
       );
       expect(tool).not.toBeNull();
 
-      const result = (await tool!.run({}, {})) as {
+      const result = (await tool!.run({}, { workspaceRoot: wsDir })) as {
         ok: boolean;
         attempts: number;
       };
 
+      // Succeeded on attempt 3 after two failed spawns — proves the retry
+      // policy reaches the javascript loader, not just the seam wrapper.
       expect(result.ok).toBe(true);
       expect(result.attempts).toBe(3);
     } finally {

--- a/apps/server/src/services/custom-tool-shared.ts
+++ b/apps/server/src/services/custom-tool-shared.ts
@@ -33,6 +33,7 @@ function isPathInsideDirectory(
 
 export interface CustomToolHandlerConfig {
   modulePath: string;
+  parallelSafe?: boolean;
   parameters?: JsonSchema;
 }
 
@@ -56,8 +57,9 @@ export function readHandlerConfig(
   const parameters = isJsonSchema(record.parameters)
     ? record.parameters
     : undefined;
+  const parallelSafe = record.parallelSafe === true;
 
-  return { modulePath, parameters };
+  return { modulePath, parallelSafe, parameters };
 }
 
 export function readHandlerModulePath(handlerConfig: unknown): string | null {
@@ -74,7 +76,7 @@ export function readHandlerModulePath(handlerConfig: unknown): string | null {
   return modulePath.trim();
 }
 
-export function isJsonSchema(value: unknown): value is JsonSchema {
+function isJsonSchema(value: unknown): value is JsonSchema {
   return typeof value === "object" && value !== null;
 }
 

--- a/apps/server/src/services/custom-tool-subprocess.ts
+++ b/apps/server/src/services/custom-tool-subprocess.ts
@@ -1,0 +1,171 @@
+import { spawn } from "node:child_process";
+import type { ToolContext } from "@nakama/core";
+
+// Shared subprocess machinery for custom tool loaders (javascript, python).
+// A registered tool can be written by any org's Super Bot profile, so both
+// handler types run as a child process with an explicit env allowlist
+// instead of inheriting the server's full environment.
+
+const SIGKILL_GRACE_MS = 5000;
+const MAX_OUTPUT_CHARS = 1_000_000;
+
+/**
+ * Builds the child process env from an explicit allowlist: PATH (needed to
+ * resolve the interpreter binary), NAKAMA_CONFIG_DIR, and the active
+ * workspace root. Nothing else from the server's environment is passed
+ * through, so provider API keys and ambient shell secrets never reach a
+ * tool's process.
+ */
+export function buildAllowlistedSubprocessEnv(
+  workspaceRoot?: string
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+
+  if (process.env.PATH) {
+    env.PATH = process.env.PATH;
+  }
+
+  if (process.env.NAKAMA_CONFIG_DIR) {
+    env.NAKAMA_CONFIG_DIR = process.env.NAKAMA_CONFIG_DIR;
+  }
+
+  if (workspaceRoot) {
+    env.NAKAMA_WORKSPACE_ROOT = workspaceRoot;
+  }
+
+  return env;
+}
+
+export interface SpawnJsonToolOptions {
+  args: string[];
+  bin: string;
+  context: ToolContext;
+  /** Working directory for the child. Keeps a tool's relative file access
+   * scoped to its own directory instead of the server's checkout. */
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  input: unknown;
+  /** Used in error messages, e.g. "Python tool", "JavaScript tool". */
+  label: string;
+  timeoutMs: number;
+}
+
+/**
+ * Spawns a tool as a subprocess, writes `input` as JSON to stdin, and parses
+ * one JSON value from stdout as the result. Kills the child (SIGTERM, then
+ * SIGKILL after a grace period) if it outlives `timeoutMs` or if
+ * `context.signal` aborts.
+ */
+export async function spawnJsonTool(
+  options: SpawnJsonToolOptions
+): Promise<unknown> {
+  const { args, bin, context, cwd, env, input, label, timeoutMs } = options;
+  const result = await new Promise<{ stderr: string; stdout: string }>(
+    (resolve, reject) => {
+      // Node SIGTERMs the child when the turn is cancelled, so a stopped chat
+      // does not leave a tool process holding the session open.
+      const child = spawn(bin, args, {
+        cwd,
+        env,
+        signal: context.signal,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      let stdout = "";
+      let stderr = "";
+      let timedOut = false;
+
+      const sigtermTimer = setTimeout(() => {
+        try {
+          child.kill("SIGTERM");
+        } catch {
+          // already exited
+        }
+        timedOut = true;
+        setTimeout(() => {
+          try {
+            child.kill("SIGKILL");
+          } catch {
+            // already exited
+          }
+        }, SIGKILL_GRACE_MS).unref();
+      }, timeoutMs);
+
+      child.stdout?.on("data", (chunk: Buffer | string) => {
+        stdout = appendCapped(stdout, String(chunk));
+      });
+
+      child.stderr?.on("data", (chunk: Buffer | string) => {
+        stderr = appendCapped(stderr, String(chunk));
+      });
+
+      // A child that exits without reading stdin can surface EPIPE here;
+      // the close handler reports the real failure.
+      child.stdin?.on("error", () => {});
+
+      child.once("error", (error) => {
+        clearTimeout(sigtermTimer);
+        reject(error);
+      });
+
+      child.once("close", (exitCode) => {
+        clearTimeout(sigtermTimer);
+        const tail = stderr.trim() || "(no stderr)";
+
+        // A child that traps SIGTERM can still exit 0 after the deadline;
+        // the budget is spent either way, so report the timeout.
+        if (timedOut) {
+          reject(
+            new Error(
+              `${label} timed out after ${timeoutMs}ms (exit code ${exitCode ?? "null"}): ${tail}`
+            )
+          );
+          return;
+        }
+
+        if (exitCode === 0) {
+          resolve({ stderr, stdout });
+          return;
+        }
+
+        reject(new Error(`${label} exit code ${exitCode ?? "null"}: ${tail}`));
+      });
+
+      // Write the input payload and close stdin so the child can finish
+      // reading and proceed to run().
+      try {
+        child.stdin?.end(JSON.stringify(input ?? {}));
+      } catch (error) {
+        clearTimeout(sigtermTimer);
+        reject(error);
+      }
+    }
+  );
+
+  const trimmed = result.stdout.trim();
+
+  if (!trimmed) {
+    throw new Error(
+      `${label} produced no output; it must print its JSON result to stdout. stderr: ${result.stderr.trim() || "(empty)"}`
+    );
+  }
+
+  try {
+    return JSON.parse(trimmed);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `${label} returned non-JSON output: ${message}; stderr: ${result.stderr.trim() || "(empty)"}`
+    );
+  }
+}
+
+function appendCapped(current: string, next: string): string {
+  const combined = current + next;
+
+  if (combined.length <= MAX_OUTPUT_CHARS) {
+    return combined;
+  }
+
+  return combined.slice(-MAX_OUTPUT_CHARS);
+}

--- a/apps/server/src/services/javascript-tool-loader.test.ts
+++ b/apps/server/src/services/javascript-tool-loader.test.ts
@@ -21,6 +21,21 @@ async function setupToolsDir(): Promise<{
   return { configDir, toolsDir };
 }
 
+function makeRecord(
+  overrides: Partial<StoredToolRecord> = {}
+): StoredToolRecord {
+  return {
+    createdAt: new Date().toISOString(),
+    description: "Echo a message",
+    handlerConfig: { modulePath: "echo.js" },
+    handlerType: "javascript",
+    id: "tool_echo",
+    name: "echo",
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
 describe("javascript tool loader", () => {
   let configDir = "";
 
@@ -37,73 +52,65 @@ describe("javascript tool loader", () => {
     }
   });
 
-  test("loads a module and runs exported run(input)", async () => {
+  test("loads a module and runs run(input) with JSON over stdin, in a subprocess", async () => {
     const { configDir: dir, toolsDir } = await setupToolsDir();
     configDir = dir;
 
     await writeFile(
       path.join(toolsDir, "echo.js"),
-      `export const parameters = {
-  type: "object",
-  properties: { message: { type: "string" } },
-  required: ["message"],
-  additionalProperties: false,
-};
+      `async function run(input, context) {
+  return { echoed: input.message, root: process.env.NAKAMA_WORKSPACE_ROOT ?? "" };
+}
 
-export async function run(input) {
-  return { echoed: input.message };
+if (import.meta.main) {
+  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
+  const result = await run(payload, {});
+  process.stdout.write(JSON.stringify(result));
 }
 `,
       "utf8"
     );
 
-    const record: StoredToolRecord = {
-      createdAt: new Date().toISOString(),
-      description: "Echo a message",
-      handlerConfig: { modulePath: "echo.js" },
-      handlerType: "javascript",
-      id: "tool_echo",
-      name: "echo",
-      updatedAt: new Date().toISOString(),
-    };
-
-    const tool = await loadJavascriptTool(record);
+    const tool = await loadJavascriptTool(makeRecord());
 
     expect(tool).not.toBeNull();
     expect(tool?.name).toBe("echo");
     expect(tool?.parallelSafe).not.toBe(true);
-    expect(tool?.parameters?.required).toEqual(["message"]);
 
-    const result = await tool!.run({ message: "hello" }, {});
-    expect(result).toEqual({ echoed: "hello" });
+    const result = (await tool!.run(
+      { message: "hello" },
+      { workspaceRoot: "/tmp/nakama-ws" }
+    )) as { echoed: string; root: string };
+    expect(result.echoed).toBe("hello");
+    // The loader must forward context.workspaceRoot to the child process as
+    // NAKAMA_WORKSPACE_ROOT, same as the Python loader.
+    expect(result.root).toBe("/tmp/nakama-ws");
   });
 
-  test("loads parallelSafe when the module exports it", async () => {
+  test("reads parallelSafe from handlerConfig, not the module", async () => {
     const { configDir: dir, toolsDir } = await setupToolsDir();
     configDir = dir;
 
     await writeFile(
       path.join(toolsDir, "parallel-echo.js"),
-      `export const parallelSafe = true;
-
-export async function run(input) {
+      `async function run(input, context) {
   return { echoed: input.message };
+}
+
+if (import.meta.main) {
+  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
+  process.stdout.write(JSON.stringify(await run(payload, {})));
 }
 `,
       "utf8"
     );
 
-    const record: StoredToolRecord = {
-      createdAt: new Date().toISOString(),
-      description: "Parallel-safe echo",
-      handlerConfig: { modulePath: "parallel-echo.js" },
-      handlerType: "javascript",
-      id: "tool_parallel_echo",
-      name: "parallel_echo",
-      updatedAt: new Date().toISOString(),
-    };
-
-    const tool = await loadJavascriptTool(record);
+    const tool = await loadJavascriptTool(
+      makeRecord({
+        handlerConfig: { modulePath: "parallel-echo.js", parallelSafe: true },
+        name: "parallel_echo",
+      })
+    );
 
     expect(tool?.parallelSafe).toBe(true);
   });
@@ -121,20 +128,260 @@ export async function run(input) {
     const { configDir: dir } = await setupToolsDir();
     configDir = dir;
 
-    const record: StoredToolRecord = {
-      createdAt: new Date().toISOString(),
-      description: "Missing module",
-      handlerConfig: { modulePath: "missing.js" },
-      handlerType: "javascript",
-      id: "tool_missing",
-      name: "missing",
-      updatedAt: new Date().toISOString(),
-    };
-
-    const tool = await loadJavascriptTool(record);
+    const tool = await loadJavascriptTool(makeRecord());
     const result = await tool!.run({}, {});
 
-    expect(result).toEqual({ error: "Tool module not found: missing.js" });
+    expect(result).toEqual({ error: "Tool module not found: echo.js" });
+  });
+
+  test("returns an error tool when the module lacks a run function", async () => {
+    const { configDir: dir, toolsDir } = await setupToolsDir();
+    configDir = dir;
+
+    await writeFile(
+      path.join(toolsDir, "norun.js"),
+      `// no run() defined
+console.log("hi");
+`,
+      "utf8"
+    );
+
+    const tool = await loadJavascriptTool(
+      makeRecord({ handlerConfig: { modulePath: "norun.js" }, name: "norun" })
+    );
+
+    const result = (await tool!.run({}, {})) as { error: string };
+    expect(result.error).toMatch(/run\s*\(/i);
+  });
+
+  test("returns an error tool when the module lacks an import.meta.main harness", async () => {
+    const { configDir: dir, toolsDir } = await setupToolsDir();
+    configDir = dir;
+
+    await writeFile(
+      path.join(toolsDir, "noharness.js"),
+      `async function run(input, context) {
+  return input;
+}
+`,
+      "utf8"
+    );
+
+    const tool = await loadJavascriptTool(
+      makeRecord({
+        handlerConfig: { modulePath: "noharness.js" },
+        name: "noharness",
+      })
+    );
+
+    const result = (await tool!.run({}, {})) as { error: string };
+    expect(result.error).toMatch(/import\.meta\.main/i);
+  });
+
+  test("returns an error tool when the module exits non-zero", async () => {
+    const { configDir: dir, toolsDir } = await setupToolsDir();
+    configDir = dir;
+
+    await writeFile(
+      path.join(toolsDir, "boom.js"),
+      `async function run(input, context) {
+  console.error("kaboom");
+  process.exit(7);
+}
+
+if (import.meta.main) {
+  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
+  process.stdout.write(JSON.stringify(await run(payload, {})));
+}
+`,
+      "utf8"
+    );
+
+    const tool = await loadJavascriptTool(
+      makeRecord({ handlerConfig: { modulePath: "boom.js" }, name: "boom" })
+    );
+
+    // A failed spawn must reject so the retry policy can retry transient
+    // failures; executeToolCall turns the throw into `{ error }` for callers.
+    const err = await tool!.run({}, {}).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/exit code/i);
+    expect((err as Error).message).toContain("kaboom");
+  });
+
+  test("process.exit() inside a tool does not affect the server process", async () => {
+    const { configDir: dir, toolsDir } = await setupToolsDir();
+    configDir = dir;
+
+    await writeFile(
+      path.join(toolsDir, "hostile-exit.js"),
+      `async function run(input, context) {
+  process.exit(1);
+}
+
+if (import.meta.main) {
+  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
+  process.stdout.write(JSON.stringify(await run(payload, {})));
+}
+`,
+      "utf8"
+    );
+
+    const tool = await loadJavascriptTool(
+      makeRecord({
+        handlerConfig: { modulePath: "hostile-exit.js" },
+        name: "hostile_exit",
+      })
+    );
+
+    const err = await tool!.run({}, {}).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/exit code/i);
+    // Reaching this assertion at all proves the child's process.exit() did
+    // not tear down the test's own (server-simulating) process.
+    expect(process.pid).toBeGreaterThan(0);
+  });
+
+  test("runs with cwd scoped to the tools directory, not the server checkout", async () => {
+    const { configDir: dir, toolsDir } = await setupToolsDir();
+    configDir = dir;
+
+    await writeFile(
+      path.join(toolsDir, "cwd-probe.js"),
+      `async function run(input, context) {
+  return { cwd: process.cwd() };
+}
+
+if (import.meta.main) {
+  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
+  process.stdout.write(JSON.stringify(await run(payload, {})));
+}
+`,
+      "utf8"
+    );
+
+    const tool = await loadJavascriptTool(
+      makeRecord({
+        handlerConfig: { modulePath: "cwd-probe.js" },
+        name: "cwd_probe",
+      })
+    );
+
+    const result = (await tool!.run({}, {})) as { cwd: string };
+    expect(path.resolve(result.cwd)).toBe(path.resolve(toolsDir));
+  });
+
+  test("cannot read a secret-shaped env var from the parent process", async () => {
+    const { configDir: dir, toolsDir } = await setupToolsDir();
+    configDir = dir;
+
+    await writeFile(
+      path.join(toolsDir, "env-probe.js"),
+      `async function run(input, context) {
+  return { secret: process.env.NAKAMA_TEST_CANARY_SECRET ?? null };
+}
+
+if (import.meta.main) {
+  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
+  process.stdout.write(JSON.stringify(await run(payload, {})));
+}
+`,
+      "utf8"
+    );
+
+    const tool = await loadJavascriptTool(
+      makeRecord({
+        handlerConfig: { modulePath: "env-probe.js" },
+        name: "env_probe",
+      })
+    );
+
+    process.env.NAKAMA_TEST_CANARY_SECRET = "canary-not-a-real-secret";
+    try {
+      const result = (await tool!.run({}, {})) as { secret: string | null };
+      expect(result.secret).toBeNull();
+    } finally {
+      delete process.env.NAKAMA_TEST_CANARY_SECRET;
+    }
+  });
+
+  test("rejects on timeout even when the module exits 0", async () => {
+    const { configDir: dir, toolsDir } = await setupToolsDir();
+    configDir = dir;
+
+    await writeFile(
+      path.join(toolsDir, "stubborn.js"),
+      `async function run(input, context) {
+  // Never resolves on its own; only the loader's SIGTERM/SIGKILL ends this.
+  await new Promise(() => {});
+}
+
+if (import.meta.main) {
+  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
+  process.stdout.write(JSON.stringify(await run(payload, {})));
+}
+`,
+      "utf8"
+    );
+
+    const tool = await loadJavascriptTool(
+      makeRecord({
+        handlerConfig: { modulePath: "stubborn.js" },
+        name: "stubborn",
+      })
+    );
+
+    process.env.NAKAMA_JAVASCRIPT_TOOL_TIMEOUT_MS = "200";
+    try {
+      const err = await tool!.run({}, {}).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toMatch(/timed out/i);
+    } finally {
+      delete process.env.NAKAMA_JAVASCRIPT_TOOL_TIMEOUT_MS;
+    }
+  });
+
+  test("concurrent calls to a parallelSafe tool do not share module state", async () => {
+    const { configDir: dir, toolsDir } = await setupToolsDir();
+    configDir = dir;
+
+    // Each call is its own OS process, so a module-level counter starts fresh
+    // every time — the #481 "race on shared global state" concern is gone
+    // structurally, not just avoided by sequencing.
+    await writeFile(
+      path.join(toolsDir, "counter.js"),
+      `let count = 0;
+
+async function run(input, context) {
+  count += 1;
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  return { count };
+}
+
+if (import.meta.main) {
+  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
+  process.stdout.write(JSON.stringify(await run(payload, {})));
+}
+`,
+      "utf8"
+    );
+
+    const tool = await loadJavascriptTool(
+      makeRecord({
+        handlerConfig: { modulePath: "counter.js", parallelSafe: true },
+        name: "counter",
+      })
+    );
+
+    const [first, second] = await Promise.all([
+      tool!.run({}, {}) as Promise<{ count: number }>,
+      tool!.run({}, {}) as Promise<{ count: number }>,
+    ]);
+
+    expect(first.count).toBe(1);
+    expect(second.count).toBe(1);
   });
 });
 
@@ -160,8 +407,13 @@ describe("tool resolver", () => {
 
     await writeFile(
       path.join(toolsDir, "adder.js"),
-      `export async function run(input) {
+      `async function run(input, context) {
   return { sum: Number(input.a) + Number(input.b) };
+}
+
+if (import.meta.main) {
+  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
+  process.stdout.write(JSON.stringify(await run(payload, {})));
 }
 `,
       "utf8"

--- a/apps/server/src/services/javascript-tool-loader.ts
+++ b/apps/server/src/services/javascript-tool-loader.ts
@@ -1,20 +1,27 @@
-import { pathToFileURL } from "node:url";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 import type { JsonSchema, ToolContext, ToolDefinition } from "@nakama/core";
 import { pathExists, permissiveObjectSchema } from "@nakama/core";
 import type { StoredToolRecord } from "@nakama/db";
 import {
   createErrorTool,
-  isJsonSchema,
   readHandlerConfig,
   resolveCustomToolModulePath,
 } from "./custom-tool-shared";
+import {
+  buildAllowlistedSubprocessEnv,
+  spawnJsonTool,
+} from "./custom-tool-subprocess";
 
-const moduleCache = new Map<string, JavascriptToolModule>();
+const BUN_BIN = process.env.NAKAMA_BUN_BIN ?? "bun";
+const DEFAULT_TIMEOUT_MS = 30_000;
 
-interface JavascriptToolModule {
-  parallelSafe?: boolean;
-  parameters?: JsonSchema;
-  run: (input: unknown, context: ToolContext) => Promise<unknown>;
+// Call-time env override so tests can shrink the kill timer.
+function resolveTimeoutMs(): number {
+  const configured = Number(process.env.NAKAMA_JAVASCRIPT_TOOL_TIMEOUT_MS);
+  return Number.isFinite(configured) && configured > 0
+    ? configured
+    : DEFAULT_TIMEOUT_MS;
 }
 
 export async function loadJavascriptTool(
@@ -47,26 +54,28 @@ export async function loadJavascriptTool(
     );
   }
 
+  // Surface the missing-`run` error at load time so the agent sees a clear
+  // message instead of a confusing JSON parse error from spawn.
   try {
-    const module = await importJavascriptModule(modulePath);
-    const parameters =
-      module.parameters ?? config.parameters ?? permissiveObjectSchema();
-
-    return {
-      description: record.description,
-      name: record.name,
-      parameters,
-      ...(module.parallelSafe ? { parallelSafe: true } : {}),
-      async run(input, context) {
-        return module.run(input, context);
-      },
-    };
+    await validateJavascriptToolModule(config.modulePath);
   } catch (error) {
     return createErrorTool(
       record,
       error instanceof Error ? error.message : String(error)
     );
   }
+
+  const parameters: JsonSchema = config.parameters ?? permissiveObjectSchema();
+
+  return {
+    description: record.description,
+    name: record.name,
+    parameters,
+    ...(config.parallelSafe ? { parallelSafe: true } : {}),
+    async run(input, context) {
+      return runJavascriptTool(modulePath, input, context);
+    },
+  };
 }
 
 export async function validateJavascriptToolModule(
@@ -78,61 +87,53 @@ export async function validateJavascriptToolModule(
     throw new Error(`Tool module not found: ${modulePath}`);
   }
 
-  await importJavascriptModule(resolvedPath);
+  // Static checks catch the obvious authoring failures before registration.
+  // Syntax errors still surface at invocation.
+  const source = await readFile(resolvedPath, "utf8");
+
+  if (!/\bfunction\s+run\s*\(|\b(?:const|let|var)\s+run\s*=/.test(source)) {
+    throw new Error("Tool module must define a run(input, context) function.");
+  }
+
+  const hasHarness =
+    /import\.meta\.main/.test(source) &&
+    /stdin/i.test(source) &&
+    /stdout/i.test(source);
+  if (!hasHarness) {
+    throw new Error(
+      "JavaScript tools must include an if (import.meta.main) harness that reads JSON from stdin and writes JSON to stdout."
+    );
+  }
 }
 
 export function resolveJavascriptModulePath(modulePath: string): string {
   return resolveCustomToolModulePath(modulePath);
 }
 
-async function importJavascriptModule(
-  modulePath: string
-): Promise<JavascriptToolModule> {
-  const cached = moduleCache.get(modulePath);
+async function runJavascriptTool(
+  modulePath: string,
+  input: unknown,
+  context: ToolContext
+): Promise<unknown> {
+  const env = buildAllowlistedSubprocessEnv(
+    readString(context?.workspaceRoot) || undefined
+  );
 
-  if (cached) {
-    return cached;
-  }
-
-  const imported = await import(pathToFileURL(modulePath).href);
-  const module = normalizeJavascriptModule(imported);
-
-  moduleCache.set(modulePath, module);
-  return module;
+  // No try/catch here on purpose, matching the Python loader: a failed spawn
+  // must reject so the retry policy in withToolRetries can retry transient
+  // failures. executeToolCall converts the throw into `{ error: message }`.
+  return spawnJsonTool({
+    args: [modulePath],
+    bin: BUN_BIN,
+    context,
+    cwd: path.dirname(modulePath),
+    env,
+    input,
+    label: "JavaScript tool",
+    timeoutMs: resolveTimeoutMs(),
+  });
 }
 
-export function invalidateJavascriptModuleCache(modulePath: string): void {
-  moduleCache.delete(modulePath);
-}
-
-function normalizeJavascriptModule(imported: unknown): JavascriptToolModule {
-  if (typeof imported !== "object" || imported === null) {
-    throw new Error("Tool module must export a run function.");
-  }
-
-  const record = imported as Record<string, unknown>;
-  const defaultExport =
-    typeof record.default === "object" && record.default !== null
-      ? (record.default as Record<string, unknown>)
-      : null;
-  const source = defaultExport ?? record;
-  const run = source.run;
-
-  if (typeof run !== "function") {
-    throw new Error("Tool module must export a run function.");
-  }
-
-  const parameters = isJsonSchema(source.parameters)
-    ? source.parameters
-    : isJsonSchema(record.parameters)
-      ? record.parameters
-      : undefined;
-  const parallelSafe =
-    source.parallelSafe === true || record.parallelSafe === true;
-
-  return {
-    parameters,
-    ...(parallelSafe ? { parallelSafe: true } : {}),
-    run: (input, context) => Promise.resolve(run(input, context)),
-  };
+function readString(value: unknown): string {
+  return typeof value === "string" ? value : "";
 }

--- a/apps/server/src/services/profile-portability.test.ts
+++ b/apps/server/src/services/profile-portability.test.ts
@@ -206,7 +206,15 @@ describe("profile portability", () => {
     });
     const toolsDir = getCustomToolsDir();
     const modulePath = "portable-echo.js";
-    const source = "export async function run(input) { return input; }\n";
+    const source = `async function run(input, context) {
+  return input;
+}
+
+if (import.meta.main) {
+  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
+  process.stdout.write(JSON.stringify(await run(payload, {})));
+}
+`;
     await mkdir(toolsDir, { recursive: true });
     await writeFile(path.join(toolsDir, modulePath), source, "utf8");
     await db.upsertTool({

--- a/apps/server/src/services/profile-service.test.ts
+++ b/apps/server/src/services/profile-service.test.ts
@@ -52,8 +52,13 @@ describe("profile service createTool", () => {
 
     await writeFile(
       path.join(toolsDir, "echo.js"),
-      `export async function run(input) {
+      `async function run(input, context) {
   return input;
+}
+
+if (import.meta.main) {
+  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
+  process.stdout.write(JSON.stringify(await run(payload, {})));
 }
 `,
       "utf8"

--- a/apps/server/src/services/python-tool-loader.test.ts
+++ b/apps/server/src/services/python-tool-loader.test.ts
@@ -224,6 +224,69 @@ if __name__ == "__main__":
     await expect(tool!.run({}, {})).rejects.toThrow(/no output/i);
   });
 
+  test("runs with cwd scoped to the tools directory, not the server checkout", async () => {
+    const { configDir: dir, toolsDir } = await setupToolsDir();
+    configDir = dir;
+
+    await writeFile(
+      path.join(toolsDir, "cwd_probe.py"),
+      `import json, os, sys
+
+def run(input, context):
+    return {"cwd": os.getcwd()}
+
+if __name__ == "__main__":
+    payload = json.loads(sys.stdin.read() or "{}")
+    sys.stdout.write(json.dumps(run(payload, {})))
+`,
+      "utf8"
+    );
+
+    const tool = await loadPythonTool(
+      makeRecord({
+        handlerConfig: { modulePath: "cwd_probe.py" },
+        name: "cwd_probe",
+      })
+    );
+
+    const result = (await tool!.run({}, {})) as { cwd: string };
+    expect(path.resolve(result.cwd)).toBe(path.resolve(toolsDir));
+  });
+
+  test("cannot read a secret-shaped env var from the parent process", async () => {
+    const { configDir: dir, toolsDir } = await setupToolsDir();
+    configDir = dir;
+
+    await writeFile(
+      path.join(toolsDir, "env_probe.py"),
+      `import json, os, sys
+
+def run(input, context):
+    return {"secret": os.environ.get("NAKAMA_TEST_CANARY_SECRET")}
+
+if __name__ == "__main__":
+    payload = json.loads(sys.stdin.read() or "{}")
+    sys.stdout.write(json.dumps(run(payload, {})))
+`,
+      "utf8"
+    );
+
+    const tool = await loadPythonTool(
+      makeRecord({
+        handlerConfig: { modulePath: "env_probe.py" },
+        name: "env_probe",
+      })
+    );
+
+    process.env.NAKAMA_TEST_CANARY_SECRET = "canary-not-a-real-secret";
+    try {
+      const result = (await tool!.run({}, {})) as { secret: string | null };
+      expect(result.secret).toBeNull();
+    } finally {
+      delete process.env.NAKAMA_TEST_CANARY_SECRET;
+    }
+  });
+
   test("rejects on timeout even when the module exits 0", async () => {
     const { configDir: dir, toolsDir } = await setupToolsDir();
     configDir = dir;

--- a/apps/server/src/services/python-tool-loader.ts
+++ b/apps/server/src/services/python-tool-loader.ts
@@ -1,5 +1,5 @@
-import { spawn } from "node:child_process";
 import { readFile } from "node:fs/promises";
+import path from "node:path";
 import type { ToolContext, ToolDefinition } from "@nakama/core";
 import { pathExists, permissiveObjectSchema } from "@nakama/core";
 import type { StoredToolRecord } from "@nakama/db";
@@ -8,11 +8,13 @@ import {
   readHandlerConfig,
   resolveCustomToolModulePath,
 } from "./custom-tool-shared";
+import {
+  buildAllowlistedSubprocessEnv,
+  spawnJsonTool,
+} from "./custom-tool-subprocess";
 
 const PYTHON_BIN = process.env.NAKAMA_PYTHON_BIN ?? "python3";
 const DEFAULT_TIMEOUT_MS = 30_000;
-const SIGKILL_GRACE_MS = 5000;
-const MAX_OUTPUT_CHARS = 1_000_000;
 
 // Call-time env override so tests can shrink the kill timer.
 function resolveTimeoutMs(): number {
@@ -112,136 +114,24 @@ async function runPythonTool(
   input: unknown,
   context: ToolContext
 ): Promise<unknown> {
-  const workspaceRoot = readString(context?.workspaceRoot);
-  const env: NodeJS.ProcessEnv = { ...process.env };
-
-  if (workspaceRoot) {
-    env.NAKAMA_WORKSPACE_ROOT = workspaceRoot;
-  }
+  const env = buildAllowlistedSubprocessEnv(
+    readString(context?.workspaceRoot) || undefined
+  );
 
   // No try/catch here on purpose: a failed spawn must reject so the retry
   // policy in withToolRetries can retry transient failures. executeToolCall
   // (packages/agent/src/tool-loop.ts) converts the throw into the same
   // `{ error: message }` shape callers already expect.
-  return spawnAndParse(modulePath, input, context, env);
-}
-
-async function spawnAndParse(
-  modulePath: string,
-  input: unknown,
-  context: ToolContext,
-  env: NodeJS.ProcessEnv
-): Promise<unknown> {
-  const timeoutMs = resolveTimeoutMs();
-  const result = await new Promise<{ stdout: string; stderr: string }>(
-    (resolve, reject) => {
-      // Node SIGTERMs the child when the turn is cancelled, so a stopped chat
-      // does not leave a python process holding the session open.
-      const child = spawn(PYTHON_BIN, [modulePath], {
-        env,
-        signal: context.signal,
-        stdio: ["pipe", "pipe", "pipe"],
-      });
-
-      let stdout = "";
-      let stderr = "";
-      let timedOut = false;
-
-      const sigtermTimer = setTimeout(() => {
-        try {
-          child.kill("SIGTERM");
-        } catch {
-          // already exited
-        }
-        timedOut = true;
-        setTimeout(() => {
-          try {
-            child.kill("SIGKILL");
-          } catch {
-            // already exited
-          }
-        }, SIGKILL_GRACE_MS).unref();
-      }, timeoutMs);
-
-      child.stdout?.on("data", (chunk: Buffer | string) => {
-        stdout = appendCapped(stdout, String(chunk));
-      });
-
-      child.stderr?.on("data", (chunk: Buffer | string) => {
-        stderr = appendCapped(stderr, String(chunk));
-      });
-
-      // A child that exits without reading stdin can surface EPIPE here;
-      // the close handler reports the real failure.
-      child.stdin?.on("error", () => {});
-
-      child.once("error", (error) => {
-        clearTimeout(sigtermTimer);
-        reject(error);
-      });
-
-      child.once("close", (exitCode) => {
-        clearTimeout(sigtermTimer);
-        const tail = stderr.trim() || "(no stderr)";
-
-        // A child that traps SIGTERM can still exit 0 after the deadline;
-        // the budget is spent either way, so report the timeout.
-        if (timedOut) {
-          reject(
-            new Error(
-              `Python tool timed out after ${timeoutMs}ms (exit code ${exitCode ?? "null"}): ${tail}`
-            )
-          );
-          return;
-        }
-
-        if (exitCode === 0) {
-          resolve({ stderr, stdout });
-          return;
-        }
-
-        reject(
-          new Error(`Python tool exit code ${exitCode ?? "null"}: ${tail}`)
-        );
-      });
-
-      // Write the input payload and close stdin so the child can finish
-      // reading and proceed to run().
-      try {
-        child.stdin?.end(JSON.stringify(input ?? {}));
-      } catch (error) {
-        clearTimeout(sigtermTimer);
-        reject(error);
-      }
-    }
-  );
-
-  const trimmed = result.stdout.trim();
-
-  if (!trimmed) {
-    throw new Error(
-      `Python tool produced no output; it must print its JSON result to stdout. stderr: ${result.stderr.trim() || "(empty)"}`
-    );
-  }
-
-  try {
-    return JSON.parse(trimmed);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(
-      `Python tool returned non-JSON output: ${message}; stderr: ${result.stderr.trim() || "(empty)"}`
-    );
-  }
-}
-
-function appendCapped(current: string, next: string): string {
-  const combined = current + next;
-
-  if (combined.length <= MAX_OUTPUT_CHARS) {
-    return combined;
-  }
-
-  return combined.slice(-MAX_OUTPUT_CHARS);
+  return spawnJsonTool({
+    args: [modulePath],
+    bin: PYTHON_BIN,
+    context,
+    cwd: path.dirname(modulePath),
+    env,
+    input,
+    label: "Python tool",
+    timeoutMs: resolveTimeoutMs(),
+  });
 }
 
 function readString(value: unknown): string {

--- a/apps/server/src/tools/super-bot-tools.test.ts
+++ b/apps/server/src/tools/super-bot-tools.test.ts
@@ -46,8 +46,13 @@ describe("super bot create_tool", () => {
 
     await writeFile(
       path.join(toolsDir, "echo.js"),
-      `export async function run(input) {
+      `async function run(input, context) {
   return input;
+}
+
+if (import.meta.main) {
+  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
+  process.stdout.write(JSON.stringify(await run(payload, {})));
 }
 `,
       "utf8"

--- a/docs/website/content/docs/builtin-tools.mdx
+++ b/docs/website/content/docs/builtin-tools.mdx
@@ -36,7 +36,7 @@ When the model requests multiple tool calls in one turn, Nakama can run them con
 
 If a turn mixes parallel-safe and sequential tools — for example `read_file` and `bash` together — the whole turn runs sequentially.
 
-Custom JavaScript tools under `~/.nakama/tools/` default to sequential. Export `parallelSafe = true` from the module to opt in.
+Custom JavaScript tools under `~/.nakama/tools/` default to sequential. Set `"parallelSafe": true` in the tool's `handlerConfig` to opt in.
 
 Parallel execution speeds up multi-file research and lets a parent agent delegate several independent `sub_agent` tasks at once. See [`sub_agent`](#sub_agent) below.
 
@@ -433,12 +433,41 @@ Confirmed restore replaces the current local data root; selective merge, schedul
 
 Custom tools live in `~/.nakama/tools/` (follows `NAKAMA_CONFIG_DIR` if set) and are registered by a platform admin from **System → Tools**. Each tool points at a module file and can then be assigned to profiles like any builtin.
 
-Two handler types are supported:
+Two handler types are supported, and both run as a subprocess per call rather than inside the Nakama server process:
 
 | Type | File | Runs on |
 |---|---|---|
-| `javascript` | `*.js` | The Nakama process (module import) |
+| `javascript` | `*.js` | A `bun` subprocess per call |
 | `python` | `*.py` | A `python3` subprocess per call |
+
+Neither handler inherits the server's full environment. The child process only gets `PATH` (to resolve the interpreter), `NAKAMA_CONFIG_DIR`, and `NAKAMA_WORKSPACE_ROOT` (the active profile workspace) — provider API keys and anything else in the server's environment are not visible to a tool. The child's working directory is the tool's own file, not the server's checkout, so relative file access stays scoped to `~/.nakama/tools/`.
+
+### Authoring a JavaScript tool
+
+A JavaScript tool is a `.js` file that defines a `run(input, context)` function and prints one JSON value to stdout when run as a script:
+
+```javascript
+// ~/.nakama/tools/word_count.js
+async function run(input, context) {
+  const text = String(input.text ?? "");
+  return { words: text.split(/\s+/).filter(Boolean).length };
+}
+
+if (import.meta.main) {
+  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
+  process.stdout.write(JSON.stringify(await run(payload, {})));
+}
+```
+
+The contract:
+
+- Nakama invokes `bun <file>` once per call and writes the call arguments to stdin as JSON.
+- Whatever the script prints to stdout must be one JSON value — that becomes the tool result the agent sees.
+- A non-zero exit code or non-JSON stdout is returned to the agent as an error message (stderr is included).
+- Calls time out after 30 seconds.
+- Set `NAKAMA_BUN_BIN` before starting Nakama if `bun` is not the right interpreter to invoke on `PATH`.
+
+Parameters and `parallelSafe` are declared in the tool's `handlerConfig` (`handlerConfig.parameters` as a JSON Schema, `handlerConfig.parallelSafe` as a boolean) — not read from the module, since each call is a fresh process. When `parameters` is omitted, the model sees a permissive open object and can pass any arguments.
 
 ### Authoring a Python tool
 
@@ -464,7 +493,6 @@ The contract:
 - Whatever the script prints to stdout must be one JSON value — that becomes the tool result the agent sees.
 - A non-zero exit code or non-JSON stdout is returned to the agent as an error message (stderr is included).
 - Calls time out after 30 seconds.
-- The child process inherits your environment plus two extras: `NAKAMA_WORKSPACE_ROOT` (the active profile workspace) and `NAKAMA_CONFIG_DIR`.
 - Set `NAKAMA_PYTHON_BIN` before starting Nakama if your interpreter is not on `PATH` as `python3`.
 
 Parameters are declared as an optional JSON Schema in the tool's `handlerConfig.parameters`. When omitted, the model sees a permissive open object and can pass any arguments.


### PR DESCRIPTION
## Summary

A registered custom tool now runs as a subprocess with an allowlisted environment and a scoped working directory, whether it's JavaScript or Python. This closes the RCE and secret-leak paths from #447.

**Before:** JavaScript tools ran via `await import()` straight inside the server process (full RCE). Python tools already ran as a subprocess, but with `{ ...process.env }` and the server's own cwd, so the server's secrets and its checkout were both reachable.
**After:** both handler types spawn through one shared helper (`custom-tool-subprocess.ts`) with an explicit env allowlist (`PATH`, `NAKAMA_CONFIG_DIR`, `NAKAMA_WORKSPACE_ROOT`) and `cwd` pinned to the tool's own directory.

Why safe:
1. Python's existing contract (stdin/stdout JSON, timeout, kill) is unchanged in shape, only its env/cwd source moved into the shared helper.
2. JavaScript's new contract (`import.meta.main` harness) mirrors Python's `__main__` harness, so the two loaders stay symmetric instead of diverging again.
3. `parameters`/`parallelSafe` move from module exports into `handlerConfig`, the one breaking change, pre-agreed with @fajarhide in the issue thread since a subprocess can't cheaply read its own exports.

Closes #447

Only re-add broader ambient env if a real workflow needs more than `NAKAMA_WORKSPACE_ROOT`/`NAKAMA_CONFIG_DIR`, a narrow, explicit opt-in later beats reverting to full inheritance.

## Evidence

Each finding from the issue's own repro has a named regression test:

| Issue finding | Test |
|---|---|
| JS tool code ran inside the server process | `javascript tool loader > loads a module and runs run(input) with JSON over stdin, in a subprocess` |
| child inherited the server's full env (canary secret + 6 unrelated `KEY`/`TOKEN`/`SECRET` vars) | `cannot read a secret-shaped env var from the parent process` (both loaders) |
| child's cwd was the checkout, source tree reachable | `runs with cwd scoped to the tools directory, not the server checkout` (both loaders) |
| `parallelSafe: true` races on shared global state (#481) | `concurrent calls to a parallelSafe tool do not share module state` |
| a tool calling `process.exit()` or looping forever had no contained failure mode | `process.exit() inside a tool does not affect the server process`, `rejects on timeout even when the module exits 0` |

```
bun test src/services/javascript-tool-loader.test.ts src/services/python-tool-loader.test.ts src/services/custom-tool-handlers.test.ts

 37 pass
 0 fail
 71 expect() calls
```

## Test plan
- [x] `bun test` (above): 37 pass, 0 fail
- [x] `bun test` full server workspace: 997 pass, 17 fail. Same 17 fail on unmodified `upstream/main` (missing `/bin/bash`, `agent-browser`, and coding-agent CLIs on this dev machine, unrelated)
- [x] `bun run knip` clean
- [ ] Manual: register a JS tool with the new stdin/stdout contract from the dashboard, run it in the tool playground
