### PR TITLE
fix(core): block reserved IPv6 web fetches

### DIFF
--- a/packages/core/src/tools/web-fetch.test.ts
+++ b/packages/core/src/tools/web-fetch.test.ts
@@ -188,6 +188,25 @@ describe("web_fetch SSRF guard", () => {
     ).rejects.toThrow(/private or reserved/);
   });
 
+  test("rejects non-global IPv6 literals", async () => {
+    stubFetch(async () => htmlResponse("<p>must not fetch</p>"));
+
+    for (const host of ["2001::1", "2001:db8::1", "::192.0.2.1"]) {
+      await expect(
+        webFetchTool.run({ url: `http://[${host}]/` }, CTX)
+      ).rejects.toThrow(/private or reserved/);
+    }
+  });
+
+  test("allows IPv6 literals adjacent to blocked ranges", async () => {
+    stubFetch(async () => htmlResponse("<p>ok</p>"));
+
+    for (const host of ["2001:200::1", "2001:db7:ffff::1", "2001:db9::1"]) {
+      const out = await webFetchTool.run({ url: `http://[${host}]/` }, CTX);
+      expect(out.status).toBe(200);
+    }
+  });
+
   test("rejects localhost hostname (resolves to loopback)", async () => {
     await expect(
       webFetchTool.run({ url: "http://localhost/" }, CTX)

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -1,5 +1,5 @@
 import { lookup as dnsLookup } from "node:dns/promises";
-import { isIP } from "node:net";
+import { BlockList, isIP } from "node:net";
 import { NodeHtmlMarkdown } from "node-html-markdown";
 import { z } from "zod";
 import type { JsonSchema, ToolDefinition } from "../contract";
@@ -59,6 +59,20 @@ const MAX_CONTENT_CHARS = 16_000;
 const TRUNCATION_MARKER = "\n...[truncated]";
 const REQUEST_TIMEOUT_MS = 30_000;
 const MAX_REDIRECTS = 5;
+
+const NON_PUBLIC_IPV6_RANGES = new BlockList();
+for (const [network, prefix] of [
+  ["::", 96], // Unspecified, loopback, and deprecated IPv4-compatible.
+  ["::ffff:0:0", 96], // IPv4-mapped.
+  ["64:ff9b::", 96], // Well-known NAT64 prefix.
+  ["2001::", 23], // IETF special-purpose assignments.
+  ["2001:db8::", 32], // Documentation range.
+  ["fc00::", 7], // Unique-local.
+  ["fe80::", 10], // Link-local.
+  ["fec0::", 10], // Deprecated site-local.
+] as const) {
+  NON_PUBLIC_IPV6_RANGES.addSubnet(network, prefix, "ipv6");
+}
 
 /**
  * Private / reserved IPv4 ranges blocked for SSRF (loopback, RFC1918, CGNAT,
@@ -132,21 +146,7 @@ function isPrivateIpv4(ip: string): boolean {
 }
 
 function isPrivateIpv6(ip: string): boolean {
-  const normalized = ip.toLowerCase();
-  return (
-    normalized === "::1" ||
-    normalized === "::" ||
-    normalized.startsWith("fc") ||
-    normalized.startsWith("fd") ||
-    normalized.startsWith("fe80:") ||
-    normalized.startsWith("fe90:") ||
-    normalized.startsWith("fea0:") ||
-    normalized.startsWith("feb0:") ||
-    normalized.startsWith("fec0:") ||
-    normalized.startsWith("::ffff:") ||
-    normalized.startsWith("::ffff:0:") ||
-    normalized.startsWith("64:ff9b:")
-  );
+  return NON_PUBLIC_IPV6_RANGES.check(ip, "ipv6");
 }
 
 function isPrivateIp(ip: string): boolean {


### PR DESCRIPTION
## Summary

Reject reserved IPv6 literals before `web_fetch` can reach the network.

**Before:** Prefix checks let `2001::/23`, `2001:db8::/32`, and deprecated IPv4-compatible addresses through.
**After:** `BlockList` applies exact IPv6 subnet boundaries while adjacent public addresses remain fetchable.

Why safe:
1. Existing loopback, mapped, NAT64, unique-local, link-local, and site-local coverage is preserved.
2. Regression tests cover both blocked ranges and the immediately adjacent allowed ranges.

Only follow up if CI reproduces the unrelated coding-agent/custom-tool process timeouts seen in the local full suite (2,593 pass, 2 timeout failures).

## Test plan
- [x] `bun test packages/core/src/tools/web-fetch.test.ts` (33 pass)
- [x] `bun test packages/core/src` (723 pass); `bun run check`; `bun run knip`; `bun run build`
- [ ] Fetch `http://[2001:db8::1]/` and confirm the private/reserved-address error

Closes #591
