### PR TITLE
fix(db): make profile org backfill atomic

### DIFF
--- a/packages/db/src/migrate.test.ts
+++ b/packages/db/src/migrate.test.ts
@@ -583,6 +583,65 @@ describe("organization schema migration", () => {
     }
   });
 
+  test("rolls back profile org backfill when a related update fails", () => {
+    const db = new Database(":memory:");
+
+    try {
+      migrateDatabase(db);
+      db.exec(`
+        INSERT INTO organizations (id, name, slug, created_at, updated_at)
+        VALUES ('org_legacy', 'Legacy', 'legacy', '2026-01-01', '2026-01-01');
+
+        INSERT INTO profiles (
+          id, name, system_prompt, model, is_super, org_id, is_default,
+          created_at, updated_at
+        ) VALUES (
+          'default', 'Default', '', NULL, 0, NULL, 0,
+          '2026-01-01', '2026-01-01'
+        );
+
+        INSERT INTO automations (
+          id, name, version, definition, profile_id, org_id, enabled,
+          created_at, updated_at
+        ) VALUES (
+          'automation_legacy', 'Legacy', 1, '{}', 'default', NULL, 1,
+          '2026-01-01', '2026-01-01'
+        );
+
+        INSERT INTO tasks (
+          id, title, description, prompt, profile_id, org_id, status, position,
+          created_at, updated_at
+        ) VALUES (
+          'task_legacy', 'Legacy', '', 'prompt', 'default', NULL, 'backlog', 0,
+          '2026-01-01', '2026-01-01'
+        );
+
+        CREATE TRIGGER fail_task_org_backfill
+        BEFORE UPDATE OF org_id ON tasks
+        BEGIN
+          SELECT RAISE(ABORT, 'forced migration failure');
+        END;
+      `);
+
+      expect(() => migrateDatabase(db)).toThrow();
+      expect(
+        db
+          .prepare("SELECT org_id, is_default FROM profiles WHERE id = ?")
+          .get("default")
+      ).toEqual({ is_default: 0, org_id: null });
+      expect(
+        db
+          .prepare("SELECT org_id FROM automations WHERE id = ?")
+          .get("automation_legacy")
+      ).toEqual({ org_id: null });
+      expect(
+        db.prepare("SELECT org_id FROM tasks WHERE id = ?").get("task_legacy")
+      ).toEqual({ org_id: null });
+    } finally {
+      db.close();
+    }
+  });
+
   test("rejects duplicate organization slug", () => {
     const db = new Database(":memory:");
 

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -784,55 +784,56 @@ function migrateSkillOrgIds(db: Database): void {
 }
 
 function migrateProfileOrgColumns(db: Database): void {
-  migrateProfilesTable(db);
+  db.transaction(() => {
+    migrateProfilesTable(db);
 
-  const firstOrg = db
-    .prepare("SELECT id FROM organizations ORDER BY id ASC LIMIT 1")
-    .get() as { id: string } | null;
+    const firstOrg = db
+      .prepare("SELECT id FROM organizations ORDER BY id ASC LIMIT 1")
+      .get() as { id: string } | null;
 
-  if (firstOrg) {
-    db.prepare(`
+    if (firstOrg) {
+      db.prepare(`
       UPDATE profiles
       SET org_id = ?
       WHERE org_id IS NULL
     `).run(firstOrg.id);
 
-    db.prepare(`
+      db.prepare(`
       UPDATE profiles
       SET is_default = 0
       WHERE org_id = ?
     `).run(firstOrg.id);
 
-    const defaultProfile = db
-      .prepare(`
+      const defaultProfile = db
+        .prepare(`
         SELECT id FROM profiles
         WHERE org_id = ? AND id = 'default'
         LIMIT 1
       `)
-      .get(firstOrg.id) as { id: string } | null;
-
-    if (defaultProfile) {
-      db.prepare(`
-        UPDATE profiles SET is_default = 1 WHERE id = ?
-      `).run(defaultProfile.id);
-    } else {
-      const anyProfile = db
-        .prepare(`
-          SELECT id FROM profiles WHERE org_id = ? ORDER BY created_at ASC LIMIT 1
-        `)
         .get(firstOrg.id) as { id: string } | null;
 
-      if (anyProfile) {
+      if (defaultProfile) {
         db.prepare(`
+        UPDATE profiles SET is_default = 1 WHERE id = ?
+      `).run(defaultProfile.id);
+      } else {
+        const anyProfile = db
+          .prepare(`
+          SELECT id FROM profiles WHERE org_id = ? ORDER BY created_at ASC LIMIT 1
+        `)
+          .get(firstOrg.id) as { id: string } | null;
+
+        if (anyProfile) {
+          db.prepare(`
           UPDATE profiles SET is_default = 1 WHERE id = ?
         `).run(anyProfile.id);
+        }
       }
+    } else {
+      db.prepare("DELETE FROM profiles WHERE org_id IS NULL").run();
     }
-  } else {
-    db.prepare("DELETE FROM profiles WHERE org_id IS NULL").run();
-  }
 
-  db.prepare(`
+    db.prepare(`
     UPDATE automations
     SET org_id = (
       SELECT org_id FROM profiles WHERE profiles.id = automations.profile_id
@@ -840,13 +841,14 @@ function migrateProfileOrgColumns(db: Database): void {
     WHERE org_id IS NULL
   `).run();
 
-  db.prepare(`
+    db.prepare(`
     UPDATE tasks
     SET org_id = (
       SELECT org_id FROM profiles WHERE profiles.id = tasks.profile_id
     )
     WHERE org_id IS NULL
   `).run();
+  })();
 }
 
 export function addOrgIdColumnIfMissing(db: Database, tableName: string): void {


### PR DESCRIPTION
## Summary

Legacy profile, automation, and task org backfills now commit together or not at all.

**Before:** a late backfill failure could leave profiles assigned to an org while related rows stayed unassigned.
**After:** `migrateProfileOrgColumns` runs its schema/default and org backfills in one SQLite transaction.

Why safe:
1. Existing backfill behavior and ordering are unchanged inside the transaction boundary
2. A forced final-statement failure proves profile, automation, and task state all roll back

Only follow up if the entire migration sequence needs one transaction; that broader concern is tracked by #536.

Closes #537

## Test plan
- [x] `bun test packages/db/src/migrate.test.ts` (20 pass)
- [x] Podman/Linux `bun test packages/db/src` (86 pass); server build and Ultracite check pass
- [x] File-backed pre-backfill boot plus second idempotency boot (all assignments complete; zero foreign-key violations)
