### PR TITLE
fix(providers): reject malformed API keys on create/update

### DIFF
--- a/apps/server/src/http/routes/models.ts
+++ b/apps/server/src/http/routes/models.ts
@@ -1220,18 +1220,38 @@ export function registerModelRoutes(
   app.post("/v1/providers", async (c) => {
     requireOrgAdminOrPlatformAdminFromContext(c);
     const body = await readJson<CreateProviderRequest>(c.req.raw);
-    return json<CreateProviderResponse>(await agent.createProvider(body));
+
+    try {
+      return json<CreateProviderResponse>(await agent.createProvider(body));
+    } catch (error) {
+      if (error instanceof NakamaApiError) {
+        return errorResponse(error.message, error.status);
+      }
+
+      const message = error instanceof Error ? error.message : String(error);
+      return errorResponse(message, 400);
+    }
   });
 
   app.patch("/v1/providers/:providerId", async (c) => {
     requireOrgAdminOrPlatformAdminFromContext(c);
     const body = await readJson<UpdateProviderRequest>(c.req.raw);
-    return json<UpdateProviderResponse>(
-      await agent.updateProvider(
-        decodeURIComponent(c.req.param("providerId")),
-        body
-      )
-    );
+
+    try {
+      return json<UpdateProviderResponse>(
+        await agent.updateProvider(
+          decodeURIComponent(c.req.param("providerId")),
+          body
+        )
+      );
+    } catch (error) {
+      if (error instanceof NakamaApiError) {
+        return errorResponse(error.message, error.status);
+      }
+
+      const message = error instanceof Error ? error.message : String(error);
+      return errorResponse(message, 400);
+    }
   });
 
   app.delete("/v1/providers/:providerId", async (c) => {

--- a/apps/server/src/services/provider-instance-helpers.test.ts
+++ b/apps/server/src/services/provider-instance-helpers.test.ts
@@ -208,18 +208,6 @@ describe("resolveProfileProviderSelection", () => {
 });
 
 describe("applyProviderInstanceUpdate", () => {
-  test("rejects an obviously malformed API key on update", () => {
-    const current: ProviderInstance = createProviderInstance({
-      id: "openai-1",
-      label: "OpenAI",
-      type: "openai",
-    });
-
-    expect(() =>
-      applyProviderInstanceUpdate(current, { apiKey: "sk-junk-qa-123" })
-    ).toThrow(/valid OpenAI API key/i);
-  });
-
   test("stores wireApi only for a recognised value on a compatible instance", () => {
     const instance = createProviderInstance({
       baseUrl: "https://endpoint.test/v1",
@@ -408,32 +396,5 @@ describe("buildProviderInstanceFromCreateRequest", () => {
         []
       )
     ).toThrow(/valid OpenAI API key/i);
-  });
-
-  test("rejects a key with the wrong provider prefix", () => {
-    expect(() =>
-      buildProviderInstanceFromCreateRequest(
-        { apiKey: `sk-${"a".repeat(48)}`, type: "anthropic" },
-        []
-      )
-    ).toThrow(/valid Anthropic API key/i);
-  });
-
-  test("accepts a well-formed API key for its provider", () => {
-    const instance = buildProviderInstanceFromCreateRequest(
-      { apiKey: `sk-${"a".repeat(48)}`, type: "openai" },
-      []
-    );
-
-    expect(instance.apiKey).toBe(`sk-${"a".repeat(48)}`);
-  });
-
-  test("does not format-check providers with opaque/self-hosted key formats", () => {
-    const instance = buildProviderInstanceFromCreateRequest(
-      { apiKey: "short", hostMode: "cloud", model: "llama3", type: "ollama" },
-      []
-    );
-
-    expect(instance.apiKey).toBe("short");
   });
 });

--- a/apps/server/src/services/provider-instance-helpers.test.ts
+++ b/apps/server/src/services/provider-instance-helpers.test.ts
@@ -208,6 +208,18 @@ describe("resolveProfileProviderSelection", () => {
 });
 
 describe("applyProviderInstanceUpdate", () => {
+  test("rejects an obviously malformed API key on update", () => {
+    const current: ProviderInstance = createProviderInstance({
+      id: "openai-1",
+      label: "OpenAI",
+      type: "openai",
+    });
+
+    expect(() =>
+      applyProviderInstanceUpdate(current, { apiKey: "sk-junk-qa-123" })
+    ).toThrow(/valid OpenAI API key/i);
+  });
+
   test("stores wireApi only for a recognised value on a compatible instance", () => {
     const instance = createProviderInstance({
       baseUrl: "https://endpoint.test/v1",
@@ -387,5 +399,41 @@ describe("buildProviderInstanceFromCreateRequest", () => {
         expect((error as NakamaApiError).status).toBe(400);
       }
     }
+  });
+
+  test("rejects an obviously malformed OpenAI API key instead of persisting it", () => {
+    expect(() =>
+      buildProviderInstanceFromCreateRequest(
+        { apiKey: "sk-junk-qa-123", model: "gpt-junk", type: "openai" },
+        []
+      )
+    ).toThrow(/valid OpenAI API key/i);
+  });
+
+  test("rejects a key with the wrong provider prefix", () => {
+    expect(() =>
+      buildProviderInstanceFromCreateRequest(
+        { apiKey: `sk-${"a".repeat(48)}`, type: "anthropic" },
+        []
+      )
+    ).toThrow(/valid Anthropic API key/i);
+  });
+
+  test("accepts a well-formed API key for its provider", () => {
+    const instance = buildProviderInstanceFromCreateRequest(
+      { apiKey: `sk-${"a".repeat(48)}`, type: "openai" },
+      []
+    );
+
+    expect(instance.apiKey).toBe(`sk-${"a".repeat(48)}`);
+  });
+
+  test("does not format-check providers with opaque/self-hosted key formats", () => {
+    const instance = buildProviderInstanceFromCreateRequest(
+      { apiKey: "short", hostMode: "cloud", model: "llama3", type: "ollama" },
+      []
+    );
+
+    expect(instance.apiKey).toBe("short");
   });
 });

--- a/apps/server/src/services/provider-instance-helpers.ts
+++ b/apps/server/src/services/provider-instance-helpers.ts
@@ -17,6 +17,7 @@ import {
   type UserConfig,
   validateCustomModels,
   validateDisplayName,
+  validateProviderApiKeyFormat,
   validateProviderInstanceLabel,
 } from "@nakama/core";
 import type {
@@ -178,6 +179,10 @@ export function buildProviderInstanceFromCreateRequest(
     throw new NakamaApiError("API key is required.", 400);
   }
 
+  if (apiKey) {
+    validateProviderApiKeyFormat(apiKey, type);
+  }
+
   if (type === "ollama") {
     const hostMode = resolveOllamaHostMode({
       baseUrl: request.baseUrl,
@@ -221,7 +226,7 @@ export function applyProviderInstanceUpdate(
   }
 
   if (request.apiKey !== undefined && request.apiKey.trim()) {
-    next.apiKey = request.apiKey.trim();
+    next.apiKey = validateProviderApiKeyFormat(request.apiKey, instance.type);
   }
 
   if (request.baseUrl !== undefined) {

--- a/packages/core/src/user-config.test.ts
+++ b/packages/core/src/user-config.test.ts
@@ -14,6 +14,7 @@ import {
   saveUserConfig,
   saveUserTimezone,
   saveUserWebPublicUrl,
+  validateProviderApiKeyFormat,
 } from "./user-config";
 
 describe("saveUserTimezone", () => {
@@ -36,6 +37,34 @@ describe("saveUserTimezone", () => {
         expect((error as NakamaApiError).status).toBe(400);
       }
     }
+  });
+});
+
+describe("validateProviderApiKeyFormat", () => {
+  test("rejects a key that is far too short for its provider", () => {
+    expect(() =>
+      validateProviderApiKeyFormat("sk-junk-qa-123", "openai")
+    ).toThrow(/valid OpenAI API key/i);
+  });
+
+  test("rejects a key with a mismatched prefix", () => {
+    expect(() =>
+      validateProviderApiKeyFormat(`AIza${"a".repeat(40)}`, "openai")
+    ).toThrow(/valid OpenAI API key/i);
+  });
+
+  test("accepts a well-formed key", () => {
+    const key = `sk-${"a".repeat(48)}`;
+    expect(validateProviderApiKeyFormat(key, "openai")).toBe(key);
+  });
+
+  test("skips format checks for providers without a documented key format", () => {
+    expect(validateProviderApiKeyFormat("short", "fireworks")).toBe("short");
+    expect(validateProviderApiKeyFormat("short", "ollama")).toBe("short");
+  });
+
+  test("returns an empty string unchanged instead of throwing", () => {
+    expect(validateProviderApiKeyFormat("", "openai")).toBe("");
   });
 });
 

--- a/packages/core/src/user-config.ts
+++ b/packages/core/src/user-config.ts
@@ -787,3 +787,52 @@ export function validateProviderInstanceLabel(
 
   return trimmed;
 }
+
+interface ApiKeyFormatRule {
+  minLength: number;
+  prefix?: string;
+}
+
+// Self-hosted/opaque-format providers (ollama, openai_compatible, cloudflare,
+// fireworks, opencode_go) are intentionally excluded: their key formats are
+// either undocumented or vary by deployment, so a prefix/length check would
+// just produce false rejections.
+const API_KEY_FORMAT_RULES: Partial<
+  Record<UserProviderName, ApiKeyFormatRule>
+> = {
+  anthropic: { minLength: 30, prefix: "sk-ant-" },
+  cerebras: { minLength: 20, prefix: "csk-" },
+  deepseek: { minLength: 30, prefix: "sk-" },
+  gemini: { minLength: 30, prefix: "AIza" },
+  openai: { minLength: 40, prefix: "sk-" },
+  openrouter: { minLength: 20, prefix: "sk-or-" },
+};
+
+export function validateProviderApiKeyFormat(
+  apiKey: string,
+  type: UserProviderName
+): string {
+  const trimmed = apiKey.trim();
+  const rule = API_KEY_FORMAT_RULES[type];
+
+  if (!(trimmed && rule)) {
+    return trimmed;
+  }
+
+  const hasWrongPrefix =
+    rule.prefix !== undefined && !trimmed.startsWith(rule.prefix);
+  const tooShort = trimmed.length < rule.minLength;
+
+  if (hasWrongPrefix || tooShort) {
+    const label = PROVIDER_TYPE_LABELS[type] ?? type;
+    const reason = hasWrongPrefix
+      ? ` (expected it to start with "${rule.prefix}")`
+      : ` (expected at least ${rule.minLength} characters)`;
+    throw new NakamaApiError(
+      `That doesn't look like a valid ${label} API key${reason}.`,
+      400
+    );
+  }
+
+  return trimmed;
+}


### PR DESCRIPTION
## Summary
- `POST /v1/providers` and `PATCH /v1/providers/:id` accepted API keys with no format sanity check, so obviously fake keys (e.g. `sk-junk-qa-123`) were persisted and only surfaced as a failure later at chat time.
- Add `validateProviderApiKeyFormat` (`packages/core/src/user-config.ts`) checking prefix/length per provider for the providers with a well-documented key format (openai, anthropic, gemini, openrouter, deepseek, cerebras). Providers with opaque/self-hosted formats (ollama, openai_compatible, cloudflare, fireworks, opencode_go) are intentionally left unchecked to avoid false rejections.
- Wire the validator into both create (`buildProviderInstanceFromCreateRequest`) and update (`applyProviderInstanceUpdate`) paths.
- `POST /v1/providers` and `PATCH /v1/providers/:id` previously had no try/catch, so thrown errors fell through to the global handler as a 500. Wrapped them to return 400 on validation errors, matching the pattern already used elsewhere in this file (e.g. Composio key validation).

Fixes #628

## Test plan
- [x] `bun test apps/server/src/services/provider-instance-helpers.test.ts` — 14 pass
- [x] `bun test packages/core/src/user-config.test.ts` — 12 pass
- [x] `bun test apps/server/src/http/routes/settings-rbac.test.ts` — 36 pass (no auth/routing regressions)
- [x] Manually reproduced the exact issue payload (`type: openai`, `apiKey: sk-junk-qa-123`, `model: gpt-junk`) against `buildProviderInstanceFromCreateRequest` before/after: before → persisted silently; after → rejected with `That doesn't look like a valid OpenAI API key (expected at least 40 characters).`