### PR TITLE
chore(platform): share channel test org/home helpers

### DIFF
--- a/apps/platform/discord/src/test-helpers.ts
+++ b/apps/platform/discord/src/test-helpers.ts
@@ -1,5 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import * as os from "node:os";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { NakamaClient, StreamHandlers } from "@nakama/client";
 import {
@@ -7,27 +6,18 @@ import {
   parseListProfilesResponse,
   parseListUserOrgsResponse,
 } from "@nakama/core/bridge-api";
-import { ChannelOrgStore } from "@nakama/core/channel-org";
+import type { ChannelOrgStore } from "@nakama/core/channel-org";
+import {
+  createDefaultTestOrgs,
+  createTestOrgStore as createSharedTestOrgStore,
+  withTempHome as withSharedTempHome,
+} from "@nakama/core/channel-test-helpers";
 import type {
   AgentQuestionnaire,
   ChatMessage,
   UserOrgSummary,
 } from "@nakama/core/contract";
 import type { Message } from "discord.js";
-
-export function createDefaultTestOrgs(): UserOrgSummary[] {
-  const now = new Date().toISOString();
-  return [
-    {
-      createdAt: now,
-      id: "org_test",
-      name: "Test Org",
-      role: "admin",
-      slug: "test-org",
-      updatedAt: now,
-    },
-  ];
-}
 
 export function createMultiTestOrgs(): UserOrgSummary[] {
   const now = new Date().toISOString();
@@ -618,41 +608,14 @@ export async function writeDiscordConfigIni(
   await writeFile(path.join(dir, "config.ini"), lines.join("\n"), "utf8");
 }
 
-export function createTestOrgStore(homeDir: string): ChannelOrgStore {
-  return new ChannelOrgStore(
-    path.join(homeDir, ".nakama", "discord", "org-selection.json")
-  );
-}
+export { createDefaultTestOrgs };
 
-let tempHomeChain: Promise<void> = Promise.resolve();
+export function createTestOrgStore(homeDir: string): ChannelOrgStore {
+  return createSharedTestOrgStore(homeDir, "discord");
+}
 
 export async function withTempHome<T>(
   run: (homeDir: string) => Promise<T>
 ): Promise<T> {
-  let release!: () => void;
-  const gate = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  const previous = tempHomeChain;
-  tempHomeChain = previous.then(() => gate);
-
-  await previous;
-
-  const homeDir = await mkdtemp(path.join(os.tmpdir(), "nakama-discord-home-"));
-  const configDir = path.join(homeDir, ".nakama");
-  const previousConfigDir = process.env.NAKAMA_CONFIG_DIR;
-  process.env.NAKAMA_CONFIG_DIR = configDir;
-
-  try {
-    return await run(homeDir);
-  } finally {
-    if (previousConfigDir === undefined) {
-      delete process.env.NAKAMA_CONFIG_DIR;
-    } else {
-      process.env.NAKAMA_CONFIG_DIR = previousConfigDir;
-    }
-
-    await rm(homeDir, { force: true, recursive: true });
-    release();
-  }
+  return withSharedTempHome("nakama-discord-home-", run);
 }

--- a/apps/platform/telegram/src/test-helpers.ts
+++ b/apps/platform/telegram/src/test-helpers.ts
@@ -1,5 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import * as os from "node:os";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { NakamaClient, StreamHandlers } from "@nakama/client";
 import {
@@ -7,7 +6,13 @@ import {
   parseListProfilesResponse,
   parseListUserOrgsResponse,
 } from "@nakama/core/bridge-api";
-import { ChannelOrgStore } from "@nakama/core/channel-org";
+import type { ChannelOrgStore } from "@nakama/core/channel-org";
+import {
+  createDefaultTestOrgs,
+  createMultiTestOrgs,
+  createTestOrgStore as createSharedTestOrgStore,
+  withTempHome as withSharedTempHome,
+} from "@nakama/core/channel-test-helpers";
 import type {
   AgentTodo,
   ChatMessage,
@@ -116,42 +121,6 @@ type StreamStep =
   | { type: "tool_end" }
   | { type: "error"; message: string }
   | { type: "resolve"; reply?: string };
-
-export function createMultiTestOrgs(): UserOrgSummary[] {
-  const now = new Date().toISOString();
-  return [
-    {
-      createdAt: now,
-      id: "org_a",
-      name: "Acme",
-      role: "admin",
-      slug: "acme",
-      updatedAt: now,
-    },
-    {
-      createdAt: now,
-      id: "org_b",
-      name: "Beta",
-      role: "member",
-      slug: "beta",
-      updatedAt: now,
-    },
-  ];
-}
-
-export function createDefaultTestOrgs(): UserOrgSummary[] {
-  const now = new Date().toISOString();
-  return [
-    {
-      createdAt: now,
-      id: "org_test",
-      name: "Test Org",
-      role: "admin",
-      slug: "test-org",
-      updatedAt: now,
-    },
-  ];
-}
 
 export function createMockClient(
   options: {
@@ -435,43 +404,14 @@ export async function writeTelegramConfigIni(
   await writeFile(path.join(dir, "config.ini"), lines.join("\n"), "utf8");
 }
 
-export function createTestOrgStore(homeDir: string): ChannelOrgStore {
-  return new ChannelOrgStore(
-    path.join(homeDir, ".nakama", "telegram", "org-selection.json")
-  );
-}
+export { createDefaultTestOrgs, createMultiTestOrgs };
 
-let tempHomeChain: Promise<void> = Promise.resolve();
+export function createTestOrgStore(homeDir: string): ChannelOrgStore {
+  return createSharedTestOrgStore(homeDir, "telegram");
+}
 
 export async function withTempHome<T>(
   run: (homeDir: string) => Promise<T>
 ): Promise<T> {
-  let release!: () => void;
-  const gate = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  const previous = tempHomeChain;
-  tempHomeChain = previous.then(() => gate);
-
-  await previous;
-
-  const homeDir = await mkdtemp(
-    path.join(os.tmpdir(), "nakama-telegram-home-")
-  );
-  const configDir = path.join(homeDir, ".nakama");
-  const previousConfigDir = process.env.NAKAMA_CONFIG_DIR;
-  process.env.NAKAMA_CONFIG_DIR = configDir;
-
-  try {
-    return await run(homeDir);
-  } finally {
-    if (previousConfigDir === undefined) {
-      delete process.env.NAKAMA_CONFIG_DIR;
-    } else {
-      process.env.NAKAMA_CONFIG_DIR = previousConfigDir;
-    }
-
-    await rm(homeDir, { force: true, recursive: true });
-    release();
-  }
+  return withSharedTempHome("nakama-telegram-home-", run);
 }

--- a/apps/platform/whatsapp/src/test-helpers.ts
+++ b/apps/platform/whatsapp/src/test-helpers.ts
@@ -1,5 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import * as os from "node:os";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { NakamaClient, StreamHandlers } from "@nakama/client";
 import {
@@ -7,7 +6,13 @@ import {
   parseListProfilesResponse,
   parseListUserOrgsResponse,
 } from "@nakama/core/bridge-api";
-import { ChannelOrgStore } from "@nakama/core/channel-org";
+import type { ChannelOrgStore } from "@nakama/core/channel-org";
+import {
+  createDefaultTestOrgs,
+  createMultiTestOrgs,
+  createTestOrgStore as createSharedTestOrgStore,
+  withTempHome as withSharedTempHome,
+} from "@nakama/core/channel-test-helpers";
 import type {
   ChatMessage,
   ProfileSummary,
@@ -27,42 +32,6 @@ type StreamStep =
   | { type: "tool_end" }
   | { type: "error"; message: string }
   | { type: "resolve"; reply?: string };
-
-export function createMultiTestOrgs(): UserOrgSummary[] {
-  const now = new Date().toISOString();
-  return [
-    {
-      createdAt: now,
-      id: "org_a",
-      name: "Acme",
-      role: "admin",
-      slug: "acme",
-      updatedAt: now,
-    },
-    {
-      createdAt: now,
-      id: "org_b",
-      name: "Beta",
-      role: "member",
-      slug: "beta",
-      updatedAt: now,
-    },
-  ];
-}
-
-export function createDefaultTestOrgs(): UserOrgSummary[] {
-  const now = new Date().toISOString();
-  return [
-    {
-      createdAt: now,
-      id: "org_test",
-      name: "Test Org",
-      role: "admin",
-      slug: "test-org",
-      updatedAt: now,
-    },
-  ];
-}
 
 export function createMockClient(
   options: {
@@ -316,14 +285,6 @@ export async function writeWhatsAppConfigIni(
   await writeFile(path.join(dir, "config.ini"), lines.join("\n"), "utf8");
 }
 
-export function createTestOrgStore(homeDir: string): ChannelOrgStore {
-  return new ChannelOrgStore(
-    path.join(homeDir, ".nakama", "whatsapp", "org-selection.json")
-  );
-}
-
-let tempHomeChain: Promise<void> = Promise.resolve();
-
 export async function waitForStreamControl(
   getStreamControl: () => MockStreamControl | null,
   timeoutMs = 2000
@@ -343,35 +304,14 @@ export async function waitForStreamControl(
   throw new Error("Timed out waiting for stream control");
 }
 
+export { createDefaultTestOrgs, createMultiTestOrgs };
+
+export function createTestOrgStore(homeDir: string): ChannelOrgStore {
+  return createSharedTestOrgStore(homeDir, "whatsapp");
+}
+
 export async function withTempHome<T>(
   run: (homeDir: string) => Promise<T>
 ): Promise<T> {
-  let release!: () => void;
-  const gate = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  const previous = tempHomeChain;
-  tempHomeChain = previous.then(() => gate);
-
-  await previous;
-
-  const homeDir = await mkdtemp(
-    path.join(os.tmpdir(), "nakama-whatsapp-home-")
-  );
-  const configDir = path.join(homeDir, ".nakama");
-  const previousConfigDir = process.env.NAKAMA_CONFIG_DIR;
-  process.env.NAKAMA_CONFIG_DIR = configDir;
-
-  try {
-    return await run(homeDir);
-  } finally {
-    if (previousConfigDir === undefined) {
-      delete process.env.NAKAMA_CONFIG_DIR;
-    } else {
-      process.env.NAKAMA_CONFIG_DIR = previousConfigDir;
-    }
-
-    await rm(homeDir, { force: true, recursive: true });
-    release();
-  }
+  return withSharedTempHome("nakama-whatsapp-home-", run);
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,7 @@
     "./bridge-api": "./src/bridge-api.ts",
     "./channel-active-stream": "./src/channel-active-stream.ts",
     "./channel-org": "./src/channel-org.ts",
+    "./channel-test-helpers": "./src/channel-test-helpers.ts",
     "./channel-session-store": "./src/channel-session-store.ts",
     "./contract": "./src/contract.ts",
     "./chat-stream-timeout": "./src/chat-stream-timeout.ts",

--- a/packages/core/src/channel-test-helpers.ts
+++ b/packages/core/src/channel-test-helpers.ts
@@ -1,0 +1,90 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import * as os from "node:os";
+import path from "node:path";
+import {
+  type ChannelOrgSelectionChannel,
+  ChannelOrgStore,
+} from "./channel-org";
+import type { UserOrgSummary } from "./contract";
+
+export function createDefaultTestOrgs(): UserOrgSummary[] {
+  const now = new Date().toISOString();
+  return [
+    {
+      createdAt: now,
+      id: "org_test",
+      name: "Test Org",
+      role: "admin",
+      slug: "test-org",
+      updatedAt: now,
+    },
+  ];
+}
+
+export function createMultiTestOrgs(): UserOrgSummary[] {
+  const now = new Date().toISOString();
+  return [
+    {
+      createdAt: now,
+      id: "org_a",
+      name: "Acme",
+      role: "admin",
+      slug: "acme",
+      updatedAt: now,
+    },
+    {
+      createdAt: now,
+      id: "org_b",
+      name: "Beta",
+      role: "member",
+      slug: "beta",
+      updatedAt: now,
+    },
+  ];
+}
+
+export function createTestOrgStore(
+  homeDir: string,
+  channel: ChannelOrgSelectionChannel
+): ChannelOrgStore {
+  return new ChannelOrgStore(
+    path.join(homeDir, ".nakama", channel, "org-selection.json")
+  );
+}
+
+const tempHomeChains = new Map<string, Promise<void>>();
+
+export async function withTempHome<T>(
+  prefix: string,
+  run: (homeDir: string) => Promise<T>
+): Promise<T> {
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const previous = tempHomeChains.get(prefix) ?? Promise.resolve();
+  tempHomeChains.set(
+    prefix,
+    previous.then(() => gate)
+  );
+
+  await previous;
+
+  const homeDir = await mkdtemp(path.join(os.tmpdir(), prefix));
+  const configDir = path.join(homeDir, ".nakama");
+  const previousConfigDir = process.env.NAKAMA_CONFIG_DIR;
+  process.env.NAKAMA_CONFIG_DIR = configDir;
+
+  try {
+    return await run(homeDir);
+  } finally {
+    if (previousConfigDir === undefined) {
+      delete process.env.NAKAMA_CONFIG_DIR;
+    } else {
+      process.env.NAKAMA_CONFIG_DIR = previousConfigDir;
+    }
+
+    await rm(homeDir, { force: true, recursive: true });
+    release();
+  }
+}


### PR DESCRIPTION
## Summary

Telegram/WhatsApp/Discord tests share org fixtures and temp-home helpers via `@nakama/core/channel-test-helpers`.

**Before:** Same helpers copy-pasted in three `test-helpers.ts` files.
**After:** One shared module; Discord keeps its own `createMultiTestOrgs` names.

Why safe:
1. Public test helper names/signatures unchanged for call sites
2. Discord multi-org names stay Personal/Nakama
3. Channel chat-handler suites pass

Only reopen per-channel copies if a channel needs a divergent home/env setup.

## Test plan
- [x] `bun test` telegram/whatsapp/discord chat-handler + discord thread-store (131 pass)
- [ ] None beyond CI
