### PR TITLE
fix(whatsapp): require a shared token on the outbound send server

### DIFF
--- a/apps/platform/whatsapp/src/outbound-server.test.ts
+++ b/apps/platform/whatsapp/src/outbound-server.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { WHATSAPP_OUTBOUND_TOKEN_HEADER } from "@nakama/core";
+import { startWhatsAppOutboundServer } from "./outbound-server";
+
+const originalConfigDir = process.env.NAKAMA_CONFIG_DIR;
+let configDir = "";
+
+afterEach(async () => {
+  process.env.NAKAMA_CONFIG_DIR = originalConfigDir;
+
+  if (configDir) {
+    await rm(configDir, { force: true, recursive: true });
+    configDir = "";
+  }
+});
+
+// Each server gets its own port: two on the default would leave the second
+// request answered by the first, already-stopped, server.
+async function startPairedServer(port: number) {
+  configDir = await mkdtemp(join(tmpdir(), "nakama-whatsapp-outbound-"));
+  process.env.NAKAMA_CONFIG_DIR = configDir;
+  await mkdir(join(configDir, "whatsapp"), { recursive: true });
+  await writeFile(
+    join(configDir, "whatsapp", "config.ini"),
+    [
+      "profile_id=default",
+      "paired_jid=628100000000@s.whatsapp.net",
+      `outbound_port=${port}`,
+      "",
+    ].join("\n"),
+    "utf8"
+  );
+
+  const sent: string[] = [];
+  const server = await startWhatsAppOutboundServer({
+    getSendHandle: () => ({
+      sendMessage: async (_jid, content) => {
+        sent.push(content.text);
+      },
+    }),
+  });
+
+  return { sent, server };
+}
+
+async function post(port: number, headers: Record<string, string>) {
+  return await fetch(`http://127.0.0.1:${port}/send`, {
+    body: JSON.stringify({ text: "hello" }),
+    headers: { "Content-Type": "application/json", ...headers },
+    method: "POST",
+  });
+}
+
+describe("whatsapp outbound server", () => {
+  test("rejects a local caller that does not know the token", async () => {
+    const { sent, server } = await startPairedServer(43_121);
+
+    try {
+      const anonymous = await post(server.port, {});
+      const wrongToken = await post(server.port, {
+        [WHATSAPP_OUTBOUND_TOKEN_HEADER]: "a".repeat(64),
+      });
+
+      expect(anonymous.status).toBe(401);
+      expect(wrongToken.status).toBe(401);
+      expect(sent).toEqual([]);
+    } finally {
+      server.stop();
+    }
+  });
+
+  test("sends when the caller presents the minted token", async () => {
+    const { sent, server } = await startPairedServer(43_122);
+
+    try {
+      const { loadWhatsAppConfigFile } = await import("@nakama/core");
+      const token = (await loadWhatsAppConfigFile())?.outboundToken ?? "";
+
+      expect(token).toHaveLength(64);
+
+      const response = await post(server.port, {
+        [WHATSAPP_OUTBOUND_TOKEN_HEADER]: token,
+      });
+
+      expect(response.status).toBe(200);
+      expect(sent).toEqual(["hello"]);
+    } finally {
+      server.stop();
+    }
+  });
+});

--- a/apps/platform/whatsapp/src/outbound-server.ts
+++ b/apps/platform/whatsapp/src/outbound-server.ts
@@ -1,7 +1,21 @@
+import { timingSafeEqual } from "node:crypto";
 import {
+  ensureWhatsAppOutboundToken,
   loadWhatsAppConfigFile,
   resolveWhatsAppOutboundPort,
+  WHATSAPP_OUTBOUND_TOKEN_HEADER,
 } from "@nakama/core";
