### PR TITLE
chore(bash): drop unused sandbox factory and test reset

### DIFF
--- a/apps/server/src/tools/bash-microsandbox-runtime.ts
+++ b/apps/server/src/tools/bash-microsandbox-runtime.ts
@@ -23,7 +23,7 @@ async function connectSandbox(name: string): Promise<Sandbox> {
   return handle.startDetached();
 }
 
-class MicrosandboxBashRuntime implements BashSandboxRuntime {
+export class MicrosandboxBashRuntime implements BashSandboxRuntime {
   async ensure(args: BashSandboxEnsureArgs): Promise<void> {
     let installed = false;
     try {
@@ -118,8 +118,4 @@ class MicrosandboxBashRuntime implements BashSandboxRuntime {
       args.signal?.removeEventListener("abort", onAbort);
     }
   }
-}
-
-export function createDefaultMicrosandboxRuntime(): BashSandboxRuntime {
-  return new MicrosandboxBashRuntime();
 }

--- a/apps/server/src/tools/bash.ts
+++ b/apps/server/src/tools/bash.ts
@@ -75,11 +75,11 @@ async function getSandboxManager(): Promise<ProfileSandboxManager> {
     return sharedSandboxManager;
   }
 
-  const { createDefaultMicrosandboxRuntime } = await import(
+  const { MicrosandboxBashRuntime } = await import(
     "./bash-microsandbox-runtime"
   );
   sharedSandboxManager = new ProfileSandboxManager(
-    createDefaultMicrosandboxRuntime()
+    new MicrosandboxBashRuntime()
   );
   return sharedSandboxManager;
 }

--- a/apps/server/src/tools/profile-sandbox-manager.ts
+++ b/apps/server/src/tools/profile-sandbox-manager.ts
@@ -112,11 +112,6 @@ export class ProfileSandboxManager {
     });
   }
 
-  /** Test helper — does not destroy sandboxes, only clears create-once cache. */
-  resetEnsuredForTests(): void {
-    this.ensured.clear();
-  }
-
   ensuredNamesForTests(): string[] {
     return [...this.ensured.keys()];
   }


### PR DESCRIPTION
## Summary

MicroSandbox bash constructs the runtime class directly; unused ensured-cache reset is gone.

**Before:** `createDefaultMicrosandboxRuntime()` + unused `resetEnsuredForTests`.
**After:** `new MicrosandboxBashRuntime()` at the manager site.

Why safe:
1. Same runtime instance path
2. Bash sandbox suites still pass
3. Targets the open microsandbox PR branch

Only re-add a factory if a second runtime construction site appears.

## Test plan
- [x] `bun test apps/server/src/tools/bash*.test.ts` (28 pass)
- [ ] None beyond CI on parent PR
