### PR TITLE
fix(cli): restore stdin encoding when TerminalInput stops

### DIFF
--- a/apps/cli/src/terminal-input.test.ts
+++ b/apps/cli/src/terminal-input.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { TerminalInput } from "./terminal-input";
+
+type StdinStub = NodeJS.ReadStream & {
+  setRawMode: (mode: boolean) => NodeJS.ReadStream;
+};
+
+describe("TerminalInput encoding", () => {
+  const restores: Array<() => void> = [];
+
+  afterEach(() => {
+    for (const restore of restores.splice(0).reverse()) {
+      restore();
+    }
+  });
+
+  function stubStdio() {
+    const stdin = process.stdin as StdinStub;
+    const setEncoding = mock((_encoding?: BufferEncoding | null) => stdin);
+    const setRawMode = mock((_mode: boolean) => stdin);
+    const resume = mock(() => stdin);
+    const on = mock(() => stdin);
+    const off = mock(() => stdin);
+    const write = mock(() => true);
+
+    const originals = {
+      off: stdin.off,
+      on: stdin.on,
+      resume: stdin.resume,
+      setEncoding: stdin.setEncoding,
+      setRawMode: stdin.setRawMode,
+      write: process.stdout.write,
+    };
+
+    stdin.setEncoding = setEncoding as typeof stdin.setEncoding;
+    stdin.setRawMode = setRawMode as typeof stdin.setRawMode;
+    stdin.resume = resume as typeof stdin.resume;
+    stdin.on = on as typeof stdin.on;
+    stdin.off = off as typeof stdin.off;
+    process.stdout.write = write as typeof process.stdout.write;
+
+    restores.push(() => {
+      stdin.setEncoding = originals.setEncoding;
+      stdin.setRawMode = originals.setRawMode;
+      stdin.resume = originals.resume;
+      stdin.on = originals.on;
+      stdin.off = originals.off;
+      process.stdout.write = originals.write;
+    });
+
+    return setEncoding;
+  }
+
+  function stubReadableEncoding(value: BufferEncoding | null) {
+    const descriptor = Object.getOwnPropertyDescriptor(
+      process.stdin,
+      "readableEncoding"
+    );
+    Object.defineProperty(process.stdin, "readableEncoding", {
+      configurable: true,
+      get: () => value,
+    });
+    restores.push(() => {
+      if (descriptor) {
+        Object.defineProperty(process.stdin, "readableEncoding", descriptor);
+      } else {
+        Reflect.deleteProperty(process.stdin, "readableEncoding");
+      }
+    });
+  }
+
+  test("stop restores stdin encoding set before start", () => {
+    stubReadableEncoding("ascii");
+    const setEncoding = stubStdio();
+    const input = new TerminalInput();
+
+    input.start();
+    input.stop();
+
+    expect(setEncoding.mock.calls.map((call) => call[0])).toEqual([
+      "utf8",
+      "ascii",
+    ]);
+  });
+
+  test("stop restores null encoding when stdin had no encoding", () => {
+    stubReadableEncoding(null);
+    const setEncoding = stubStdio();
+    const input = new TerminalInput();
+
+    input.start();
+    input.stop();
+
+    expect(setEncoding.mock.calls.map((call) => call[0])).toEqual([
+      "utf8",
+      null,
+    ]);
+  });
+});

--- a/apps/cli/src/terminal-input.ts
+++ b/apps/cli/src/terminal-input.ts
@@ -73,6 +73,7 @@ export class TerminalInput {
   private active = false;
   private mouseTracking = false;
   private pending = "";
+  private previousEncoding: BufferEncoding | null = null;
   private listeners = new Set<(chunk: string) => void>();
   private cursorWaiters = new Set<(row: number) => void>();
 
@@ -82,6 +83,7 @@ export class TerminalInput {
     }
 
     this.active = true;
+    this.previousEncoding = process.stdin.readableEncoding;
     process.stdin.setEncoding("utf8");
     process.stdin.setRawMode(true);
     process.stdin.resume();
@@ -101,6 +103,9 @@ export class TerminalInput {
     this.active = false;
     process.stdin.off("data", this.handleData);
     process.stdin.setRawMode(false);
+    process.stdin.setEncoding(
+      this.previousEncoding as BufferEncoding | undefined
+    );
 
     if (this.mouseTracking) {
       process.stdout.write("\x1b[?1000l\x1b[?1006l");


### PR DESCRIPTION
## Summary

Leaving interactive chat restores stdin encoding so later readline/error fallbacks keep the prior encoding.

**Before:** `TerminalInput.stop()` (via `cleanupChat`) cleared raw mode/listeners but left `utf8` set.
**After:** `start()` saves `readableEncoding`; `stop()` restores it (including `null` Buffer mode).

Why safe:
1. Only touches encoding restore on the existing start/stop path
2. Preserves whatever encoding was active before chat (`ascii`, `null`, etc.)
3. Regression tests cover ascii and null restore

Only re-open if a TTY path still needs encoding after stop for a reason we missed.

## Test plan
- [x] `bun test apps/cli/src/terminal-input.test.ts apps/cli/src/terminal-screen.test.ts` (7 pass)
- [x] `bun run check -- apps/cli/src/terminal-input.ts apps/cli/src/terminal-input.test.ts`
- [ ] Exit CLI chat then trigger a readline/error fallback — encoding matches pre-chat

Closes #621
