### PR TITLE
feat(web): move knowledge to Profiles and lean org skills UI

### DIFF
--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -1,7 +1,11 @@
-import { ArrowLeft01Icon, ArrowRight01Icon } from "hugeicons-react";
+import {
+  ArrowDown01Icon,
+  ArrowLeft01Icon,
+  ArrowRight01Icon,
+} from "hugeicons-react";
 import type { ElementType } from "react";
 import { useMemo } from "react";
-import { Link, Outlet, useLocation, useSearchParams } from "react-router-dom";
+import { Link, Outlet, useLocation } from "react-router-dom";
 import { CommandPalette } from "@/components/CommandPalette";
 import { OrgSwitcher } from "@/components/OrgSwitcher";
 import { ProfileRail } from "@/components/ProfileRail";
@@ -18,7 +22,10 @@ import { useAppContext } from "@/context/use-app-context";
 import { useAuth } from "@/context/use-auth";
 import { usePrefetchAppData } from "@/hooks/use-app-queries";
 import { useAutomationUnreadTotal } from "@/hooks/use-automations";
-import { useSidebarCollapsed } from "@/hooks/use-sidebar-collapsed";
+import {
+  useSidebarCollapsed,
+  useSystemNavCollapsed,
+} from "@/hooks/use-sidebar-collapsed";
 import { chatProfileIdFromPath } from "@/lib/chat-history";
 import {
   findNavItem,
@@ -30,7 +37,6 @@ import {
 } from "@/lib/navigation";
 import { cn } from "@/lib/utils";
 import { AgentWorkTabs } from "@/pages/automations/agent-work-tabs";
-import { ProfileDetailTabButton } from "@/pages/profiles/profiles-ui";
 
 export function Layout() {
   const location = useLocation();
@@ -41,6 +47,8 @@ export function Layout() {
   const prefetchAppData = usePrefetchAppData();
   const { data: automationUnreadTotal = 0 } = useAutomationUnreadTotal();
   const { collapsed, toggle } = useSidebarCollapsed();
+  const { collapsed: systemNavCollapsed, toggle: toggleSystemNav } =
+    useSystemNavCollapsed();
   const activeNav = findNavItem(page);
   const navGroups = useMemo(
     () =>
@@ -76,41 +84,81 @@ export function Layout() {
             </div>
 
             <nav className="no-scrollbar flex min-h-0 flex-1 flex-col overflow-y-auto">
-              {navGroups.map((group) => (
-                <div
-                  aria-label={group.label}
-                  className="sidebar-nav-group"
-                  key={group.id}
-                  role="group"
-                >
-                  <div className="sidebar-nav-group-items">
-                    {group.items.map((item) => (
-                      <SidebarNavButton
-                        active={item.id === page}
-                        badge={
-                          item.id === "automations"
-                            ? automationUnreadTotal
-                            : undefined
-                        }
-                        collapsed={collapsed}
-                        icon={item.icon}
-                        item={item}
-                        key={item.id}
-                        onPrefetch={
-                          item.id === "automations"
-                            ? prefetchAppData
-                            : undefined
-                        }
-                        to={
-                          item.id === "soul"
-                            ? `${navHrefForPage(item.id, chatProfileId)}?tab=tools`
-                            : navHrefForPage(item.id, chatProfileId)
-                        }
-                      />
-                    ))}
+              {navGroups.map((group) => {
+                const containsActive =
+                  group.collapsible === true &&
+                  group.items.some((item) => item.id === page);
+                const groupExpanded = !systemNavCollapsed || containsActive;
+                // Icon rail always shows every destination; tree collapse only
+                // applies when labels are visible.
+                const itemsVisible =
+                  !group.collapsible || collapsed || groupExpanded;
+
+                return (
+                  <div
+                    aria-label={group.label}
+                    className="sidebar-nav-group"
+                    data-items-hidden={itemsVisible ? undefined : true}
+                    data-tree={group.collapsible || undefined}
+                    key={group.id}
+                    role="group"
+                  >
+                    {group.collapsible && !collapsed ? (
+                      <button
+                        aria-expanded={groupExpanded}
+                        className="sidebar-nav-group-label"
+                        onClick={() => {
+                          if (groupExpanded && containsActive) {
+                            return;
+                          }
+                          toggleSystemNav();
+                        }}
+                        type="button"
+                      >
+                        <ArrowDown01Icon
+                          aria-hidden="true"
+                          className={cn(
+                            "sidebar-nav-group-chevron",
+                            !groupExpanded && "-rotate-90"
+                          )}
+                          strokeWidth={1.75}
+                        />
+                        <span className="truncate">{group.label}</span>
+                      </button>
+                    ) : null}
+                    <div
+                      aria-hidden={!itemsVisible}
+                      className="sidebar-nav-group-items"
+                      inert={itemsVisible ? undefined : true}
+                    >
+                      {group.items.map((item) => (
+                        <SidebarNavButton
+                          active={item.id === page}
+                          badge={
+                            item.id === "automations"
+                              ? automationUnreadTotal
+                              : undefined
+                          }
+                          collapsed={collapsed}
+                          icon={item.icon}
+                          item={item}
+                          key={item.id}
+                          onPrefetch={
+                            item.id === "automations"
+                              ? prefetchAppData
+                              : undefined
+                          }
+                          to={
+                            item.id === "soul"
+                              ? `${navHrefForPage(item.id, chatProfileId)}?tab=tools`
+                              : navHrefForPage(item.id, chatProfileId)
+                          }
+                        />
+                      ))}
+                    </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </nav>
           </aside>
 
@@ -119,8 +167,6 @@ export function Layout() {
               <header className="app-shell-header gap-4 bg-card px-6">
                 {page === "automations" ? (
                   <AgentWorkTabs />
-                ) : page === "files" ? (
-                  <FilesViewTabs />
                 ) : page === "soul" || page === "profiles" ? null : (
                   <h1 className="type-brand min-w-0 truncate">
                     {activeNav?.label}
@@ -199,46 +245,6 @@ function NarrowViewportNotice() {
         To chat with your agent from a phone, use the Telegram, WhatsApp or
         Discord bridge instead.
       </p>
-    </div>
-  );
-}
-
-function FilesViewTabs() {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const view =
-    searchParams.get("tab") === "knowledge" ? "knowledge" : "artifacts";
-
-  function selectView(nextView: "artifacts" | "knowledge") {
-    if (nextView === "artifacts") {
-      searchParams.delete("tab");
-    } else {
-      searchParams.set("tab", nextView);
-    }
-    setSearchParams(searchParams);
-  }
-
-  return (
-    <div
-      aria-label="Files views"
-      className="flex h-full min-w-0 items-stretch"
-      role="tablist"
-    >
-      <ProfileDetailTabButton
-        active={view === "artifacts"}
-        controls="files-page-panel-artifacts"
-        id="files-page-tab-artifacts"
-        onSelect={() => selectView("artifacts")}
-      >
-        Artifacts
-      </ProfileDetailTabButton>
-      <ProfileDetailTabButton
-        active={view === "knowledge"}
-        controls="files-page-panel-knowledge"
-        id="files-page-tab-knowledge"
-        onSelect={() => selectView("knowledge")}
-      >
-        Knowledge base
-      </ProfileDetailTabButton>
     </div>
   );
 }

--- a/apps/web/src/components/profiles/ProfileOrgBooleanOverrideField.tsx
+++ b/apps/web/src/components/profiles/ProfileOrgBooleanOverrideField.tsx
@@ -1,5 +1,6 @@
 import type {
   ProfileDetail,
+  ProfileSummary,
   UpdateProfileRequest,
 } from "@nakama/core/contract";
 import { useState } from "react";
@@ -76,6 +77,128 @@ export function ProfileOrgBooleanOverrideField({
       profile={profile}
       savedToast={savedToast}
     />
+  );
+}
+
+/** Org settings: pick a profile, then set inherit/on/off for one boolean field. */
+export function OrgSettingsProfileBooleanOverrideField({
+  profiles,
+  disabled = false,
+  field,
+  ariaLabel,
+  offLabel,
+  onLabel,
+  savedToast,
+}: {
+  ariaLabel: string;
+  disabled?: boolean;
+  field: OverrideField;
+  offLabel: string;
+  onLabel: string;
+  profiles: ProfileSummary[];
+  savedToast: string;
+}) {
+  const [profileId, setProfileId] = useState("");
+  const selected = profiles.find((profile) => profile.id === profileId) ?? null;
+
+  if (profiles.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center">
+      <Select
+        disabled={disabled}
+        onValueChange={(next) => setProfileId(next ? String(next) : "")}
+        value={profileId}
+      >
+        <SelectTrigger aria-label="Profile override" className="h-8 max-w-xs">
+          <SelectValue placeholder="Profile override" />
+        </SelectTrigger>
+        <SelectContent>
+          {profiles.map((profile) => (
+            <SelectItem key={profile.id} value={profile.id}>
+              {profile.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {selected ? (
+        <OrgSettingsProfileOverrideSelect
+          ariaLabel={ariaLabel}
+          disabled={disabled}
+          field={field}
+          key={`${selected.id}:${field}:${String(selected[field])}`}
+          offLabel={offLabel}
+          onLabel={onLabel}
+          profile={selected}
+          savedToast={savedToast}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function OrgSettingsProfileOverrideSelect({
+  profile,
+  disabled = false,
+  field,
+  ariaLabel,
+  offLabel,
+  onLabel,
+  savedToast,
+}: {
+  ariaLabel: string;
+  disabled?: boolean;
+  field: OverrideField;
+  offLabel: string;
+  onLabel: string;
+  profile: ProfileSummary;
+  savedToast: string;
+}) {
+  const updateMutation = useUpdateProfileMutation();
+  const [value, setValue] = useState<OverrideValue>(() =>
+    toOverrideValue(profile[field])
+  );
+  const busy = updateMutation.isPending;
+
+  async function handleOverrideChange(nextValue: OverrideValue) {
+    setValue(nextValue);
+    try {
+      await updateMutation.mutateAsync({
+        input: { [field]: fromOverrideValue(nextValue) },
+        profileId: profile.id,
+      });
+      toast(savedToast);
+    } catch (err) {
+      setValue(toOverrideValue(profile[field]));
+      toast(formatError(err));
+    }
+  }
+
+  return (
+    <>
+      <Select
+        disabled={disabled || busy}
+        onValueChange={(next) => {
+          if (!next) {
+            return;
+          }
+          void handleOverrideChange(next as OverrideValue);
+        }}
+        value={value}
+      >
+        <SelectTrigger aria-label={ariaLabel} className="h-8 max-w-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="inherit">Inherit org default</SelectItem>
+          <SelectItem value="on">{onLabel}</SelectItem>
+          <SelectItem value="off">{offLabel}</SelectItem>
+        </SelectContent>
+      </Select>
+      {busy ? <Spinner /> : null}
+    </>
   );
 }
 

--- a/apps/web/src/components/settings/SkillsCuratorOrgCard.tsx
+++ b/apps/web/src/components/settings/SkillsCuratorOrgCard.tsx
@@ -87,14 +87,9 @@ export function SkillsCuratorOrgCard() {
   return (
     <Card className="w-full overflow-hidden shadow-none">
       <div className="border-border border-b px-4 py-3">
-        <div className="flex items-start justify-between gap-4">
-          <div className="min-w-0 space-y-0.5">
-            <p className="font-medium text-foreground text-sm">Skill curator</p>
-            <p className="max-w-prose text-muted-foreground text-xs leading-relaxed">
-              Unused skills are moved to archive after 90 days, not deleted.
-            </p>
-          </div>
-          <div className="flex shrink-0 items-center gap-2 pt-0.5">
+        <div className="flex items-center justify-between gap-4">
+          <p className="font-medium text-foreground text-sm">Skill curator</p>
+          <div className="flex shrink-0 items-center gap-2">
             {busy ? <Spinner /> : null}
             <Switch
               aria-label="Enable skill curator"
@@ -108,11 +103,9 @@ export function SkillsCuratorOrgCard() {
         </div>
       </div>
       <div className="border-border border-b px-4 py-3">
-        <div className="flex items-start justify-between gap-4">
-          <p className="font-medium text-foreground text-sm">
-            Consolidate overlapping skills (LLM)
-          </p>
-          <div className="flex shrink-0 items-center gap-2 pt-0.5">
+        <div className="flex items-center justify-between gap-4">
+          <p className="text-foreground text-sm">Consolidate</p>
+          <div className="flex shrink-0 items-center gap-2">
             {busy ? <Spinner /> : null}
             <Switch
               aria-label="Enable skill consolidate"
@@ -128,19 +121,22 @@ export function SkillsCuratorOrgCard() {
         </div>
       </div>
       <div className="flex flex-col gap-3 px-4 py-3">
-        <p className="text-muted-foreground text-xs">
+        <p className="text-muted-foreground text-xs tabular-nums">
+          {latest?.dryRun ? "Preview · " : null}
           Last run{" "}
           {formatRunTime(lastRunAt ?? activeOrg.skillsCuratorLastRunAt)}
         </p>
         {latest ? (
-          <p className="text-muted-foreground text-xs">
-            {latest.dryRun ? "Preview" : "Last report"} · stale {latest.stale} ·
-            archived {latest.archived} · skipped{" "}
+          <p className="text-muted-foreground text-xs tabular-nums">
+            Stale {latest.stale} · Archived {latest.archived} · Skipped{" "}
             {latest.skippedBundled +
               latest.skippedAutomation +
               latest.skippedTooNew +
-              latest.skippedError}
-            {` · consolidate merged ${latest.consolidateMerged ?? 0} · deslop ${latest.consolidateDeslopified ?? 0} · staged ${latest.consolidateStaged ?? 0} · applied ${latest.consolidateApplied ?? 0}`}
+              latest.skippedError}{" "}
+            · Merged {latest.consolidateMerged ?? 0} · Deslop{" "}
+            {latest.consolidateDeslopified ?? 0} · Staged{" "}
+            {latest.consolidateStaged ?? 0} · Applied{" "}
+            {latest.consolidateApplied ?? 0}
           </p>
         ) : null}
         <div className="flex flex-wrap gap-2">

--- a/apps/web/src/components/settings/SkillsPostTurnReviewOrgCard.tsx
+++ b/apps/web/src/components/settings/SkillsPostTurnReviewOrgCard.tsx
@@ -1,165 +1,12 @@
-import type { ProfileSummary } from "@nakama/core/contract";
 import { useState } from "react";
+import { OrgSettingsProfileBooleanOverrideField } from "@/components/profiles/ProfileOrgBooleanOverrideField";
 import { Card } from "@/components/ui/card";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import { useAuth } from "@/context/use-auth";
 import { useProfilesQuery } from "@/hooks/use-app-queries";
-import { useUpdateProfileMutation } from "@/hooks/use-resource-mutations";
 import { formatError } from "@/lib/client";
 import { toast } from "@/lib/toast";
-
-type OverrideValue = "inherit" | "on" | "off";
-
-function toOverrideValue(value: boolean | null | undefined): OverrideValue {
-  if (value === true) {
-    return "on";
-  }
-  if (value === false) {
-    return "off";
-  }
-  return "inherit";
-}
-
-function fromOverrideValue(value: OverrideValue): boolean | null {
-  if (value === "on") {
-    return true;
-  }
-  if (value === "off") {
-    return false;
-  }
-  return null;
-}
-
-function OrgProfilePostTurnReviewOverrideSelect({
-  profile,
-  disabled = false,
-}: {
-  profile: ProfileSummary;
-  disabled?: boolean;
-}) {
-  const updateMutation = useUpdateProfileMutation();
-  const [value, setValue] = useState<OverrideValue>(() =>
-    toOverrideValue(profile.skillsPostTurnReview)
-  );
-  const busy = updateMutation.isPending;
-
-  async function handleOverrideChange(nextValue: OverrideValue) {
-    setValue(nextValue);
-    try {
-      await updateMutation.mutateAsync({
-        input: { skillsPostTurnReview: fromOverrideValue(nextValue) },
-        profileId: profile.id,
-      });
-      toast("Profile post-turn review setting saved.");
-    } catch (err) {
-      setValue(toOverrideValue(profile.skillsPostTurnReview));
-      toast(formatError(err));
-    }
-  }
-
-  return (
-    <>
-      <Select
-        disabled={disabled || busy}
-        onValueChange={(next) => {
-          if (!next) {
-            return;
-          }
-          void handleOverrideChange(next as OverrideValue);
-        }}
-        value={value}
-      >
-        <SelectTrigger
-          aria-label="Post-turn skill review override"
-          className="h-8 max-w-xs"
-        >
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="inherit">Inherit org default</SelectItem>
-          <SelectItem value="on">Enable review</SelectItem>
-          <SelectItem value="off">Disable review</SelectItem>
-        </SelectContent>
-      </Select>
-      {busy ? <Spinner /> : null}
-    </>
-  );
-}
-
-function OrgProfilePostTurnReviewField({
-  profiles,
-  disabled = false,
-}: {
-  profiles: ProfileSummary[];
-  disabled?: boolean;
-}) {
-  const [profileId, setProfileId] = useState<string>("");
-  const selectedProfile =
-    profiles.find((profile) => profile.id === profileId) ?? null;
-
-  if (profiles.length === 0) {
-    return null;
-  }
-
-  return (
-    <div className="px-4 py-3">
-      <p className="mb-2 font-medium text-muted-foreground text-xs">
-        Per-profile override
-      </p>
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-        <Select
-          disabled={disabled}
-          onValueChange={(next) => setProfileId(next ? String(next) : "")}
-          value={profileId}
-        >
-          <SelectTrigger aria-label="Profile" className="h-8 max-w-xs">
-            <SelectValue placeholder="Select profile" />
-          </SelectTrigger>
-          <SelectContent>
-            {profiles.map((profile) => (
-              <SelectItem key={profile.id} value={profile.id}>
-                {profile.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        {selectedProfile ? (
-          <OrgProfilePostTurnReviewOverrideSelect
-            disabled={disabled}
-            key={`${selectedProfile.id}:${String(selectedProfile.skillsPostTurnReview)}`}
-            profile={selectedProfile}
-          />
-        ) : (
-          <Select disabled value="inherit">
-            <SelectTrigger
-              aria-label="Post-turn skill review override"
-              className="h-8 max-w-xs"
-            >
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="inherit">Inherit org default</SelectItem>
-              <SelectItem value="on">Enable review</SelectItem>
-              <SelectItem value="off">Disable review</SelectItem>
-            </SelectContent>
-          </Select>
-        )}
-      </div>
-      <p className="mt-1.5 text-muted-foreground text-xs">
-        Overrides the org-wide post-turn review setting for the selected profile
-        only.
-      </p>
-    </div>
-  );
-}
 
 export function SkillsPostTurnReviewOrgCard() {
   const { activeOrg, updateOrg } = useAuth();
@@ -191,17 +38,11 @@ export function SkillsPostTurnReviewOrgCard() {
   return (
     <Card className="w-full overflow-hidden shadow-none">
       <div className="border-border border-b px-4 py-3">
-        <div className="flex items-start justify-between gap-4">
-          <div className="min-w-0 space-y-0.5">
-            <p className="font-medium text-foreground text-sm">
-              Post-turn skill review
-            </p>
-            <p className="max-w-prose text-muted-foreground text-xs leading-relaxed">
-              Suggest skill updates after complex chats. Apply directly, or
-              stage for admin review when write approval is on.
-            </p>
-          </div>
-          <div className="flex shrink-0 items-center gap-2 pt-0.5">
+        <div className="flex items-center justify-between gap-4">
+          <p className="font-medium text-foreground text-sm">
+            Post-turn skill review
+          </p>
+          <div className="flex shrink-0 items-center gap-2">
             {busy ? <Spinner /> : null}
             <Switch
               aria-label="Enable post-turn skill review"
@@ -212,7 +53,15 @@ export function SkillsPostTurnReviewOrgCard() {
           </div>
         </div>
       </div>
-      <OrgProfilePostTurnReviewField disabled={busy} profiles={profiles} />
+      <OrgSettingsProfileBooleanOverrideField
+        ariaLabel="Post-turn skill review override"
+        disabled={busy}
+        field="skillsPostTurnReview"
+        offLabel="Disable review"
+        onLabel="Enable review"
+        profiles={profiles}
+        savedToast="Profile post-turn review setting saved."
+      />
     </Card>
   );
 }

--- a/apps/web/src/components/settings/SkillsWriteApprovalOrgCard.tsx
+++ b/apps/web/src/components/settings/SkillsWriteApprovalOrgCard.tsx
@@ -1,48 +1,18 @@
-import type { ProfileSummary } from "@nakama/core/contract";
 import { type ReactNode, useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
+import { OrgSettingsProfileBooleanOverrideField } from "@/components/profiles/ProfileOrgBooleanOverrideField";
 import { SkillProposalsPanel } from "@/components/profiles/SkillProposalsPanel";
 import { Card } from "@/components/ui/card";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import { useAuth } from "@/context/use-auth";
 import { useProfilesQuery } from "@/hooks/use-app-queries";
-import { useUpdateProfileMutation } from "@/hooks/use-resource-mutations";
 import { useSkillProposals } from "@/hooks/use-skill-proposals";
 import { formatError } from "@/lib/client";
 import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 
 type SkillApprovalTab = "gate" | "proposals";
-
-type OverrideValue = "inherit" | "on" | "off";
-
-function toOverrideValue(value: boolean | null | undefined): OverrideValue {
-  if (value === true) {
-    return "on";
-  }
-  if (value === false) {
-    return "off";
-  }
-  return "inherit";
-}
-
-function fromOverrideValue(value: OverrideValue): boolean | null {
-  if (value === "on") {
-    return true;
-  }
-  if (value === "off") {
-    return false;
-  }
-  return null;
-}
 
 function SkillApprovalTabButton({
   active,
@@ -66,128 +36,6 @@ function SkillApprovalTabButton({
     >
       {children}
     </button>
-  );
-}
-
-function OrgProfileSkillsWriteApprovalOverrideSelect({
-  profile,
-  disabled = false,
-}: {
-  profile: ProfileSummary;
-  disabled?: boolean;
-}) {
-  const updateMutation = useUpdateProfileMutation();
-  const [value, setValue] = useState<OverrideValue>(() =>
-    toOverrideValue(profile.skillsWriteApproval)
-  );
-  const busy = updateMutation.isPending;
-
-  async function handleOverrideChange(nextValue: OverrideValue) {
-    setValue(nextValue);
-    try {
-      await updateMutation.mutateAsync({
-        input: { skillsWriteApproval: fromOverrideValue(nextValue) },
-        profileId: profile.id,
-      });
-      toast("Profile skill write approval setting saved.");
-    } catch (err) {
-      setValue(toOverrideValue(profile.skillsWriteApproval));
-      toast(formatError(err));
-    }
-  }
-
-  return (
-    <>
-      <Select
-        disabled={disabled || busy}
-        onValueChange={(next) => {
-          if (!next) {
-            return;
-          }
-          void handleOverrideChange(next as OverrideValue);
-        }}
-        value={value}
-      >
-        <SelectTrigger
-          aria-label="Skill write approval override"
-          className="h-8 max-w-xs"
-        >
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="inherit">Inherit org default</SelectItem>
-          <SelectItem value="on">Require approval</SelectItem>
-          <SelectItem value="off">Allow immediate writes</SelectItem>
-        </SelectContent>
-      </Select>
-      {busy ? <Spinner /> : null}
-    </>
-  );
-}
-
-function OrgProfileSkillsWriteApprovalField({
-  profiles,
-  disabled = false,
-}: {
-  profiles: ProfileSummary[];
-  disabled?: boolean;
-}) {
-  const [profileId, setProfileId] = useState<string>("");
-  const selectedProfile =
-    profiles.find((profile) => profile.id === profileId) ?? null;
-
-  if (profiles.length === 0) {
-    return null;
-  }
-
-  return (
-    <div className="px-4 py-3">
-      <p className="mb-2 font-medium text-muted-foreground text-xs">
-        Per-profile override
-      </p>
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-        <Select
-          disabled={disabled}
-          onValueChange={(next) => setProfileId(next ? String(next) : "")}
-          value={profileId}
-        >
-          <SelectTrigger aria-label="Profile" className="h-8 max-w-xs">
-            <SelectValue placeholder="Select profile" />
-          </SelectTrigger>
-          <SelectContent>
-            {profiles.map((profile) => (
-              <SelectItem key={profile.id} value={profile.id}>
-                {profile.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        {selectedProfile ? (
-          <OrgProfileSkillsWriteApprovalOverrideSelect
-            disabled={disabled}
-            key={`${selectedProfile.id}:${String(selectedProfile.skillsWriteApproval)}`}
-            profile={selectedProfile}
-          />
-        ) : (
-          <Select disabled value="inherit">
-            <SelectTrigger
-              aria-label="Skill write approval override"
-              className="h-8 max-w-xs"
-            >
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="inherit">Inherit org default</SelectItem>
-              <SelectItem value="on">Require approval</SelectItem>
-              <SelectItem value="off">Allow immediate writes</SelectItem>
-            </SelectContent>
-          </Select>
-        )}
-      </div>
-      <p className="mt-1.5 text-muted-foreground text-xs">
-        Overrides the org-wide gate for the selected profile only.
-      </p>
-    </div>
   );
 }
 
@@ -236,18 +84,12 @@ export function SkillsWriteApprovalOrgCard() {
   return (
     <Card className="w-full overflow-hidden shadow-none">
       <div className="border-border border-b px-4 py-3">
-        <div className="flex items-start justify-between gap-4">
-          <div className="min-w-0 space-y-0.5">
-            <p className="font-medium text-foreground text-sm">
-              Skill write approval
-            </p>
-            <p className="max-w-prose text-muted-foreground text-xs leading-relaxed">
-              When enabled, agent skill creates, patches, and deletes require
-              org admin approval before they go live.
-            </p>
-          </div>
+        <div className="flex items-center justify-between gap-4">
+          <p className="font-medium text-foreground text-sm">
+            Skill write approval
+          </p>
           {activeTab === "gate" ? (
-            <div className="flex shrink-0 items-center gap-2 pt-0.5">
+            <div className="flex shrink-0 items-center gap-2">
               {busy ? <Spinner /> : null}
               <Switch
                 aria-label="Require approval for skill writes"
@@ -266,7 +108,7 @@ export function SkillsWriteApprovalOrgCard() {
             active={activeTab === "gate"}
             onClick={() => setActiveTab("gate")}
           >
-            Gate settings
+            Settings
           </SkillApprovalTabButton>
           <SkillApprovalTabButton
             active={activeTab === "proposals"}
@@ -291,9 +133,14 @@ export function SkillsWriteApprovalOrgCard() {
           />
         ) : null
       ) : (
-        <OrgProfileSkillsWriteApprovalField
+        <OrgSettingsProfileBooleanOverrideField
+          ariaLabel="Skill write approval override"
           disabled={busy}
+          field="skillsWriteApproval"
+          offLabel="Allow immediate writes"
+          onLabel="Require approval"
           profiles={profiles}
+          savedToast="Profile skill write approval setting saved."
         />
       )}
     </Card>

--- a/apps/web/src/hooks/use-sidebar-collapsed.ts
+++ b/apps/web/src/hooks/use-sidebar-collapsed.ts
@@ -1,7 +1,9 @@
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   getInitialSidebarCollapsed,
+  getInitialSystemNavCollapsed,
   SIDEBAR_COLLAPSED_KEY,
+  SIDEBAR_SYSTEM_NAV_COLLAPSED_KEY,
 } from "@/lib/sidebar";
 
 export function useSidebarCollapsed() {
@@ -15,9 +17,25 @@ export function useSidebarCollapsed() {
     }
   }, [collapsed]);
 
-  const toggle = useCallback(() => {
-    setCollapsedState((current) => !current);
-  }, []);
+  return {
+    collapsed,
+    toggle: () => setCollapsedState((current) => !current),
+  };
+}
 
-  return { collapsed, toggle };
+export function useSystemNavCollapsed() {
+  const [collapsed, setCollapsed] = useState(getInitialSystemNavCollapsed);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(SIDEBAR_SYSTEM_NAV_COLLAPSED_KEY, String(collapsed));
+    } catch {
+      // Ignore storage failures (private browsing, etc.)
+    }
+  }, [collapsed]);
+
+  return {
+    collapsed,
+    toggle: () => setCollapsed((current) => !current),
+  };
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -570,8 +570,13 @@
     transition:
       opacity 220ms cubic-bezier(0.4, 0, 0.2, 1),
       max-height 320ms cubic-bezier(0.4, 0, 0.2, 1),
-      margin 320ms cubic-bezier(0.4, 0, 0.2, 1);
-    @apply mb-1.5 overflow-hidden px-3 text-xs text-muted-foreground/55 motion-reduce:transition-none;
+      margin 320ms cubic-bezier(0.4, 0, 0.2, 1),
+      color 150ms ease-out;
+    @apply mb-1.5 flex w-full cursor-pointer items-center gap-1 overflow-hidden rounded-md px-2 py-1 text-left text-xs text-muted-foreground/55 motion-reduce:transition-none;
+  }
+
+  .sidebar-nav-group-label:hover {
+    @apply text-muted-foreground;
   }
 
   .sidebar-shell:not([data-collapsed]) .sidebar-nav-group-label {
@@ -581,7 +586,11 @@
 
   .sidebar-shell[data-collapsed] .sidebar-nav-group-label {
     transition-delay: 0ms;
-    @apply mb-0 max-h-0 opacity-0;
+    @apply pointer-events-none mb-0 max-h-0 opacity-0;
+  }
+
+  .sidebar-nav-group-chevron {
+    @apply size-3 shrink-0 transition-transform duration-200 ease-out motion-reduce:transition-none;
   }
 
   .sidebar-nav-divider {
@@ -600,6 +609,14 @@
     @apply flex flex-col;
   }
 
+  .sidebar-shell:not([data-collapsed]) .sidebar-nav-group[data-tree] {
+    @apply mt-3;
+  }
+
+  .sidebar-shell[data-collapsed] .sidebar-nav-group[data-tree] {
+    @apply mt-1.5;
+  }
+
   .sidebar-nav-group-items {
     @apply flex flex-col gap-0.5 overflow-visible;
   }
@@ -610,6 +627,13 @@
 
   aside[data-collapsed] .sidebar-nav-group-items {
     @apply items-center gap-1.5;
+  }
+
+  .sidebar-nav-group[data-tree][data-items-hidden] .sidebar-nav-group-items {
+    transition:
+      opacity 220ms cubic-bezier(0.4, 0, 0.2, 1),
+      max-height 220ms cubic-bezier(0.4, 0, 0.2, 1);
+    @apply pointer-events-none max-h-0 overflow-hidden opacity-0 motion-reduce:transition-none;
   }
 
   .scope-item {

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -34,6 +34,8 @@ export interface NavItem {
 }
 
 export interface NavGroup {
+  /** When true, sidebar renders a collapsible tree under `label`. */
+  collapsible?: boolean;
   id: string;
   items: NavItem[];
   label: string;
@@ -85,7 +87,7 @@ export const NAV_GROUPS: NavGroup[] = [
     label: "Agent",
   },
   {
-    id: "system",
+    id: "organization",
     items: [
       navItem(
         "organization",
@@ -93,6 +95,13 @@ export const NAV_GROUPS: NavGroup[] = [
         "Members, memory, and org settings",
         Building03Icon
       ),
+    ],
+    label: "Organization",
+  },
+  {
+    collapsible: true,
+    id: "system",
+    items: [
       navItem(
         "integrations",
         "Integrations",

--- a/apps/web/src/lib/sidebar.test.ts
+++ b/apps/web/src/lib/sidebar.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test } from "bun:test";
+import { getInitialSystemNavCollapsed } from "./sidebar";
+
+describe("sidebar system nav collapse", () => {
+  test("defaults to expanded when storage is empty", () => {
+    expect(getInitialSystemNavCollapsed()).toBe(false);
+  });
+});

--- a/apps/web/src/lib/sidebar.ts
+++ b/apps/web/src/lib/sidebar.ts
@@ -1,8 +1,18 @@
 export const SIDEBAR_COLLAPSED_KEY = "nakama-sidebar-collapsed";
+export const SIDEBAR_SYSTEM_NAV_COLLAPSED_KEY =
+  "nakama-sidebar-system-nav-collapsed";
 
 export function getInitialSidebarCollapsed(): boolean {
   try {
     return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+export function getInitialSystemNavCollapsed(): boolean {
+  try {
+    return localStorage.getItem(SIDEBAR_SYSTEM_NAV_COLLAPSED_KEY) === "true";
   } catch {
     return false;
   }

--- a/apps/web/src/pages/FilesPage.tsx
+++ b/apps/web/src/pages/FilesPage.tsx
@@ -1,13 +1,12 @@
 import type { ArtifactFile } from "@nakama/core/contract";
 import { useCallback, useMemo, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { Navigate, useSearchParams } from "react-router-dom";
 import {
   ARTIFACT_TYPE_FILTER_LABELS,
   type ArtifactTypeFilter,
   artifactMatchesTypeFilter,
   availableArtifactTypeFilters,
 } from "@/components/soul-tools/artifacts-tab-filters";
-import { KnowledgeTab } from "@/components/soul-tools/KnowledgeTab";
 import { ChatAttachmentPanelProvider } from "@/context/chat-attachment-panel-context";
 import { useActiveChatProfile } from "@/context/use-active-chat-profile";
 import { useProfilesQuery } from "@/hooks/use-app-queries";
@@ -21,6 +20,7 @@ import {
   resolveFilesProfileId,
   setStoredFilesViewMode,
 } from "@/lib/files-page.shared";
+import { PAGE_PATHS } from "@/lib/navigation";
 import { ArtifactFolderBreadcrumb } from "@/pages/files/files-artifact-folder-breadcrumb";
 import {
   listArtifactsInFolder,
@@ -38,8 +38,6 @@ export function FilesPage() {
   const { data: profiles = [] } = useProfilesQuery();
   const profileId = resolveFilesProfileId({ activeProfileId, profiles });
   const [searchParams, setSearchParams] = useSearchParams();
-  const view =
-    searchParams.get("tab") === "knowledge" ? "knowledge" : "artifacts";
   const folderPrefix = normalizeArtifactFolderPrefix(
     searchParams.get("folder") ?? ""
   );
@@ -124,6 +122,14 @@ export function FilesPage() {
     setStoredFilesViewMode(mode);
   }
 
+  if (searchParams.get("tab") === "knowledge") {
+    const params = new URLSearchParams({ tab: "knowledge" });
+    if (profileId) {
+      params.set("profile", profileId);
+    }
+    return <Navigate replace to={`${PAGE_PATHS.profiles}?${params}`} />;
+  }
+
   if (!profileId) {
     return (
       <div className="p-4 sm:p-6">
@@ -170,71 +176,54 @@ export function FilesPage() {
     <ChatAttachmentPanelProvider presentation="overlay">
       <div className="no-scrollbar min-h-0 flex-1 overflow-y-auto p-4 sm:p-6">
         <div className="space-y-4">
-          {view === "artifacts" ? (
-            <div
-              aria-labelledby="files-page-tab-artifacts"
-              className="space-y-4"
-              id="files-page-panel-artifacts"
-              role="tabpanel"
-            >
-              <FilesToolbar
-                isFetching={isFetching}
-                onRefresh={() => void refetch()}
-                onViewModeChange={handleViewModeChange}
-                showViewModeToggle={totalCount > 0}
-                viewMode={viewMode}
-              />
+          <FilesToolbar
+            isFetching={isFetching}
+            onRefresh={() => void refetch()}
+            onViewModeChange={handleViewModeChange}
+            showViewModeToggle={totalCount > 0}
+            viewMode={viewMode}
+          />
 
-              {totalCount > 0 ? (
-                <FilesSearchRow
-                  onSearchQueryChange={setSearchQuery}
-                  onTypeFilterChange={setTypeFilter}
-                  searchQuery={searchQuery}
-                  typeFilter={effectiveTypeFilter}
-                  typeOptions={typeOptions}
-                />
-              ) : null}
+          {totalCount > 0 ? (
+            <FilesSearchRow
+              onSearchQueryChange={setSearchQuery}
+              onTypeFilterChange={setTypeFilter}
+              searchQuery={searchQuery}
+              typeFilter={effectiveTypeFilter}
+              typeOptions={typeOptions}
+            />
+          ) : null}
 
-              {folderPrefix && !isSearching ? (
-                <ArtifactFolderBreadcrumb
-                  onNavigate={handleFolderChange}
-                  prefix={folderPrefix}
-                />
-              ) : null}
+          {folderPrefix && !isSearching ? (
+            <ArtifactFolderBreadcrumb
+              onNavigate={handleFolderChange}
+              prefix={folderPrefix}
+            />
+          ) : null}
 
-              <FilesArtifactViews
-                artifacts={artifacts}
-                deletePending={deleteMutation.isPending}
-                emptyFilterMessage={emptyFilterMessage}
-                error={error}
-                folders={listing.folders}
-                isLoading={isLoading}
-                listingFiles={listing.files}
-                onDelete={setDeleteTarget}
-                onOpenFolder={handleFolderChange}
-                pagination={
-                  hasNextPage
-                    ? {
-                        loadingMore: isFetchingNextPage,
-                        onShowMore: () => void fetchNextPage(),
-                        remainingCount,
-                      }
-                    : null
-                }
-                profileId={profileId}
-                showFullPath={isSearching}
-                viewMode={viewMode}
-              />
-            </div>
-          ) : (
-            <div
-              aria-labelledby="files-page-tab-knowledge"
-              id="files-page-panel-knowledge"
-              role="tabpanel"
-            >
-              <KnowledgeTab profileId={profileId} />
-            </div>
-          )}
+          <FilesArtifactViews
+            artifacts={artifacts}
+            deletePending={deleteMutation.isPending}
+            emptyFilterMessage={emptyFilterMessage}
+            error={error}
+            folders={listing.folders}
+            isLoading={isLoading}
+            listingFiles={listing.files}
+            onDelete={setDeleteTarget}
+            onOpenFolder={handleFolderChange}
+            pagination={
+              hasNextPage
+                ? {
+                    loadingMore: isFetchingNextPage,
+                    onShowMore: () => void fetchNextPage(),
+                    remainingCount,
+                  }
+                : null
+            }
+            profileId={profileId}
+            showFullPath={isSearching}
+            viewMode={viewMode}
+          />
         </div>
       </div>
 

--- a/apps/web/src/pages/profiles/profiles-page-layout.tsx
+++ b/apps/web/src/pages/profiles/profiles-page-layout.tsx
@@ -1,5 +1,6 @@
 import { createPortal } from "react-dom";
 import { SkillProposalsPanel } from "@/components/profiles/SkillProposalsPanel";
+import { KnowledgeTab } from "@/components/soul-tools/KnowledgeTab";
 import { SoulTab } from "@/components/soul-tools/SoulTab";
 import { useAuth } from "@/context/use-auth";
 import { useAppNavigation } from "@/hooks/use-app-navigation";
@@ -80,6 +81,14 @@ export function ProfilesPageLayout(state: ProfilesPageState) {
                   Prompt
                 </ProfileDetailTabButton>
               ) : null}
+              <ProfileDetailTabButton
+                active={detailTab === "knowledge"}
+                controls="profile-detail-panel-knowledge"
+                id="profile-detail-tab-knowledge"
+                onSelect={() => setDetailTab("knowledge")}
+              >
+                Knowledge
+              </ProfileDetailTabButton>
               {isOrgAdmin ? (
                 <ProfileDetailTabButton
                   active={detailTab === "proposals"}
@@ -170,6 +179,15 @@ export function ProfilesPageLayout(state: ProfilesPageState) {
               role="tabpanel"
             >
               <SoulTab profileId={selectedId} />
+            </div>
+          ) : detailTab === "knowledge" ? (
+            <div
+              aria-labelledby="profile-detail-tab-knowledge"
+              className="no-scrollbar min-h-0 flex-1 overflow-y-auto p-4 sm:p-5"
+              id="profile-detail-panel-knowledge"
+              role="tabpanel"
+            >
+              <KnowledgeTab profileId={selectedId} />
             </div>
           ) : null
         ) : (

--- a/apps/web/src/pages/profiles/profiles-page.shared.ts
+++ b/apps/web/src/pages/profiles/profiles-page.shared.ts
@@ -11,12 +11,12 @@ export type ProfileSaveStatus =
   | "saved"
   | "error";
 
-export type ProfileDetailTab = "profile" | "prompt" | "proposals";
+export type ProfileDetailTab = "profile" | "prompt" | "knowledge" | "proposals";
 
 export function resolveProfileDetailTab(
   value: string | null
 ): ProfileDetailTab {
-  if (value === "prompt" || value === "proposals") {
+  if (value === "prompt" || value === "knowledge" || value === "proposals") {
     return value;
   }
 

--- a/docs/website/content/docs/artifacts.mdx
+++ b/docs/website/content/docs/artifacts.mdx
@@ -9,7 +9,7 @@ This page covers the dashboard side. For how an agent saves a file in the first 
 
 ## The Files page
 
-**Files** in the sidebar has two tabs. **Artifacts** lists what the agent saved for the active profile. **Knowledge base** manages the documents the agent searches with `knowledge_base_search`.
+**Files** lists artifacts the agent saved for the active profile. Upload and manage knowledge-base documents from the **Knowledge** tab on [Profiles](/profiles).
 
 ![The Files page, with a markdown artifact open in the preview panel](/screenshots/artifact-markdown-toc.png)
 

--- a/docs/website/content/docs/profiles.mdx
+++ b/docs/website/content/docs/profiles.mdx
@@ -154,7 +154,7 @@ Memory writes and archives use bundled skills (`update-profile-memory`, `archive
 | `MEMORY.md` | Yes (via soul stack) | `update-profile-memory` skill + `read_file` / `edit_file` / `write_file` |
 | `memory-archive/` | No | `archive-profile-memory` skill + file tools |
 | `artifacts/` | No ([Files page](/artifacts), download API, web chat preview) | `save-artifact` skill + `write_file` or `write_docx` |
-| Knowledge base | Via `knowledge_base_search` when assigned | Upload via dashboard; search at runtime |
+| Knowledge base | Via `knowledge_base_search` when assigned | Upload via **Profiles → Knowledge**; search at runtime |
 | Profile skills | Via skill matcher when relevant | `manage-skills` skill or dashboard |
 
 Active `MEMORY.md` has a **4096-byte** soft limit. When it is full, the agent should archive old bullets before adding new ones.
@@ -163,7 +163,7 @@ Org memory has separate limits: **8192 bytes** for the live file and **2048 byte
 
 This data is isolated per org and per profile. Two orgs never read or write the same directory, even if profile ids happen to match.
 
-Each profile also sees the default Nakama documentation source in the Knowledge tab:
+Each profile also sees the default Nakama documentation source on **Profiles → Knowledge**:
 
 ```text
 https://ahmadrosid.github.io/nakama/llms.txt


### PR DESCRIPTION
## Summary

Org admins manage knowledge on **Profiles → Knowledge**; Files is artifacts-only. Org skill settings drop the essay copy.

**Before:** Knowledge lived under `/files?tab=knowledge` (platform-admin Files only); org skill cards had subtitle/footer narrative.
**After:** Profiles detail tab `?tab=knowledge`; `/files?tab=knowledge` redirects; org toggles are label + control only.

Why safe:
1. Same `KnowledgeTab` surface — only the host route/tab moves
2. Legacy Files URL redirects with profile preserved when known
3. −100 lines net after ponytail (shared override field, boolean System collapse)

Only re-add Files knowledge if non-admin Profiles access is too narrow for a tenant.

## Test plan
- [x] `bun test apps/web/src/lib/sidebar.test.ts apps/web/src/lib/navigation.test.ts apps/web/src/lib/files-page.shared.test.ts` (14 pass)
- [ ] Open Profiles → Knowledge on a profile; confirm `/files?tab=knowledge` lands there
