### PR TITLE
fix(bash): detect Cursor Agent streams structurally

### DIFF
--- a/apps/server/src/tools/cursor-agent-output.test.ts
+++ b/apps/server/src/tools/cursor-agent-output.test.ts
@@ -17,6 +17,77 @@ describe("cursor-agent-output", () => {
     expect(looksLikeCursorAgentStreamJson("plain text answer")).toBe(false);
   });
 
+  test("does not classify ordinary JSON with nested Cursor event names", () => {
+    const stdout = JSON.stringify({
+      metadata: { type: "assistant" },
+      name: "ordinary-command-output",
+      scripts: { type: "result" },
+      type: "module",
+    });
+
+    expect(looksLikeCursorAgentStreamJson(stdout)).toBe(false);
+    expect(formatCodingAgentBashStdout(stdout, { exitCode: 0 })).toBe(stdout);
+  });
+
+  test("does not classify ordinary NDJSON with a top-level result type", () => {
+    const stdout = [
+      JSON.stringify({ records: 37, status: "ok", type: "result" }),
+      JSON.stringify({ id: 123, type: "row", value: "preserve me" }),
+    ].join("\n");
+
+    expect(looksLikeCursorAgentStreamJson(stdout)).toBe(false);
+    expect(formatCodingAgentBashStdout(stdout, { exitCode: 0 })).toBe(stdout);
+  });
+
+  test("requires a complete init event before Cursor activity", () => {
+    const initEvent = {
+      cwd: "/tmp/repo",
+      model: "composer-2",
+      subtype: "init",
+      type: "system",
+    };
+    const activityEvent = { result: "done", type: "result" };
+
+    const invalidStreams = [
+      [activityEvent, initEvent],
+      [{ ...initEvent, model: undefined }, activityEvent],
+      [{ ...initEvent, cwd: undefined }, activityEvent],
+      [initEvent],
+    ];
+    for (const events of invalidStreams) {
+      const stdout = events.map((event) => JSON.stringify(event)).join("\n");
+      expect(looksLikeCursorAgentStreamJson(stdout)).toBe(false);
+    }
+  });
+
+  test("requires at least 80 percent parseable NDJSON lines", () => {
+    const initEvent = JSON.stringify({
+      cwd: "/tmp/repo",
+      model: "composer-2",
+      subtype: "init",
+      type: "system",
+    });
+    const resultEvent = JSON.stringify({
+      result: "done",
+      subtype: "success",
+      type: "result",
+    });
+    const validData = JSON.stringify({ status: "ordinary" });
+    const atThreshold = [
+      initEvent,
+      resultEvent,
+      validData,
+      validData,
+      "not-json",
+    ].join("\n");
+    const belowThreshold = [initEvent, resultEvent, validData, "not-json"].join(
+      "\n"
+    );
+
+    expect(looksLikeCursorAgentStreamJson(atThreshold)).toBe(true);
+    expect(looksLikeCursorAgentStreamJson(belowThreshold)).toBe(false);
+  });
+
   test("summarizes assistant text, tools, and result from the end of a long stream", () => {
     const noise = Array.from({ length: 200 }, (_, i) =>
       JSON.stringify({

--- a/apps/server/src/tools/cursor-agent-output.ts
+++ b/apps/server/src/tools/cursor-agent-output.ts
@@ -8,22 +8,59 @@
 const MAX_SUMMARY_CHARS = 24_000;
 const MAX_ASSISTANT_CHARS = 12_000;
 const MAX_TOOL_LINES = 40;
+const MIN_CURSOR_AGENT_JSON_LINE_RATIO = 0.8;
+const CURSOR_AGENT_ACTIVITY_TYPES = new Set([
+  "assistant",
+  "tool_call",
+  "result",
+]);
 
 export function looksLikeCursorAgentStreamJson(stdout: string): boolean {
-  const sample = stdout.slice(0, 4000);
-  if (!sample.includes('"type"')) {
+  const lines = stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0) {
     return false;
   }
 
+  let parsedLineCount = 0;
+  let firstParsedObject: Record<string, unknown> | null = null;
+  let hasActivityEvent = false;
+  for (const line of lines) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    parsedLineCount += 1;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      continue;
+    }
+
+    const event = parsed as Record<string, unknown>;
+    if (!firstParsedObject) {
+      firstParsedObject = event;
+      continue;
+    }
+
+    const type = event.type;
+    if (typeof type === "string" && CURSOR_AGENT_ACTIVITY_TYPES.has(type)) {
+      hasActivityEvent = true;
+    }
+  }
+
+  const hasInitEvent =
+    firstParsedObject?.type === "system" &&
+    firstParsedObject.subtype === "init" &&
+    typeof firstParsedObject.model === "string" &&
+    typeof firstParsedObject.cwd === "string";
   return (
-    sample.includes('"type":"system"') ||
-    sample.includes('"type": "system"') ||
-    sample.includes('"type":"assistant"') ||
-    sample.includes('"type": "assistant"') ||
-    sample.includes('"type":"tool_call"') ||
-    sample.includes('"type": "tool_call"') ||
-    sample.includes('"type":"result"') ||
-    sample.includes('"type": "result"')
+    hasInitEvent &&
+    hasActivityEvent &&
+    parsedLineCount / lines.length >= MIN_CURSOR_AGENT_JSON_LINE_RATIO
   );
 }
 


### PR DESCRIPTION
## Summary

Coding-agent bash runs preserve ordinary JSON while continuing to summarize real Cursor `stream-json` output.

**Before:** Any JSON containing a recognized `"type"` substring could be mislabeled as Cursor output and discarded.
**After:** Detection requires Cursor's documented init event, a later activity event, and at least 80% parseable NDJSON lines.

Why safe:
1. The `system/init` anchor requires string `model` and `cwd` fields.
2. Uncertain streams fall back to the existing raw tail-capped output.
3. Regression tests cover JSON collisions, malformed streams, the ratio boundary, and valid Cursor streams.

Only follow up if ordinary output is found that reproduces Cursor's complete init-first stream structure.

Closes #524

## Test plan
- [x] `bun test apps/server/src/tools/cursor-agent-output.test.ts` (8 pass); Podman/Linux cursor + bash suites (19 pass); server production build and Ultracite check (pass)
- [ ] Run a coding-agent bash command that prints ordinary JSON — output remains unchanged
