### PR TITLE
refactor(composio): drop single-impl ApiClient interface

### DIFF
--- a/apps/server/src/services/composio-api-client.ts
+++ b/apps/server/src/services/composio-api-client.ts
@@ -19,27 +19,6 @@ export interface ComposioSessionMcpEndpoint {
   url: string;
 }
 
-export interface ComposioApiClient {
-  createProfileSession(
-    userId: string,
-    toolkitSlugs: string[],
-    allowedToolsByToolkit: Record<string, string[] | null>,
-    connectedAccountsByToolkit?: Record<string, string>
-  ): Promise<ComposioSessionMcpEndpoint>;
-  deleteConnectedAccount(connectedAccountId: string): Promise<void>;
-  linkToolkitAccount(
-    userId: string,
-    toolkitSlug: string,
-    callbackUrl: string
-  ): Promise<ComposioLinkResult>;
-  listCatalogToolkits(options?: {
-    limit?: number;
-  }): Promise<ComposioCatalogToolkit[]>;
-  listSessionTools(
-    session: ComposioSessionMcpEndpoint
-  ): Promise<ComposioCachedToolSummary[]>;
-}
-
 export function extractComposioListItems<T>(
   response: { items?: T[] } | T[] | null | undefined
 ): T[] {
@@ -228,7 +207,7 @@ export function parseSessionToolItems(
     .filter((tool): tool is ComposioCachedToolSummary => tool !== null);
 }
 
-export class SdkComposioApiClient implements ComposioApiClient {
+export class ComposioApiClient {
   private readonly composio: Composio;
 
   constructor(apiKey: string) {

--- a/apps/server/src/services/composio-service.ts
+++ b/apps/server/src/services/composio-service.ts
@@ -27,9 +27,8 @@ import type {
 } from "@nakama/db";
 import type { AuthService } from "./auth-service";
 import {
-  type ComposioApiClient,
+  ComposioApiClient,
   type ComposioSessionMcpEndpoint,
-  SdkComposioApiClient,
 } from "./composio-api-client";
 import { encryptComposioSecret } from "./composio-secret";
 
@@ -141,7 +140,7 @@ export class ComposioService {
       return this.apiClientCache.client;
     }
 
-    const client = new SdkComposioApiClient(apiKey);
+    const client = new ComposioApiClient(apiKey);
 
     this.apiClientCache = { client, key: apiKey };
     return client;
@@ -210,7 +209,7 @@ export class ComposioService {
       throw new NakamaApiError("Composio API key is required.", 400);
     }
 
-    const client = new SdkComposioApiClient(resolvedKey);
+    const client = new ComposioApiClient(resolvedKey);
 
     try {
       await client.listCatalogToolkits({ limit: 1 });


### PR DESCRIPTION
## Summary

Composio uses the concrete client class as its type — no separate interface.

**Before:** `ComposioApiClient` interface + `SdkComposioApiClient` impl.
**After:** One `ComposioApiClient` class; tests mock structurally.

Why safe:
1. Tests already build plain objects matching the methods
2. Production only constructed `SdkComposioApiClient`
3. Suite still green

Only re-add an interface if a second real client appears.

## Test plan
- [x] `bun test` composio api/service/routes (27 pass)
- [ ] Connect one toolkit in a dev org (optional)
