### PR TITLE
fix(web): restore /automations scroll when expanded runs are tall

### DIFF
--- a/apps/web/src/pages/AutomationsPage.tsx
+++ b/apps/web/src/pages/AutomationsPage.tsx
@@ -1,6 +1,7 @@
 import { useSearchParams } from "react-router-dom";
 import { agentWorkTabFromSearchParams } from "@/lib/navigation";
 import { AutomationsDialogs } from "@/pages/automations/automations-dialogs";
+import { agentWorkPanelClassName } from "@/pages/automations/automations-page.shared";
 import { AutomationsPageLayout } from "@/pages/automations/automations-page-layout";
 import { useAutomationsPage } from "@/pages/automations/use-automations-page";
 import { TasksPage } from "@/pages/TasksPage";
@@ -15,7 +16,7 @@ export function AutomationsPage() {
       {activeTab === "automations" ? (
         <div
           aria-labelledby="agent-work-tab-automations"
-          className="min-h-0 flex-1"
+          className={agentWorkPanelClassName}
           id="agent-work-panel-automations"
           role="tabpanel"
         >
@@ -24,7 +25,7 @@ export function AutomationsPage() {
       ) : (
         <div
           aria-labelledby="agent-work-tab-tasks"
-          className="min-h-0 flex-1"
+          className={agentWorkPanelClassName}
           id="agent-work-panel-tasks"
           role="tabpanel"
         >

--- a/apps/web/src/pages/automations/automations-page.shared.test.ts
+++ b/apps/web/src/pages/automations/automations-page.shared.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { agentWorkPanelClassName } from "@/pages/automations/automations-page.shared";
+
+describe("agentWorkPanelClassName", () => {
+  test("keeps agent work tabpanels in the flex height chain so run history can scroll", () => {
+    const classes = agentWorkPanelClassName.split(/\s+/);
+
+    expect(classes).toContain("flex");
+    expect(classes).toContain("flex-col");
+    expect(classes).toContain("min-h-0");
+    expect(classes).toContain("flex-1");
+    expect(classes).toContain("overflow-hidden");
+  });
+});

--- a/apps/web/src/pages/automations/automations-page.shared.ts
+++ b/apps/web/src/pages/automations/automations-page.shared.ts
@@ -6,6 +6,15 @@ import type {
 
 export const sectionClass = "rounded-md border border-border bg-card";
 
+/**
+ * Agent work tabpanels sit under a flex column shell with overflow-hidden.
+ * They must themselves be flex columns with min-h-0 so children that use
+ * flex-1 + overflow-y-auto (run history, tasks board) stay viewport-bound
+ * when expanded run output grows tall.
+ */
+export const agentWorkPanelClassName =
+  "flex min-h-0 flex-1 flex-col overflow-hidden";
+
 export function formatTrigger(trigger: AutomationTrigger): string {
   if (trigger.type === "manual") {
     return "Manual trigger";


### PR DESCRIPTION
## Summary
- Agent work tabpanels under `/automations` were `min-h-0 flex-1` but not flex containers, so nested `flex-1` + `overflow-y-auto` never received a viewport-bounded height.
- When a run was expanded with long output, content grew past the `h-svh overflow-hidden` shell and could not scroll.
- Tabpanels now use `flex min-h-0 flex-1 flex-col overflow-hidden` so collapsed/expanded run history scrolls in the detail pane as intended.

## Test plan
- [ ] Open `/automations`, select an automation with a long run output
- [ ] Expand the run — confirm the detail pane scrolls and the page is not stuck
- [ ] Collapse the run — confirm layout still looks correct
- [ ] Switch to the Tasks tab and confirm the board still scrolls normally
- [x] `bun run check --` on touched files
- [x] `bun test apps/web/src/pages/automations/automations-page.shared.test.ts`
- [x] `bun run --filter @nakama/web build`

## Browser proof
Recorded against branch `fix/automations-expanded-run-scroll` on an isolated local stack (Playwright video).

1. Open `/automations`
2. Select automation with a long run output
3. Expand the run
4. Scroll through the expanded content

https://github.com/user-attachments/assets/b991dc1a-332d-4d8e-a0c4-2518e55f3a1a

Made with [Cursor](https://cursor.com)
