### PR TITLE
fix(web): drop non-null assertion in MCP config import

### DIFF
--- a/apps/web/src/lib/mcp-config-import.test.ts
+++ b/apps/web/src/lib/mcp-config-import.test.ts
@@ -78,4 +78,11 @@ describe("parseMcpConfigJson", () => {
       ok: false,
     });
   });
+
+  test("returns an error when mcpServers is empty", () => {
+    const result = parseMcpConfigJson(`{ "mcpServers": {} }`);
+
+    expect(result).not.toBeNull();
+    expect(result?.ok).toBe(false);
+  });
 });

--- a/apps/web/src/lib/mcp-config-import.ts
+++ b/apps/web/src/lib/mcp-config-import.ts
@@ -40,11 +40,12 @@ export function parseMcpConfigJson(text: string): ParseMcpConfigResult | null {
     return { error: "No MCP server config found in JSON.", ok: false };
   }
 
-  if (entries.length === 0) {
+  const first = entries[0];
+  if (!first) {
     return { error: "mcpServers is empty.", ok: false };
   }
 
-  const [name, serverConfig] = entries[0]!;
+  const [name, serverConfig] = first;
 
   if (typeof serverConfig !== "object" || serverConfig === null) {
     return { error: "Invalid server config.", ok: false };


### PR DESCRIPTION
## Summary

MCP JSON import no longer relies on a non-null assertion for the first server entry — Fixes #579.

**Before:** After an empty-length guard, `entries[0]!` was the only thing preventing a crash if the guard drifted.
**After:** Bind `first = entries[0]`; missing entry returns the empty-`mcpServers` error path.

Why safe:
1. Same success path for non-empty configs
2. Empty `mcpServers` still fails closed (`ok: false`)
3. Unit coverage for the empty case

Only revisit if `readServerEntries` starts returning sparse arrays.

## Test plan
- [x] `bun test ./apps/web/src/lib/mcp-config-import.test.ts` (6 pass)
- [x] CI: test + knip + react-doctor green
- [ ] Paste `{ "mcpServers": {} }` in MCP import — still rejected; paste a valid server — still imports

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
