### PR TITLE
fix(workers): scope cross-org profile listing per request

### DIFF
--- a/apps/platform/discord/src/chat-handler.ts
+++ b/apps/platform/discord/src/chat-handler.ts
@@ -941,10 +941,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
           }
         : isThread
           ? null
-          : resolveProfileInScopes(
-              await listProfileScopes(orgs, currentOrgId),
-              arg
-            );
+          : resolveProfileInScopes(await listProfileScopes(orgs), arg);
 
     if (!resolved) {
       await messenger.send("Unknown profile. Send /profile to see the list.");
@@ -980,30 +977,26 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     );
   }
 
+  // The org travels with the request. Borrowing client.setOrgId per iteration
+  // let a concurrent chat read another org's profiles between the awaits.
   async function listProfileScopes(
-    orgs: Array<{ id: string; name: string }>,
-    restoreOrgId?: string
+    orgs: Array<{ id: string; name: string }>
   ): Promise<ProfileScope[]> {
     const scopes: ProfileScope[] = [];
 
     for (const org of orgs) {
-      client.setOrgId(org.id);
-      const profiles = await listSelectableProfiles();
+      const profiles = await listSelectableProfiles(org.id);
 
       if (profiles.length > 0) {
         scopes.push({ orgId: org.id, orgName: org.name, profiles });
       }
     }
 
-    if (restoreOrgId) {
-      client.setOrgId(restoreOrgId);
-    }
-
     return scopes;
   }
 
-  async function listSelectableProfiles() {
-    const { profiles } = await client.listProfiles();
+  async function listSelectableProfiles(orgId?: string) {
+    const { profiles } = await client.listProfiles(orgId);
     return filterProfilesForChatAccess(profiles, { excludeSuperBot: true });
   }
 

--- a/apps/platform/telegram/src/chat-handler.test.ts
+++ b/apps/platform/telegram/src/chat-handler.test.ts
@@ -1765,6 +1765,52 @@ describe("bridge API integration", () => {
     });
   });
 
