### PR TITLE
refactor(tools): shrink custom tool subprocess loaders after #653

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,7 +148,7 @@ Always build context with `buildToolExecutionContext()` (`packages/core/src/tool
 | Chat | `agent-service` → `buildChatSession()` → `buildToolExecutionContext(...)` |
 | Tool loop | `packages/agent/src/tool-loop.ts` → `executeToolCall()`; parallel batching in `packages/agent/src/chat.ts` when every call in the turn is `parallelSafe` |
 
-**Parallel tool calls:** Built-in read/search/fetch tools (`read_file`, `search_files`, `knowledge_base_search`, `web_search`, `web_fetch`) set `parallelSafe: true` on `ToolDefinition`. Mutating, shell, delegation, and session-state tools stay sequential. Custom JS tools default to sequential; export `parallelSafe: true` from the module to opt in. Custom Python tools cannot opt in — each call spawns a subprocess and stays sequential. When a turn mixes parallel-safe and sequential tools, the whole turn runs sequentially.
+**Parallel tool calls:** Built-in read/search/fetch tools (`read_file`, `search_files`, `knowledge_base_search`, `web_search`, `web_fetch`) set `parallelSafe: true` on `ToolDefinition`. Mutating, shell, delegation, and session-state tools stay sequential. Custom JS tools default to sequential; set `handlerConfig.parallelSafe: true` to opt in. Custom Python tools cannot opt in — each call spawns a subprocess and stays sequential. When a turn mixes parallel-safe and sequential tools, the whole turn runs sequentially.
 
 | Flow | Entry |
 |---|---|

--- a/apps/server/src/services/custom-tool-handlers.test.ts
+++ b/apps/server/src/services/custom-tool-handlers.test.ts
@@ -216,7 +216,7 @@ if __name__ == "__main__":
       `import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
-async function run(input, context) {
+export async function run(input, context) {
   const root = process.env.NAKAMA_WORKSPACE_ROOT ?? "/tmp";
   const counter = path.join(root, "attempts.txt");
   let n = existsSync(counter) ? Number(readFileSync(counter, "utf8").trim() || "0") : 0;
@@ -227,11 +227,6 @@ async function run(input, context) {
     process.exit(3);
   }
   return { ok: true, attempts: n };
-}
-
-if (import.meta.main) {
-  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
-  process.stdout.write(JSON.stringify(await run(payload, {})));
 }
 `,
       "utf8"

--- a/apps/server/src/services/custom-tool-shared.ts
+++ b/apps/server/src/services/custom-tool-shared.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import type { JsonSchema, ToolDefinition } from "@nakama/core";
+import type { JsonSchema, ToolContext, ToolDefinition } from "@nakama/core";
 import { getCustomToolsDir, permissiveObjectSchema } from "@nakama/core";
 import type { StoredToolRecord } from "@nakama/db";
 
@@ -16,6 +16,65 @@ export function createErrorTool(
     parameters: permissiveObjectSchema(),
     async run() {
       return { error: message };
+    },
+  };
+}
+
+export function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value ? value : undefined;
+}
+
+/** Shared load path for javascript/python subprocess tools. */
+export async function loadCustomSubprocessTool(options: {
+  allowParallelSafe?: boolean;
+  record: StoredToolRecord;
+  resolveModulePath: (modulePath: string) => string;
+  run: (
+    modulePath: string,
+    input: unknown,
+    context: ToolContext
+  ) => Promise<unknown>;
+  validateModule: (modulePath: string) => Promise<void>;
+}): Promise<ToolDefinition | null> {
+  const { allowParallelSafe, record, resolveModulePath, run, validateModule } =
+    options;
+  const config = readHandlerConfig(record.handlerConfig);
+
+  if (!config?.modulePath) {
+    return createErrorTool(
+      record,
+      `Tool "${record.name}" is missing handlerConfig.modulePath.`
+    );
+  }
+
+  let modulePath: string;
+
+  try {
+    modulePath = resolveModulePath(config.modulePath);
+  } catch (error) {
+    return createErrorTool(
+      record,
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+
+  // validateModule owns the missing-file check so load does not pathExists twice.
+  try {
+    await validateModule(config.modulePath);
+  } catch (error) {
+    return createErrorTool(
+      record,
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+
+  return {
+    description: record.description,
+    name: record.name,
+    parameters: config.parameters ?? permissiveObjectSchema(),
+    ...(allowParallelSafe && config.parallelSafe ? { parallelSafe: true } : {}),
+    async run(input, context) {
+      return run(modulePath, input, context);
     },
   };
 }

--- a/apps/server/src/services/custom-tool-shared.ts
+++ b/apps/server/src/services/custom-tool-shared.ts
@@ -6,7 +6,7 @@ import type { StoredToolRecord } from "@nakama/db";
 // Helpers shared by the custom tool loaders (javascript, python, and any
 // future handler type registered in custom-tool-handlers.ts).
 
-export function createErrorTool(
+function createErrorTool(
   record: StoredToolRecord,
   message: string
 ): ToolDefinition {
@@ -90,13 +90,13 @@ function isPathInsideDirectory(
   );
 }
 
-export interface CustomToolHandlerConfig {
+interface CustomToolHandlerConfig {
   modulePath: string;
   parallelSafe?: boolean;
   parameters?: JsonSchema;
 }
 
-export function readHandlerConfig(
+function readHandlerConfig(
   handlerConfig: unknown
 ): CustomToolHandlerConfig | null {
   if (typeof handlerConfig !== "object" || handlerConfig === null) {

--- a/apps/server/src/services/custom-tool-subprocess.ts
+++ b/apps/server/src/services/custom-tool-subprocess.ts
@@ -8,15 +8,16 @@ import type { ToolContext } from "@nakama/core";
 
 const SIGKILL_GRACE_MS = 5000;
 const MAX_OUTPUT_CHARS = 1_000_000;
+const DEFAULT_TIMEOUT_MS = 30_000;
 
-/**
- * Builds the child process env from an explicit allowlist: PATH (needed to
- * resolve the interpreter binary), NAKAMA_CONFIG_DIR, and the active
- * workspace root. Nothing else from the server's environment is passed
- * through, so provider API keys and ambient shell secrets never reach a
- * tool's process.
- */
-export function buildAllowlistedSubprocessEnv(
+function resolveCustomToolTimeoutMs(): number {
+  const configured = Number(process.env.NAKAMA_CUSTOM_TOOL_TIMEOUT_MS);
+  return Number.isFinite(configured) && configured > 0
+    ? configured
+    : DEFAULT_TIMEOUT_MS;
+}
+
+function buildAllowlistedSubprocessEnv(
   workspaceRoot?: string
 ): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {};
@@ -43,23 +44,25 @@ export interface SpawnJsonToolOptions {
   /** Working directory for the child. Keeps a tool's relative file access
    * scoped to its own directory instead of the server's checkout. */
   cwd: string;
-  env: NodeJS.ProcessEnv;
   input: unknown;
   /** Used in error messages, e.g. "Python tool", "JavaScript tool". */
   label: string;
-  timeoutMs: number;
+  workspaceRoot?: string;
 }
 
 /**
  * Spawns a tool as a subprocess, writes `input` as JSON to stdin, and parses
  * one JSON value from stdout as the result. Kills the child (SIGTERM, then
- * SIGKILL after a grace period) if it outlives `timeoutMs` or if
+ * SIGKILL after a grace period) if it outlives the timeout or if
  * `context.signal` aborts.
  */
 export async function spawnJsonTool(
   options: SpawnJsonToolOptions
 ): Promise<unknown> {
-  const { args, bin, context, cwd, env, input, label, timeoutMs } = options;
+  const { args, bin, context, cwd, input, label, workspaceRoot } = options;
+  const env = buildAllowlistedSubprocessEnv(workspaceRoot);
+  const timeoutMs = resolveCustomToolTimeoutMs();
+
   const result = await new Promise<{ stderr: string; stdout: string }>(
     (resolve, reject) => {
       // Node SIGTERMs the child when the turn is cancelled, so a stopped chat

--- a/apps/server/src/services/javascript-tool-loader.test.ts
+++ b/apps/server/src/services/javascript-tool-loader.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { realpathSync } from "node:fs";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -52,20 +53,14 @@ describe("javascript tool loader", () => {
     }
   });
 
-  test("loads a module and runs run(input) with JSON over stdin, in a subprocess", async () => {
+  test("loads a module and runs exported run(input) in a subprocess", async () => {
     const { configDir: dir, toolsDir } = await setupToolsDir();
     configDir = dir;
 
     await writeFile(
       path.join(toolsDir, "echo.js"),
-      `async function run(input, context) {
+      `export async function run(input, context) {
   return { echoed: input.message, root: process.env.NAKAMA_WORKSPACE_ROOT ?? "" };
-}
-
-if (import.meta.main) {
-  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
-  const result = await run(payload, {});
-  process.stdout.write(JSON.stringify(result));
 }
 `,
       "utf8"
@@ -82,8 +77,6 @@ if (import.meta.main) {
       { workspaceRoot: "/tmp/nakama-ws" }
     )) as { echoed: string; root: string };
     expect(result.echoed).toBe("hello");
-    // The loader must forward context.workspaceRoot to the child process as
-    // NAKAMA_WORKSPACE_ROOT, same as the Python loader.
     expect(result.root).toBe("/tmp/nakama-ws");
   });
 
