### PR TITLE
fix(web): let markdown artifact preview fill the panel width

### DIFF
--- a/apps/web/src/components/chat/artifact-attachment-panel-body.shared.test.ts
+++ b/apps/web/src/components/chat/artifact-attachment-panel-body.shared.test.ts
@@ -100,4 +100,15 @@ describe("artifact panel body class", () => {
       })
     ).toBe("flex flex-col overflow-hidden p-0");
   });
+
+  test("markdown preview uses the full panel width", () => {
+    expect(
+      artifactPanelBodyClassName({
+        isHtml: false,
+        isImage: false,
+        isMarkdown: true,
+        previewMode: "preview",
+      })
+    ).toBe("artifact-preview-panel");
+  });
 });

--- a/apps/web/src/components/chat/artifact-attachment-panel-body.shared.ts
+++ b/apps/web/src/components/chat/artifact-attachment-panel-body.shared.ts
@@ -147,6 +147,8 @@ export function artifactPanelBodyClassName({
   if (!isMarkdown || previewMode === "source") {
     return "flex flex-col overflow-hidden p-0";
   }
+
+  return "artifact-preview-panel";
 }
 
 export function artifactPanelSubtitle({

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -668,7 +668,8 @@
     letter-spacing: 0.01em;
   }
 
-  .artifact-share-page .chat-markdown {
+  .artifact-share-page .chat-markdown,
+  .artifact-preview-panel .chat-markdown {
     max-width: none;
   }
 


### PR DESCRIPTION
## Summary

Open a markdown artifact → preview body uses the full panel width.

**Before:** `.chat-markdown` stayed capped at `68ch` (~601px in a 768px panel), leaving a right gutter.
**After:** artifact preview panels add `artifact-preview-panel` and lift that cap (`max-width: none`, ~735px).

Why safe:
1. Chat message markdown still uses `68ch`
2. Same pattern as the public share page (`.artifact-share-page`)
3. Source toggle / HTML / spreadsheet body classes unchanged

Only revisit if a reviewer wants reading-measure back inside wide panels.

## Screenshots

| Before | After |
| --- | --- |
| ![Before: 68ch gutter](https://github.com/user-attachments/assets/7f6c1530-d14a-4781-bd98-41f0101bc5d4) | ![After: full panel width](https://github.com/user-attachments/assets/a36add89-12cf-4f9f-9e26-5afa38b77649) |

Measured in the shots: markdown box `600.6px` → `735px` (panel `767px`).

## Test plan
- [x] `bun test apps/web/src/components/chat/artifact-attachment-panel-body.shared.test.ts` (6 pass)
- [x] Browser before/after on `/files` preview (computed `max-width` `68ch` → `none`)
- [ ] Open a `.md` artifact in Files, widen the panel — body should track the panel edge
