### PR TITLE
fix(cli): bail early on oversized clipboard images

### DIFF
--- a/apps/cli/src/clipboard-image.test.ts
+++ b/apps/cli/src/clipboard-image.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, mock, test } from "bun:test";
+import { MAX_IMAGE_BYTES, type NakamaApiError } from "@nakama/core";
+
+const tinyPng = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+  "base64"
+);
+
+let hasImageResult = false;
+let imageBytes: Uint8Array | null = null;
+
+mock.module("@crosscopy/clipboard", () => ({
+  getImageBinary: async () => imageBytes,
+  hasImage: () => hasImageResult,
+}));
+
+const { readClipboardImage } = await import("./clipboard-image");
+
+describe("readClipboardImage", () => {
+  test("returns null when clipboard has no image", async () => {
+    hasImageResult = false;
+    imageBytes = null;
+
+    expect(await readClipboardImage()).toBeNull();
+  });
+
+  test("returns a validated attachment for a small clipboard image", async () => {
+    hasImageResult = true;
+    imageBytes = new Uint8Array(tinyPng);
+
+    expect(await readClipboardImage()).toEqual({
+      data: tinyPng.toString("base64"),
+      mediaType: "image/png",
+    });
+  });
+
+  test("rejects oversized clipboard bytes before base64 encoding", async () => {
+    hasImageResult = true;
+    imageBytes = new Uint8Array(MAX_IMAGE_BYTES + 1);
+
+    await expect(readClipboardImage()).rejects.toMatchObject({
+      message: `Each image must be at most ${MAX_IMAGE_BYTES / (1024 * 1024)} MB.`,
+      name: "NakamaApiError",
+      status: 400,
+    } satisfies Partial<NakamaApiError>);
+  });
+});

--- a/apps/cli/src/clipboard-image.ts
+++ b/apps/cli/src/clipboard-image.ts
@@ -1,5 +1,10 @@
 import { getImageBinary, hasImage } from "@crosscopy/clipboard";
-import { type ImageAttachment, validateImageAttachments } from "@nakama/core";
+import {
+  type ImageAttachment,
+  MAX_IMAGE_BYTES,
+  NakamaApiError,
+  validateImageAttachments,
+} from "@nakama/core";
 
 export async function readClipboardImage(): Promise<ImageAttachment | null> {
   if (!hasImage()) {
@@ -10,6 +15,13 @@ export async function readClipboardImage(): Promise<ImageAttachment | null> {
 
   if (!bytes?.length) {
     return null;
+  }
+
+  if (bytes.length > MAX_IMAGE_BYTES) {
+    throw new NakamaApiError(
+      `Each image must be at most ${MAX_IMAGE_BYTES / (1024 * 1024)} MB.`,
+      400
+    );
   }
 
   const attachment: ImageAttachment = {


### PR DESCRIPTION
## Summary

CLI clipboard paste rejects huge images before Base64 encoding — no more ~67 MB string spike.

**Before:** full clipboard bytes → Base64 → then `validateImageAttachments` rejects
**After:** `bytes.length > MAX_IMAGE_BYTES` throws the same `NakamaApiError` first

Why safe:
1. Same message/status as `validateImageAttachments` size path
2. Valid images still encode + validate as before
3. Only adds an early length check

Only re-add post-encode size validation alone if a path bypasses this bailout.

## Test plan
- [x] `bun test apps/cli/src/clipboard-image.test.ts` (3 pass)
- [x] `bun test apps/cli/src/image-input.test.ts packages/core/src/message-content.test.ts` (related; all pass)
- [x] `bun x ultracite check apps/cli/src/clipboard-image.ts apps/cli/src/clipboard-image.test.ts`
- [ ] `/paste` with a normal screenshot still attaches; oversized clipboard still shows "Each image must be at most 5 MB."

Closes #610
