### PR TITLE
fix(web): clear stuck chat stream state and related races

### DIFF
--- a/apps/web/src/components/soul-tools/mcp-tab/McpFormEditors.tsx
+++ b/apps/web/src/components/soul-tools/mcp-tab/McpFormEditors.tsx
@@ -9,13 +9,6 @@ import { Input } from "@/components/ui/input";
 import { createClientId, syncRowKeys } from "@/lib/client-id";
 import { cn } from "@/lib/utils";
 
-function mcpArgKey(arg: string, index: number, args: string[]): string {
-  const priorMatches = args
-    .slice(0, index)
-    .filter((value) => value === arg).length;
-  return priorMatches === 0 ? arg : `${arg}:${priorMatches + 1}`;
-}
-
 export function McpFormField({
   label,
   htmlFor,
@@ -66,6 +59,8 @@ export function McpArgsEditor({
   onChange: (args: string[]) => void;
 }) {
   const [draft, setDraft] = useState("");
+  const argKeysRef = useRef<string[]>([]);
+  syncRowKeys(argKeysRef.current, args.length);
 
   function addArg(value: string) {
     const trimmed = value.trim();
@@ -79,6 +74,7 @@ export function McpArgsEditor({
   }
 
   function removeArg(index: number) {
+    argKeysRef.current.splice(index, 1);
     onChange(args.filter((_, argIndex) => argIndex !== index));
   }
 
@@ -130,7 +126,7 @@ export function McpArgsEditor({
       {args.map((arg, index) => (
         <span
           className="inline-flex h-5 max-w-full shrink-0 items-center gap-0.5 rounded-md border border-border bg-muted/50 pr-0.5 pl-1.5 text-foreground text-xs"
-          key={mcpArgKey(arg, index, args)}
+          key={argKeysRef.current[index]}
         >
           <span className="truncate">{arg}</span>
           <button

--- a/apps/web/src/lib/chat-history-route.test.ts
+++ b/apps/web/src/lib/chat-history-route.test.ts
@@ -48,11 +48,6 @@ describe("chat history route helpers", () => {
     expect(readRequestedProfileFromNewChatSearch(url.search)).toBe("gary-vee");
   });
 
-  test("buildNewChatPath is stable for the same profile", () => {
-    expect(buildNewChatPath("gary-vee")).toBe(buildNewChatPath("gary-vee"));
-    expect(buildNewChatPath()).toBe(buildNewChatPath());
-  });
-
   test("storeChatDraft uses unique keys for rapid calls", () => {
     const store = new Map<string, string>();
     const previousSessionStorage = globalThis.sessionStorage;

--- a/apps/web/src/lib/chat-history-route.test.ts
+++ b/apps/web/src/lib/chat-history-route.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "bun:test";
 import {
   buildChatPath,
   buildNewChatPath,
+  CHAT_DRAFT_STORAGE_PREFIX,
   chatProfileIdFromPath,
+  consumeStoredChatDraft,
   isChatSessionPath,
   isProfilesPath,
   parseChatRouteParams,
@@ -15,6 +17,7 @@ import {
   resolveDefaultProfileId,
   resolveHistoryProfileId,
   resolveProfilesPageProfileId,
+  storeChatDraft,
   writeStoredActiveChatProfileId,
 } from "./chat-history";
 
@@ -41,7 +44,45 @@ describe("chat history route helpers", () => {
     expect(url.pathname).toBe("/chat");
     expect(url.searchParams.get("new")).toBe("1");
     expect(url.searchParams.get("profile")).toBe("gary-vee");
+    expect(url.searchParams.get("_")).toBeNull();
     expect(readRequestedProfileFromNewChatSearch(url.search)).toBe("gary-vee");
+  });
+
+  test("buildNewChatPath is stable for the same profile", () => {
+    expect(buildNewChatPath("gary-vee")).toBe(buildNewChatPath("gary-vee"));
+    expect(buildNewChatPath()).toBe(buildNewChatPath());
+  });
+
+  test("storeChatDraft uses unique keys for rapid calls", () => {
+    const store = new Map<string, string>();
+    const previousSessionStorage = globalThis.sessionStorage;
+    Object.defineProperty(globalThis, "sessionStorage", {
+      configurable: true,
+      value: {
+        getItem: (key: string) => store.get(key) ?? null,
+        removeItem: (key: string) => {
+          store.delete(key);
+        },
+        setItem: (key: string, value: string) => {
+          store.set(key, value);
+        },
+      },
+    });
+
+    try {
+      const keys = Array.from({ length: 20 }, (_, index) =>
+        storeChatDraft(`draft-${index}`)
+      );
+      expect(new Set(keys).size).toBe(keys.length);
+      expect(consumeStoredChatDraft(keys[0]!)).toBe("draft-0");
+      expect(consumeStoredChatDraft(keys[1]!)).toBe("draft-1");
+      expect(store.has(`${CHAT_DRAFT_STORAGE_PREFIX}${keys[0]}`)).toBe(false);
+    } finally {
+      Object.defineProperty(globalThis, "sessionStorage", {
+        configurable: true,
+        value: previousSessionStorage,
+      });
+    }
   });
 
   test("reads the requested profile only for new chat links", () => {

--- a/apps/web/src/lib/chat-history.ts
+++ b/apps/web/src/lib/chat-history.ts
@@ -16,6 +16,7 @@ import {
   extractWebSearchBlocksFromProviderContent,
   WEB_SEARCH_TOOL_NAME,
 } from "@/lib/chat-stream-web-search";
+import { createClientId } from "@/lib/client-id";
 
 export interface RequestedChatSession {
   profileId: string;
@@ -33,7 +34,7 @@ export function buildChatBasePath(): string {
  * query string or the remounted page falls back to the default profile.
  */
 export function buildNewChatPath(profileId?: string | null): string {
-  const params = new URLSearchParams({ _: String(Date.now()), new: "1" });
+  const params = new URLSearchParams({ new: "1" });
   if (profileId) {
     params.set("profile", profileId);
   }
@@ -96,7 +97,7 @@ export function consumeStoredChatDraft(key: string): string | null {
 }
 
 export function storeChatDraft(draft: string): string {
-  const key = `d${Date.now()}`;
+  const key = createClientId();
   sessionStorage.setItem(`${CHAT_DRAFT_STORAGE_PREFIX}${key}`, draft);
   return key;
 }

--- a/apps/web/src/lib/chat-stream-finalize.test.ts
+++ b/apps/web/src/lib/chat-stream-finalize.test.ts
@@ -10,8 +10,8 @@ describe("finalizeStreamingMessages", () => {
         content: "partial",
         id: "a1",
         role: "assistant",
-        streaming: false,
-        thinkingStreaming: false,
+        streaming: true,
+        thinkingStreaming: true,
       },
       {
         content: "search_files stopped",
@@ -42,14 +42,6 @@ describe("finalizeStreamingMessages", () => {
         thinkingStreaming: false,
       },
     ];
-
-    // Simulate abort after an earlier assistant was finalized by tool end,
-    // leaving a prior assistant still marked streaming while a later one exists.
-    messages[1] = {
-      ...messages[1]!,
-      streaming: true,
-      thinkingStreaming: true,
-    };
 
     const next = finalizeStreamingMessages(messages);
 

--- a/apps/web/src/lib/chat-stream-finalize.test.ts
+++ b/apps/web/src/lib/chat-stream-finalize.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import type { ChatListItem } from "@/lib/chat-history";
+import { finalizeStreamingMessages } from "./chat-stream";
+
+describe("finalizeStreamingMessages", () => {
+  test("clears streaming on every affected assistant, not only the last one", () => {
+    const messages: ChatListItem[] = [
+      { content: "hi", id: "u1", role: "user" },
+      {
+        content: "partial",
+        id: "a1",
+        role: "assistant",
+        streaming: false,
+        thinkingStreaming: false,
+      },
+      {
+        content: "search_files stopped",
+        id: "t1",
+        role: "tool",
+        tool: "search_files",
+        toolStatus: "done",
+      },
+      {
+        content: "still open",
+        id: "a2",
+        role: "assistant",
+        streaming: true,
+        thinkingStreaming: true,
+      },
+      {
+        content: "bash",
+        id: "t2",
+        role: "tool",
+        tool: "bash",
+        toolStatus: "running",
+      },
+      {
+        content: "later partial",
+        id: "a3",
+        role: "assistant",
+        streaming: false,
+        thinkingStreaming: false,
+      },
+    ];
+
+    // Simulate abort after an earlier assistant was finalized by tool end,
+    // leaving a prior assistant still marked streaming while a later one exists.
+    messages[1] = {
+      ...messages[1]!,
+      streaming: true,
+      thinkingStreaming: true,
+    };
+
+    const next = finalizeStreamingMessages(messages);
+
+    expect(next[1]).toMatchObject({
+      id: "a1",
+      streaming: false,
+      thinkingStreaming: false,
+    });
+    expect(next[3]).toMatchObject({
+      id: "a2",
+      streaming: false,
+      thinkingStreaming: false,
+    });
+    expect(next[4]).toMatchObject({
+      artifactStreaming: false,
+      content: "bash stopped",
+      id: "t2",
+      toolStatus: "done",
+    });
+    expect(next[5]).toMatchObject({
+      id: "a3",
+      streaming: false,
+      thinkingStreaming: false,
+    });
+  });
+});

--- a/apps/web/src/lib/chat-stream.ts
+++ b/apps/web/src/lib/chat-stream.ts
@@ -403,31 +403,29 @@ export function isAbortError(error: unknown): boolean {
 export function finalizeStreamingMessages(
   messages: ChatListItem[]
 ): ChatListItem[] {
-  const next = messages.map((message) =>
-    message.role === "tool" && message.toolStatus === "running"
-      ? {
-          ...message,
-          artifactStreaming: false,
-          content: `${message.tool} stopped`,
-          toolStatus: "done" as const,
-        }
-      : message
-  );
+  return messages.map((message) => {
+    if (message.role === "tool" && message.toolStatus === "running") {
+      return {
+        ...message,
+        artifactStreaming: false,
+        content: `${message.tool} stopped`,
+        toolStatus: "done" as const,
+      };
+    }
 
-  for (let index = next.length - 1; index >= 0; index -= 1) {
-    const message = next[index];
-
-    if (message?.role === "assistant") {
-      next[index] = {
+    if (
+      message.role === "assistant" &&
+      (message.streaming || message.thinkingStreaming)
+    ) {
+      return {
         ...message,
         streaming: false,
         thinkingStreaming: false,
       };
-      break;
     }
-  }
 
-  return next;
+    return message;
+  });
 }
 
 export function deriveChatStatus(

--- a/apps/web/src/lib/client-id.test.ts
+++ b/apps/web/src/lib/client-id.test.ts
@@ -10,4 +10,20 @@ describe("syncRowKeys", () => {
     syncRowKeys(keys, 1);
     expect(keys).toEqual([first]);
   });
+
+  test("middle splice keeps sibling keys stable after remove-and-readd", () => {
+    const keys: string[] = [];
+    syncRowKeys(keys, 3);
+    const [first, , third] = keys;
+
+    keys.splice(1, 1);
+    syncRowKeys(keys, 2);
+    expect(keys).toEqual([first, third]);
+
+    syncRowKeys(keys, 3);
+    expect(keys[0]).toBe(first);
+    expect(keys[1]).toBe(third);
+    expect(keys[2]).not.toBe(first);
+    expect(keys[2]).not.toBe(third);
+  });
 });

--- a/apps/web/src/pages/chat/use-chat-page.ts
+++ b/apps/web/src/pages/chat/use-chat-page.ts
@@ -563,13 +563,17 @@ export function useChatPage() {
 
   const handleProfileSwitch = useCallback(
     (nextProfileId: string) => {
-      if (!nextProfileId || nextProfileId === profileId || busy) {
+      if (
+        !nextProfileId ||
+        nextProfileId === profileIdRef.current ||
+        busyRef.current
+      ) {
         return;
       }
       setProfileId(nextProfileId);
       enterDraftChat(nextProfileId);
     },
-    [profileId, busy, enterDraftChat]
+    [enterDraftChat]
   );
 
   useEffect(


### PR DESCRIPTION
## Summary

Abort, profile switch, MCP args, chat drafts, and New chat URLs no longer leave stuck or colliding UI state. Fixes #518, #516, #519, #571, and #570.

**Before:** Abort left earlier assistants marked streaming. Profile switch used stale busy/profile values. MCP arg keys collided after remove-and-readd. Rapid Send reused draft keys. New chat always changed `_` in the URL.
**After:** `finalizeStreamingMessages` clears every streaming assistant. Profile switch reads `profileIdRef`/`busyRef`. MCP args use `syncRowKeys`. Drafts use `createClientId`. New chat path drops `_`.

Why safe:
1. Finalize only flips flags on assistants that still stream or think-stream
2. Profile switch guard matches the registered switch handler
3. New chat still carries `new=1` and `profile`

Only re-check if a second New chat click must re-run while the URL still has `?new=1` (no `_` cache buster). No hook unit test covers #516.

## Test plan
- [x] `bun test apps/web/src/lib/chat-stream-finalize.test.ts apps/web/src/lib/chat-history-route.test.ts apps/web/src/lib/client-id.test.ts` (16 pass)
- [x] `bun run --cwd apps/web build` (tsc + vite ok)
- [x] `bun x ultracite check` on changed files (ok)
- [ ] Abort mid-tool turn: no assistant stays on streaming UI
- [ ] Switch profile while busy is blocked; switch when idle works
