### PR TITLE
fix(cli): guard setRawMode(false) in chat cleanup

### DIFF
--- a/apps/cli/src/chat.test.ts
+++ b/apps/cli/src/chat.test.ts
@@ -5,6 +5,7 @@ import type {
   ProfileSummary,
 } from "@nakama/core";
 import {
+  disableRawModeIfActive,
   formatErrorLines,
   formatStatusLines,
   isEscInterruptKey,
@@ -92,5 +93,46 @@ describe("isEscInterruptKey", () => {
   test("matches only a standalone escape key", () => {
     expect(isEscInterruptKey("\u001b")).toBe(true);
     expect(isEscInterruptKey("\u001b[A")).toBe(false);
+  });
+});
+
+describe("disableRawModeIfActive", () => {
+  test("skips setRawMode when stdin is not a TTY", () => {
+    const calls: boolean[] = [];
+    disableRawModeIfActive({
+      isRaw: true,
+      isTTY: false,
+      setRawMode: (mode) => {
+        calls.push(mode);
+      },
+    } as NodeJS.ReadStream);
+
+    expect(calls).toEqual([]);
+  });
+
+  test("skips setRawMode when raw mode is already off", () => {
+    const calls: boolean[] = [];
+    disableRawModeIfActive({
+      isRaw: false,
+      isTTY: true,
+      setRawMode: (mode) => {
+        calls.push(mode);
+      },
+    } as NodeJS.ReadStream);
+
+    expect(calls).toEqual([]);
+  });
+
+  test("disables raw mode when a TTY is currently raw", () => {
+    const calls: boolean[] = [];
+    disableRawModeIfActive({
+      isRaw: true,
+      isTTY: true,
+      setRawMode: (mode) => {
+        calls.push(mode);
+      },
+    } as NodeJS.ReadStream);
+
+    expect(calls).toEqual([false]);
   });
 });

--- a/apps/cli/src/chat.test.ts
+++ b/apps/cli/src/chat.test.ts
@@ -135,4 +135,16 @@ describe("disableRawModeIfActive", () => {
 
     expect(calls).toEqual([false]);
   });
+
+  test("swallows setRawMode errors so cleanup can continue", () => {
+    expect(() =>
+      disableRawModeIfActive({
+        isRaw: true,
+        isTTY: true,
+        setRawMode: () => {
+          throw new Error("setRawMode rejected");
+        },
+      } as NodeJS.ReadStream)
+    ).not.toThrow();
+  });
 });

--- a/apps/cli/src/chat.ts
+++ b/apps/cli/src/chat.ts
@@ -1148,7 +1148,11 @@ export function disableRawModeIfActive(
     return;
   }
 
-  stdin.setRawMode(false);
+  try {
+    stdin.setRawMode(false);
+  } catch {
+    // Cleanup must not throw if the TTY rejects the mode change.
+  }
 }
 
 export function isEscInterruptKey(key: string): boolean {

--- a/apps/cli/src/chat.ts
+++ b/apps/cli/src/chat.ts
@@ -1019,8 +1019,9 @@ async function runBlockingChat(context: ChatContext): Promise<void> {
       }
     }
   } finally {
+    disableRawModeIfActive(process.stdin);
+
     if (process.stdin.isTTY) {
-      process.stdin.setRawMode(false);
       process.stdin.pause();
     }
 
@@ -1139,6 +1140,17 @@ export function formatErrorLines(error: unknown): string[] {
   return ["", ...formatError(error).split(/\r?\n/)];
 }
 
+/** Disable raw mode only when stdin is a TTY currently in raw mode. */
+export function disableRawModeIfActive(
+  stdin: NodeJS.ReadStream = process.stdin
+): void {
+  if (!(stdin.isTTY && stdin.isRaw && typeof stdin.setRawMode === "function")) {
+    return;
+  }
+
+  stdin.setRawMode(false);
+}
+
 export function isEscInterruptKey(key: string): boolean {
   return key === "\u001b";
 }
@@ -1165,8 +1177,8 @@ function startEscAbortListener(onAbort: () => void): () => void {
   return () => {
     stdin.off("data", onData);
 
-    if (!wasRaw && process.stdin.isTTY) {
-      stdin.setRawMode(false);
+    if (!wasRaw) {
+      disableRawModeIfActive(stdin);
     }
   };
 }


### PR DESCRIPTION
## Summary

CLI chat cleanup disables raw mode only when stdin is already a raw TTY — Fixes #543.

**Before:** `finally` always called `setRawMode(false)` on a TTY; a throw there could abort the rest of cleanup.
**After:** Shared `disableRawModeIfActive` (TTY + `isRaw` + try/catch) used from `runBlockingChat` finally and ESC-abort teardown.

Why safe:
1. Same restore when raw mode is active
2. Non-TTY / already-cooked paths no-op; setRawMode errors are swallowed
3. Unit coverage for skip, disable, and throw cases

Only re-check if a Bun/Node stdin mock reports `isRaw` incorrectly during tests.

## Test plan
- [x] `bun test ./apps/cli/src/chat.test.ts` (12 pass)
- [x] CI: test + knip + react-doctor green
- [ ] Enter interactive CLI chat on a TTY, exit with `/exit` and with Ctrl+C — terminal returns to cooked mode

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
