### PR TITLE
fix(telegram): keep the bot token out of the error log

### DIFF
--- a/apps/platform/telegram/src/bot.test.ts
+++ b/apps/platform/telegram/src/bot.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { inspect } from "node:util";
+import { Bot } from "grammy";
+import { redactBotToken } from "./bot";
+
+const TOKEN = "7654321098:AAF_fakeTokenValueDoNotUse_zzzz12345";
+
+describe("redactBotToken", () => {
+  // The leak is not hypothetical: grammY keeps the failed request path on the
+  // error, and the Bot API puts the token in that path. Use a real grammY error
+  // rather than a hand-written one, or the test stops tracking the library.
+  test("keeps the bot token out of a logged grammY network error", async () => {
+    let captured: unknown;
+
+    try {
+      await new Bot(TOKEN, {
+        client: { apiRoot: "http://127.0.0.1:9" },
+      }).api.getMe();
+    } catch (error) {
+      captured = error;
+    }
+
+    const logged = inspect(captured);
+    expect(logged).toContain(TOKEN);
+    expect(redactBotToken(logged, TOKEN)).not.toContain(TOKEN);
+    expect(redactBotToken(logged, TOKEN)).toContain("/bot<redacted>/getMe");
+  });
+
+  test("leaves the text alone when no token is configured", () => {
+    expect(redactBotToken("Network request for 'getMe' failed!", "")).toBe(
+      "Network request for 'getMe' failed!"
+    );
+  });
+});

--- a/apps/platform/telegram/src/bot.ts
+++ b/apps/platform/telegram/src/bot.ts
@@ -1,7 +1,17 @@
+import { inspect } from "node:util";
 import { Bot } from "grammy";
 import { type ChatHandlerDeps, createChatHandler } from "./chat-handler";
 import type { TelegramBridgeConfig } from "./config";
 import type { TelegramBotInfo } from "./group-message";
+
+/**
+ * grammY's HttpError keeps the failed request on the error, and the Bot API
+ * carries the token in the request path (`/bot<token>/getMe`), so logging the
+ * error object writes the token into the log on every network failure.
+ */
+export function redactBotToken(text: string, botToken: string): string {
+  return botToken ? text.replaceAll(botToken, "<redacted>") : text;
+}
 
 export async function createBot(
   config: TelegramBridgeConfig,
@@ -26,7 +36,10 @@ export async function createBot(
   bot.on("message", handleMessage);
 
   bot.catch((error) => {
-    console.error("Telegram bot error:", error);
+    console.error(
+      "Telegram bot error:",
+      redactBotToken(inspect(error), config.botToken)
+    );
   });
 
   return bot;


### PR DESCRIPTION
## Summary

The Telegram bot token was written into the log on every Bot API network failure. Closes #567.

**Before:** `bot.catch` logged the whole error object. The Bot API carries the token in the request path, so grammY's `HttpError` keeps `/bot<token>/getMe` on the error, and printing it prints the credential.
**After:** the handler inspects the error and replaces the configured token first, so the path stays readable and the token does not survive.

Why safe:
1. Only the token string is replaced, so the message, the stack and the failing path all stay in the log. `apps/platform/telegram/src/bot.ts:29` was the one site in the three bridges that logged an error object rather than `error.message`.
2. It reads `config.botToken`, already in scope in `createBot`, so nothing new is plumbed through.

The issue points at three other places, and none of them leaks. `telegram/src/index.ts:84-92`, `discord/src/index.ts:83-93` and `whatsapp/src/index.ts:171-175` log `error.message` only, and for grammY that message is `Network request for 'getMe' failed!` with nothing in it. Discord is clean at the object level too: discord.js sends the token in an `Authorization` header, and neither its 401 nor its connection error carries it. The pairing code is fine as well: `whatsapp/src/index.ts:155` logs `pairing code yes` or `no` rather than the value, and neither `handlePairing` nor `verifyAndPairWhatsAppUser` logs the text it was given.

The suggested `scrubText` is the wrong tool here. It is written for stack traces, where it redacts every quoted string, every brace structure and every word over 32 characters, and it truncates at 4000. Pointed at a log line it removes the failing path along with the token.

## Test plan
- [x] `bun run test`, exit 0, 2629 pass / 0 fail across 11 workspaces
- [x] `bun run check` (ultracite) and `bun run knip`, both exit 0
- [x] New test watched failing with the redaction made a no-op: `Expected to not contain: "7654321098:AAF_fake..."`
- [x] Reproduced against grammy 1.43.0 with an unreachable `apiRoot`, printing what `bot.catch` prints

```
before: token in log = true
  path: 'http://127.0.0.1:9/bot7654321098:AAF_fakeTokenValueDoNotUse_zzzz12345/getMe',
after: token in log = false
  path: 'http://127.0.0.1:9/bot<redacted>/getMe',
```

Discord, same shape, for the record:

```
--- invalid token against discord.com
  message : 401: Unauthorized
  token in printed object : false
--- network failure
  message : Unable to connect. Is the computer able to access the url?
  token in printed object : false
```

The test asserts the raw `inspect` output still contains the token before it checks the redaction, so it fails loudly if grammY ever stops putting the path on the error, instead of passing on nothing.
