### PR TITLE
fix(error-tracking): fold role guards into settings-rbac

### DIFF
--- a/apps/server/src/http/routes/error-tracking.test.ts
+++ b/apps/server/src/http/routes/error-tracking.test.ts
@@ -4,7 +4,6 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createInMemoryDatabaseAdapter } from "@nakama/db";
 import { AgentService } from "../../services/agent-service";
-import { AuthService } from "../../services/auth-service";
 import { createMinimalHonoApp } from "../test-app-helpers";
 import { loginUserSession, seedOrgAdmin } from "../test-session-helpers";
 
@@ -16,46 +15,11 @@ async function createApp() {
   );
 
   const databaseAdapter = createInMemoryDatabaseAdapter();
-  const authService = new AuthService();
 
   return createMinimalHonoApp({
     agent: new AgentService(null, null, databaseAdapter),
-    authService,
     databaseAdapter,
   });
-}
-
-async function seedMember(
-  databaseAdapter: ReturnType<typeof createInMemoryDatabaseAdapter>,
-  authService: AuthService,
-  role: "member" | "viewer"
-) {
-  const now = new Date().toISOString();
-  const email = `${role}@example.com`;
-  const password = "password123";
-
-  await databaseAdapter.createUser({
-    createdAt: now,
-    email,
-    id: `user_${role}`,
-    passwordHash: await authService.hashPassword(password),
-    updatedAt: now,
-  });
-  await databaseAdapter.upsertOrganization({
-    createdAt: now,
-    id: "org_test",
-    name: "Test Org",
-    slug: "test-org",
-    updatedAt: now,
-  });
-  await databaseAdapter.upsertOrgMember({
-    createdAt: now,
-    orgId: "org_test",
-    role,
-    userId: `user_${role}`,
-  });
-
-  return { email, orgId: "org_test", password };
 }
 
 describe("error tracking routes", () => {
@@ -133,31 +97,6 @@ describe("error tracking routes", () => {
 
     expect(response.status).toBe(400);
   });
-
-  for (const role of ["member", "viewer"] as const) {
-    test(`a ${role} cannot write the workspace-wide DSN`, async () => {
-      const { app, databaseAdapter, authService } = await createApp();
-      const { email, password, orgId } = await seedMember(
-        databaseAdapter,
-        authService,
-        role
-      );
-      const session = await loginUserSession(app, email, password, orgId);
-
-      const response = await app.fetch(
-        new Request("http://localhost:4310/v1/settings/error-tracking", {
-          body: JSON.stringify({ dsn: DSN }),
-          headers: session.headers({
-            "Content-Type": "application/json",
-            "X-CSRF-Token": session.csrfToken,
-          }),
-          method: "PUT",
-        })
-      );
-
-      expect(response.status).toBe(403);
-    });
-  }
 
   test("the test event is refused before a DSN is saved", async () => {
     const { app, databaseAdapter } = await createApp();

--- a/apps/server/src/http/routes/settings-rbac.test.ts
+++ b/apps/server/src/http/routes/settings-rbac.test.ts
@@ -56,6 +56,12 @@ const GLOBAL_WRITES: Array<{ body?: unknown; method: string; path: string }> = [
     path: "/v1/settings/discord/handshake",
   },
   { body: { apiKey: "c" }, method: "PUT", path: "/v1/settings/composio" },
+  {
+    body: { dsn: "https://publickey@errors.example.com/42" },
+    method: "PUT",
+    path: "/v1/settings/error-tracking",
+  },
+  { method: "POST", path: "/v1/settings/error-tracking/test" },
   { body: { enabled: true }, method: "PUT", path: "/v1/settings/whatsapp" },
   {
     body: { phoneNumber: "1" },
@@ -81,8 +87,10 @@ function createApp() {
       deleteProvider: record("deleteProvider"),
       discoverModels: record("discoverModels"),
       listProfiles: async () => ({ profiles: [{ id: "default" }] }),
+      sendErrorTrackingTest: record("sendErrorTrackingTest"),
       setComposioSettings: record("setComposioSettings"),
       setDiscordSettings: record("setDiscordSettings"),
+      setErrorTrackingSettings: record("setErrorTrackingSettings"),
       setImageGenerationSettings: record("setImageGenerationSettings"),
       setTelegramSettings: record("setTelegramSettings"),
       setTranscriptionSettings: record("setTranscriptionSettings"),

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -1174,12 +1174,7 @@ export class AgentService {
       })
     );
 
-    return {
-      delivered,
-      message: delivered
-        ? "Test event delivered. It should appear in your project within a few seconds."
-        : "The ingest rejected the event or could not be reached. Check the DSN.",
-    };
+    return { delivered };
   }
 
   async getEmailSettings(): Promise<EmailSettingsResponse> {

--- a/apps/web/src/components/ErrorTrackingSettingsCard.tsx
+++ b/apps/web/src/components/ErrorTrackingSettingsCard.tsx
@@ -64,7 +64,11 @@ export function ErrorTrackingSettingsCard() {
 
     try {
       const result = await testMutation.mutateAsync();
-      setTestResult(result.message);
+      setTestResult(
+        result.delivered
+          ? "Test event delivered. It should appear in your project within a few seconds."
+          : "The ingest rejected the event or could not be reached. Check the DSN."
+      );
     } catch (error) {
       setFormError(formatError(error));
     }

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -1323,7 +1323,6 @@ export interface UpdateErrorTrackingSettingsRequest {
 
 export interface SendErrorTrackingTestResponse {
   delivered: boolean;
-  message: string;
 }
 
 export type NotificationDestinationChannel = "telegram";


### PR DESCRIPTION
## Summary

Error-tracking admin writes sit in `settings-rbac` with the other workspace-global settings; the test-event API returns only `{ delivered }`.

**Before:** duplicate member/viewer 403 + `seedMember` in `error-tracking.test.ts`; server owned the status sentence.
**After:** PUT/POST paths on `GLOBAL_WRITES`; card maps `delivered` → copy (email test pattern).

Why safe:
1. Same `requireOrgAdminOrPlatformAdmin` guard — rbac now asserts agent methods are never called
2. UI strings unchanged; only the transport field is gone
3. −55 lines, same operator flow

Only re-add a server `message` if a non-web client needs the sentence without its own copy.

## Test plan
- [x] `bun test apps/server/src/http/routes/error-tracking.test.ts apps/server/src/http/routes/settings-rbac.test.ts` (44 pass)
- [ ] Save a DSN as org admin, then as member confirm Save/Test still 403

Refs #444.
