### PR TITLE
fix(discord): harden inbound image caps and mime inference

### DIFF
--- a/apps/platform/discord/src/chat-handler.test.ts
+++ b/apps/platform/discord/src/chat-handler.test.ts
@@ -9,6 +9,7 @@ import {
   resetChatLocksForTests,
   withChatLock,
 } from "./chat-handler";
+import { TOO_MANY_IMAGES_REPLY, UNSUPPORTED_ATTACHMENT_REPLY } from "./images";
 import { SessionStore } from "./session-store";
 import {
   createDmMessage,
@@ -1700,6 +1701,127 @@ describe("createChatHandler inbound images", () => {
 
       expect(calls.sendStream).toBe(0);
       expect(dm.sentMessages).toContain("Text messages only.");
+    });
+  });
+
+  test("pdf-only DM gets unsupported attachment reply", async () => {
+    await withTempHome(async (homeDir) => {
+      const { handleMessage, calls } = await createPairedHandler(homeDir);
+      const dm = createDmMessage({
+        attachments: [
+          {
+            contentType: "application/pdf",
+            name: "notes.pdf",
+            size: 100,
+          },
+        ],
+        content: "",
+        userId: "424242424242424242",
+      });
+      await handleMessage(dm.message);
+
+      expect(calls.sendStream).toBe(0);
+      expect(dm.sentMessages).toContain(UNSUPPORTED_ATTACHMENT_REPLY);
+    });
+  });
+
+  test("too many images rejects without starting chat", async () => {
+    await withTempHome(async (homeDir) => {
+      const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(new Uint8Array(8), { status: 200 })
+      );
+
+      try {
+        const { handleMessage, calls } = await createPairedHandler(homeDir);
+        const dm = createDmMessage({
+          attachments: Array.from({ length: 6 }, (_, index) => ({
+            contentType: "image/png",
+            name: `shot-${index}.png`,
+            size: 8,
+            url: `https://cdn.example/shot-${index}.png`,
+          })),
+          content: "",
+          userId: "424242424242424242",
+        });
+        await handleMessage(dm.message);
+
+        expect(calls.sendStream).toBe(0);
+        expect(dm.sentMessages).toContain(TOO_MANY_IMAGES_REPLY);
+        expect(fetchSpy).not.toHaveBeenCalled();
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+  });
+
+  test("guild mention plus image-only reaches the agent", async () => {
+    await withTempHome(async (homeDir) => {
+      const pngBytes = new Uint8Array([137, 80, 78, 71]);
+      const streamedInputs: unknown[] = [];
+      const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(pngBytes, { status: 200 })
+      );
+
+      try {
+        const { handleMessage } = await createPairedHandler(homeDir, {
+          onSendStream: async (input) => {
+            streamedInputs.push(input);
+            return "Got the screenshot.";
+          },
+        });
+
+        const guild = createGuildChatMessage({
+          attachments: [
+            {
+              contentType: "image/png",
+              name: "shot.png",
+              size: pngBytes.byteLength,
+            },
+          ],
+          content: "<@bot_id>",
+          mentionsBot: true,
+          userId: "424242424242424242",
+        });
+        await handleMessage(guild.message);
+
+        expect(streamedInputs.length).toBe(1);
+        expect(
+          (streamedInputs[0] as { images?: unknown[] }).images
+        ).toHaveLength(1);
+        expect(guild.threadSentMessages).toContain("Got the screenshot.");
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+  });
+
+  test("guild image without mention does not fetch", async () => {
+    await withTempHome(async (homeDir) => {
+      const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(new Uint8Array(8), { status: 200 })
+      );
+
+      try {
+        const { handleMessage, calls } = await createPairedHandler(homeDir);
+        const guild = createGuildChatMessage({
+          attachments: [
+            {
+              contentType: "image/png",
+              name: "shot.png",
+              size: 8,
+            },
+          ],
+          content: "",
+          mentionsBot: false,
+          userId: "424242424242424242",
+        });
+        await handleMessage(guild.message);
+
+        expect(calls.sendStream).toBe(0);
+        expect(fetchSpy).not.toHaveBeenCalled();
+      } finally {
+        fetchSpy.mockRestore();
+      }
     });
   });
 });

--- a/apps/platform/discord/src/chat-handler.ts
+++ b/apps/platform/discord/src/chat-handler.ts
@@ -54,7 +54,7 @@ import {
   resolveOrgChannelId,
   stripBotMention,
 } from "./guild-message";
-import { buildDiscordImageInput } from "./images";
+import { buildDiscordImageInput, UNSUPPORTED_ATTACHMENT_REPLY } from "./images";
 import { isIgnorableInteractionError } from "./interaction-errors";
 import {
   createDiscordMessenger,
@@ -241,16 +241,20 @@ export function createChatHandler(deps: ChatHandlerDeps) {
       }
     }
 
-    let imageInput: Awaited<ReturnType<typeof buildDiscordImageInput>> = null;
-    try {
-      imageInput = await buildDiscordImageInput(message);
-    } catch (error) {
-      await messenger.send(formatError(error));
+    const imageBuild = await buildDiscordImageInput(message);
+
+    if (imageBuild?.kind === "reject") {
+      await messenger.send(imageBuild.message);
       return;
     }
 
+    const imageInput = imageBuild?.kind === "input" ? imageBuild.input : null;
+
     if (!(text || imageInput)) {
-      await messenger.send("Text messages only.");
+      const hasStickers = (message.stickers?.size ?? 0) > 0;
+      await messenger.send(
+        hasStickers ? UNSUPPORTED_ATTACHMENT_REPLY : "Text messages only."
+      );
       return;
     }
 

--- a/apps/platform/discord/src/images.test.ts
+++ b/apps/platform/discord/src/images.test.ts
@@ -59,7 +59,7 @@ describe("buildDiscordImageInput", () => {
     const result = await buildDiscordImageInput(
       createMessage({
         attachments: [{ contentType: "application/pdf", name: "doc.pdf" }],
-        content: "see pdf",
+        content: "",
       })
     );
 
@@ -67,6 +67,42 @@ describe("buildDiscordImageInput", () => {
       kind: "reject",
       message: UNSUPPORTED_ATTACHMENT_REPLY,
     });
+  });
+
+  test("ignores non-image attachments when caption text is present", async () => {
+    const result = await buildDiscordImageInput(
+      createMessage({
+        attachments: [{ contentType: "application/pdf", name: "doc.pdf" }],
+        content: "see pdf",
+      })
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test("does not treat pdf as image when filename looks like png", async () => {
+    fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(new Uint8Array(8), { status: 200 })
+    );
+
+    const result = await buildDiscordImageInput(
+      createMessage({
+        attachments: [
+          {
+            contentType: "application/pdf",
+            name: "shot.png",
+            size: 8,
+          },
+        ],
+        content: "",
+      })
+    );
+
+    expect(result).toEqual({
+      kind: "reject",
+      message: UNSUPPORTED_ATTACHMENT_REPLY,
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   test("downloads allowed images and uses content as caption", async () => {

--- a/apps/platform/discord/src/images.test.ts
+++ b/apps/platform/discord/src/images.test.ts
@@ -1,13 +1,23 @@
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
-import { MAX_IMAGE_BYTES } from "@nakama/core/message-content";
+import {
+  MAX_ATTACHMENTS_PER_MESSAGE,
+  MAX_IMAGE_BYTES,
+} from "@nakama/core/message-content";
 import type { Attachment, Message } from "discord.js";
 import { Collection } from "discord.js";
-import { buildDiscordImageInput } from "./images";
+import {
+  buildDiscordImageInput,
+  DOWNLOAD_FAILED_REPLY,
+  OVERSIZED_IMAGE_REPLY,
+  TOO_MANY_IMAGES_REPLY,
+  UNSUPPORTED_ATTACHMENT_REPLY,
+} from "./images";
 
 function createMessage(options: {
   content?: string;
   attachments?: Array<{
     contentType?: string | null;
+    name?: string;
     size?: number;
     url?: string;
   }>;
@@ -16,7 +26,8 @@ function createMessage(options: {
 
   for (const [index, attachment] of (options.attachments ?? []).entries()) {
     attachments.set(String(index + 1), {
-      contentType: attachment.contentType ?? "image/png",
+      contentType: attachment.contentType ?? null,
+      name: attachment.name ?? `image-${index + 1}.png`,
       size: attachment.size ?? 32,
       url: attachment.url ?? `https://cdn.example/image-${index + 1}.png`,
     } as Attachment);
@@ -36,15 +47,26 @@ describe("buildDiscordImageInput", () => {
     fetchSpy = undefined;
   });
 
-  test("returns null when there are no image attachments", async () => {
+  test("returns null when there are no attachments", async () => {
+    const result = await buildDiscordImageInput(
+      createMessage({ content: "hi" })
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test("rejects non-image attachments", async () => {
     const result = await buildDiscordImageInput(
       createMessage({
-        attachments: [{ contentType: "application/pdf" }],
+        attachments: [{ contentType: "application/pdf", name: "doc.pdf" }],
         content: "see pdf",
       })
     );
 
-    expect(result).toBeNull();
+    expect(result).toEqual({
+      kind: "reject",
+      message: UNSUPPORTED_ATTACHMENT_REPLY,
+    });
   });
 
   test("downloads allowed images and uses content as caption", async () => {
@@ -55,41 +77,162 @@ describe("buildDiscordImageInput", () => {
 
     const result = await buildDiscordImageInput(
       createMessage({
-        attachments: [{ contentType: "image/png", size: pngBytes.byteLength }],
+        attachments: [
+          {
+            contentType: "image/png",
+            name: "shot.png",
+            size: pngBytes.byteLength,
+          },
+        ],
         content: "what is this?",
       })
     );
 
     expect(result).toEqual({
-      images: [
-        {
-          data: Buffer.from(pngBytes).toString("base64"),
-          mediaType: "image/png",
-        },
-      ],
-      message: "what is this?",
+      input: {
+        images: [
+          {
+            data: Buffer.from(pngBytes).toString("base64"),
+            mediaType: "image/png",
+          },
+        ],
+        message: "what is this?",
+      },
+      kind: "input",
     });
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
-  test("rejects oversized images before fetch completes the turn", async () => {
+  test("infers jpeg from filename when contentType is null", async () => {
+    const jpegBytes = new Uint8Array([0xff, 0xd8, 0xff]);
+    fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(jpegBytes, { status: 200 })
+    );
+
+    const result = await buildDiscordImageInput(
+      createMessage({
+        attachments: [
+          {
+            contentType: null,
+            name: "photo.jpg",
+            size: jpegBytes.byteLength,
+          },
+        ],
+      })
+    );
+
+    expect(result).toEqual({
+      input: {
+        images: [
+          {
+            data: Buffer.from(jpegBytes).toString("base64"),
+            mediaType: "image/jpeg",
+          },
+        ],
+        message: "",
+      },
+      kind: "input",
+    });
+  });
+
+  test("rejects when more than max valid images without downloading", async () => {
     fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(new Uint8Array(8), { status: 200 })
     );
 
-    await expect(
-      buildDiscordImageInput(
-        createMessage({
-          attachments: [
-            {
-              contentType: "image/jpeg",
-              size: MAX_IMAGE_BYTES + 1,
-            },
-          ],
-        })
-      )
-    ).rejects.toThrow(/too large/i);
+    const attachments = Array.from(
+      { length: MAX_ATTACHMENTS_PER_MESSAGE + 1 },
+      (_, index) => ({
+        contentType: "image/png",
+        name: `shot-${index}.png`,
+        size: 8,
+      })
+    );
 
+    const result = await buildDiscordImageInput(createMessage({ attachments }));
+
+    expect(result).toEqual({
+      kind: "reject",
+      message: TOO_MANY_IMAGES_REPLY,
+    });
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("rejects oversized images before fetch", async () => {
+    fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(new Uint8Array(8), { status: 200 })
+    );
+
+    const result = await buildDiscordImageInput(
+      createMessage({
+        attachments: [
+          {
+            contentType: "image/jpeg",
+            name: "big.jpg",
+            size: MAX_IMAGE_BYTES + 1,
+          },
+        ],
+      })
+    );
+
+    expect(result).toEqual({
+      kind: "reject",
+      message: OVERSIZED_IMAGE_REPLY,
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("keeps valid images and ignores invalid siblings", async () => {
+    const pngBytes = new Uint8Array([137, 80, 78, 71]);
+    fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(pngBytes, { status: 200 })
+    );
+
+    const result = await buildDiscordImageInput(
+      createMessage({
+        attachments: [
+          {
+            contentType: "image/png",
+            name: "ok.png",
+            size: pngBytes.byteLength,
+          },
+          {
+            contentType: "application/pdf",
+            name: "notes.pdf",
+            size: 100,
+          },
+        ],
+      })
+    );
+
+    expect(result?.kind).toBe("input");
+    if (result?.kind === "input") {
+      expect(result.input.images).toHaveLength(1);
+      expect(result.input.images[0]?.mediaType).toBe("image/png");
+    }
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects download failures without throwing", async () => {
+    fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 500 })
+    );
+
+    const result = await buildDiscordImageInput(
+      createMessage({
+        attachments: [
+          {
+            contentType: "image/png",
+            name: "shot.png",
+            size: 32,
+          },
+        ],
+      })
+    );
+
+    expect(result).toEqual({
+      kind: "reject",
+      message: DOWNLOAD_FAILED_REPLY,
+    });
   });
 });

--- a/apps/platform/discord/src/images.ts
+++ b/apps/platform/discord/src/images.ts
@@ -25,7 +25,7 @@ export const UNSUPPORTED_ATTACHMENT_REPLY =
 export const DOWNLOAD_FAILED_REPLY =
   "Could not download that image. Try again.";
 
-export interface DiscordImageInput {
+interface DiscordImageInput {
   images: ImageAttachment[];
   message: string;
 }

--- a/apps/platform/discord/src/images.ts
+++ b/apps/platform/discord/src/images.ts
@@ -14,49 +14,126 @@ const ALLOWED_IMAGE_MEDIA_TYPES = new Set([
   "image/webp",
 ]);
 
+export const OVERSIZED_IMAGE_REPLY =
+  "Image is too large. Maximum size is 5 MB.";
+
+export const TOO_MANY_IMAGES_REPLY = `At most ${MAX_ATTACHMENTS_PER_MESSAGE} images per message.`;
+
+export const UNSUPPORTED_ATTACHMENT_REPLY =
+  "Unsupported attachment. Send a jpeg, png, gif, or webp image (max 5 MB).";
+
+export const DOWNLOAD_FAILED_REPLY =
+  "Could not download that image. Try again.";
+
 export interface DiscordImageInput {
   images: ImageAttachment[];
   message: string;
 }
 
+export type DiscordImageBuildResult =
+  | { kind: "input"; input: DiscordImageInput }
+  | { kind: "reject"; message: string }
+  | null;
+
 export async function buildDiscordImageInput(
   message: Message
-): Promise<DiscordImageInput | null> {
-  const attachments = [...(message.attachments?.values() ?? [])]
-    .filter(isAllowedImageAttachment)
-    .slice(0, MAX_ATTACHMENTS_PER_MESSAGE);
+): Promise<DiscordImageBuildResult> {
+  const attachments = [...(message.attachments?.values() ?? [])];
 
   if (attachments.length === 0) {
     return null;
   }
 
-  const images: ImageAttachment[] = [];
+  const valid: Attachment[] = [];
+  let sawOversizedImage = false;
 
   for (const attachment of attachments) {
-    images.push(await downloadDiscordImage(attachment));
+    const mediaType = resolveAttachmentMediaType(attachment);
+
+    if (!ALLOWED_IMAGE_MEDIA_TYPES.has(mediaType)) {
+      continue;
+    }
+
+    if (attachment.size > MAX_IMAGE_BYTES) {
+      sawOversizedImage = true;
+      continue;
+    }
+
+    valid.push(attachment);
   }
 
-  validateImageAttachments(images);
+  if (valid.length > MAX_ATTACHMENTS_PER_MESSAGE) {
+    return { kind: "reject", message: TOO_MANY_IMAGES_REPLY };
+  }
 
-  return {
-    images,
-    message: message.content?.trim() ?? "",
-  };
+  if (valid.length === 0) {
+    if (sawOversizedImage) {
+      return { kind: "reject", message: OVERSIZED_IMAGE_REPLY };
+    }
+
+    return { kind: "reject", message: UNSUPPORTED_ATTACHMENT_REPLY };
+  }
+
+  try {
+    const images: ImageAttachment[] = [];
+
+    for (const attachment of valid) {
+      images.push(await downloadDiscordImage(attachment));
+    }
+
+    validateImageAttachments(images);
+
+    return {
+      input: {
+        images,
+        message: message.content?.trim() ?? "",
+      },
+      kind: "input",
+    };
+  } catch (error) {
+    if (error instanceof Error && /too large/i.test(error.message)) {
+      return { kind: "reject", message: OVERSIZED_IMAGE_REPLY };
+    }
+
+    return { kind: "reject", message: DOWNLOAD_FAILED_REPLY };
+  }
 }
 
-function isAllowedImageAttachment(attachment: Attachment): boolean {
-  return ALLOWED_IMAGE_MEDIA_TYPES.has(
-    normalizeMimeType(attachment.contentType ?? "")
-  );
+function resolveAttachmentMediaType(attachment: Attachment): string {
+  const fromHeader = normalizeMimeType(attachment.contentType ?? "");
+
+  if (ALLOWED_IMAGE_MEDIA_TYPES.has(fromHeader)) {
+    return fromHeader;
+  }
+
+  return inferMediaTypeFromName(attachment.name ?? "");
+}
+
+function inferMediaTypeFromName(name: string): string {
+  const extension = name.slice(name.lastIndexOf(".")).toLowerCase();
+
+  switch (extension) {
+    case ".jpg":
+    case ".jpeg":
+      return "image/jpeg";
+    case ".png":
+      return "image/png";
+    case ".gif":
+      return "image/gif";
+    case ".webp":
+      return "image/webp";
+    default:
+      return "";
+  }
 }
 
 async function downloadDiscordImage(
   attachment: Attachment
 ): Promise<ImageAttachment> {
-  const mediaType = normalizeMimeType(attachment.contentType ?? "");
+  const mediaType = resolveAttachmentMediaType(attachment);
 
   if (attachment.size > MAX_IMAGE_BYTES) {
-    throw new Error("Image is too large. Maximum size is 5 MB.");
+    throw new Error(OVERSIZED_IMAGE_REPLY);
   }
 
   const response = await fetch(attachment.url);
@@ -68,7 +145,7 @@ async function downloadDiscordImage(
   const bytes = await response.arrayBuffer();
 
   if (bytes.byteLength > MAX_IMAGE_BYTES) {
-    throw new Error("Image is too large. Maximum size is 5 MB.");
+    throw new Error(OVERSIZED_IMAGE_REPLY);
   }
 
   return {

--- a/apps/platform/discord/src/images.ts
+++ b/apps/platform/discord/src/images.ts
@@ -71,6 +71,11 @@ export async function buildDiscordImageInput(
       return { kind: "reject", message: OVERSIZED_IMAGE_REPLY };
     }
 
+    // Non-image attachments with caption/text: ignore files and let the text path run.
+    if (message.content?.trim()) {
+      return null;
+    }
+
     return { kind: "reject", message: UNSUPPORTED_ATTACHMENT_REPLY };
   }
 
@@ -100,10 +105,17 @@ export async function buildDiscordImageInput(
 }
 
 function resolveAttachmentMediaType(attachment: Attachment): string {
-  const fromHeader = normalizeMimeType(attachment.contentType ?? "");
+  const rawContentType = attachment.contentType?.trim() ?? "";
 
-  if (ALLOWED_IMAGE_MEDIA_TYPES.has(fromHeader)) {
-    return fromHeader;
+  if (rawContentType) {
+    const fromHeader = normalizeMimeType(rawContentType);
+
+    if (ALLOWED_IMAGE_MEDIA_TYPES.has(fromHeader)) {
+      return fromHeader;
+    }
+
+    // Explicit non-image content type — do not override from filename.
+    return "";
   }
 
   return inferMediaTypeFromName(attachment.name ?? "");

--- a/apps/platform/discord/src/images.ts
+++ b/apps/platform/discord/src/images.ts
@@ -1,4 +1,7 @@
-import { normalizeMimeType } from "@nakama/core/artifact-mime";
+import {
+  inferArtifactMimeType,
+  normalizeMimeType,
+} from "@nakama/core/artifact-mime";
 import type { ImageAttachment } from "@nakama/core/contract";
 import {
   MAX_ATTACHMENTS_PER_MESSAGE,
@@ -44,7 +47,7 @@ export async function buildDiscordImageInput(
     return null;
   }
 
-  const valid: Attachment[] = [];
+  const valid: Array<{ attachment: Attachment; mediaType: string }> = [];
   let sawOversizedImage = false;
 
   for (const attachment of attachments) {
@@ -59,7 +62,7 @@ export async function buildDiscordImageInput(
       continue;
     }
 
-    valid.push(attachment);
+    valid.push({ attachment, mediaType });
   }
 
   if (valid.length > MAX_ATTACHMENTS_PER_MESSAGE) {
@@ -82,8 +85,8 @@ export async function buildDiscordImageInput(
   try {
     const images: ImageAttachment[] = [];
 
-    for (const attachment of valid) {
-      images.push(await downloadDiscordImage(attachment));
+    for (const { attachment, mediaType } of valid) {
+      images.push(await downloadDiscordImage(attachment, mediaType));
     }
 
     validateImageAttachments(images);
@@ -96,7 +99,7 @@ export async function buildDiscordImageInput(
       kind: "input",
     };
   } catch (error) {
-    if (error instanceof Error && /too large/i.test(error.message)) {
+    if (error instanceof Error && error.message === OVERSIZED_IMAGE_REPLY) {
       return { kind: "reject", message: OVERSIZED_IMAGE_REPLY };
     }
 
@@ -105,49 +108,20 @@ export async function buildDiscordImageInput(
 }
 
 function resolveAttachmentMediaType(attachment: Attachment): string {
-  const rawContentType = attachment.contentType?.trim() ?? "";
+  const declared = normalizeMimeType(attachment.contentType ?? "");
 
-  if (rawContentType) {
-    const fromHeader = normalizeMimeType(rawContentType);
-
-    if (ALLOWED_IMAGE_MEDIA_TYPES.has(fromHeader)) {
-      return fromHeader;
-    }
-
-    // Explicit non-image content type — do not override from filename.
-    return "";
+  if (declared) {
+    return ALLOWED_IMAGE_MEDIA_TYPES.has(declared) ? declared : "";
   }
 
-  return inferMediaTypeFromName(attachment.name ?? "");
-}
-
-function inferMediaTypeFromName(name: string): string {
-  const extension = name.slice(name.lastIndexOf(".")).toLowerCase();
-
-  switch (extension) {
-    case ".jpg":
-    case ".jpeg":
-      return "image/jpeg";
-    case ".png":
-      return "image/png";
-    case ".gif":
-      return "image/gif";
-    case ".webp":
-      return "image/webp";
-    default:
-      return "";
-  }
+  const inferred = inferArtifactMimeType(attachment.name ?? "");
+  return ALLOWED_IMAGE_MEDIA_TYPES.has(inferred) ? inferred : "";
 }
 
 async function downloadDiscordImage(
-  attachment: Attachment
+  attachment: Attachment,
+  mediaType: string
 ): Promise<ImageAttachment> {
-  const mediaType = resolveAttachmentMediaType(attachment);
-
-  if (attachment.size > MAX_IMAGE_BYTES) {
-    throw new Error(OVERSIZED_IMAGE_REPLY);
-  }
-
   const response = await fetch(attachment.url);
 
   if (!response.ok) {

--- a/apps/platform/discord/src/test-helpers.ts
+++ b/apps/platform/discord/src/test-helpers.ts
@@ -207,6 +207,7 @@ export function createDmMessage(options: {
   content?: string;
   attachments?: Array<{
     contentType?: string | null;
+    name?: string;
     size?: number;
     url?: string;
   }>;
@@ -242,6 +243,7 @@ export function createDmMessage(options: {
     string,
     {
       contentType: string | null;
+      name: string;
       size: number;
       url: string;
     }
@@ -250,6 +252,7 @@ export function createDmMessage(options: {
   for (const [index, attachment] of (options.attachments ?? []).entries()) {
     attachments.set(String(index + 1), {
       contentType: attachment.contentType ?? "image/png",
+      name: attachment.name ?? `image-${index + 1}.png`,
       size: attachment.size ?? 32,
       url: attachment.url ?? `https://cdn.example/image-${index + 1}.png`,
     });
@@ -261,6 +264,7 @@ export function createDmMessage(options: {
     channel,
     client: { user: { id: "bot_id", username: "nakamabot" } },
     content: options.content ?? "",
+    stickers: { size: 0 },
   } as unknown as Message;
 
   return {
@@ -292,6 +296,12 @@ export function createGuildChatMessage(options: {
   /** Parent id returned by channel.fetch() when initial parentId is null. */
   fetchParentId?: string;
   content?: string;
+  attachments?: Array<{
+    contentType?: string | null;
+    name?: string;
+    size?: number;
+    url?: string;
+  }>;
   mentionsBot?: boolean;
   mentionedRoleIds?: string[];
   botHeldRoleIds?: string[];
@@ -418,8 +428,27 @@ export function createGuildChatMessage(options: {
     },
   };
 
+  const attachments = new Map<
+    string,
+    {
+      contentType: string | null;
+      name: string;
+      size: number;
+      url: string;
+    }
+  >();
+
+  for (const [index, attachment] of (options.attachments ?? []).entries()) {
+    attachments.set(String(index + 1), {
+      contentType: attachment.contentType ?? "image/png",
+      name: attachment.name ?? `image-${index + 1}.png`,
+      size: attachment.size ?? 32,
+      url: attachment.url ?? `https://cdn.example/image-${index + 1}.png`,
+    });
+  }
+
   const message = {
-    attachments: new Map(),
+    attachments,
     author: { bot: false, id: userId },
     channel,
     client: {
@@ -464,6 +493,7 @@ export function createGuildChatMessage(options: {
       });
       return thread;
     },
+    stickers: { size: 0 },
   } as unknown as Message;
 
   return {

--- a/apps/platform/discord/src/test-helpers.ts
+++ b/apps/platform/discord/src/test-helpers.ts
@@ -201,16 +201,49 @@ export interface MockDmMessage {
   sentMessages: string[];
 }
 
+type MockAttachmentInput = {
+  contentType?: string | null;
+  name?: string;
+  size?: number;
+  url?: string;
+};
+
+function buildMockAttachments(inputs: MockAttachmentInput[] | undefined): Map<
+  string,
+  {
+    contentType: string | null;
+    name: string;
+    size: number;
+    url: string;
+  }
+> {
+  const attachments = new Map<
+    string,
+    {
+      contentType: string | null;
+      name: string;
+      size: number;
+      url: string;
+    }
+  >();
+
+  for (const [index, attachment] of (inputs ?? []).entries()) {
+    attachments.set(String(index + 1), {
+      contentType: attachment.contentType ?? "image/png",
+      name: attachment.name ?? `image-${index + 1}.png`,
+      size: attachment.size ?? 32,
+      url: attachment.url ?? `https://cdn.example/image-${index + 1}.png`,
+    });
+  }
+
+  return attachments;
+}
+
 export function createDmMessage(options: {
   userId?: string;
   channelId?: string;
   content?: string;
-  attachments?: Array<{
-    contentType?: string | null;
-    name?: string;
-    size?: number;
-    url?: string;
-  }>;
+  attachments?: MockAttachmentInput[];
 }): MockDmMessage {
   const sentMessages: string[] = [];
   let fileSendCalls = 0;
@@ -239,27 +272,8 @@ export function createDmMessage(options: {
     sendTyping: async () => {},
   };
 
-  const attachments = new Map<
-    string,
-    {
-      contentType: string | null;
-      name: string;
-      size: number;
-      url: string;
-    }
-  >();
-
-  for (const [index, attachment] of (options.attachments ?? []).entries()) {
-    attachments.set(String(index + 1), {
-      contentType: attachment.contentType ?? "image/png",
-      name: attachment.name ?? `image-${index + 1}.png`,
-      size: attachment.size ?? 32,
-      url: attachment.url ?? `https://cdn.example/image-${index + 1}.png`,
-    });
-  }
-
   const message = {
-    attachments,
+    attachments: buildMockAttachments(options.attachments),
     author: { bot: false, id: options.userId ?? "424242424242424242" },
     channel,
     client: { user: { id: "bot_id", username: "nakamabot" } },
@@ -296,12 +310,7 @@ export function createGuildChatMessage(options: {
   /** Parent id returned by channel.fetch() when initial parentId is null. */
   fetchParentId?: string;
   content?: string;
-  attachments?: Array<{
-    contentType?: string | null;
-    name?: string;
-    size?: number;
-    url?: string;
-  }>;
+  attachments?: MockAttachmentInput[];
   mentionsBot?: boolean;
   mentionedRoleIds?: string[];
   botHeldRoleIds?: string[];
@@ -428,27 +437,8 @@ export function createGuildChatMessage(options: {
     },
   };
 
-  const attachments = new Map<
-    string,
-    {
-      contentType: string | null;
-      name: string;
-      size: number;
-      url: string;
-    }
-  >();
-
-  for (const [index, attachment] of (options.attachments ?? []).entries()) {
-    attachments.set(String(index + 1), {
-      contentType: attachment.contentType ?? "image/png",
-      name: attachment.name ?? `image-${index + 1}.png`,
-      size: attachment.size ?? 32,
-      url: attachment.url ?? `https://cdn.example/image-${index + 1}.png`,
-    });
-  }
-
   const message = {
-    attachments,
+    attachments: buildMockAttachments(options.attachments),
     author: { bot: false, id: userId },
     channel,
     client: {

--- a/docs/website/content/docs/discord.mdx
+++ b/docs/website/content/docs/discord.mdx
@@ -21,7 +21,7 @@ With Discord enabled, users can:
 - stop, clear, compact, or restart conversations
 - receive streaming replies with typing indicators and live todo progress
 
-Discord currently supports **text messages only**. Attachments and voice are not forwarded to the agent.
+Discord can send **images** (jpeg, png, gif, webp — up to 5 images, 5 MB each) to the agent, with or without a caption. Other attachments and voice are not forwarded yet.
 
 ## Step 1: Create the bot in Discord
 


### PR DESCRIPTION
## Summary

Discord inbound images reject over-cap batches, infer mime from filename when needed, and document vision support — closing the gaps left after #659.

**Before:** Silent `.slice(0, 5)` truncation; null `contentType` false-rejected; docs still said text-only.
**After:** Cap/oversized/download failures return short rejects without partial downloads; filename inference only when contentType is absent; docs match.

Why safe:
1. Shared `MAX_ATTACHMENTS_PER_MESSAGE` / `MAX_IMAGE_BYTES` unchanged
2. Guild no-mention still skips before fetch
3. Text + non-image file still chats (attachments ignored)

Only re-open if Discord starts sending misleading `contentType` on real images without a filename extension.

## Test plan
- [x] `bun test apps/platform/discord/src/images.test.ts apps/platform/discord/src/chat-handler.test.ts` (54 pass)
- [ ] DM six images → bot replies with at-most-5 message; no agent turn

Closes #655

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
