### PR TITLE
fix(server): scope profile avatar reads to the caller's org

### DIFF
--- a/apps/server/src/http/app.test.ts
+++ b/apps/server/src/http/app.test.ts
@@ -118,10 +118,6 @@ function createServerOptions() {
         bytes: new Uint8Array([1, 2, 3]),
         mediaType: "image/png",
       }),
-      getProfileAvatarByProfileId: async (_profileId: string) => ({
-        bytes: new Uint8Array([1, 2, 3]),
-        mediaType: "image/png",
-      }),
       getProfileSoulStack: async (_profileId: string) => ({
         stack: ["SOUL.md"],
       }),

--- a/apps/server/src/http/public-routes.ts
+++ b/apps/server/src/http/public-routes.ts
@@ -25,7 +25,6 @@ export function isPublicRouteRequest(
   return (
     PUBLIC_ROUTES.has(pathname) ||
     /^\/v1\/notify\/[^/]+$/.test(pathname) ||
-    (method === "GET" && /^\/v1\/profiles\/[^/]+\/avatar$/.test(pathname)) ||
     (method === "GET" &&
       /^\/v1\/public\/artifact-shares\/[^/]+$/.test(pathname))
   );

--- a/apps/server/src/http/routes/profiles-avatar-org-scope.test.ts
+++ b/apps/server/src/http/routes/profiles-avatar-org-scope.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import { createInMemoryDatabaseAdapter } from "@nakama/db";
+import { AgentService } from "../../services/agent-service";
+import { setupTestConfigDir } from "../../test-config-dir";
+import { createMinimalHonoApp } from "../test-app-helpers";
+import { loginUserSession, seedOrgAdmin } from "../test-session-helpers";
+
+setupTestConfigDir("nakama-profile-avatar-org-scope-test-");
+
+const PASSWORD = "password123";
+const ATTACKER_ORG = "org_attacker";
+const VICTIM_ORG = "org_victim";
+const VICTIM_PROFILE = "profile_victim";
+
+const tinyPngBase64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+async function createScenario() {
+  const databaseAdapter = createInMemoryDatabaseAdapter();
+  const agent = new AgentService({ providers: [] }, null, databaseAdapter);
+  const { app } = createMinimalHonoApp({ agent, databaseAdapter });
+
+  await seedOrgAdmin(databaseAdapter, {
+    email: "attacker@example.com",
+    orgId: ATTACKER_ORG,
+    password: PASSWORD,
+    userId: "user_attacker",
+  });
+  await seedOrgAdmin(databaseAdapter, {
+    email: "victim@example.com",
+    orgId: VICTIM_ORG,
+    password: PASSWORD,
+    profileId: VICTIM_PROFILE,
+    userId: "user_victim",
+  });
+
+  await agent.uploadProfileAvatar(VICTIM_ORG, VICTIM_PROFILE, {
+    data: tinyPngBase64,
+    mediaType: "image/png",
+  });
+
+  return { app };
+}
+
+const AVATAR_PATH = `http://localhost:4310/v1/profiles/${VICTIM_PROFILE}/avatar`;
+
+describe("GET /v1/profiles/:profileId/avatar is org scoped", () => {
+  test("rejects anonymous callers", async () => {
+    const { app } = await createScenario();
+
+    const response = await app.fetch(new Request(AVATAR_PATH));
+
+    expect(response.status).toBe(401);
+  });
+
+  test("hides the avatar from another org", async () => {
+    const { app } = await createScenario();
+    const attacker = await loginUserSession(
+      app,
+      "attacker@example.com",
+      PASSWORD,
+      ATTACKER_ORG
+    );
+
+    const response = await app.fetch(
+      new Request(AVATAR_PATH, { headers: attacker.headers() })
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  // The web UI renders avatars in an <img> tag, which sends the session cookie
+  // and no X-Org-Id header, so the org has to resolve from the session alone.
+  test("serves the avatar to its own org from the session cookie alone", async () => {
+    const { app } = await createScenario();
+    const victim = await loginUserSession(
+      app,
+      "victim@example.com",
+      PASSWORD,
+      VICTIM_ORG
+    );
+
+    const response = await app.fetch(
+      new Request(AVATAR_PATH, { headers: { Cookie: victim.cookieHeader } })
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("image/png");
+  });
+});

--- a/apps/server/src/http/routes/profiles.ts
+++ b/apps/server/src/http/routes/profiles.ts
@@ -871,8 +871,9 @@ export function registerProfileRoutes(
   );
 
   app.get("/v1/profiles/:profileId/avatar", async (c) => {
+    const orgId = requireActiveOrgIdFromContext(c);
     const profileId = decodeURIComponent(c.req.param("profileId"));
-    const avatar = await agent.getProfileAvatarByProfileId(profileId);
+    const avatar = await agent.getProfileAvatar(orgId, profileId);
     return new Response(avatar.bytes, {
       headers: { "Content-Type": avatar.mediaType },
     });

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -2775,12 +2775,6 @@ export class AgentService {
     return this.profileService.getProfileAvatar(orgId, profileId);
   }
 
-  async getProfileAvatarByProfileId(
-    profileId: string
-  ): Promise<{ mediaType: string; bytes: Buffer }> {
-    return this.profileService.getProfileAvatarByProfileId(profileId);
-  }
-
   async deleteProfileAvatar(orgId: string, profileId: string): Promise<void> {
     return this.profileService.deleteProfileAvatar(orgId, profileId);
   }

--- a/apps/server/src/services/profile-service.test.ts
+++ b/apps/server/src/services/profile-service.test.ts
@@ -213,10 +213,6 @@ describe("profile service avatar", () => {
     expect(avatar.mediaType).toBe("image/png");
     expect(avatar.bytes.length).toBeGreaterThan(0);
 
-    const publicAvatar = await service.getProfileAvatarByProfileId(profileId);
-    expect(publicAvatar.mediaType).toBe("image/png");
-    expect(publicAvatar.bytes.length).toBeGreaterThan(0);
-
     await service.deleteProfileAvatar(ORG_ID, profileId);
 
     const afterDelete = await service.getProfile(ORG_ID, profileId);

--- a/apps/server/src/services/profile-service.ts
+++ b/apps/server/src/services/profile-service.ts
@@ -599,18 +599,6 @@ export class ProfileService {
     return avatar;
   }
 
-  async getProfileAvatarByProfileId(
-    profileId: string
-  ): Promise<{ mediaType: string; bytes: Buffer }> {
-    const profile = await this.db.getProfile(profileId);
-
-    if (!profile?.orgId) {
-      throw new NakamaApiError("Profile not found.", 404);
-    }
-
-    return this.getProfileAvatar(profile.orgId, profileId);
-  }
-
   async deleteProfileAvatar(orgId: string, profileId: string): Promise<void> {
     const profile = await this.requireProfile(orgId, profileId);
     const removed = await deleteProfileAvatar(orgId, profileId);


### PR DESCRIPTION
## Summary

Any profile id returns that profile's avatar to anyone, from any org, with no session at all. Closes #508.

**Before:** the route matched the public-route regex and called `getProfileAvatarByProfileId`, which read the org off the profile row instead of off the caller.
**After:** it resolves the active org from the request and calls the already-scoped `getProfileAvatar`. The by-id variant is deleted rather than guarded, so nothing can reach the unscoped read again.

Why safe:
1. The web UI renders avatars in an `<img>` tag, which sends the session cookie and no `X-Org-Id` header. `resolveOrgId` falls back to the session's `activeOrgId`, which `POST /v1/auth/active-org` keeps current server-side, so that path still works. The third test pins it with a bare `Cookie` header rather than `session.headers()`, which would add the org header and hide the regression.
2. Nothing else reads the route. `getProfileAvatarUrl` in `packages/client` builds a relative path used only by `ProfileAvatar.tsx`, and no bridge, email or public page fetches an avatar. `PublicArtifactSharePage.tsx` renders none.

This reopens the change from #702, which was closed without a comment. If there is a reason avatars are meant to be readable without a session, say so and I will close this instead of guessing.

## Test plan
- [x] `bun run test`, exit 0, 2630 pass / 0 fail across 11 workspaces
- [x] `bun run check` (ultracite) and `bun run knip`, both exit 0
- [x] New tests watched failing on main: `rejects anonymous callers` got 200 instead of 401, `hides the avatar from another org` got 200 instead of 404
- [x] Live check on a throwaway instance, own config dir, port 4397, two orgs, avatar uploaded to a profile in Org A

On `main`:

```
### anonymous, no cookie at all
  HTTP 200  70 bytes  image/png
### logged in, switched to Org B
  switch=200
  HTTP 200  70 bytes  image/png
```

Same instance and same sqlite, on this branch:

```
### anonymous, no cookie at all
  HTTP 401  {"error":"Authentication required"}
### logged in, switched to Org B
  HTTP 404  {"error":"Profile not found."}
### switched back to Org A, cookie only, no X-Org-Id
  HTTP 200  70 bytes  image/png
```

The third line is the one that matters for the UI: no org header, and it still serves.
