### PR TITLE
fix(server): pin the OAuth callback base to the configured public URL

### DIFF
--- a/apps/server/src/services/artifact-share-service.ts
+++ b/apps/server/src/services/artifact-share-service.ts
@@ -8,7 +8,6 @@ import {
   readArtifactFile,
   readArtifactShareSnapshot,
   resolveArtifactMimeType,
-  resolveWebPublicUrl,
   writeArtifactShareSnapshot,
 } from "@nakama/core";
 import type {
@@ -30,21 +29,10 @@ export function resolveArtifactShareBaseUrl(options: {
   clientOrigin?: string;
   request?: Request;
 }): string {
-  const resolved = resolveComposioCallbackBaseUrl({
+  return resolveComposioCallbackBaseUrl({
     clientOrigin: options.clientOrigin,
     request: options.request,
   });
-
-  if (!isLoopbackComposioCallbackBaseUrl(resolved)) {
-    return resolved;
-  }
-
-  const configured = resolveWebPublicUrl();
-  if (configured && !isLoopbackComposioCallbackBaseUrl(configured)) {
-    return configured;
-  }
-
-  return resolved;
 }
 
 export class ArtifactShareService {

--- a/apps/server/src/services/composio-callback-url.test.ts
+++ b/apps/server/src/services/composio-callback-url.test.ts
@@ -63,6 +63,69 @@ describe("composio-callback-url", () => {
     }
   });
 
+  test("caller headers cannot move the callback off the configured URL", () => {
+    const previous = process.env.NAKAMA_WEB_PUBLIC_URL;
+    process.env.NAKAMA_WEB_PUBLIC_URL = "https://deployed.example.com";
+    const request = new Request(
+      "http://127.0.0.1:4310/v1/composio/toolkits/gmail/connect",
+      {
+        headers: {
+          Origin: "https://evil.example.com",
+          "X-Forwarded-Host": "evil.example.com",
+          "X-Forwarded-Proto": "https",
+        },
+        method: "POST",
+      }
+    );
+
+    try {
+      expect(
+        resolveComposioCallbackBaseUrl({
+          clientOrigin: "https://evil.example.com",
+          request,
+        })
+      ).toBe("https://deployed.example.com");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.NAKAMA_WEB_PUBLIC_URL;
+      } else {
+        process.env.NAKAMA_WEB_PUBLIC_URL = previous;
+      }
+    }
+  });
+
+  test("an unparseable clientOrigin does not become the callback base", () => {
+    const configDir = join(tmpdir(), `nakama-callback-url-unset-${Date.now()}`);
+    mkdirSync(configDir, { recursive: true });
+    const previousConfigDir = process.env.NAKAMA_CONFIG_DIR;
+    const previousPublicUrl = process.env.NAKAMA_WEB_PUBLIC_URL;
+    process.env.NAKAMA_CONFIG_DIR = configDir;
+    delete process.env.NAKAMA_WEB_PUBLIC_URL;
+    const request = new Request(
+      "http://127.0.0.1:4310/v1/composio/toolkits/gmail/connect",
+      { method: "POST" }
+    );
+
+    try {
+      expect(
+        resolveComposioCallbackBaseUrl({
+          clientOrigin: "javascript:alert(1)",
+          request,
+        })
+      ).toBe("http://127.0.0.1:4310");
+    } finally {
+      if (previousConfigDir === undefined) {
+        delete process.env.NAKAMA_CONFIG_DIR;
+      } else {
+        process.env.NAKAMA_CONFIG_DIR = previousConfigDir;
+      }
+      if (previousPublicUrl !== undefined) {
+        process.env.NAKAMA_WEB_PUBLIC_URL = previousPublicUrl;
+      }
+      rmSync(configDir, { force: true, recursive: true });
+    }
+  });
+
   test("persistWebPublicUrl preserves path segments", async () => {
     const configDir = join(tmpdir(), `nakama-callback-url-test-${Date.now()}`);
     mkdirSync(configDir, { recursive: true });

--- a/apps/server/src/services/composio-callback-url.ts
+++ b/apps/server/src/services/composio-callback-url.ts
@@ -55,33 +55,43 @@ export async function getWebPublicUrlSettings(): Promise<WebPublicUrlSettingsRes
   };
 }
 
-/** OAuth callback base URL — prefers the browser origin from the active request. */
+/**
+ * OAuth callback base URL. A configured public URL is the operator's answer and
+ * wins: clientOrigin, Origin, Referer and X-Forwarded-Host all come from the
+ * caller, and this base ends up in the redirect_uri an OAuth code is delivered
+ * to. They still decide when nothing is configured, which is how a dev install
+ * on localhost works, and they have to parse as an http(s) URL to be used.
+ */
 export function resolveComposioCallbackBaseUrl(
   options: { clientOrigin?: string; request?: Request } = {}
 ): string {
+  const configured = resolveWebPublicUrl();
+  if (configured) {
+    return configured;
+  }
+
   const fromBrowser = resolveRequestClientOrigin(
     options.request,
     options.clientOrigin
   );
-  if (fromBrowser) {
+  if (fromBrowser && isValidBaseUrl(fromBrowser)) {
     return fromBrowser;
   }
 
   if (options.request) {
     const forwardedHost = options.request.headers.get("x-forwarded-host");
-    if (forwardedHost) {
-      const forwardedProto =
-        options.request.headers.get("x-forwarded-proto") ?? "http";
-      return `${forwardedProto}://${forwardedHost}`;
+    const forwardedProto =
+      options.request.headers.get("x-forwarded-proto") ?? "http";
+    const forwarded = forwardedHost
+      ? `${forwardedProto}://${forwardedHost}`
+      : null;
+
+    if (forwarded && isValidBaseUrl(forwarded)) {
+      return forwarded;
     }
 
     const url = new URL(options.request.url);
     return `${url.protocol}//${url.host}`;
-  }
-
-  const configured = resolveWebPublicUrl();
-  if (configured) {
-    return configured;
   }
 
   const webPort = process.env.NAKAMA_WEB_PORT?.trim() || "3003";


### PR DESCRIPTION
Closes #477.

`resolveComposioCallbackBaseUrl` read `clientOrigin`, `Origin`, `Referer` or `X-Forwarded-Host` first and only reached the configured public URL when there was no request at all. That base becomes the `redirect_uri` an OAuth code is delivered to, and all four inputs belong to the caller. Nothing validated them either, so a connect body carrying `callbackOrigin: "javascript:alert(1)"` went through as the base.

A configured `NAKAMA_WEB_PUBLIC_URL` (or the `~/.nakama` web public URL) now wins. Caller-supplied values still decide when nothing is configured, which is how a dev install on localhost keeps working, and they have to parse as an http or https URL to be used at all.

`resolveArtifactShareBaseUrl` loses its loopback fallback: it re-read the same configured URL that the shared resolver now returns first, so every branch of it had become unreachable.

Before, on `main`:

```
(fail) caller headers cannot move the callback off the configured URL
  Expected: "https://deployed.example.com"
  Received: "https://evil.example.com"

(fail) an unparseable clientOrigin does not become the callback base
  Expected: "http://127.0.0.1:4310"
  Received: "javascript:alert(1)"
```

After:

```
7 pass  0 fail
```

Not in this PR: #478 asks to raise `PUT /v1/system/web-public-url` from org admin to platform admin. That guard matches what PR #305 settled for every other workspace-global setting, and the reorder here removes the header path that made the knob interesting. Worth deciding across all of those routes at once rather than one of them.

Full suite: `bun run test`, exit 0, 2609 pass / 0 fail across 11 workspaces.
