### PR TITLE
fix(db): bump sessions.updated_at on replaceMessagesForSession

### DIFF
--- a/packages/db/sql/schema.sql
+++ b/packages/db/sql/schema.sql
@@ -44,6 +44,7 @@ CREATE TABLE IF NOT EXISTS sessions (
   channel TEXT NOT NULL,
   user_id TEXT,
   created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
   title TEXT,
   model TEXT,
   agent_todos TEXT DEFAULT '[]' NOT NULL,

--- a/packages/db/src/adapters/in-memory.ts
+++ b/packages/db/src/adapters/in-memory.ts
@@ -64,6 +64,7 @@ export function createInMemoryDatabaseAdapter(): DatabaseAdapter {
   const profileSkills = new Map<string, Set<string>>();
   const skillUsage = new Map<string, StoredSkillUsageRecord>();
   const sessions = new Map<string, StoredSessionRecord>();
+  const sessionUpdatedAt = new Map<string, string>();
   const sessionMessages = new Map<string, StoredSessionMessageRecord[]>();
   const attachments = new Map<string, StoredAttachmentRecord>();
   const usersById = new Map<string, StoredUserRecord>();
@@ -299,6 +300,7 @@ export function createInMemoryDatabaseAdapter(): DatabaseAdapter {
 
     async deleteSession(id) {
       sessionMessages.delete(id);
+      sessionUpdatedAt.delete(id);
       return sessions.delete(id);
     },
 
@@ -965,7 +967,11 @@ export function createInMemoryDatabaseAdapter(): DatabaseAdapter {
             session.profileId === profileId && session.channel === channel
         )
         .map((session) =>
-          summarizeSession(session, sessionMessages.get(session.id) ?? [])
+          summarizeSession(
+            session,
+            sessionMessages.get(session.id) ?? [],
+            sessionUpdatedAt.get(session.id)
+          )
         )
         .filter((summary) => summary.messageCount > 0)
         .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
@@ -1143,6 +1149,12 @@ export function createInMemoryDatabaseAdapter(): DatabaseAdapter {
 
     async replaceMessagesForSession(sessionId, messages) {
       sessionMessages.set(sessionId, [...messages]);
+      const updatedAt = messages.reduce(
+        (latest, message) =>
+          message.createdAt > latest ? message.createdAt : latest,
+        new Date().toISOString()
+      );
+      sessionUpdatedAt.set(sessionId, updatedAt);
     },
 
     async replaceProfileComposioToolkits(profileId, assignments) {
@@ -1483,6 +1495,9 @@ export function createInMemoryDatabaseAdapter(): DatabaseAdapter {
 
     async upsertSession(record) {
       sessions.set(record.id, record);
+      if (!sessionUpdatedAt.has(record.id)) {
+        sessionUpdatedAt.set(record.id, record.createdAt);
+      }
     },
 
     async upsertSkill(record) {
@@ -1527,13 +1542,22 @@ export function createInMemoryDatabaseAdapter(): DatabaseAdapter {
 
 function summarizeSession(
   session: StoredSessionRecord,
-  messages: StoredSessionMessageRecord[]
+  messages: StoredSessionMessageRecord[],
+  sessionUpdatedAt?: string
 ): StoredSessionSummaryRecord {
   const sorted = [...messages].sort((left, right) => left.seq - right.seq);
-  const updatedAt =
+  const fromMessages =
     sorted.length > 0
-      ? sorted[sorted.length - 1]!.createdAt
+      ? sorted.reduce(
+          (latest, message) =>
+            message.createdAt > latest ? message.createdAt : latest,
+          sorted[0]!.createdAt
+        )
       : session.createdAt;
+  const updatedAt =
+    sessionUpdatedAt && sessionUpdatedAt > fromMessages
+      ? sessionUpdatedAt
+      : fromMessages;
   const firstUser = sorted.find(
     (message) =>
       typeof message.payload === "object" &&

--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -107,6 +107,7 @@ interface SessionRow {
   model: string | null;
   profile_id: string;
   title: string | null;
+  updated_at?: string | null;
   user_id?: string | null;
 }
 
@@ -612,14 +613,17 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
   const listSessionsStmt = db.prepare("SELECT * FROM sessions");
   const getSessionStmt = db.prepare("SELECT * FROM sessions WHERE id = ?");
   const upsertSessionStmt = db.prepare(`
-    INSERT INTO sessions (id, profile_id, channel, created_at, user_id, model)
-    VALUES (?, ?, ?, ?, ?, ?)
+    INSERT INTO sessions (id, profile_id, channel, created_at, updated_at, user_id, model)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(id) DO UPDATE SET
       profile_id = excluded.profile_id,
       channel = excluded.channel,
       user_id = COALESCE(excluded.user_id, sessions.user_id),
       model = excluded.model
   `);
+  const updateSessionUpdatedAtStmt = db.prepare(
+    "UPDATE sessions SET updated_at = ? WHERE id = ?"
+  );
   const deleteSessionStmt = db.prepare("DELETE FROM sessions WHERE id = ?");
   const updateSessionModelStmt = db.prepare(
     "UPDATE sessions SET model = ? WHERE id = ?"
@@ -673,7 +677,10 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
       s.created_at,
       s.title,
       COUNT(m.id) AS message_count,
-      COALESCE(MAX(m.created_at), s.created_at) AS updated_at,
+      max(
+        COALESCE(MAX(m.created_at), s.created_at),
+        COALESCE(s.updated_at, s.created_at)
+      ) AS updated_at,
       (
         SELECT payload
         FROM session_messages
@@ -2588,17 +2595,29 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
     },
 
     async replaceMessagesForSession(sessionId, messages) {
-      deleteMessagesForSessionStmt.run(sessionId);
+      const updatedAt = messages.reduce(
+        (latest, message) =>
+          message.createdAt > latest ? message.createdAt : latest,
+        new Date().toISOString()
+      );
 
-      for (const message of messages) {
-        appendMessageStmt.run(
-          message.id,
-          sessionId,
-          message.seq,
-          JSON.stringify(message.payload),
-          message.createdAt
-        );
-      }
+      const replace = db.transaction(() => {
+        deleteMessagesForSessionStmt.run(sessionId);
+
+        for (const message of messages) {
+          appendMessageStmt.run(
+            message.id,
+            sessionId,
+            message.seq,
+            JSON.stringify(message.payload),
+            message.createdAt
+          );
+        }
+
+        updateSessionUpdatedAtStmt.run(updatedAt, sessionId);
+      });
+
+      replace();
     },
 
     async replaceProfileComposioToolkits(profileId, assignments) {
@@ -2916,6 +2935,7 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
         record.id,
         record.profileId,
         record.channel,
+        record.createdAt,
         record.createdAt,
         record.userId ?? null,
         record.model

--- a/packages/db/src/migrate.test.ts
+++ b/packages/db/src/migrate.test.ts
@@ -112,9 +112,9 @@ describe("legacy profile id migration", () => {
           ('profile_default', 'skill_test'),
           ('profile_super_bot', 'skill_test');
 
-        INSERT INTO sessions (id, profile_id, channel, created_at, title, agent_todos) VALUES
-          ('session_default', 'profile_default', 'cli', '2026-06-19T00:00:00.000Z', NULL, '[]'),
-          ('session_super', 'profile_super_bot', 'cli', '2026-06-19T00:00:00.000Z', NULL, '[]');
+        INSERT INTO sessions (id, profile_id, channel, created_at, updated_at, title, agent_todos) VALUES
+          ('session_default', 'profile_default', 'cli', '2026-06-19T00:00:00.000Z', '2026-06-19T00:00:00.000Z', NULL, '[]'),
+          ('session_super', 'profile_super_bot', 'cli', '2026-06-19T00:00:00.000Z', '2026-06-19T00:00:00.000Z', NULL, '[]');
 
         INSERT INTO tasks (
           id,
@@ -491,6 +491,7 @@ describe("chat session schema", () => {
         name: string;
       }>;
       expect(columns.some((column) => column.name === "model")).toBe(true);
+      expect(columns.some((column) => column.name === "updated_at")).toBe(true);
     } finally {
       db.close();
     }

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1130,6 +1130,24 @@ function migrateSessionsTable(db: Database): void {
       ALTER TABLE sessions ADD COLUMN user_id TEXT REFERENCES users (id) ON DELETE SET NULL;
     `);
   }
+
+  if (!columnNames.has("updated_at")) {
+    db.exec(`
+      ALTER TABLE sessions ADD COLUMN updated_at TEXT;
+    `);
+    db.exec(`
+      UPDATE sessions
+      SET updated_at = COALESCE(
+        (
+          SELECT MAX(created_at)
+          FROM session_messages
+          WHERE session_id = sessions.id
+        ),
+        created_at
+      )
+      WHERE updated_at IS NULL;
+    `);
+  }
 }
 
 function migrateWorkspaceSettingsTable(db: Database): void {

--- a/packages/db/src/replace-messages-updated-at.test.ts
+++ b/packages/db/src/replace-messages-updated-at.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import { createInMemoryDatabaseAdapter } from "./adapters/in-memory";
+import { createSqliteDatabase } from "./adapters/sqlite";
+import type { DatabaseAdapter } from "./types";
+
+async function seedSession(adapter: DatabaseAdapter): Promise<void> {
+  const now = "2020-01-01T00:00:00.000Z";
+  await adapter.upsertOrganization({
+    createdAt: now,
+    id: "org_test",
+    name: "Test",
+    slug: "test",
+    updatedAt: now,
+  });
+  await adapter.upsertProfile({
+    createdAt: now,
+    id: "profile_test",
+    isDefault: true,
+    isSuper: false,
+    model: "provider-1::profile-model",
+    name: "Test",
+    orgId: "org_test",
+    systemPrompt: "Test",
+    updatedAt: now,
+  });
+  await adapter.upsertSession({
+    agentQuestionnaire: null,
+    agentTodos: [],
+    channel: "web",
+    createdAt: now,
+    id: "session_test",
+    model: null,
+    profileId: "profile_test",
+    title: null,
+    userId: null,
+  });
+}
+
+describe("replaceMessagesForSession bumps session updatedAt", () => {
+  test("sqlite: summary updatedAt advances past stale message createdAt", async () => {
+    const database = await createSqliteDatabase(":memory:");
+    try {
+      await seedSession(database.adapter);
+      const stale = "2020-06-01T00:00:00.000Z";
+      const beforeReplace = new Date().toISOString();
+
+      await database.adapter.replaceMessagesForSession("session_test", [
+        {
+          createdAt: stale,
+          id: "msg_1",
+          payload: { content: "hello", role: "user" },
+          seq: 0,
+          sessionId: "session_test",
+        },
+      ]);
+
+      const summaries = await database.adapter.listSessionSummaries(
+        "profile_test",
+        "web"
+      );
+      expect(summaries).toHaveLength(1);
+      expect(summaries[0]!.updatedAt > stale).toBe(true);
+      expect(summaries[0]!.updatedAt >= beforeReplace).toBe(true);
+    } finally {
+      database.close();
+    }
+  });
+
+  test("in-memory: summary updatedAt advances past stale message createdAt", async () => {
+    const adapter = createInMemoryDatabaseAdapter();
+    await seedSession(adapter);
+    const stale = "2020-06-01T00:00:00.000Z";
+    const beforeReplace = new Date().toISOString();
+
+    await adapter.replaceMessagesForSession("session_test", [
+      {
+        createdAt: stale,
+        id: "msg_1",
+        payload: { content: "hello", role: "user" },
+        seq: 0,
+        sessionId: "session_test",
+      },
+    ]);
+
+    const summaries = await adapter.listSessionSummaries("profile_test", "web");
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]!.updatedAt > stale).toBe(true);
+    expect(summaries[0]!.updatedAt >= beforeReplace).toBe(true);
+  });
+
+  test("sqlite: append after replace does not regress summary updatedAt", async () => {
+    const database = await createSqliteDatabase(":memory:");
+    try {
+      await seedSession(database.adapter);
+      const stale = "2020-06-01T00:00:00.000Z";
+
+      await database.adapter.replaceMessagesForSession("session_test", [
+        {
+          createdAt: stale,
+          id: "msg_1",
+          payload: { content: "hello", role: "user" },
+          seq: 0,
+          sessionId: "session_test",
+        },
+      ]);
+
+      const afterReplace = (
+        await database.adapter.listSessionSummaries("profile_test", "web")
+      )[0]!.updatedAt;
+
+      await database.adapter.appendMessagesForSession("session_test", [
+        {
+          createdAt: stale,
+          id: "msg_2",
+          payload: { content: "again", role: "user" },
+          seq: 1,
+          sessionId: "session_test",
+        },
+      ]);
+
+      const afterAppend = (
+        await database.adapter.listSessionSummaries("profile_test", "web")
+      )[0]!.updatedAt;
+
+      expect(afterAppend).toBe(afterReplace);
+      expect(afterAppend > stale).toBe(true);
+    } finally {
+      database.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Replace/compaction of session messages advances the session-list timestamp even when message `createdAt` values stay stale — Fixes #606.

**Before:** Summaries used `MAX(m.created_at)` only, so `replaceMessagesForSession` with old message times left the sidebar stamp stuck.
**After:** `sessions.updated_at` (migrated + schema); replace bumps it to at least now inside one SQLite transaction; summaries take `max(message times, sessions.updated_at)`.

Why safe:
1. Migration backfills from existing message max / `created_at`
2. SQLite + in-memory stay aligned; append does not rewrite the column
3. Regression test covers stale replace and append-after-replace

Only re-check if a caller needs append itself to bump `sessions.updated_at` independently of message timestamps.

## Test plan
- [x] `bun test packages/db/src/replace-messages-updated-at.test.ts packages/db/src/migrate.test.ts packages/db/src/session-model.test.ts` (23 pass)
- [x] `bun test packages/db/src/` (81 pass)
- [ ] Compact or regenerate a chat whose message stamps stay old — sidebar “updated” moves to now
