### PR TITLE
fix(server): require auth for the tool catalog

### DIFF
--- a/apps/server/src/http/public-routes.test.ts
+++ b/apps/server/src/http/public-routes.test.ts
@@ -21,8 +21,8 @@ describe("isPublicRouteRequest", () => {
     ).toBe(true);
   });
 
-  test("allows GET /v1/tools without auth but not POST", () => {
-    expect(isPublicRouteRequest("GET", "/v1/tools")).toBe(true);
+  test("keeps the tool catalog behind auth", () => {
+    expect(isPublicRouteRequest("GET", "/v1/tools")).toBe(false);
     expect(isPublicRouteRequest("POST", "/v1/tools")).toBe(false);
     expect(isPublicRouteRequest("POST", "/v1/tools/tool_x/run")).toBe(false);
   });

--- a/apps/server/src/http/public-routes.ts
+++ b/apps/server/src/http/public-routes.ts
@@ -11,14 +11,13 @@ export const PUBLIC_ROUTES = new Set([
   "/v1/auth/accept-invite",
   "/v1/composio/oauth/callback",
   "/v1/tasks/__capability_probe__/messages",
-  "/v1/tools",
 ]);
 
 export function isPublicRouteRequest(
   method: string,
   pathname: string
 ): boolean {
-  if (pathname === "/v1/auth/me" || pathname === "/v1/tools") {
+  if (pathname === "/v1/auth/me") {
     return method === "GET";
   }
 

--- a/apps/server/src/http/routes/system.ts
+++ b/apps/server/src/http/routes/system.ts
@@ -1,6 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { isComposioConfiguredAsync, NAKAMA_API_VERSION } from "@nakama/core";
 import type { UpdateWebPublicUrlRequest } from "@nakama/core/contract";
+import { BUILTIN_TOOL_IDS } from "@nakama/core/tools/protected";
 import {
   getWebPublicUrlSettings,
   persistWebPublicUrl,
@@ -31,6 +32,8 @@ const DOCS_HTML = `<!doctype html>
 </html>
 `;
 
+const BUILTIN_TOOL_NAMES = Object.keys(BUILTIN_TOOL_IDS);
+
 export function registerSystemRoutes(
   app: HonoApp,
   options: ServerOptions
@@ -39,6 +42,10 @@ export function registerSystemRoutes(
   const healthResponseSchema = z
     .object({
       apiVersion: z.number().int(),
+      builtinTools: z.array(z.string()).openapi({
+        description:
+          "Names of the built-in tools this build registers. The CLI reads it to tell a stale server from a current one before it has credentials.",
+      }),
       composioAvailable: z.boolean().openapi({
         description:
           "Whether Composio is reachable. Always false on /health (no live probe). Check GET /v1/system/status for the probed value.",
@@ -175,6 +182,7 @@ export function registerSystemRoutes(
     return c.json(
       {
         apiVersion: NAKAMA_API_VERSION,
+        builtinTools: BUILTIN_TOOL_NAMES,
         composioAvailable: false,
         composioConfigured,
         ok: true,

--- a/apps/server/src/http/routes/tools-catalog-auth.test.ts
+++ b/apps/server/src/http/routes/tools-catalog-auth.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { setupTestConfigDir } from "../../test-config-dir";
+import { createMinimalHonoApp } from "../test-app-helpers";
+import { setupFreshInstallSession } from "../test-session-helpers";
+
+setupTestConfigDir("nakama-tools-catalog-auth-test-");
+
+// packages/core/src/ensure-server.ts reads these off /health before the CLI has
+// credentials. If any of them stops being served there, the CLI decides the
+// running server is stale and spawns a second one.
+const REQUIRED_BUILTIN_TOOLS = [
+  "write_file",
+  "delete_file",
+  "edit_file",
+  "read_file",
+  "search_files",
+  "web_search",
+];
+
+function createApp() {
+  const agent = {
+    listProfiles: async () => ({ profiles: [{ id: "default" }] }),
+    listTools: async () => ({
+      tools: [{ id: "tool_custom_scraper", name: "custom_scraper" }],
+    }),
+    providerConfigured: true,
+  };
+
+  return createMinimalHonoApp({ agent });
+}
+
+describe("GET /v1/tools", () => {
+  test("rejects anonymous callers", async () => {
+    const { app } = createApp();
+
+    const response = await app.fetch(
+      new Request("http://localhost:4310/v1/tools")
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  test("serves the catalog to an authenticated caller", async () => {
+    const { app, databaseAdapter } = createApp();
+    const session = await setupFreshInstallSession(app, databaseAdapter);
+
+    const response = await app.fetch(
+      new Request("http://localhost:4310/v1/tools", {
+        headers: session.headers(),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      tools: [{ id: "tool_custom_scraper", name: "custom_scraper" }],
+    });
+  });
+});
+
+describe("GET /health", () => {
+  test("carries the built-in tool names the CLI probe needs", async () => {
+    const { app } = createApp();
+
+    const response = await app.fetch(
+      new Request("http://localhost:4310/health")
+    );
+
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as { builtinTools: string[] };
+    for (const name of REQUIRED_BUILTIN_TOOLS) {
+      expect(payload.builtinTools).toContain(name);
+    }
+  });
+});

--- a/packages/core/src/ensure-server.ts
+++ b/packages/core/src/ensure-server.ts
@@ -102,6 +102,7 @@ async function isServerHealthy(serverUrl: string): Promise<boolean> {
     const payload = (await response.json()) as {
       ok?: boolean;
       apiVersion?: number;
+      builtinTools?: string[];
     };
 
     if (payload.ok !== true || payload.apiVersion !== NAKAMA_API_VERSION) {
@@ -112,22 +113,7 @@ async function isServerHealthy(serverUrl: string): Promise<boolean> {
       return false;
     }
 
-    const toolsResponse = await fetch(`${serverUrl}/v1/tools`, {
-      signal: controller.signal,
-    });
-
-    if (!toolsResponse.ok) {
-      return false;
-    }
-
-    const toolsPayload = (await toolsResponse.json()) as {
-      tools?: Array<{ name?: string }>;
-    };
-    const toolNames = new Set(
-      (toolsPayload.tools ?? [])
-        .map((tool) => tool.name)
-        .filter((name): name is string => typeof name === "string")
-    );
+    const toolNames = new Set(payload.builtinTools ?? []);
 
     return REQUIRED_BUILTIN_TOOLS.every((name) => toolNames.has(name));
   } catch {


### PR DESCRIPTION
## Summary

An unauthenticated caller could list every registered tool on an instance, including the names and descriptions of an operator's custom JavaScript and Python tools. Closes #506.

**Before:** `GET /v1/tools` was in `PUBLIC_ROUTES`, so it answered anyone with the whole catalog.
**After:** the route needs a session. The CLI capability probe reads the built-in tool names off `/health` instead, which is public already.

Why safe:
1. The route was public for one reason: `isServerHealthy` in `packages/core/src/ensure-server.ts` fetches it with no credentials to tell a current server from a stale one. Deleting the entry on its own gives that probe a 401, and the CLI then starts a second server against the one already running. So `/health` now carries `builtinTools`, the probe reads it there, and the second fetch is gone.
2. `/health` already exists to answer this question and already carries `apiVersion`. The names it now adds are compile-time constants from `BUILTIN_TOOL_IDS`, already hardcoded in the CLI and in this repo, so nothing operator-specific moves to a public route.
3. Every in-app caller goes through `NakamaClient.request`, which sends credentials.

One upgrade note: a CLI on this build probing a server from an older build sees no `builtinTools`, judges it stale and restarts it once. That is the probe doing its job, and it happens one time per upgrade.

## Test plan
- [x] `bun run test`, exit 0, 2630 pass / 0 fail across 11 workspaces
- [x] `bun run check` (ultracite) and `bun run knip`, both exit 0
- [x] New tests watched failing with the fix reverted: `rejects anonymous callers` got 200 instead of 401, and the `/health` test errored because `builtinTools` was not an array
- [x] Live check on a throwaway instance, own config dir, port 4399, with a custom JS tool registered

Anonymous, on `main`:

```
$ curl -s -o /tmp/t.json -w "HTTP %{http_code}\n" http://127.0.0.1:4399/v1/tools
HTTP 200
17 tools returned
  acme_billing_export: Pulls the monthly invoice CSV from the internal billing service

$ curl -s http://127.0.0.1:4399/health
{"apiVersion":1,"composioAvailable":false,"composioConfigured":false,"ok":true,
 "providerConfigured":false,"userConfigured":true}
```

Same instance, same sqlite, on this branch:

```
$ curl -s -o /tmp/t.json -w "HTTP %{http_code}\n" http://127.0.0.1:4399/v1/tools
HTTP 401
{"error":"Authentication required"}

$ curl -s -b cookies -w "HTTP %{http_code}\n" http://127.0.0.1:4399/v1/tools
HTTP 200
17 tools returned
  acme_billing_export: Pulls the monthly invoice CSV from the internal billing service

$ curl -s http://127.0.0.1:4399/health
{"apiVersion":1,"builtinTools":["delete_file","edit_file","email","extract_document_text",
 "knowledge_base_search","read_file","search_files","web_fetch","web_search","write_docx",
 "write_file"],"composioAvailable":false,...}
```

The probe itself, calling the real `ensureServerRunning` against a `/health` that differs only in that field:

```
/health with builtinTools
verdict: healthy, no server spawned

/health without builtinTools
verdict: stale, tried to spawn a replacement
```