+
+function tokenMatches(provided: string | null, expected: string): boolean {
+  if (!provided) {
+    return false;
+  }
+
+  const actual = Buffer.from(provided.trim());
+  const wanted = Buffer.from(expected);
+
+  return actual.length === wanted.length && timingSafeEqual(actual, wanted);
+}
 
 export interface WhatsAppOutboundSendHandle {
   sendMessage: (jid: string, content: { text: string }) => Promise<unknown>;
@@ -16,6 +30,8 @@ export async function startWhatsAppOutboundServer(
 ): Promise<{ port: number; stop: () => void }> {
   const config = await loadWhatsAppConfigFile();
   const port = resolveWhatsAppOutboundPort(config);
+  // Mint it before the port opens so the first send already has a token to send.
+  await ensureWhatsAppOutboundToken();
   let stopped = false;
 
   const server = Bun.serve({
@@ -28,6 +44,23 @@ export async function startWhatsAppOutboundServer(
 
       if (request.method === "POST" && url.pathname === "/send") {
         const latestConfig = await loadWhatsAppConfigFile();
+        // Re-read per request: pairing can create the config after startup.
+        const expectedToken =
+          latestConfig?.outboundToken?.trim() ||
+          (await ensureWhatsAppOutboundToken());
+
+        if (
+          !(
+            expectedToken &&
+            tokenMatches(
+              request.headers.get(WHATSAPP_OUTBOUND_TOKEN_HEADER),
+              expectedToken
+            )
+          )
+        ) {
+          return Response.json({ error: "Unauthorized." }, { status: 401 });
+        }
+
         const pairedJid = latestConfig?.pairedJid?.trim();
 
         if (!pairedJid) {

--- a/packages/core/src/channels/whatsapp-outbound.ts
+++ b/packages/core/src/channels/whatsapp-outbound.ts
@@ -3,6 +3,8 @@ import type { ChannelSendResult, WhatsAppOutboundAdapter } from "./types";
 
 const DEFAULT_OUTBOUND_PORT = 4312;
 
+export const WHATSAPP_OUTBOUND_TOKEN_HEADER = "x-nakama-token";
+
 export interface WhatsAppOutboundOptions {
   fetchImpl?: typeof fetch;
 }
@@ -42,7 +44,12 @@ export function createWhatsAppOutboundAdapter(
         const port = resolveWhatsAppOutboundPort(config);
         const response = await fetchImpl(`http://127.0.0.1:${port}/send`, {
           body: JSON.stringify({ text: input.text }),
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            ...(config.outboundToken
+              ? { [WHATSAPP_OUTBOUND_TOKEN_HEADER]: config.outboundToken }
+              : {}),
+          },
           method: "POST",
         });
 

--- a/packages/core/src/whatsapp-config.ts
+++ b/packages/core/src/whatsapp-config.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import { rm } from "node:fs/promises";
 import { join } from "node:path";
 import {
@@ -24,6 +25,7 @@ export const DEFAULT_WHATSAPP_PROFILE_ID = "default";
 export interface WhatsAppConfigFile {
   allowedPhones: string[];
   outboundPort?: string | null;
+  outboundToken?: string | null;
   pairedJid: string | null;
   pairedLid: string | null;
   pairingCode: string | null;
@@ -209,16 +211,40 @@ export async function loadWhatsAppConfigFile(): Promise<WhatsAppConfigFile | nul
   const pairedJid = values.paired_jid?.trim() || null;
   const pairedLid = values.paired_lid?.trim() || null;
   const outboundPort = values.outbound_port?.trim() || null;
+  const outboundToken = values.outbound_token?.trim() || null;
 
   return {
     allowedPhones: parseAllowedWhatsAppPhones(values.allowed_phones ?? ""),
     outboundPort,
+    outboundToken,
     pairedJid,
     pairedLid,
     pairingCode,
     phoneNumber,
     profileId,
   };
+}
+
+/**
+ * Shared secret for the loopback outbound server, minted on first use and kept
+ * in the 0600 config file, so a process running as another user cannot post to
+ * 127.0.0.1/send and make the bot message the paired owner.
+ */
+export async function ensureWhatsAppOutboundToken(): Promise<string | null> {
+  const config = await loadWhatsAppConfigFile();
+
+  if (!config) {
+    return null;
+  }
+
+  if (config.outboundToken) {
+    return config.outboundToken;
+  }
+
+  const outboundToken = randomBytes(32).toString("hex");
+  await writeWhatsAppConfigFile({ ...config, outboundToken });
+
+  return outboundToken;
 }
 
 export function toWhatsAppSettingsPublic(
@@ -266,6 +292,8 @@ async function writeWhatsAppConfigFile(
     ...(config.allowedPhones.length > 0
       ? [`allowed_phones=${config.allowedPhones.join(",")}`]
       : []),
+    ...(config.outboundPort ? [`outbound_port=${config.outboundPort}`] : []),
+    ...(config.outboundToken ? [`outbound_token=${config.outboundToken}`] : []),
     "",
   ];
 


### PR DESCRIPTION
Closes #513.

`POST 127.0.0.1:<port>/send` accepted a JSON body and forwarded the text to the paired owner with no credential. Binding to loopback keeps it off the network, but every process on the host could still send as the account.

The worker mints a 32-byte token into the WhatsApp config file, which `writeTextFile` writes 0600, and checks `X-Nakama-Token` against it with `timingSafeEqual`. The outbound adapter reads the same file and sends the header, so both halves stay in step with no new configuration and no migration step for existing installs. The token is resolved per request because pairing can create the config after the server is already listening.

The config writer now keeps `outbound_port` too. It was parsed but never written back, so any rewrite silently dropped an operator's custom port, and writing the token would have been the next thing to trigger that.

Before, on `main`, starting the server against a paired config and posting with no header at all:

```
status: 200 {"ok":true}
delivered to the paired owner: [ "posted by any local process" ]
```

After, same script:

```
status: 401 {"error":"Unauthorized."}
delivered to the paired owner: []
```

Full suite: `bun run test`, exit 0, 2602 pass / 0 fail across 11 workspaces.
