### PR TITLE
chore(db): trim replace-messages updatedAt follow-up

### DIFF
--- a/packages/db/src/adapters/in-memory.ts
+++ b/packages/db/src/adapters/in-memory.ts
@@ -1549,11 +1549,7 @@ function summarizeSession(
   const sorted = [...messages].sort((left, right) => left.seq - right.seq);
   const fromMessages =
     sorted.length > 0
-      ? sorted.reduce(
-          (latest, message) =>
-            message.createdAt > latest ? message.createdAt : latest,
-          sorted[0]!.createdAt
-        )
+      ? sorted[sorted.length - 1]!.createdAt
       : session.createdAt;
   const updatedAt =
     sessionUpdatedAt && sessionUpdatedAt > fromMessages

--- a/packages/db/src/replace-messages-updated-at.test.ts
+++ b/packages/db/src/replace-messages-updated-at.test.ts
@@ -37,56 +37,38 @@ async function seedSession(adapter: DatabaseAdapter): Promise<void> {
 }
 
 describe("replaceMessagesForSession bumps session updatedAt", () => {
-  test("sqlite: summary updatedAt advances past stale message createdAt", async () => {
-    const database = await createSqliteDatabase(":memory:");
-    try {
-      await seedSession(database.adapter);
-      const stale = "2020-06-01T00:00:00.000Z";
-      const beforeReplace = new Date().toISOString();
+  for (const kind of ["sqlite", "in-memory"] as const) {
+    test(`${kind}: summary updatedAt advances past stale message createdAt`, async () => {
+      const database =
+        kind === "sqlite" ? await createSqliteDatabase(":memory:") : null;
+      const adapter = database?.adapter ?? createInMemoryDatabaseAdapter();
+      try {
+        await seedSession(adapter);
+        const stale = "2020-06-01T00:00:00.000Z";
+        const beforeReplace = new Date().toISOString();
 
-      await database.adapter.replaceMessagesForSession("session_test", [
-        {
-          createdAt: stale,
-          id: "msg_1",
-          payload: { content: "hello", role: "user" },
-          seq: 0,
-          sessionId: "session_test",
-        },
-      ]);
+        await adapter.replaceMessagesForSession("session_test", [
+          {
+            createdAt: stale,
+            id: "msg_1",
+            payload: { content: "hello", role: "user" },
+            seq: 0,
+            sessionId: "session_test",
+          },
+        ]);
 
-      const summaries = await database.adapter.listSessionSummaries(
-        "profile_test",
-        "web"
-      );
-      expect(summaries).toHaveLength(1);
-      expect(summaries[0]!.updatedAt > stale).toBe(true);
-      expect(summaries[0]!.updatedAt >= beforeReplace).toBe(true);
-    } finally {
-      database.close();
-    }
-  });
-
-  test("in-memory: summary updatedAt advances past stale message createdAt", async () => {
-    const adapter = createInMemoryDatabaseAdapter();
-    await seedSession(adapter);
-    const stale = "2020-06-01T00:00:00.000Z";
-    const beforeReplace = new Date().toISOString();
-
-    await adapter.replaceMessagesForSession("session_test", [
-      {
-        createdAt: stale,
-        id: "msg_1",
-        payload: { content: "hello", role: "user" },
-        seq: 0,
-        sessionId: "session_test",
-      },
-    ]);
-
-    const summaries = await adapter.listSessionSummaries("profile_test", "web");
-    expect(summaries).toHaveLength(1);
-    expect(summaries[0]!.updatedAt > stale).toBe(true);
-    expect(summaries[0]!.updatedAt >= beforeReplace).toBe(true);
-  });
+        const summaries = await adapter.listSessionSummaries(
+          "profile_test",
+          "web"
+        );
+        expect(summaries).toHaveLength(1);
+        expect(summaries[0]!.updatedAt > stale).toBe(true);
+        expect(summaries[0]!.updatedAt >= beforeReplace).toBe(true);
+      } finally {
+        database?.close();
+      }
+    });
+  }
 
   test("sqlite: append after replace does not regress summary updatedAt", async () => {
     const database = await createSqliteDatabase(":memory:");


### PR DESCRIPTION
## Summary

Ponytail follow-up to #675 — shorter in-memory summary path and one less duplicated regression test.

**Before:** in-memory walked every message for max `createdAt`; advance test body copied for sqlite + in-memory.
**After:** last-by-seq `createdAt` again (`sessionUpdatedAt` still wins on replace); one `for` loop covers both adapters.

Why safe:
1. Replace bump still comes from `sessionUpdatedAt` / `sessions.updated_at`
2. Same three assertions, same pass count
3. −22 lines, no behavior change for the #606 path

Only re-add a max-over-messages pass if in-memory must match SQL `MAX(m.created_at)` when seq and timestamps diverge without a replace.

## Test plan
- [x] `bun test packages/db/src/replace-messages-updated-at.test.ts` (3 pass)
- [ ] Edit/regenerate a chat session with stale message stamps — sidebar “updated” still moves to now

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
