### PR TITLE
fix(db): make message appends atomic

### DIFF
--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -653,6 +653,19 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
     INSERT INTO session_messages (id, session_id, seq, payload, created_at)
     VALUES (?, ?, ?, ?, ?)
   `);
+  const appendMessagesTransaction = db.transaction(
+    (sessionId: string, messages: StoredSessionMessageRecord[]) => {
+      for (const message of messages) {
+        appendMessageStmt.run(
+          message.id,
+          sessionId,
+          message.seq,
+          JSON.stringify(message.payload),
+          message.createdAt
+        );
+      }
+    }
+  );
   const deleteMessagesForSessionStmt = db.prepare(
     "DELETE FROM session_messages WHERE session_id = ?"
   );
@@ -1579,15 +1592,7 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
 
   return {
     async appendMessagesForSession(sessionId, messages) {
-      for (const message of messages) {
-        appendMessageStmt.run(
-          message.id,
-          sessionId,
-          message.seq,
-          JSON.stringify(message.payload),
-          message.createdAt
-        );
-      }
+      appendMessagesTransaction(sessionId, messages);
     },
 
     async assignMcpServerToProfile(profileId, serverId) {

--- a/packages/db/src/replace-messages-updated-at.test.ts
+++ b/packages/db/src/replace-messages-updated-at.test.ts
@@ -111,3 +111,49 @@ describe("replaceMessagesForSession bumps session updatedAt", () => {
     }
   });
 });
+
+describe("appendMessagesForSession", () => {
+  test("sqlite preserves prior state when a batch fails", async () => {
+    const database = await createSqliteDatabase(":memory:");
+    try {
+      await seedSession(database.adapter);
+      const createdAt = "2020-06-01T00:00:00.000Z";
+      await database.adapter.appendMessagesForSession("session_test", [
+        {
+          createdAt,
+          id: "msg_existing",
+          payload: { content: "existing", role: "user" },
+          seq: 0,
+          sessionId: "session_test",
+        },
+      ]);
+
+      await expect(
+        database.adapter.appendMessagesForSession("session_test", [
+          {
+            createdAt,
+            id: "msg_new",
+            payload: { content: "new", role: "assistant" },
+            seq: 1,
+            sessionId: "session_test",
+          },
+          {
+            createdAt,
+            id: "msg_existing",
+            payload: { content: "duplicate", role: "user" },
+            seq: 2,
+            sessionId: "session_test",
+          },
+        ])
+      ).rejects.toThrow();
+
+      expect(
+        (await database.adapter.listMessagesForSession("session_test")).map(
+          (message) => message.id
+        )
+      ).toEqual(["msg_existing"]);
+    } finally {
+      database.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Failing SQLite message batches now roll back completely, preserving the session state that existed before the append.

Closes #532.

**Before:** A later insert failure left earlier messages from the same batch committed, while the caller still treated persistence as failed.
**After:** `appendMessagesForSession` executes its existing insert loop in one SQLite transaction.

Why safe:
1. The transaction changes only the SQLite append path; the API, payloads, and error propagation remain unchanged.
2. The regression first preserves an existing message, then proves a later duplicate-key failure does not retain the batch prefix.
3. Removing the transaction makes the regression fail with the extra inserted message.

Only follow up for replace semantics under #531; `replaceMessagesForSession` is intentionally unchanged.

## Test plan
- [x] `bun test packages/db/src/replace-messages-updated-at.test.ts` (4 pass on Bun 1.3.0, 1.3.10, and 1.3.14)
- [x] DB tests excluding the existing Windows-incompatible `reopen.test.ts` (82 pass, 2 platform skips)
- [x] `bun run --filter @nakama/db build` and targeted `bun x ultracite check` (pass)
- [x] GitHub Ubuntu CI on pinned Bun 1.3.14 (test, knip, react-doctor pass)