### PR TITLE
refactor(settings): collapse sole-provider flags into isSole

### DIFF
--- a/apps/web/src/components/settings/ProviderSettingsCard.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsCard.tsx
@@ -93,10 +93,10 @@ export function ProviderSettingsCard({
                     <ProviderInstanceCard
                       catalog={catalog}
                       instance={instance}
-                      isDefaultProvider={
+                      isSole={
+                        providers.length === 1 ||
                         providersResponse?.defaultProviderId === instance.id
                       }
-                      isLastProvider={providers.length === 1}
                       key={instance.id}
                       onDelete={async (providerId) => {
                         await deleteProviderMutation.mutateAsync(providerId);

--- a/apps/web/src/components/settings/provider-instance-card.tsx
+++ b/apps/web/src/components/settings/provider-instance-card.tsx
@@ -74,8 +74,7 @@ export function ProviderInstanceCard({
   onUpdate,
   onDelete,
   onError,
-  isDefaultProvider = false,
-  isLastProvider = false,
+  isSole = false,
 }: {
   instance: ProviderInstanceSummary;
   catalog: ProviderModelOption[];
@@ -85,14 +84,12 @@ export function ProviderInstanceCard({
   ) => Promise<void>;
   onDelete: (providerId: string) => Promise<void>;
   onError: (error: string | null) => void;
-  isDefaultProvider?: boolean;
-  isLastProvider?: boolean;
+  isSole?: boolean;
 }) {
   const card = useProviderInstanceCard({
     catalog,
     instance,
-    isDefaultProvider,
-    isLastProvider,
+    isSole,
     onDelete,
     onError,
     onUpdate,

--- a/apps/web/src/components/settings/use-provider-instance-card.ts
+++ b/apps/web/src/components/settings/use-provider-instance-card.ts
@@ -36,8 +36,7 @@ export function useProviderInstanceCard({
   onUpdate,
   onDelete,
   onError,
-  isDefaultProvider = false,
-  isLastProvider = false,
+  isSole = false,
 }: {
   instance: ProviderInstanceSummary;
   catalog: ProviderModelOption[];
@@ -47,8 +46,7 @@ export function useProviderInstanceCard({
   ) => Promise<void>;
   onDelete: (providerId: string) => Promise<void>;
   onError: (error: string | null) => void;
-  isDefaultProvider?: boolean;
-  isLastProvider?: boolean;
+  isSole?: boolean;
 }) {
   const [replaceKeyOpen, setReplaceKeyOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
@@ -164,15 +162,11 @@ export function useProviderInstanceCard({
   };
 
   const handleDelete = async () => {
-    const soleWarning =
-      isLastProvider || isDefaultProvider
-        ? "This is your only/default LLM provider. "
-        : "";
-    const confirmed = window.confirm(
-      `${soleWarning}Remove ${instance.label} (${instance.type})? Models using this provider will stop working. This cannot be undone.`
-    );
-
-    if (!confirmed) {
+    if (
+      !window.confirm(
+        `${isSole ? "This is your only/default LLM provider. " : ""}Remove ${instance.label} (${instance.type})? Models using this provider will stop working. This cannot be undone.`
+      )
+    ) {
       return;
     }
 


### PR DESCRIPTION
## Summary
Follow-up to #632 review: collapse `isDefaultProvider` + `isLastProvider` into one `isSole` prop and inline `window.confirm` like `McpTab.tsx`.

(The squash merge of #632 raced ahead of the review-fix push.)

## Test plan
- [ ] Settings → Remove provider → confirm still warns when sole/default
- [ ] Cancel still keeps the row

Made with [Cursor](https://cursor.com)