### PR TITLE
feat(web): move Organization to its own sidebar page

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -36,6 +36,10 @@ const NotificationsPage = lazyPage(
   () => import("@/pages/NotificationsPage"),
   "NotificationsPage"
 );
+const OrganizationPage = lazyPage(
+  () => import("@/pages/OrganizationPage"),
+  "OrganizationPage"
+);
 const ProfilesPage = lazyPage(
   () => import("@/pages/ProfilesPage"),
   "ProfilesPage"
@@ -139,6 +143,7 @@ function AppShell() {
                     path="/tasks"
                   />
                   <Route element={<IntegrationsPage />} path="/integrations" />
+                  <Route element={<OrganizationPage />} path="/organization" />
                   <Route
                     element={<NotificationsPage />}
                     path="/notifications"

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -143,7 +143,12 @@ function AppShell() {
                     path="/tasks"
                   />
                   <Route element={<IntegrationsPage />} path="/integrations" />
-                  <Route element={<OrganizationPage />} path="/organization" />
+                  <Route element={<PlatformAdminGuard allowOrgAdmin />}>
+                    <Route
+                      element={<OrganizationPage />}
+                      path="/organization"
+                    />
+                  </Route>
                   <Route
                     element={<NotificationsPage />}
                     path="/notifications"

--- a/apps/web/src/hooks/use-notifications.ts
+++ b/apps/web/src/hooks/use-notifications.ts
@@ -3,11 +3,7 @@ import { useAuth } from "@/context/use-auth";
 import { useAutomationsQuery } from "@/hooks/use-automations";
 import { useOrgMemoryProposals } from "@/hooks/use-org-memory-proposals";
 import { useSkillProposals } from "@/hooks/use-skill-proposals";
-import {
-  orgMemoryProposalsPath,
-  orgSkillProposalsPath,
-  PAGE_PATHS,
-} from "@/lib/navigation";
+import { orgSkillProposalsPath, PAGE_PATHS } from "@/lib/navigation";
 
 export type NotificationKind =
   | "automation-run"
@@ -85,7 +81,7 @@ export function useNotifications(): {
           count: 1,
           createdAt: proposal.createdAt,
           description: proposal.bullet,
-          href: orgMemoryProposalsPath(),
+          href: `${PAGE_PATHS.organization}?orgMemory=proposals`,
           id: `org-memory-${proposal.id}`,
           kind: "org-memory-proposal",
           kindLabel: "Org memory",

--- a/apps/web/src/hooks/use-notifications.ts
+++ b/apps/web/src/hooks/use-notifications.ts
@@ -3,7 +3,11 @@ import { useAuth } from "@/context/use-auth";
 import { useAutomationsQuery } from "@/hooks/use-automations";
 import { useOrgMemoryProposals } from "@/hooks/use-org-memory-proposals";
 import { useSkillProposals } from "@/hooks/use-skill-proposals";
-import { orgSkillProposalsPath, PAGE_PATHS } from "@/lib/navigation";
+import {
+  orgMemoryProposalsPath,
+  orgSkillProposalsPath,
+  PAGE_PATHS,
+} from "@/lib/navigation";
 
 export type NotificationKind =
   | "automation-run"
@@ -81,7 +85,7 @@ export function useNotifications(): {
           count: 1,
           createdAt: proposal.createdAt,
           description: proposal.bullet,
-          href: `${PAGE_PATHS.soul}?tab=organization&orgMemory=proposals`,
+          href: orgMemoryProposalsPath(),
           id: `org-memory-${proposal.id}`,
           kind: "org-memory-proposal",
           kindLabel: "Org memory",

--- a/apps/web/src/lib/navigation.test.ts
+++ b/apps/web/src/lib/navigation.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 import {
   agentWorkTabFromSearchParams,
   agentWorkTabPath,
+  orgMemoryProposalsPath,
+  orgSkillProposalsPath,
   pageIdFromPath,
   visibleNavGroups,
 } from "./navigation";
@@ -20,30 +22,34 @@ describe("visibleNavGroups", () => {
       "files",
       "history",
       "integrations",
+      "organization",
       "profiles",
       "settings",
       "soul",
     ]);
   });
 
-  test("an org admin gets System and Profiles but not platform-admin pages", () => {
+  test("an org admin gets System, Organization, and Profiles but not platform-admin pages", () => {
     // `soul` is in PLATFORM_ADMIN_PAGE_IDS yet reachable by an org admin: the
     // canAccessSystemPage branch runs before the platform-admin check.
     const ids = pageIdsFor(false, "admin");
     expect(ids).toContain("soul");
+    expect(ids).toContain("organization");
     expect(ids).toContain("profiles");
     expect(ids).toContain("integrations");
     expect(ids).not.toContain("files");
   });
 
-  test("a member loses System, a viewer also loses Integrations", () => {
+  test("a member loses System and Organization, a viewer also loses Integrations", () => {
     const member = pageIdsFor(false, "member");
     expect(member).toContain("integrations");
     expect(member).not.toContain("soul");
+    expect(member).not.toContain("organization");
 
     const viewer = pageIdsFor(false, "viewer");
     expect(viewer).not.toContain("integrations");
     expect(viewer).not.toContain("soul");
+    expect(viewer).not.toContain("organization");
   });
 
   test("groups left with no reachable item are dropped", () => {
@@ -81,5 +87,18 @@ describe("agent work navigation", () => {
   test("maps the legacy tasks path to the unified page", () => {
     expect(pageIdFromPath("/tasks")).toBe("automations");
     expect(pageIdFromPath("/automations")).toBe("automations");
+  });
+});
+
+describe("organization navigation", () => {
+  test("maps the organization path", () => {
+    expect(pageIdFromPath("/organization")).toBe("organization");
+  });
+
+  test("builds proposal deep links on the organization page", () => {
+    expect(orgMemoryProposalsPath()).toBe("/organization?orgMemory=proposals");
+    expect(orgSkillProposalsPath("p1")).toBe(
+      "/organization?skillProposals=proposals&profileId=p1"
+    );
   });
 });

--- a/apps/web/src/lib/navigation.test.ts
+++ b/apps/web/src/lib/navigation.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test";
 import {
   agentWorkTabFromSearchParams,
   agentWorkTabPath,
-  orgMemoryProposalsPath,
   orgSkillProposalsPath,
   pageIdFromPath,
   visibleNavGroups,
@@ -95,8 +94,7 @@ describe("organization navigation", () => {
     expect(pageIdFromPath("/organization")).toBe("organization");
   });
 
-  test("builds proposal deep links on the organization page", () => {
-    expect(orgMemoryProposalsPath()).toBe("/organization?orgMemory=proposals");
+  test("builds skill proposal deep links on the organization page", () => {
     expect(orgSkillProposalsPath("p1")).toBe(
       "/organization?skillProposals=proposals&profileId=p1"
     );

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -1,5 +1,6 @@
 import {
   Brain03Icon,
+  Building03Icon,
   Chat01Icon,
   Folder01Icon,
   Notification01Icon,
@@ -21,6 +22,7 @@ export type PageId =
   | "automations"
   | "tasks"
   | "integrations"
+  | "organization"
   | "settings"
   | "notifications";
 
@@ -85,6 +87,12 @@ export const NAV_GROUPS: NavGroup[] = [
   {
     id: "system",
     items: [
+      navItem(
+        "organization",
+        "Organization",
+        "Members, memory, and org settings",
+        Building03Icon
+      ),
       navItem(
         "integrations",
         "Integrations",
@@ -170,7 +178,11 @@ export function visibleNavGroups(access: {
 
   for (const group of NAV_GROUPS) {
     const items = group.items.filter((item) => {
-      if (item.id === "soul" || item.id === "profiles") {
+      if (
+        item.id === "soul" ||
+        item.id === "profiles" ||
+        item.id === "organization"
+      ) {
         return canAccessSystemPage(access.isPlatformAdmin, access.orgRole);
       }
 
@@ -256,12 +268,15 @@ export const toolPlaygroundBackTarget = (
 export function orgSkillProposalsPath(profileId?: string): string {
   const params = new URLSearchParams({
     skillProposals: "proposals",
-    tab: "organization",
   });
   if (profileId) {
     params.set("profileId", profileId);
   }
-  return `${PAGE_PATHS.soul}?${params.toString()}`;
+  return `${PAGE_PATHS.organization}?${params.toString()}`;
+}
+
+export function orgMemoryProposalsPath(): string {
+  return queryPath(PAGE_PATHS.organization, { orgMemory: "proposals" });
 }
 
 export const PAGE_PATHS: Record<PageId, string> = {
@@ -271,6 +286,7 @@ export const PAGE_PATHS: Record<PageId, string> = {
   history: "/history",
   integrations: "/integrations",
   notifications: "/notifications",
+  organization: "/organization",
   profiles: "/profiles",
   settings: "/settings",
   soul: "/system",

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -275,10 +275,6 @@ export function orgSkillProposalsPath(profileId?: string): string {
   return `${PAGE_PATHS.organization}?${params.toString()}`;
 }
 
-export function orgMemoryProposalsPath(): string {
-  return queryPath(PAGE_PATHS.organization, { orgMemory: "proposals" });
-}
-
 export const PAGE_PATHS: Record<PageId, string> = {
   automations: "/automations",
   chat: "/chat",

--- a/apps/web/src/pages/OrganizationPage.tsx
+++ b/apps/web/src/pages/OrganizationPage.tsx
@@ -1,0 +1,31 @@
+import { Navigate } from "react-router-dom";
+import { OrganizationPanel } from "@/components/system/OrganizationPanel";
+import { Spinner } from "@/components/ui/spinner";
+import { useAuth } from "@/context/use-auth";
+import { canAccessSystemPage } from "@/lib/navigation";
+
+export function OrganizationPage() {
+  const { user, activeOrg, isLoading } = useAuth();
+  const canAccess = canAccessSystemPage(
+    user?.isPlatformAdmin === true,
+    activeOrg?.role
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-64 items-center justify-center text-muted-foreground text-sm">
+        <Spinner className="size-5" />
+      </div>
+    );
+  }
+
+  if (!canAccess) {
+    return <Navigate replace to="/chat" />;
+  }
+
+  return (
+    <section className="overflow-hidden rounded-md border border-border bg-card">
+      <OrganizationPanel />
+    </section>
+  );
+}

--- a/apps/web/src/pages/OrganizationPage.tsx
+++ b/apps/web/src/pages/OrganizationPage.tsx
@@ -1,28 +1,6 @@
-import { Navigate } from "react-router-dom";
 import { OrganizationPanel } from "@/components/system/OrganizationPanel";
-import { Spinner } from "@/components/ui/spinner";
-import { useAuth } from "@/context/use-auth";
-import { canAccessSystemPage } from "@/lib/navigation";
 
 export function OrganizationPage() {
-  const { user, activeOrg, isLoading } = useAuth();
-  const canAccess = canAccessSystemPage(
-    user?.isPlatformAdmin === true,
-    activeOrg?.role
-  );
-
-  if (isLoading) {
-    return (
-      <div className="flex min-h-64 items-center justify-center text-muted-foreground text-sm">
-        <Spinner className="size-5" />
-      </div>
-    );
-  }
-
-  if (!canAccess) {
-    return <Navigate replace to="/chat" />;
-  }
-
   return (
     <section className="overflow-hidden rounded-md border border-border bg-card">
       <OrganizationPanel />

--- a/apps/web/src/pages/SystemPage.test.ts
+++ b/apps/web/src/pages/SystemPage.test.ts
@@ -5,13 +5,11 @@ describe("SystemPage tab access", () => {
   test("shows status to all system users and MCP only to platform admins", () => {
     expect(visibleSystemTabs(true).map((tab) => tab.id)).toEqual([
       "status",
-      "organization",
       "tools",
       "mcp",
     ]);
     expect(visibleSystemTabs(false).map((tab) => tab.id)).toEqual([
       "status",
-      "organization",
       "tools",
     ]);
   });
@@ -19,8 +17,8 @@ describe("SystemPage tab access", () => {
   test("resolves status for all system users and forces non-platform users off admin tabs", () => {
     expect(resolveSystemTab("status", true)).toBe("status");
     expect(resolveSystemTab("status", false)).toBe("status");
-    expect(resolveSystemTab("organization", true)).toBe("organization");
-    expect(resolveSystemTab("organization", false)).toBe("organization");
+    expect(resolveSystemTab("organization", true)).toBe("tools");
+    expect(resolveSystemTab("organization", false)).toBe("tools");
     expect(resolveSystemTab("mcp", true)).toBe("mcp");
     expect(resolveSystemTab("mcp", false)).toBe("tools");
     expect(resolveSystemTab("data", true)).toBe("tools");

--- a/apps/web/src/pages/SystemPage.tsx
+++ b/apps/web/src/pages/SystemPage.tsx
@@ -55,7 +55,6 @@ export function SystemPage() {
     return <Navigate replace to="/chat" />;
   }
 
-  // Legacy deep links: /system?tab=organization → /organization
   if (searchParams.get("tab") === "organization") {
     const next = new URLSearchParams(searchParams);
     next.delete("tab");

--- a/apps/web/src/pages/SystemPage.tsx
+++ b/apps/web/src/pages/SystemPage.tsx
@@ -3,10 +3,9 @@ import { createPortal } from "react-dom";
 import { Navigate, useSearchParams } from "react-router-dom";
 import { McpTab } from "@/components/soul-tools/McpTab";
 import { ToolsTab } from "@/components/soul-tools/ToolsTab";
-import { OrganizationPanel } from "@/components/system/OrganizationPanel";
 import { Spinner } from "@/components/ui/spinner";
 import { useAuth } from "@/context/use-auth";
-import { canAccessSystemPage } from "@/lib/navigation";
+import { canAccessSystemPage, PAGE_PATHS } from "@/lib/navigation";
 import { cn } from "@/lib/utils";
 import { StatusPage } from "@/pages/StatusPage";
 import {
@@ -21,8 +20,6 @@ export function SystemPage() {
   const isPlatformAdmin = user?.isPlatformAdmin === true;
   const canAccess = canAccessSystemPage(isPlatformAdmin, activeOrg?.role);
   const [searchParams, setSearchParams] = useSearchParams();
-  const tab = resolveSystemTab(searchParams.get("tab"), isPlatformAdmin);
-  const visibleTabs = visibleSystemTabs(isPlatformAdmin);
   const pageHeaderActions =
     typeof document === "undefined"
       ? null
@@ -58,6 +55,22 @@ export function SystemPage() {
     return <Navigate replace to="/chat" />;
   }
 
+  // Legacy deep links: /system?tab=organization → /organization
+  if (searchParams.get("tab") === "organization") {
+    const next = new URLSearchParams(searchParams);
+    next.delete("tab");
+    const qs = next.toString();
+    return (
+      <Navigate
+        replace
+        to={qs ? `${PAGE_PATHS.organization}?${qs}` : PAGE_PATHS.organization}
+      />
+    );
+  }
+
+  const tab = resolveSystemTab(searchParams.get("tab"), isPlatformAdmin);
+  const visibleTabs = visibleSystemTabs(isPlatformAdmin);
+
   return (
     <>
       {pageHeaderActions
@@ -90,8 +103,6 @@ export function SystemPage() {
         >
           {tab === "status" ? (
             <StatusPage embedded />
-          ) : tab === "organization" ? (
-            <OrganizationPanel />
           ) : tab === "tools" ? (
             <ToolsTab embedded />
           ) : (

--- a/apps/web/src/pages/system-page.shared.ts
+++ b/apps/web/src/pages/system-page.shared.ts
@@ -1,5 +1,4 @@
 import {
-  Building03Icon,
   DashboardSquare01Icon,
   LayoutGridIcon,
   Plug01Icon,
@@ -7,7 +6,6 @@ import {
 
 export const SYSTEM_TABS = [
   { icon: DashboardSquare01Icon, id: "status" as const, label: "Status" },
-  { icon: Building03Icon, id: "organization" as const, label: "Organization" },
   { icon: LayoutGridIcon, id: "tools" as const, label: "Tools" },
   { icon: Plug01Icon, id: "mcp" as const, label: "MCP" },
 ] as const;
@@ -20,10 +18,6 @@ export function resolveSystemTab(
 ): SystemTabId {
   if (value === "status") {
     return "status";
-  }
-
-  if (value === "organization") {
-    return "organization";
   }
 
   if (!isPlatformAdmin) {
@@ -43,7 +37,6 @@ export function visibleSystemTabs(isPlatformAdmin: boolean) {
   }
 
   return SYSTEM_TABS.filter(
-    (item) =>
-      item.id === "status" || item.id === "organization" || item.id === "tools"
+    (item) => item.id === "status" || item.id === "tools"
   );
 }

--- a/docs/website/scripts/capture-self-improving-skills-screenshots.sh
+++ b/docs/website/scripts/capture-self-improving-skills-screenshots.sh
@@ -107,7 +107,7 @@ scroll_to_skill_card() {
 
 open_org_page() {
   local query="$1"
-  $AB --session "$SESSION" open "${BASE_URL}/system?tab=organization${query}"
+  $AB --session "$SESSION" open "${BASE_URL}/organization${query}"
   $AB --session "$SESSION" wait 2500
   scroll_to_skill_card
 }
@@ -117,7 +117,7 @@ open_org_page ""
 $AB --session "$SESSION" screenshot "$SCREENSHOT_DIR/skill-write-approval-gate.png"
 
 # Proposals tab with pending deploy-checklist row
-open_org_page "&skillProposals=proposals"
+open_org_page "?skillProposals=proposals"
 $AB --session "$SESSION" screenshot "$SCREENSHOT_DIR/skill-write-approval-proposals.png"
 
 # Review dialog for the seeded proposal


### PR DESCRIPTION
## Summary

Org admins open **Organization** from the sidebar at `/organization` — members, memory, and skill gates are no longer a System tab.

**Before:** buried under `/system?tab=organization`
![Before: Organization as a System tab](https://github.com/user-attachments/assets/4bd19109-d83d-41b0-a337-4fc08e5b5dce)

**After:** sidebar item → `/organization` (legacy tab URL still redirects)
![After: Organization as its own sidebar page](https://github.com/user-attachments/assets/3d7a5a7f-d1a9-4282-92f2-560e299e44c1)

Why safe:
1. Same `canAccessSystemPage` gate (platform admin or org admin)
2. Proposal / notification deep links retargeted; old `?tab=organization` redirects with query params kept
3. System tabs shrink to Status / Tools / MCP only

Only follow up if any external bookmark still assumes Organization lives inside System tabs and skips the redirect.

## Test plan
- [x] `bun test apps/web/src/pages/SystemPage.test.ts apps/web/src/lib/navigation.test.ts` (12 pass)
- [x] Before/after UI screenshots attached (main vs this branch)
- [ ] Open sidebar → Organization → confirm members/memory cards; hit `/system?tab=organization&orgMemory=proposals` and confirm redirect to `/organization?orgMemory=proposals`