@@ -93,13 +86,8 @@ if (import.meta.main) {
 
     await writeFile(
       path.join(toolsDir, "parallel-echo.js"),
-      `async function run(input, context) {
+      `export async function run(input, context) {
   return { echoed: input.message };
-}
-
-if (import.meta.main) {
-  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
-  process.stdout.write(JSON.stringify(await run(payload, {})));
 }
 `,
       "utf8"
@@ -134,14 +122,15 @@ if (import.meta.main) {
     expect(result).toEqual({ error: "Tool module not found: echo.js" });
   });
 
-  test("returns an error tool when the module lacks a run function", async () => {
+  test("returns an error tool when the module lacks an exported run function", async () => {
     const { configDir: dir, toolsDir } = await setupToolsDir();
     configDir = dir;
 
     await writeFile(
       path.join(toolsDir, "norun.js"),
-      `// no run() defined
-console.log("hi");
+      `async function run(input, context) {
+  return input;
+}
 `,
       "utf8"
     );
@@ -151,31 +140,7 @@ console.log("hi");
     );
 
     const result = (await tool!.run({}, {})) as { error: string };
-    expect(result.error).toMatch(/run\s*\(/i);
-  });
-
-  test("returns an error tool when the module lacks an import.meta.main harness", async () => {
-    const { configDir: dir, toolsDir } = await setupToolsDir();
-    configDir = dir;
-
-    await writeFile(
-      path.join(toolsDir, "noharness.js"),
-      `async function run(input, context) {
-  return input;
-}
-`,
-      "utf8"
-    );
-
-    const tool = await loadJavascriptTool(
-      makeRecord({
-        handlerConfig: { modulePath: "noharness.js" },
-        name: "noharness",
-      })
-    );
-
-    const result = (await tool!.run({}, {})) as { error: string };
-    expect(result.error).toMatch(/import\.meta\.main/i);
+    expect(result.error).toMatch(/export.*run/i);
   });
 
   test("returns an error tool when the module exits non-zero", async () => {
@@ -184,14 +149,9 @@ console.log("hi");
 
     await writeFile(
       path.join(toolsDir, "boom.js"),
-      `async function run(input, context) {
+      `export async function run(input, context) {
   console.error("kaboom");
   process.exit(7);
-}
-
-if (import.meta.main) {
-  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
-  process.stdout.write(JSON.stringify(await run(payload, {})));
 }
 `,
       "utf8"
@@ -201,8 +161,6 @@ if (import.meta.main) {
       makeRecord({ handlerConfig: { modulePath: "boom.js" }, name: "boom" })
     );
 
-    // A failed spawn must reject so the retry policy can retry transient
-    // failures; executeToolCall turns the throw into `{ error }` for callers.
     const err = await tool!.run({}, {}).catch((e: unknown) => e);
 
     expect(err).toBeInstanceOf(Error);
@@ -216,13 +174,8 @@ if (import.meta.main) {
 
     await writeFile(
       path.join(toolsDir, "hostile-exit.js"),
-      `async function run(input, context) {
+      `export async function run(input, context) {
   process.exit(1);
-}
-
-if (import.meta.main) {
-  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
-  process.stdout.write(JSON.stringify(await run(payload, {})));
 }
 `,
       "utf8"
@@ -239,8 +192,6 @@ if (import.meta.main) {
 
     expect(err).toBeInstanceOf(Error);
     expect((err as Error).message).toMatch(/exit code/i);
-    // Reaching this assertion at all proves the child's process.exit() did
-    // not tear down the test's own (server-simulating) process.
     expect(process.pid).toBeGreaterThan(0);
   });
 
@@ -250,13 +201,8 @@ if (import.meta.main) {
 
     await writeFile(
       path.join(toolsDir, "cwd-probe.js"),
-      `async function run(input, context) {
+      `export async function run(input, context) {
   return { cwd: process.cwd() };
-}
-
-if (import.meta.main) {
-  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
-  process.stdout.write(JSON.stringify(await run(payload, {})));
 }
 `,
       "utf8"
@@ -270,7 +216,7 @@ if (import.meta.main) {
     );
 
     const result = (await tool!.run({}, {})) as { cwd: string };
-    expect(path.resolve(result.cwd)).toBe(path.resolve(toolsDir));
+    expect(realpathSync(result.cwd)).toBe(realpathSync(toolsDir));
   });
 
   test("cannot read a secret-shaped env var from the parent process", async () => {
@@ -279,13 +225,8 @@ if (import.meta.main) {
 
     await writeFile(
       path.join(toolsDir, "env-probe.js"),
-      `async function run(input, context) {
+      `export async function run(input, context) {
   return { secret: process.env.NAKAMA_TEST_CANARY_SECRET ?? null };
-}
-
-if (import.meta.main) {
-  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
-  process.stdout.write(JSON.stringify(await run(payload, {})));
 }
 `,
       "utf8"
@@ -313,14 +254,8 @@ if (import.meta.main) {
 
     await writeFile(
       path.join(toolsDir, "stubborn.js"),
-      `async function run(input, context) {
-  // Never resolves on its own; only the loader's SIGTERM/SIGKILL ends this.
+      `export async function run(input, context) {
   await new Promise(() => {});
-}
-
-if (import.meta.main) {
-  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
-  process.stdout.write(JSON.stringify(await run(payload, {})));
 }
 `,
       "utf8"
@@ -333,13 +268,13 @@ if (import.meta.main) {
       })
     );
 
-    process.env.NAKAMA_JAVASCRIPT_TOOL_TIMEOUT_MS = "200";
+    process.env.NAKAMA_CUSTOM_TOOL_TIMEOUT_MS = "200";
     try {
       const err = await tool!.run({}, {}).catch((e: unknown) => e);
       expect(err).toBeInstanceOf(Error);
       expect((err as Error).message).toMatch(/timed out/i);
     } finally {
-      delete process.env.NAKAMA_JAVASCRIPT_TOOL_TIMEOUT_MS;
+      delete process.env.NAKAMA_CUSTOM_TOOL_TIMEOUT_MS;
     }
   });
 
@@ -347,22 +282,14 @@ if (import.meta.main) {
     const { configDir: dir, toolsDir } = await setupToolsDir();
     configDir = dir;
 
-    // Each call is its own OS process, so a module-level counter starts fresh
-    // every time — the #481 "race on shared global state" concern is gone
-    // structurally, not just avoided by sequencing.
     await writeFile(
       path.join(toolsDir, "counter.js"),
       `let count = 0;
 
-async function run(input, context) {
+export async function run(input, context) {
   count += 1;
   await new Promise((resolve) => setTimeout(resolve, 50));
   return { count };
-}
-
-if (import.meta.main) {
-  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
-  process.stdout.write(JSON.stringify(await run(payload, {})));
 }
 `,
       "utf8"
@@ -407,13 +334,8 @@ describe("tool resolver", () => {
 
     await writeFile(
       path.join(toolsDir, "adder.js"),
-      `async function run(input, context) {
+      `export async function run(input, context) {
   return { sum: Number(input.a) + Number(input.b) };
-}
-
-if (import.meta.main) {
-  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
-  process.stdout.write(JSON.stringify(await run(payload, {})));
 }
 `,
       "utf8"

--- a/apps/server/src/services/javascript-tool-loader.ts
+++ b/apps/server/src/services/javascript-tool-loader.ts
@@ -1,81 +1,31 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import type { JsonSchema, ToolContext, ToolDefinition } from "@nakama/core";
-import { pathExists, permissiveObjectSchema } from "@nakama/core";
+import { fileURLToPath } from "node:url";
+import type { ToolContext, ToolDefinition } from "@nakama/core";
+import { pathExists } from "@nakama/core";
 import type { StoredToolRecord } from "@nakama/db";
 import {
-  createErrorTool,
-  readHandlerConfig,
+  loadCustomSubprocessTool,
+  readOptionalString,
   resolveCustomToolModulePath,
 } from "./custom-tool-shared";
-import {
-  buildAllowlistedSubprocessEnv,
-  spawnJsonTool,
-} from "./custom-tool-subprocess";
+import { spawnJsonTool } from "./custom-tool-subprocess";
 
 const BUN_BIN = process.env.NAKAMA_BUN_BIN ?? "bun";
-const DEFAULT_TIMEOUT_MS = 30_000;
-
-// Call-time env override so tests can shrink the kill timer.
-function resolveTimeoutMs(): number {
-  const configured = Number(process.env.NAKAMA_JAVASCRIPT_TOOL_TIMEOUT_MS);
-  return Number.isFinite(configured) && configured > 0
-    ? configured
-    : DEFAULT_TIMEOUT_MS;
-}
+const RUNNER_PATH = fileURLToPath(
+  new URL("./javascript-tool-runner.js", import.meta.url)
+);
 
 export async function loadJavascriptTool(
   record: StoredToolRecord
 ): Promise<ToolDefinition | null> {
-  const config = readHandlerConfig(record.handlerConfig);
-
-  if (!config?.modulePath) {
-    return createErrorTool(
-      record,
-      `Tool "${record.name}" is missing handlerConfig.modulePath.`
-    );
-  }
-
-  let modulePath: string;
-
-  try {
-    modulePath = resolveJavascriptModulePath(config.modulePath);
-  } catch (error) {
-    return createErrorTool(
-      record,
-      error instanceof Error ? error.message : String(error)
-    );
-  }
-
-  if (!(await pathExists(modulePath))) {
-    return createErrorTool(
-      record,
-      `Tool module not found: ${config.modulePath}`
-    );
-  }
-
-  // Surface the missing-`run` error at load time so the agent sees a clear
-  // message instead of a confusing JSON parse error from spawn.
-  try {
-    await validateJavascriptToolModule(config.modulePath);
-  } catch (error) {
-    return createErrorTool(
-      record,
-      error instanceof Error ? error.message : String(error)
-    );
-  }
-
-  const parameters: JsonSchema = config.parameters ?? permissiveObjectSchema();
-
-  return {
-    description: record.description,
-    name: record.name,
-    parameters,
-    ...(config.parallelSafe ? { parallelSafe: true } : {}),
-    async run(input, context) {
-      return runJavascriptTool(modulePath, input, context);
-    },
-  };
+  return loadCustomSubprocessTool({
+    allowParallelSafe: true,
+    record,
+    resolveModulePath: resolveJavascriptModulePath,
+    run: runJavascriptTool,
+    validateModule: validateJavascriptToolModule,
+  });
 }
 
 export async function validateJavascriptToolModule(
@@ -91,18 +41,12 @@ export async function validateJavascriptToolModule(
   // Syntax errors still surface at invocation.
   const source = await readFile(resolvedPath, "utf8");
 
-  if (!/\bfunction\s+run\s*\(|\b(?:const|let|var)\s+run\s*=/.test(source)) {
-    throw new Error("Tool module must define a run(input, context) function.");
-  }
-
-  const hasHarness =
-    /import\.meta\.main/.test(source) &&
-    /stdin/i.test(source) &&
-    /stdout/i.test(source);
-  if (!hasHarness) {
-    throw new Error(
-      "JavaScript tools must include an if (import.meta.main) harness that reads JSON from stdin and writes JSON to stdout."
-    );
+  if (
+    !/\bexport\s+(?:async\s+)?function\s+run\s*\(|\bexport\s+(?:const|let|var)\s+run\s*=/.test(
+      source
+    )
+  ) {
+    throw new Error("Tool module must export a run(input, context) function.");
   }
 }
 
@@ -115,25 +59,16 @@ async function runJavascriptTool(
   input: unknown,
   context: ToolContext
 ): Promise<unknown> {
-  const env = buildAllowlistedSubprocessEnv(
-    readString(context?.workspaceRoot) || undefined
-  );
-
-  // No try/catch here on purpose, matching the Python loader: a failed spawn
-  // must reject so the retry policy in withToolRetries can retry transient
-  // failures. executeToolCall converts the throw into `{ error: message }`.
+  // No try/catch here on purpose: a failed spawn must reject so the retry
+  // policy in withToolRetries can retry transient failures. executeToolCall
+  // converts the throw into `{ error: message }`.
   return spawnJsonTool({
-    args: [modulePath],
+    args: [RUNNER_PATH, modulePath],
     bin: BUN_BIN,
     context,
     cwd: path.dirname(modulePath),
-    env,
     input,
     label: "JavaScript tool",
-    timeoutMs: resolveTimeoutMs(),
+    workspaceRoot: readOptionalString(context?.workspaceRoot),
   });
-}
-
-function readString(value: unknown): string {
-  return typeof value === "string" ? value : "";
 }

--- a/apps/server/src/services/javascript-tool-runner.js
+++ b/apps/server/src/services/javascript-tool-runner.js
@@ -1,0 +1,20 @@
+import { pathToFileURL } from "node:url";
+
+const modulePath = process.argv[2];
+if (!modulePath) {
+  console.error("Missing tool module path");
+  process.exit(1);
+}
+
+const mod = await import(pathToFileURL(modulePath).href);
+const run = typeof mod.run === "function" ? mod.run : mod.default?.run;
+if (typeof run !== "function") {
+  console.error("Tool module must export a run(input, context) function.");
+  process.exit(1);
+}
+
+const payload = JSON.parse((await Bun.stdin.text()) || "{}");
+const result = await run(payload, {
+  workspaceRoot: process.env.NAKAMA_WORKSPACE_ROOT,
+});
+process.stdout.write(JSON.stringify(result));

--- a/apps/server/src/services/profile-portability.test.ts
+++ b/apps/server/src/services/profile-portability.test.ts
@@ -206,13 +206,8 @@ describe("profile portability", () => {
     });
     const toolsDir = getCustomToolsDir();
     const modulePath = "portable-echo.js";
-    const source = `async function run(input, context) {
+    const source = `export async function run(input, context) {
   return input;
-}
-
-if (import.meta.main) {
-  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
-  process.stdout.write(JSON.stringify(await run(payload, {})));
 }
 `;
     await mkdir(toolsDir, { recursive: true });

--- a/apps/server/src/services/profile-service.test.ts
+++ b/apps/server/src/services/profile-service.test.ts
@@ -52,13 +52,8 @@ describe("profile service createTool", () => {
 
     await writeFile(
       path.join(toolsDir, "echo.js"),
-      `async function run(input, context) {
+      `export async function run(input) {
   return input;
-}
-
-if (import.meta.main) {
-  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
-  process.stdout.write(JSON.stringify(await run(payload, {})));
 }
 `,
       "utf8"

--- a/apps/server/src/services/python-tool-loader.test.ts
+++ b/apps/server/src/services/python-tool-loader.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { realpathSync } from "node:fs";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -250,7 +251,7 @@ if __name__ == "__main__":
     );
 
     const result = (await tool!.run({}, {})) as { cwd: string };
-    expect(path.resolve(result.cwd)).toBe(path.resolve(toolsDir));
+    expect(realpathSync(result.cwd)).toBe(realpathSync(toolsDir));
   });
 
   test("cannot read a secret-shaped env var from the parent process", async () => {
@@ -323,11 +324,11 @@ if __name__ == "__main__":
       })
     );
 
-    process.env.NAKAMA_PYTHON_TOOL_TIMEOUT_MS = "200";
+    process.env.NAKAMA_CUSTOM_TOOL_TIMEOUT_MS = "200";
     try {
       await expect(tool!.run({}, {})).rejects.toThrow(/timed out/i);
     } finally {
-      delete process.env.NAKAMA_PYTHON_TOOL_TIMEOUT_MS;
+      delete process.env.NAKAMA_CUSTOM_TOOL_TIMEOUT_MS;
     }
   });
 

--- a/apps/server/src/services/python-tool-loader.ts
+++ b/apps/server/src/services/python-tool-loader.ts
@@ -1,80 +1,26 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import type { ToolContext, ToolDefinition } from "@nakama/core";
-import { pathExists, permissiveObjectSchema } from "@nakama/core";
+import { pathExists } from "@nakama/core";
 import type { StoredToolRecord } from "@nakama/db";
 import {
-  createErrorTool,
-  readHandlerConfig,
+  loadCustomSubprocessTool,
+  readOptionalString,
   resolveCustomToolModulePath,
 } from "./custom-tool-shared";
-import {
-  buildAllowlistedSubprocessEnv,
-  spawnJsonTool,
-} from "./custom-tool-subprocess";
+import { spawnJsonTool } from "./custom-tool-subprocess";
 
 const PYTHON_BIN = process.env.NAKAMA_PYTHON_BIN ?? "python3";
-const DEFAULT_TIMEOUT_MS = 30_000;
-
-// Call-time env override so tests can shrink the kill timer.
-function resolveTimeoutMs(): number {
-  const configured = Number(process.env.NAKAMA_PYTHON_TOOL_TIMEOUT_MS);
-  return Number.isFinite(configured) && configured > 0
-    ? configured
-    : DEFAULT_TIMEOUT_MS;
-}
 
 export async function loadPythonTool(
   record: StoredToolRecord
 ): Promise<ToolDefinition | null> {
-  const config = readHandlerConfig(record.handlerConfig);
-
-  if (!config?.modulePath) {
-    return createErrorTool(
-      record,
-      `Tool "${record.name}" is missing handlerConfig.modulePath.`
-    );
-  }
-
-  let modulePath: string;
-
-  try {
-    modulePath = resolvePythonModulePath(config.modulePath);
-  } catch (error) {
-    return createErrorTool(
-      record,
-      error instanceof Error ? error.message : String(error)
-    );
-  }
-
-  if (!(await pathExists(modulePath))) {
-    return createErrorTool(
-      record,
-      `Tool module not found: ${config.modulePath}`
-    );
-  }
-
-  // Surface the missing-`run` error at load time so the agent sees a clear
-  // message instead of a confusing JSON parse error from spawn.
-  try {
-    await validatePythonToolModule(config.modulePath);
-  } catch (error) {
-    return createErrorTool(
-      record,
-      error instanceof Error ? error.message : String(error)
-    );
-  }
-
-  const parameters = config.parameters ?? permissiveObjectSchema();
-
-  return {
-    description: record.description,
-    name: record.name,
-    parameters,
-    async run(input, context) {
-      return runPythonTool(modulePath, input, context);
-    },
-  };
+  return loadCustomSubprocessTool({
+    record,
+    resolveModulePath: resolvePythonModulePath,
+    run: runPythonTool,
+    validateModule: validatePythonToolModule,
+  });
 }
 
 export async function validatePythonToolModule(
@@ -114,26 +60,16 @@ async function runPythonTool(
   input: unknown,
   context: ToolContext
 ): Promise<unknown> {
-  const env = buildAllowlistedSubprocessEnv(
-    readString(context?.workspaceRoot) || undefined
-  );
-
   // No try/catch here on purpose: a failed spawn must reject so the retry
   // policy in withToolRetries can retry transient failures. executeToolCall
-  // (packages/agent/src/tool-loop.ts) converts the throw into the same
-  // `{ error: message }` shape callers already expect.
+  // converts the throw into `{ error: message }`.
   return spawnJsonTool({
     args: [modulePath],
     bin: PYTHON_BIN,
     context,
     cwd: path.dirname(modulePath),
-    env,
     input,
     label: "Python tool",
-    timeoutMs: resolveTimeoutMs(),
+    workspaceRoot: readOptionalString(context?.workspaceRoot),
   });
-}
-
-function readString(value: unknown): string {
-  return typeof value === "string" ? value : "";
 }

--- a/apps/server/src/tools/super-bot-tools.test.ts
+++ b/apps/server/src/tools/super-bot-tools.test.ts
@@ -46,13 +46,8 @@ describe("super bot create_tool", () => {
 
     await writeFile(
       path.join(toolsDir, "echo.js"),
-      `async function run(input, context) {
+      `export async function run(input) {
   return input;
-}
-
-if (import.meta.main) {
-  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
-  process.stdout.write(JSON.stringify(await run(payload, {})));
 }
 `,
       "utf8"

--- a/docs/website/content/docs/builtin-tools.mdx
+++ b/docs/website/content/docs/builtin-tools.mdx
@@ -444,25 +444,19 @@ Neither handler inherits the server's full environment. The child process only g
 
 ### Authoring a JavaScript tool
 
-A JavaScript tool is a `.js` file that defines a `run(input, context)` function and prints one JSON value to stdout when run as a script:
+A JavaScript tool is a `.js` file that exports a `run(input, context)` function. Nakama loads it through a small runner subprocess — you do not write a stdin/stdout harness yourself:
 
 ```javascript
 // ~/.nakama/tools/word_count.js
-async function run(input, context) {
+export async function run(input, context) {
   const text = String(input.text ?? "");
   return { words: text.split(/\s+/).filter(Boolean).length };
-}
-
-if (import.meta.main) {
-  const payload = JSON.parse((await Bun.stdin.text()) || "{}");
-  process.stdout.write(JSON.stringify(await run(payload, {})));
 }
 ```
 
 The contract:
 
-- Nakama invokes `bun <file>` once per call and writes the call arguments to stdin as JSON.
-- Whatever the script prints to stdout must be one JSON value — that becomes the tool result the agent sees.
+- Nakama invokes `bun` with a built-in runner that imports your module, calls `run`, and prints one JSON value to stdout.
 - A non-zero exit code or non-JSON stdout is returned to the agent as an error message (stderr is included).
 - Calls time out after 30 seconds.
 - Set `NAKAMA_BUN_BIN` before starting Nakama if `bun` is not the right interpreter to invoke on `PATH`.


### PR DESCRIPTION
## Summary

JS custom tools are just `export async function run` again; loaders share one path — −150 lines after #653.

**Before:** each JS tool pasted an `import.meta.main` harness; JS/Python loaders duplicated load/timeout/env wiring.
**After:** `javascript-tool-runner.js` imports `run`; `loadCustomSubprocessTool` + `spawnJsonTool({ workspaceRoot })` own the shared bits.

Why safe:
1. Isolation contract unchanged — allowlisted env, tools-dir cwd, timeout/kill
2. Runner only adds the stdin/stdout glue authors were pasting by hand
3. Same regression suite (cwd, secrets, timeout, retries, parallelSafe)

Only re-add a per-file JS harness if a workflow needs to run the `.js` file as a standalone CLI outside Nakama.

## Test plan
- [x] `bun test src/services/javascript-tool-loader.test.ts src/services/python-tool-loader.test.ts src/services/custom-tool-handlers.test.ts src/services/profile-service.test.ts src/services/profile-portability.test.ts src/tools/super-bot-tools.test.ts` (95 pass)
- [ ] Register a JS tool with only `export async function run` in the playground — result returns as before
