### PR TITLE
fix(web): keep theme MediaQueryList listener stable

### DIFF
--- a/apps/web/src/context/theme-context.tsx
+++ b/apps/web/src/context/theme-context.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { ThemeContext } from "@/context/theme-context-shared";
@@ -21,29 +22,36 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const [resolvedTheme, setResolvedTheme] = useState(() =>
     resolveTheme(getInitialTheme())
   );
+  const themeRef = useRef(theme);
+  themeRef.current = theme;
+
+  const syncTheme = useCallback(() => {
+    const currentTheme = themeRef.current;
+    applyTheme(currentTheme);
+    setResolvedTheme(resolveTheme(currentTheme));
+
+    try {
+      localStorage.setItem(THEME_STORAGE_KEY, currentTheme);
+    } catch {
+      // Ignore storage failures (private browsing, etc.)
+    }
+  }, []);
 
   useEffect(() => {
-    const syncTheme = () => {
-      applyTheme(theme);
-      setResolvedTheme(resolveTheme(theme));
-
-      try {
-        localStorage.setItem(THEME_STORAGE_KEY, theme);
-      } catch {
-        // Ignore storage failures (private browsing, etc.)
-      }
-    };
-
     syncTheme();
+  }, [theme, syncTheme]);
 
-    if (theme !== "system") {
-      return;
-    }
-
+  useEffect(() => {
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-    mediaQuery.addEventListener("change", syncTheme);
-    return () => mediaQuery.removeEventListener("change", syncTheme);
-  }, [theme]);
+    const handleChange = () => {
+      if (themeRef.current !== "system") {
+        return;
+      }
+      syncTheme();
+    };
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, [syncTheme]);
 
   const setTheme = useCallback((nextTheme: Theme) => {
     setThemeState(nextTheme);


### PR DESCRIPTION
## Summary

OS theme preference changes stay wired without re-binding on every theme toggle — Fixes #569.

**Before:** `useEffect` depended on `[theme]`, so each toggle tore down/re-attached the `matchMedia` listener (and could miss a change in the gap).
**After:** Theme lives in a ref; `syncTheme` is stable; one MediaQueryList listener that no-ops unless preference is `system`.

Why safe:
1. Theme apply + `localStorage` still run when `theme` changes
2. System preference only drives updates when mode is `system`
3. No public API change

Only revisit if a second `matchMedia` source is added elsewhere without sharing this listener.

## Test plan
- [x] `bun test ./apps/web/src/lib/elapsed-time.test.ts` (6 pass)
- [x] CI: test + knip + react-doctor green
- [ ] Toggle light → dark → system; flip OS appearance while on system — UI follows; no flicker from listener churn

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
