### PR TITLE
fix(server): require channel on GET /v1/sessions

### DIFF
--- a/apps/server/src/http/app.test.ts
+++ b/apps/server/src/http/app.test.ts
@@ -910,6 +910,46 @@ describe("createHonoApp", () => {
     });
   });
 
+  test("GET /v1/sessions rejects missing or invalid channel", async () => {
+    const options = createServerOptions();
+    const app = createHonoApp(options);
+    const session = await setupFreshInstallSession(
+      app,
+      options.databaseAdapter
+    );
+    const listCalls: Array<{ channel: string; profileId: string }> = [];
+    const originalListSessions = options.agent.listSessions;
+    options.agent.listSessions = async (orgId, profileId, channel) => {
+      listCalls.push({ channel, profileId });
+      return originalListSessions(orgId, profileId, channel);
+    };
+
+    const missingChannel = await app.fetch(
+      new Request("http://localhost:4310/v1/sessions?profileId=default", {
+        headers: session.headers(),
+      })
+    );
+    expect(missingChannel.status).toBe(400);
+    await expect(missingChannel.json()).resolves.toMatchObject({
+      error: expect.any(String),
+    });
+
+    const invalidChannel = await app.fetch(
+      new Request(
+        "http://localhost:4310/v1/sessions?profileId=default&channel=not-a-channel",
+        {
+          headers: session.headers(),
+        }
+      )
+    );
+    expect(invalidChannel.status).toBe(400);
+    await expect(invalidChannel.json()).resolves.toMatchObject({
+      error: expect.any(String),
+    });
+
+    expect(listCalls).toEqual([]);
+  });
+
   const smokeRoutes = [
     {
       expected: { lines: ["last:50"], worker: "whatsapp" },

--- a/apps/server/src/http/routes/sessions.ts
+++ b/apps/server/src/http/routes/sessions.ts
@@ -398,7 +398,7 @@ export function registerSessionRoutes(
   app.get("/v1/sessions", async (c) => {
     const orgId = requireActiveOrgIdFromContext(c);
     const profileId = c.req.query("profileId")?.trim();
-    const channel = parseChannel(c.req.query("channel") ?? "web");
+    const channel = parseChannel(c.req.query("channel"));
 
     if (!profileId) {
       return errorResponse("profileId is required.", 400);

--- a/apps/server/src/tools/session-tools.ts
+++ b/apps/server/src/tools/session-tools.ts
@@ -6,7 +6,7 @@ import {
 } from "@nakama/core";
 import type { AgentService } from "../services/agent-service";
 
-/** Matches `GET /v1/sessions` — optional channel, default web. */
+/** Tool-side default when the model omits channel; HTTP list requires an explicit channel. */
 const DEFAULT_CHANNEL: AgentChannel = "web";
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 200;
@@ -75,7 +75,7 @@ export function createSessionTools(agent: AgentService): ToolDefinition[] {
         properties: {
           channel: {
             description:
-              "Which channel's sessions to list. Defaults to web, the same default the sessions API uses.",
+              "Which channel's sessions to list. Defaults to web when omitted.",
             enum: [...AGENT_CHANNELS],
             type: "string",
           },


### PR DESCRIPTION
## Summary

`GET /v1/sessions` without `channel` (or with a bad value) now returns 400 instead of silently listing `web` sessions.

**Before:** missing query used `?? "web"`, so `parseChannel` never ran and listing returned web sessions.
**After:** `parseChannel(c.req.query("channel"))` — absent/invalid → same 400 path as other bad channels.

Why safe:
1. Typed client already always sends `channel` (defaults to `"web"` client-side)
2. Valid `channel=web` path unchanged; existing create/list smoke test still passes
3. Tool `list_profile_sessions` still defaults to web locally; only HTTP list is stricter

Only re-add a server default if a raw HTTP client depends on omitted `channel` → web.

Fixes #553

## Test plan
- [x] `bun test apps/server/src/http/app.test.ts apps/server/src/app.test.ts apps/server/src/http/routes/sessions.org-scope.test.ts apps/server/src/http/routes/sessions.stream.test.ts apps/server/src/tools/session-tools.test.ts` (87 pass)
- [x] `bun x ultracite check` on touched files
- [ ] `GET /v1/sessions?profileId=<id>` without `channel` → 400; with `&channel=web` → 200
