### PR TITLE
feat(discord): support inbound image attachments for agent chat

### DIFF
--- a/apps/platform/discord/src/chat-handler.test.ts
+++ b/apps/platform/discord/src/chat-handler.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import path from "node:path";
 import type { ChatMessage } from "@nakama/core/contract";
 import { loadDiscordConfigFile } from "@nakama/core/discord-config";
@@ -1635,5 +1635,71 @@ describe("createChatHandler guild thread routing", () => {
     releaseHang();
     await first;
     expect(order).toEqual(["first-start", "second", "first-end"]);
+  });
+});
+
+describe("createChatHandler inbound images", () => {
+  test("image-only DM reaches the agent with images populated", async () => {
+    await withTempHome(async (homeDir) => {
+      const pngBytes = new Uint8Array([137, 80, 78, 71]);
+      const streamedInputs: unknown[] = [];
+      const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(pngBytes, { status: 200 })
+      );
+
+      try {
+        const { handleMessage } = await createPairedHandler(homeDir, {
+          onSendStream: async (input) => {
+            streamedInputs.push(input);
+            return "Looks like a PNG.";
+          },
+        });
+
+        const dm = createDmMessage({
+          attachments: [
+            {
+              contentType: "image/png",
+              size: pngBytes.byteLength,
+              url: "https://cdn.example/shot.png",
+            },
+          ],
+          content: "",
+          userId: "424242424242424242",
+        });
+        await handleMessage(dm.message);
+
+        expect(streamedInputs).toEqual([
+          {
+            images: [
+              {
+                data: Buffer.from(pngBytes).toString("base64"),
+                mediaType: "image/png",
+              },
+            ],
+            message: "",
+          },
+        ]);
+        expect(dm.sentMessages).toContain("Looks like a PNG.");
+        expect(
+          dm.sentMessages.some((reply) => /text messages only/i.test(reply))
+        ).toBe(false);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+  });
+
+  test("empty non-image DM still gets Text messages only.", async () => {
+    await withTempHome(async (homeDir) => {
+      const { handleMessage, calls } = await createPairedHandler(homeDir);
+      const dm = createDmMessage({
+        content: "",
+        userId: "424242424242424242",
+      });
+      await handleMessage(dm.message);
+
+      expect(calls.sendStream).toBe(0);
+      expect(dm.sentMessages).toContain("Text messages only.");
+    });
   });
 });

--- a/apps/platform/discord/src/chat-handler.ts
+++ b/apps/platform/discord/src/chat-handler.ts
@@ -14,7 +14,7 @@ import {
   formatOrgSwitchConfirmation,
   prepareChannelOrgContext,
 } from "@nakama/core/channel-org";
-import type { SendMessageInput } from "@nakama/core/contract";
+import type { ImageAttachment, SendMessageInput } from "@nakama/core/contract";
 import { addDiscordAllowedUserId } from "@nakama/core/discord-config";
 import {
   filterProfilesForChatAccess,
@@ -54,6 +54,7 @@ import {
   resolveOrgChannelId,
   stripBotMention,
 } from "./guild-message";
+import { buildDiscordImageInput } from "./images";
 import { isIgnorableInteractionError } from "./interaction-errors";
 import {
   createDiscordMessenger,
@@ -240,12 +241,20 @@ export function createChatHandler(deps: ChatHandlerDeps) {
       }
     }
 
-    if (!text) {
+    let imageInput: Awaited<ReturnType<typeof buildDiscordImageInput>> = null;
+    try {
+      imageInput = await buildDiscordImageInput(message);
+    } catch (error) {
+      await messenger.send(formatError(error));
+      return;
+    }
+
+    if (!(text || imageInput)) {
       await messenger.send("Text messages only.");
       return;
     }
 
-    if (command === "/org" || command === "/profile") {
+    if (text && (command === "/org" || command === "/profile")) {
       await withChatLock(conversationKey, async () => {
         await handleTextCommand(
           text,
@@ -259,7 +268,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
       return;
     }
 
-    if (text.startsWith("/") && !isAttachOnlyCommand(text)) {
+    if (text?.startsWith("/") && !isAttachOnlyCommand(text)) {
       await messenger.send(
         "Use slash commands from Discord's command menu for session control."
       );
@@ -267,11 +276,11 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     }
 
     const messageText =
-      isGuild && botInfo
+      text && isGuild && botInfo
         ? stripBotMention(text, botInfo, mentionedBotRoleIds)
-        : text;
+        : (text ?? "");
 
-    if (!messageText) {
+    if (!(messageText || imageInput)) {
       return;
     }
 
@@ -303,7 +312,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     console.log(
       "[discord] chat start",
       replyConversationKey,
-      messageText.slice(0, 80)
+      messageText.slice(0, 80) || "(image)"
     );
 
     await withChatLock(replyConversationKey, async () => {
@@ -313,7 +322,8 @@ export function createChatHandler(deps: ChatHandlerDeps) {
         replyMessenger,
         messageText,
         isGuild,
-        replyIsThread
+        replyIsThread,
+        imageInput?.images
       );
     });
 
@@ -646,7 +656,8 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     messenger: DiscordMessenger,
     attachUserText: string,
     isGuild: boolean,
-    isThread: boolean
+    isThread: boolean,
+    images?: ImageAttachment[]
   ): Promise<void> {
     const session = await resolveSession(conversationKey);
     const profileId = sessionStore.get(conversationKey)?.profileId;
@@ -668,7 +679,10 @@ export function createChatHandler(deps: ChatHandlerDeps) {
 
     // Forward free text to the agent — do not gate Discord replies on questionnaire parsing.
     const streamInput = withGroupContext(
-      { message: attachUserText },
+      {
+        images,
+        message: attachUserText,
+      },
       isGuild,
       isThread
     );

--- a/apps/platform/discord/src/images.test.ts
+++ b/apps/platform/discord/src/images.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { MAX_IMAGE_BYTES } from "@nakama/core/message-content";
+import type { Attachment, Message } from "discord.js";
+import { Collection } from "discord.js";
+import { buildDiscordImageInput } from "./images";
+
+function createMessage(options: {
+  content?: string;
+  attachments?: Array<{
+    contentType?: string | null;
+    size?: number;
+    url?: string;
+  }>;
+}): Message {
+  const attachments = new Collection<string, Attachment>();
+
+  for (const [index, attachment] of (options.attachments ?? []).entries()) {
+    attachments.set(String(index + 1), {
+      contentType: attachment.contentType ?? "image/png",
+      size: attachment.size ?? 32,
+      url: attachment.url ?? `https://cdn.example/image-${index + 1}.png`,
+    } as Attachment);
+  }
+
+  return {
+    attachments,
+    content: options.content ?? "",
+  } as unknown as Message;
+}
+
+describe("buildDiscordImageInput", () => {
+  let fetchSpy: ReturnType<typeof spyOn> | undefined;
+
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+    fetchSpy = undefined;
+  });
+
+  test("returns null when there are no image attachments", async () => {
+    const result = await buildDiscordImageInput(
+      createMessage({
+        attachments: [{ contentType: "application/pdf" }],
+        content: "see pdf",
+      })
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test("downloads allowed images and uses content as caption", async () => {
+    const pngBytes = new Uint8Array([137, 80, 78, 71]);
+    fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(pngBytes, { status: 200 })
+    );
+
+    const result = await buildDiscordImageInput(
+      createMessage({
+        attachments: [{ contentType: "image/png", size: pngBytes.byteLength }],
+        content: "what is this?",
+      })
+    );
+
+    expect(result).toEqual({
+      images: [
+        {
+          data: Buffer.from(pngBytes).toString("base64"),
+          mediaType: "image/png",
+        },
+      ],
+      message: "what is this?",
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects oversized images before fetch completes the turn", async () => {
+    fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(new Uint8Array(8), { status: 200 })
+    );
+
+    await expect(
+      buildDiscordImageInput(
+        createMessage({
+          attachments: [
+            {
+              contentType: "image/jpeg",
+              size: MAX_IMAGE_BYTES + 1,
+            },
+          ],
+        })
+      )
+    ).rejects.toThrow(/too large/i);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/platform/discord/src/images.ts
+++ b/apps/platform/discord/src/images.ts
@@ -1,0 +1,78 @@
+import { normalizeMimeType } from "@nakama/core/artifact-mime";
+import type { ImageAttachment } from "@nakama/core/contract";
+import {
+  MAX_ATTACHMENTS_PER_MESSAGE,
+  MAX_IMAGE_BYTES,
+  validateImageAttachments,
+} from "@nakama/core/message-content";
+import type { Attachment, Message } from "discord.js";
+
+const ALLOWED_IMAGE_MEDIA_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+]);
+
+export interface DiscordImageInput {
+  images: ImageAttachment[];
+  message: string;
+}
+
+export async function buildDiscordImageInput(
+  message: Message
+): Promise<DiscordImageInput | null> {
+  const attachments = [...(message.attachments?.values() ?? [])]
+    .filter(isAllowedImageAttachment)
+    .slice(0, MAX_ATTACHMENTS_PER_MESSAGE);
+
+  if (attachments.length === 0) {
+    return null;
+  }
+
+  const images: ImageAttachment[] = [];
+
+  for (const attachment of attachments) {
+    images.push(await downloadDiscordImage(attachment));
+  }
+
+  validateImageAttachments(images);
+
+  return {
+    images,
+    message: message.content?.trim() ?? "",
+  };
+}
+
+function isAllowedImageAttachment(attachment: Attachment): boolean {
+  return ALLOWED_IMAGE_MEDIA_TYPES.has(
+    normalizeMimeType(attachment.contentType ?? "")
+  );
+}
+
+async function downloadDiscordImage(
+  attachment: Attachment
+): Promise<ImageAttachment> {
+  const mediaType = normalizeMimeType(attachment.contentType ?? "");
+
+  if (attachment.size > MAX_IMAGE_BYTES) {
+    throw new Error("Image is too large. Maximum size is 5 MB.");
+  }
+
+  const response = await fetch(attachment.url);
+
+  if (!response.ok) {
+    throw new Error(`Failed to download image (${response.status}).`);
+  }
+
+  const bytes = await response.arrayBuffer();
+
+  if (bytes.byteLength > MAX_IMAGE_BYTES) {
+    throw new Error("Image is too large. Maximum size is 5 MB.");
+  }
+
+  return {
+    data: Buffer.from(bytes).toString("base64"),
+    mediaType,
+  };
+}

--- a/apps/platform/discord/src/test-helpers.ts
+++ b/apps/platform/discord/src/test-helpers.ts
@@ -205,6 +205,11 @@ export function createDmMessage(options: {
   userId?: string;
   channelId?: string;
   content?: string;
+  attachments?: Array<{
+    contentType?: string | null;
+    size?: number;
+    url?: string;
+  }>;
 }): MockDmMessage {
   const sentMessages: string[] = [];
   let fileSendCalls = 0;
@@ -233,7 +238,25 @@ export function createDmMessage(options: {
     sendTyping: async () => {},
   };
 
+  const attachments = new Map<
+    string,
+    {
+      contentType: string | null;
+      size: number;
+      url: string;
+    }
+  >();
+
+  for (const [index, attachment] of (options.attachments ?? []).entries()) {
+    attachments.set(String(index + 1), {
+      contentType: attachment.contentType ?? "image/png",
+      size: attachment.size ?? 32,
+      url: attachment.url ?? `https://cdn.example/image-${index + 1}.png`,
+    });
+  }
+
   const message = {
+    attachments,
     author: { bot: false, id: options.userId ?? "424242424242424242" },
     channel,
     client: { user: { id: "bot_id", username: "nakamabot" } },
@@ -396,6 +419,7 @@ export function createGuildChatMessage(options: {
   };
 
   const message = {
+    attachments: new Map(),
     author: { bot: false, id: userId },
     channel,
     client: {


### PR DESCRIPTION
## Summary

Discord users can drop a screenshot (optional caption) and the agent sees it via `SendMessageInput.images` — same path as Telegram/web.

**Before:** Image DM/thread → `Text messages only.`; agent never sees the bytes.
**After:** `buildDiscordImageInput` downloads jpeg/png/gif/webp (≤5, ≤5 MB) and passes `images` through `handleChatMessage`.

Why safe:
1. Reuses existing `SendMessageInput.images` + `validateImageAttachments` — no new agent API
2. Guild mention/thread routing unchanged; image-only uses `deriveThreadName` → "Nakama chat"
3. Non-image empties still get `Text messages only.`

Only follow up if Discord CDN content-types are often missing (we skip untyped attachments).

Fixes #655

## Test plan
- [x] `bun test apps/platform/discord/src/images.test.ts apps/platform/discord/src/chat-handler.test.ts` (43 pass)
- [ ] DM the bot a PNG with caption — agent describes it; no `Text messages only.`
