### PR TITLE
fix(db): stamp updated_at separately when archiving orgs

### DIFF
--- a/packages/db/src/adapters/in-memory.ts
+++ b/packages/db/src/adapters/in-memory.ts
@@ -1220,10 +1220,11 @@ export function createInMemoryDatabaseAdapter(): DatabaseAdapter {
         return false;
       }
 
+      const now = new Date().toISOString();
       const updated = {
         ...organization,
         archivedAt,
-        updatedAt: archivedAt,
+        updatedAt: now,
       };
       organizations.set(orgId, updated);
       organizationsBySlug.set(updated.slug, updated);

--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -2638,9 +2638,10 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
     },
 
     async tryMarkOrganizationArchived(orgId, archivedAt) {
+      const now = new Date().toISOString();
       const result = tryMarkOrganizationArchivedStmt.run(
         archivedAt,
-        archivedAt,
+        now,
         orgId
       );
       return result.changes > 0;

--- a/packages/db/src/organization-archive.test.ts
+++ b/packages/db/src/organization-archive.test.ts
@@ -1,5 +1,24 @@
 import { describe, expect, test } from "bun:test";
 import { createInMemoryDatabaseAdapter } from "./adapters/in-memory";
+import { createSqliteDatabase } from "./adapters/sqlite";
+import type { DatabaseAdapter } from "./types";
+
+async function seedTwoActiveOrgs(db: DatabaseAdapter, createdAt: string) {
+  await db.upsertOrganization({
+    createdAt,
+    id: "org_a",
+    name: "A",
+    slug: "a",
+    updatedAt: createdAt,
+  });
+  await db.upsertOrganization({
+    createdAt,
+    id: "org_b",
+    name: "B",
+    slug: "b",
+    updatedAt: createdAt,
+  });
+}
 
 describe("organization archive persistence", () => {
   test("upsert and get round-trip archivedAt", async () => {
@@ -78,22 +97,54 @@ describe("organization archive persistence", () => {
   test("tryMarkOrganizationArchived archives when another org remains", async () => {
     const db = createInMemoryDatabaseAdapter();
     const now = "2026-08-21T00:00:00.000Z";
-    await db.upsertOrganization({
-      createdAt: now,
-      id: "org_a",
-      name: "A",
-      slug: "a",
-      updatedAt: now,
-    });
-    await db.upsertOrganization({
-      createdAt: now,
-      id: "org_b",
-      name: "B",
-      slug: "b",
-      updatedAt: now,
-    });
+    await seedTwoActiveOrgs(db, now);
 
     expect(await db.tryMarkOrganizationArchived("org_a", now)).toBe(true);
     expect((await db.getOrganizationById("org_a"))?.archivedAt).toBe(now);
+  });
+
+  test("tryMarkOrganizationArchived stamps updated_at separately from archived_at (in-memory)", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const createdAt = "2026-01-01T00:00:00.000Z";
+    const archivedAt = "2026-06-15T12:00:00.000Z";
+    await seedTwoActiveOrgs(db, createdAt);
+
+    const before = new Date().toISOString();
+    expect(await db.tryMarkOrganizationArchived("org_a", archivedAt)).toBe(
+      true
+    );
+    const after = new Date().toISOString();
+
+    const org = await db.getOrganizationById("org_a");
+    expect(org?.archivedAt).toBe(archivedAt);
+    expect(org?.updatedAt).toBeDefined();
+    expect(org?.updatedAt).not.toBe(archivedAt);
+    expect(org!.updatedAt >= before).toBe(true);
+    expect(org!.updatedAt <= after).toBe(true);
+  });
+
+  test("tryMarkOrganizationArchived stamps updated_at separately from archived_at (sqlite)", async () => {
+    const database = await createSqliteDatabase(":memory:");
+    const db = database.adapter;
+    const createdAt = "2026-01-01T00:00:00.000Z";
+    const archivedAt = "2026-06-15T12:00:00.000Z";
+    try {
+      await seedTwoActiveOrgs(db, createdAt);
+
+      const before = new Date().toISOString();
+      expect(await db.tryMarkOrganizationArchived("org_a", archivedAt)).toBe(
+        true
+      );
+      const after = new Date().toISOString();
+
+      const org = await db.getOrganizationById("org_a");
+      expect(org?.archivedAt).toBe(archivedAt);
+      expect(org?.updatedAt).toBeDefined();
+      expect(org?.updatedAt).not.toBe(archivedAt);
+      expect(org!.updatedAt >= before).toBe(true);
+      expect(org!.updatedAt <= after).toBe(true);
+    } finally {
+      database.close();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Archiving an org keeps the provided `archived_at` and stamps `updated_at` with a fresh `now` — Fixes #549.

**Before:** `tryMarkOrganizationArchived` wrote the same timestamp into `archived_at` and `updated_at`.
**After:** sqlite + in-memory pass `archivedAt` then a separate ISO `now` for `updated_at`.

Why safe:
1. Archive success/refusal rules unchanged
2. Both adapters updated the same way
3. Unit coverage for sqlite + in-memory stamp split

Only revisit if callers start relying on `updated_at === archived_at` for archive detection (they should use `archived_at`).

## Test plan
- [x] `bun test ./packages/db/src/organization-archive.test.ts` (6 pass)
- [x] CI: test + knip + react-doctor green
- [ ] Archive a non-last org in platform UI — `archived_at` stays the chosen time; `updated_at` is wall-clock now

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
