### PR TITLE
fix(server): strip shell-hijacking keys from spawn env

### DIFF
--- a/apps/server/src/services/coding-agent-spawn-env.ts
+++ b/apps/server/src/services/coding-agent-spawn-env.ts
@@ -309,6 +309,19 @@ export async function buildSpawnEnvForHarness(
   return buildOpenCodeSpawnEnv(routing, providerType);
 }
 
+/**
+ * Env keys that run code before the spawned command does, so a caller that can
+ * name one owns the process: `bash -lc` sources BASH_ENV, the loader reads
+ * the LD_ and DYLD_ preload keys, node reads NODE_OPTIONS (--require), python
+ * reads the PYTHON keys (sitecustomize), and BASH_FUNC_ smuggles in shell
+ * functions. The bash tool
+ * takes this map straight from the model, so the filter is always on rather
+ * than opt-in. Bare `ENV` is left alone: bash only sources it in posix mode,
+ * and it is a common application setting.
+ */
+const HIJACKING_ENV_KEY =
+  /^(BASH_ENV|IFS|PS4|SHELLOPTS|BASHOPTS|NODE_OPTIONS|BASH_FUNC_.*|LD_.*|DYLD_.*|PYTHON.*)$/;
+
 export function mergeCodingAgentSpawnEnv(
   baseEnv: NodeJS.ProcessEnv,
   spawnEnv: Record<string, string>,
@@ -318,9 +331,19 @@ export function mergeCodingAgentSpawnEnv(
   } = {}
 ): NodeJS.ProcessEnv {
   const callerEnv = options.callerEnv ?? {};
-  const merged: Record<string, string> = { ...spawnEnv };
+  const merged: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(spawnEnv)) {
+    if (!HIJACKING_ENV_KEY.test(key)) {
+      merged[key] = value;
+    }
+  }
 
   for (const [key, value] of Object.entries(callerEnv)) {
+    if (HIJACKING_ENV_KEY.test(key)) {
+      continue;
+    }
+
     if (
       options.protectCredentialKeys &&
       CODING_AGENT_CREDENTIAL_ENV_KEYS.includes(

--- a/apps/server/src/tools/bash.test.ts
+++ b/apps/server/src/tools/bash.test.ts
@@ -200,6 +200,32 @@ describe("bash tool", () => {
     expect(result.stdout).toContain("Full coding-agent log:");
   });
 
+  // `/bin/bash -lc` sources BASH_ENV before it runs the command, so an env key
+  // the model chose is arbitrary code execution unless it is stripped.
+  test("drops env keys that hijack the shell before the command runs", async () => {
+    workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "nakama-bash-"));
+    const hijackPath = path.join(workspaceRoot, "hijack.sh");
+    await writeFile(hijackPath, "echo HIJACKED\n", "utf8");
+
+    const result = await runBash(
+      {
+        command: 'echo "keep=$KEEP_ME preload=$LD_PRELOAD node=$NODE_OPTIONS"',
+        env: {
+          BASH_ENV: hijackPath,
+          KEEP_ME: "kept",
+          LD_PRELOAD: "/tmp/evil.so",
+          NODE_OPTIONS: "--require=/tmp/evil.js",
+        },
+      },
+      { orgId: "org_test", profileId: "profile_test" },
+      { workspaceRoot }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain("HIJACKED");
+    expect(result.stdout.trim()).toBe("keep=kept preload= node=");
+  });
+
   test("prunes coding-agent logs to the newest 10 and leaves other artifacts", async () => {
     workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "nakama-bash-"));
     const logDir = path.join(workspaceRoot, "artifacts", "coding-agent-runs");


### PR DESCRIPTION
Closes #480. Also covers #528 and #596, which are the same missing denylist seen from the coding-agent side.

`runBash` passes the model's `env` map into `mergeCodingAgentSpawnEnv`, which merged it over `process.env` and spawned `/bin/bash -lc`. A login shell sources `BASH_ENV` before it runs the command, so the map decided what executed first. `LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, `NODE_OPTIONS` and the `PYTHON` keys get there through the loader and the interpreters instead.

The filter lives in `mergeCodingAgentSpawnEnv`, not in `bash.ts`, because `coding-agent-bash-env.ts` routes the same model-supplied map through `callerEnv`. It is always on. The credential filter is untouched: still opt-in, still `callerEnv` only, so the harness bundle keeps setting its own `ANTHROPIC_` and `OPENAI_` values.

Bare `ENV` is left out of the list. Bash sources it only in posix mode, and it is a common application setting, so stripping it costs more than it buys.

Scope, stated plainly: the bash tool runs arbitrary commands by design, so this does not add a boundary against a caller who already reaches the tool. What it closes is the gap where an env key rewrites what a *later* spawn runs, including the coding-agent harness, without appearing in the command string an operator reads.

Before, on `main`:

```
(fail) drops env keys that hijack the shell before the command runs
  Expected to not contain: "HIJACKED"
  Received: "HIJACKED\nkeep=kept preload=/tmp/evil.so node=--require=/tmp/evil.js\n"
```

After:

```
keep=kept preload= node=
24 pass  0 fail
```

The passthrough half of that assertion is deliberate: `KEEP_ME` still reaches the shell, so the filter is not just emptying the map.

Full suite: `bun run test`, exit 0, 2604 pass / 0 fail across 11 workspaces.
