### PR TITLE
shrink(cli): collapse clipboard magic-byte checks

### DIFF
--- a/apps/cli/src/clipboard-image.ts
+++ b/apps/cli/src/clipboard-image.ts
@@ -8,47 +8,23 @@ import {
 export function detectClipboardImageMediaType(
   bytes: Uint8Array | Buffer
 ): ImageAttachment["mediaType"] {
-  if (
-    bytes.length >= 8 &&
-    bytes[0] === 0x89 &&
-    bytes[1] === 0x50 &&
-    bytes[2] === 0x4e &&
-    bytes[3] === 0x47
-  ) {
+  const eq = (sig: number[], off = 0) =>
+    bytes.length >= off + sig.length &&
+    sig.every((value, index) => bytes[off + index] === value);
+
+  if (eq([0x89, 0x50, 0x4e, 0x47])) {
     return "image/png";
   }
-
-  if (
-    bytes.length >= 3 &&
-    bytes[0] === 0xff &&
-    bytes[1] === 0xd8 &&
-    bytes[2] === 0xff
-  ) {
+  if (eq([0xff, 0xd8, 0xff])) {
     return "image/jpeg";
   }
-
   if (
-    bytes.length >= 6 &&
-    bytes[0] === 0x47 &&
-    bytes[1] === 0x49 &&
-    bytes[2] === 0x46 &&
-    bytes[3] === 0x38 &&
+    eq([0x47, 0x49, 0x46, 0x38]) &&
     (bytes[4] === 0x37 || bytes[4] === 0x39)
   ) {
     return "image/gif";
   }
-
-  if (
-    bytes.length >= 12 &&
-    bytes[0] === 0x52 &&
-    bytes[1] === 0x49 &&
-    bytes[2] === 0x46 &&
-    bytes[3] === 0x46 &&
-    bytes[8] === 0x57 &&
-    bytes[9] === 0x45 &&
-    bytes[10] === 0x42 &&
-    bytes[11] === 0x50
-  ) {
+  if (eq([0x52, 0x49, 0x46, 0x46]) && eq([0x57, 0x45, 0x42, 0x50], 8)) {
     return "image/webp";
   }
 


### PR DESCRIPTION
## Summary

Clipboard media-type sniffing uses a tiny `eq` helper → same PNG/JPEG/GIF/WebP detection, −24 lines.

**Before:** ~45 lines of per-byte `if` chains in `detectClipboardImageMediaType`.
**After:** shared `eq(sig, off?)` + four short returns.

Why safe:
1. Same signatures and throw path as #649
2. Existing unit tests still cover all four types + reject + oversize
3. No API or caller changes

Only revisit if a fifth clipboard format needs a non-prefix match (then keep `eq`, add one branch).

## Test plan
- [x] `bun test ./apps/cli/src/clipboard-image.test.ts` (4 pass)
- [ ] Paste a PNG from clipboard in the CLI — still attaches as `image/png`
