### PR TITLE
fix(web): stabilize Virtuoso scrollerRef callback

### DIFF
--- a/apps/web/src/components/chat/chat-message-list.tsx
+++ b/apps/web/src/components/chat/chat-message-list.tsx
@@ -183,6 +183,10 @@ function ChatMessageListSession({
     stickIntentRef.current = atBottom;
   }, []);
 
+  const handleScrollerRef = useCallback((ref: HTMLElement | Window | null) => {
+    scrollerRef.current = ref instanceof HTMLElement ? ref : null;
+  }, []);
+
   // followOutput is Virtuoso's documented append follower. It scrolls with
   // align-end semantics, so skip it while the list still fits the viewport.
   const handleFollowOutput = useCallback((_atBottom: boolean) => {
@@ -311,9 +315,7 @@ function ChatMessageListSession({
           initialTopMostItemIndex={0}
           itemContent={renderTurn}
           ref={virtuosoRef}
-          scrollerRef={(ref) => {
-            scrollerRef.current = ref instanceof HTMLElement ? ref : null;
-          }}
+          scrollerRef={handleScrollerRef}
           totalListHeightChanged={handleTotalListHeightChanged}
         />
         <ConversationScrollButton />


### PR DESCRIPTION
## Summary

Virtuoso keeps the same scroller DOM binding across chat re-renders — Fixes #582.

**Before:** Inline `scrollerRef` arrow reallocated every render → Virtuoso unbound/rebound the scroller each time.
**After:** Stable `handleScrollerRef` via `useCallback` (`chat-message-list.tsx`).

Why safe:
1. Same assign logic (`HTMLElement` only); empty deps
2. No scroll/stickiness behavior change

Only re-check if Virtuoso starts warning about stale scroller refs after a major upgrade.

## Test plan
- [x] `bun test ./apps/web/src/lib/chat-list-stickiness.test.ts` (2 pass)
- [x] CI: test + knip + react-doctor green
- [ ] Open a long chat, scroll mid-thread, stream a reply — stickiness still works; no scroll jump on unrelated re-renders

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
