### PR TITLE
docs(discord): note gateway-only interaction integrity (#559)

### DIFF
--- a/apps/platform/discord/src/bot.ts
+++ b/apps/platform/discord/src/bot.ts
@@ -61,6 +61,12 @@ export async function createBot(
     }
   });
 
+  // Integrity: interactions arrive over the gateway WebSocket (discord.js +
+  // intents above), authenticated by the bot token — not via Discord's HTTP
+  // Interactions Endpoint. Ed25519 signature verification (X-Signature-Ed25519 /
+  // X-Signature-Timestamp) does not apply on this path. If we ever expose an
+  // HTTP interaction endpoint, verify signatures with the app public key before
+  // handling the body; do not copy this gateway-only handler as-is.
   client.on(Events.InteractionCreate, async (interaction) => {
     if (!interaction.isChatInputCommand()) {
       return;


### PR DESCRIPTION
## Summary

Document that Discord slash handling is gateway-only → Ed25519 HTTP signature checks are N/A until an Interactions Endpoint exists (#559).

**Before:** `InteractionCreate` looked like it might need HTTP signature verification with no stated assumption.
**After:** Comment on the handler states gateway/WebSocket + bot-token auth; future HTTP endpoints must verify Ed25519 first.

Why safe:
1. Comment-only; no runtime or dependency change
2. Matches today's discord.js gateway path (no HTTP interactions endpoint)
3. Explicit follow-up if someone adds HTTP interactions later

Only re-add / follow up if we ship a Discord HTTP Interactions Endpoint without signature verification.

## Test plan
- [x] Reviewed `apps/platform/discord/src/bot.ts` InteractionCreate path (gateway intents only; no signature code present)
- [ ] Skim the new comment above `Events.InteractionCreate` — assumption matches how the bot logs in

Closes #559