+  test("/profile scopes each org's listing to that org, not the client's", async () => {
+    await withTempHome(async (homeDir) => {
+      await writeTelegramConfigIni(homeDir, {
+        botToken: "1234567890:TEST",
+        pairedUserIds: [1001],
+      });
+
+      const authStore = new TelegramAuthStore();
+      await authStore.reload();
+      const { client, listProfilesOrgIds } = createMockClient({
+        orgs: createMultiTestOrgs(),
+        profilesByOrgId: {
+          org_a: [{ id: "default", isDefault: true, name: "Default Bot" }],
+          org_b: [{ id: "gary", isDefault: true, name: "Gary Vee" }],
+        },
+      });
+      const sessionStore = new SessionStore(
+        path.join(homeDir, ".nakama", "telegram", "chat-sessions.json")
+      );
+      const orgStore = createTestOrgStore(homeDir);
+      await orgStore.load();
+      orgStore.set("u:1001", "org_a");
+      await orgStore.save();
+      const handleMessage = createChatHandler({
+        authStore,
+        client,
+        config: { botToken: "1234567890:TEST", profileId: "default" },
+        orgStore,
+        sessionStore,
+      });
+
+      const switchProfile = createMessageContext({
+        text: "/profile gary-vee",
+        userId: 1001,
+      });
+      await handleMessage(switchProfile.ctx);
+
+      // The cross-org scan names each org on its own request instead of
+      // repointing the shared client, which a concurrent chat would read.
+      expect(listProfilesOrgIds.filter((id) => id !== null)).toEqual([
+        "org_a",
+        "org_b",
+      ]);
+    });
+  });
+
   test("/profile accepts the visible list number in the current org", async () => {
     await withTempHome(async (homeDir) => {
       await writeTelegramConfigIni(homeDir, {

--- a/apps/platform/telegram/src/chat-handler.ts
+++ b/apps/platform/telegram/src/chat-handler.ts
@@ -666,15 +666,12 @@ export function createChatHandler(deps: ChatHandlerDeps) {
           }
         : isTopic
           ? null
-          : resolveProfileInScopes(
-              await listProfileScopes(orgs, currentOrgId),
-              arg
-            );
+          : resolveProfileInScopes(await listProfileScopes(orgs), arg);
 
     if (!resolved) {
       if (isTopic && currentOrgId) {
         const crossOrgMatch = resolveProfileInScopes(
-          await listProfileScopes(orgs, currentOrgId),
+          await listProfileScopes(orgs),
           arg
         );
 
@@ -719,30 +716,26 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     );
   }
 
+  // The org travels with the request. Borrowing client.setOrgId per iteration
+  // let a concurrent chat read another org's profiles between the awaits.
   async function listProfileScopes(
-    orgs: Array<{ id: string; name: string }>,
-    restoreOrgId?: string
+    orgs: Array<{ id: string; name: string }>
   ): Promise<ProfileScope[]> {
     const scopes: ProfileScope[] = [];
 
     for (const org of orgs) {
-      client.setOrgId(org.id);
-      const profiles = await listSelectableProfiles();
+      const profiles = await listSelectableProfiles(org.id);
 
       if (profiles.length > 0) {
         scopes.push({ orgId: org.id, orgName: org.name, profiles });
       }
     }
 
-    if (restoreOrgId) {
-      client.setOrgId(restoreOrgId);
-    }
-
     return scopes;
   }
 
-  async function listSelectableProfiles() {
-    const { profiles } = await client.listProfiles();
+  async function listSelectableProfiles(orgId?: string) {
+    const { profiles } = await client.listProfiles(orgId);
     return filterProfilesForChatAccess(profiles, { excludeSuperBot: true });
   }
 

--- a/apps/platform/telegram/src/test-helpers.ts
+++ b/apps/platform/telegram/src/test-helpers.ts
@@ -161,6 +161,7 @@ export function createMockClient(
     transcribeAudio: 0,
   };
   const orgIds: string[] = [];
+  const listProfilesOrgIds: Array<string | null> = [];
   let lastCreateSessionProfileId: string | undefined;
   let lastStreamInput: unknown;
 
@@ -307,10 +308,12 @@ export function createMockClient(
       ok: true,
       providerConfigured: options.providerConfigured ?? false,
     }),
-    listProfiles: async () => {
+    listProfiles: async (orgId?: string) => {
       calls.listProfiles += 1;
+      listProfilesOrgIds.push(orgId ?? null);
+      const scopeOrgId = orgId ?? activeOrgId;
       const scopedProfiles =
-        (activeOrgId ? options.profilesByOrgId?.[activeOrgId] : undefined) ??
+        (scopeOrgId ? options.profilesByOrgId?.[scopeOrgId] : undefined) ??
         profiles;
 
       return parseListProfilesResponse({
@@ -365,6 +368,7 @@ export function createMockClient(
     getLastStreamInput: () => lastStreamInput,
     getStreamControl: () => streamControl,
     getStreamControls: () => streamControls,
+    listProfilesOrgIds,
     orgIds,
   };
 }

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -92,6 +92,25 @@ test("clients send org context on authenticated requests", async () => {
   expect(headers.get("X-Org-Id")).toBe("org_test");
 });
 
+test("listProfiles takes an org id per call, overriding the client's", async () => {
+  const fetchCalls: Array<{ input: RequestInfo | URL; init?: RequestInit }> =
+    [];
+  const client = new NakamaClient({
+    authToken: "local-auth-token",
+    baseUrl: "http://localhost:4310",
+    fetch: async (input, init) => {
+      fetchCalls.push({ init, input });
+      return Response.json({ profiles: [] });
+    },
+    orgId: "org_test",
+  });
+
+  await client.listProfiles("org_other");
+
+  const headers = new Headers(fetchCalls[0]!.init?.headers);
+  expect(headers.get("X-Org-Id")).toBe("org_other");
+});
+
 test("non-browser clients send local auth as a bearer token", async () => {
   const fetchCalls: Array<{ input: RequestInfo | URL; init?: RequestInit }> =
     [];

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -651,8 +651,11 @@ export class NakamaClient {
     );
   }
 
-  async listProfiles(): Promise<ListProfilesResponse> {
-    return this.request<ListProfilesResponse>("/v1/profiles");
+  async listProfiles(orgId?: string): Promise<ListProfilesResponse> {
+    return this.request<ListProfilesResponse>(
+      "/v1/profiles",
+      orgId ? { headers: { "X-Org-Id": orgId } } : undefined
+    );
   }
 
   async getProfile(profileId: string): Promise<ProfileResponse> {


### PR DESCRIPTION
Closes #512.

`listProfileScopes` repointed the shared `NakamaClient` with `setOrgId` once per org and restored it at the end. Each `await` in that loop is a window where a concurrent chat reads the client while it points at another org. Discord and Telegram both carried the loop, so both are fixed.

`listProfiles` now takes an org id and sends it as `X-Org-Id`, which is the per-request pattern `getOrgSkillCuratorLatest` and the other org routes already use. The borrow-and-restore dance is deleted rather than guarded with a lock.

Before, on `main`, the same test:

```
(fail) /profile scopes each org's listing to that org, not the client's
  Expected: [ "org_a", "org_b" ]
  Received: [ null, null ]
```

After:

```
46 pass  0 fail   (telegram)
28 pass  0 fail   (client)
```

Left alone on purpose: the per-chat `client.setOrgId` calls have the same shape and want the same treatment, but that reaches every client method a chat turn uses and is a bigger change than this ticket. Say the word and I will open it separately.

Full suite: `bun run test`, exit 0, 2610 pass / 0 fail across 11 workspaces.
