### PR TITLE
fix(core): enforce custom file modes

### DIFF
--- a/packages/core/src/fs.test.ts
+++ b/packages/core/src/fs.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmod, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeTextFile } from "./fs";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    await rm(directory, { force: true, recursive: true });
+  }
+});
+
+async function createExistingFile(mode: number): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "nakama-fs-"));
+  temporaryDirectories.push(directory);
+  const path = join(directory, "config.txt");
+  await writeFile(path, "old", { mode });
+  await chmod(path, mode);
+  return path;
+}
+
+async function modeOf(path: string): Promise<number> {
+  // biome-ignore lint/suspicious/noBitwiseOperators: permission bits are stored in st_mode.
+  return (await stat(path)).mode & 0o777;
+}
+
+describe("writeTextFile permissions", () => {
+  test("repairs an existing file to a custom mode by default", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const path = await createExistingFile(0o666);
+
+    await writeTextFile(path, "new", { mode: 0o640 });
+
+    expect(await modeOf(path)).toBe(0o640);
+  });
+
+  test("keeps existing permissions when chmod is explicitly disabled", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const path = await createExistingFile(0o666);
+
+    await writeTextFile(path, "new", { chmod: false, mode: 0o640 });
+
+    expect(await modeOf(path)).toBe(0o666);
+  });
+});

--- a/packages/core/src/fs.ts
+++ b/packages/core/src/fs.ts
@@ -71,7 +71,7 @@ export async function writeTextFile(
   await ensureDir(directory, options.ensureDirMode ?? PRIVATE_DIR_MODE);
   await writeFile(path, content, { encoding: "utf8", mode });
 
-  if (options.chmod ?? mode === PRIVATE_FILE_MODE) {
+  if (options.chmod ?? true) {
     await chmod(path, mode);
   }
 }


### PR DESCRIPTION
## Summary

Write a text file with a custom mode → existing files receive the requested permissions instead of keeping looser bits.

**Before:** `writeTextFile(..., { mode })` only enforced mode `0600`; other modes depended on create-time umask and left existing permissions unchanged.
**After:** every requested mode is enforced by default, while `chmod: false` remains an explicit opt-out.

Why safe:
1. Default private-file behavior remains `0600`
2. Regression coverage verifies both custom-mode enforcement and explicit opt-out

Only follow up if a caller intentionally needs umask-preserved custom modes; use `chmod: false` for that case.

## Test plan
- [x] `bun test packages/core/src` (723 pass)
- [x] `bun test` (2595 pass); `bun run check`, `bun run knip`, and `bun run build`
- [ ] Rewrite an existing config file with a custom mode and verify the requested bits replace looser permissions

Closes #597
