### PR TITLE
fix(server): reject malformed optional JSON

### DIFF
--- a/apps/server/src/http/routes/composio.ts
+++ b/apps/server/src/http/routes/composio.ts
@@ -14,7 +14,7 @@ import {
   requireNotViewerFromContext,
   requireOrgAdminFromContext,
 } from "../org-guards";
-import { errorResponse, json, readJson } from "../shared";
+import { errorResponse, json, readJson, readOptionalJson } from "../shared";
 import type { HonoApp } from "../types";
 
 export function registerComposioOAuthRoutes(
@@ -152,8 +152,9 @@ export function registerComposioRoutes(
     const auth = requireNotViewerFromContext(c);
 
     try {
-      const body = await readJson<ComposioConnectRequest>(c.req.raw).catch(
-        () => ({})
+      const body = await readOptionalJson<ComposioConnectRequest>(
+        c.req.raw,
+        {}
       );
       return json<ComposioConnectResponse>(
         await service.connectToolkit(

--- a/apps/server/src/http/routes/models.ts
+++ b/apps/server/src/http/routes/models.ts
@@ -54,7 +54,13 @@ import {
   requireOrgAdminFromContext,
   requireOrgAdminOrPlatformAdminFromContext,
 } from "../org-guards";
-import { errorResponse, getRequestAuth, json, readJson } from "../shared";
+import {
+  errorResponse,
+  getRequestAuth,
+  json,
+  readJson,
+  readOptionalJson,
+} from "../shared";
 import type { HonoApp } from "../types";
 
 export function registerModelRoutes(
@@ -1399,9 +1405,7 @@ export function registerModelRoutes(
 
   app.post("/v1/settings/email/test", async (c) => {
     const auth = requireOrgAdminFromContext(c);
-    const body = await readJson<SendEmailTestRequest>(c.req.raw).catch(
-      () => ({}) as SendEmailTestRequest
-    );
+    const body = await readOptionalJson<SendEmailTestRequest>(c.req.raw, {});
 
     try {
       return json<SendEmailTestResponse>(

--- a/apps/server/src/http/routes/org-curator.ts
+++ b/apps/server/src/http/routes/org-curator.ts
@@ -7,7 +7,7 @@ import type {
 } from "@nakama/core/contract";
 import type { ServerOptions } from "../context";
 import { requireOrgAdminFromContext } from "../org-guards";
-import { json, readJson } from "../shared";
+import { json, readOptionalJson } from "../shared";
 import type { HonoApp } from "../types";
 
 export function registerOrgCuratorRoutes(
@@ -96,11 +96,9 @@ export function registerOrgCuratorRoutes(
   app.post("/v1/orgs/:orgId/curator/run", async (c) => {
     const auth = requireOrgAdminFromContext(c);
     const orgId = resolveOrgId(c, auth.activeOrgId ?? "");
-    const body = await readJson<RunSkillCuratorRequest>(c.req.raw).catch(
-      () => ({
-        dryRun: false,
-      })
-    );
+    const body = await readOptionalJson<RunSkillCuratorRequest>(c.req.raw, {
+      dryRun: false,
+    });
     const result = await requireCurator().run(orgId, {
       dryRun: body.dryRun === true,
       trigger: "manual",

--- a/apps/server/src/http/routes/org-memory.ts
+++ b/apps/server/src/http/routes/org-memory.ts
@@ -16,7 +16,7 @@ import {
   requireNotViewerFromContext,
   requireOrgAdminFromContext,
 } from "../org-guards";
-import { json, readJson } from "../shared";
+import { json, readJson, readOptionalJson } from "../shared";
 import type { HonoApp } from "../types";
 
 export function registerOrgMemoryRoutes(
@@ -758,9 +758,7 @@ export function registerOrgMemoryRoutes(
       const orgId = resolveOrgId(c, auth.activeOrgId ?? "");
       const proposalId = decodeURIComponent(c.req.param("proposalId"));
       const service = requireService();
-      const body = await readJson<{ pin?: boolean }>(c.req.raw).catch(
-        () => ({})
-      );
+      const body = await readOptionalJson<{ pin?: boolean }>(c.req.raw, {});
       const proposal = await service.approveProposal(
         orgId,
         proposalId,

--- a/apps/server/src/http/routes/profiles-clone.test.ts
+++ b/apps/server/src/http/routes/profiles-clone.test.ts
@@ -119,4 +119,59 @@ describe("POST /v1/profiles/:profileId/clone", () => {
       before.length + 1
     );
   }, 20_000);
+
+  test("malformed JSON returns 400 without cloning a profile", async () => {
+    const { app, databaseAdapter } = createApp();
+    const session = await setupFreshInstallSession(
+      app,
+      databaseAdapter,
+      "platform3@example.com"
+    );
+    const orgId = session.orgId!;
+    const before = await databaseAdapter.listProfilesForOrg(orgId);
+    const source = before.find((profile) => !profile.isSuper);
+
+    const response = await app.fetch(
+      new Request(`${BASE}/v1/profiles/${source!.id}/clone`, {
+        body: "{",
+        headers: session.headers(
+          {
+            "Content-Type": "application/json",
+            "X-CSRF-Token": session.csrfToken,
+          },
+          orgId
+        ),
+        method: "POST",
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(await databaseAdapter.listProfilesForOrg(orgId)).toHaveLength(
+      before.length
+    );
+  }, 20_000);
+
+  test("an empty body keeps the optional clone defaults", async () => {
+    const { app, databaseAdapter } = createApp();
+    const session = await setupFreshInstallSession(
+      app,
+      databaseAdapter,
+      "platform4@example.com"
+    );
+    const orgId = session.orgId!;
+    const before = await databaseAdapter.listProfilesForOrg(orgId);
+    const source = before.find((profile) => !profile.isSuper);
+
+    const response = await app.fetch(
+      new Request(`${BASE}/v1/profiles/${source!.id}/clone`, {
+        headers: session.headers({ "X-CSRF-Token": session.csrfToken }, orgId),
+        method: "POST",
+      })
+    );
+
+    expect(response.status).toBe(201);
+    expect(await databaseAdapter.listProfilesForOrg(orgId)).toHaveLength(
+      before.length + 1
+    );
+  }, 20_000);
 });

--- a/apps/server/src/http/routes/profiles.ts
+++ b/apps/server/src/http/routes/profiles.ts
@@ -30,7 +30,7 @@ import {
   requireOrgAdminOrPlatformAdminFromContext,
   requirePlatformAdminFromContext,
 } from "../org-guards";
-import { getRequestAuth, json, readJson } from "../shared";
+import { getRequestAuth, json, readJson, readOptionalJson } from "../shared";
 import type { HonoApp } from "../types";
 
 const ORG_ADMIN_PROFILE_SETTING_KEYS = new Set([
@@ -959,9 +959,7 @@ export function registerProfileRoutes(
     requirePlatformAdminFromContext(c);
     const orgId = requireActiveOrgIdFromContext(c);
     const profileId = decodeURIComponent(c.req.param("profileId"));
-    const body = await readJson<CloneProfileRequest>(c.req.raw).catch(
-      () => ({}) as CloneProfileRequest
-    );
+    const body = await readOptionalJson<CloneProfileRequest>(c.req.raw, {});
     return json<ProfileResponse>(
       await agent.cloneProfile(orgId, profileId, body),
       201

--- a/apps/server/src/http/routes/sessions.ts
+++ b/apps/server/src/http/routes/sessions.ts
@@ -27,6 +27,7 @@ import {
   json,
   parseChannel,
   readJson,
+  readOptionalJson,
   streamMessage,
   streamTurnSubscribe,
 } from "../shared";
@@ -453,9 +454,7 @@ export function registerSessionRoutes(
     requireNotViewerFromContext(c);
     const orgId = requireActiveOrgIdFromContext(c);
     const sessionId = decodeURIComponent(c.req.param("sessionId"));
-    const body = await readJson<CompactSessionRequest>(c.req.raw).catch(
-      () => ({})
-    );
+    const body = await readOptionalJson<CompactSessionRequest>(c.req.raw, {});
     const result = await agent.compactSession(
       sessionId,
       {

--- a/apps/server/src/http/shared.test.ts
+++ b/apps/server/src/http/shared.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { readOptionalJson } from "./shared";
+
+const URL = "http://localhost:4310/test";
+
+describe("readOptionalJson", () => {
+  test("returns the fallback for an empty optional body", async () => {
+    const request = new Request(URL, { body: " \n", method: "POST" });
+
+    await expect(
+      readOptionalJson(request, { enabled: false })
+    ).resolves.toEqual({ enabled: false });
+  });
+
+  test("rejects malformed non-empty JSON", async () => {
+    const request = new Request(URL, { body: "{", method: "POST" });
+
+    await expect(readOptionalJson(request, {})).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+});

--- a/apps/server/src/http/shared.ts
+++ b/apps/server/src/http/shared.ts
@@ -364,6 +364,25 @@ export async function readJson<T>(request: Request): Promise<T> {
   }
 }
 
+export async function readOptionalJson<T>(
+  request: Request,
+  fallback: T
+): Promise<T> {
+  const body = await request.text();
+  if (!body.trim()) {
+    return fallback;
+  }
+
+  try {
+    return JSON.parse(body) as T;
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      throw new NakamaApiError("Invalid JSON in request body.", 400);
+    }
+    throw err;
+  }
+}
+
 export function json<T>(body: T, status = 200, headers?: Headers): Response {
   const responseHeaders = new Headers(headers);
   responseHeaders.set("Content-Type", "application/json; charset=utf-8");

--- a/apps/server/src/http/shared.ts
+++ b/apps/server/src/http/shared.ts
@@ -375,11 +375,8 @@ export async function readOptionalJson<T>(
 
   try {
     return JSON.parse(body) as T;
-  } catch (err) {
-    if (err instanceof SyntaxError) {
-      throw new NakamaApiError("Invalid JSON in request body.", 400);
-    }
-    throw err;
+  } catch {
+    throw new NakamaApiError("Invalid JSON in request body.", 400);
   }
 }
 


### PR DESCRIPTION
## Summary

Send malformed optional JSON → receive 400 before any route mutation; empty optional bodies still use their defaults.

**Before:** Six routes caught every parse failure and silently treated malformed JSON as `{}`.
**After:** `readOptionalJson` falls back only for an empty body and preserves `readJson`'s 400 behavior otherwise.

Why safe:
1. Existing optional-body defaults remain unchanged across clone, curator, memory, Composio, compaction, and email-test routes.
2. Regression coverage proves malformed clone input writes nothing while an empty body still clones successfully.

Only follow up if an optional endpoint intentionally needs to accept non-JSON content.

## Test plan
- [x] `bun test apps/server/src/http/shared.test.ts apps/server/src/http/routes/profiles-clone.test.ts` (6 pass)
- [x] `bun test` (2,612 pass); `bun run check`; `bun run knip`; `bun run build`
- [ ] POST `{` to an affected route and confirm HTTP 400 with no mutation

Closes #551
