### PR TITLE
fix(cli): reject unknown keys in cli.ini parse

### DIFF
--- a/apps/cli/src/cli-config.test.ts
+++ b/apps/cli/src/cli-config.test.ts
@@ -1,31 +1,69 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtemp, readFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   getCliConfigPath,
+  loadSavedCliOrgId,
   loadSavedCliProfileId,
+  saveCliOrgId,
   saveCliProfileId,
 } from "./cli-config";
 
+async function withCliConfigDir<T>(run: () => Promise<T>): Promise<T> {
+  const configDir = await mkdtemp(join(tmpdir(), "nakama-cli-"));
+  const previous = process.env.NAKAMA_CONFIG_DIR;
+  process.env.NAKAMA_CONFIG_DIR = configDir;
+
+  try {
+    return await run();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.NAKAMA_CONFIG_DIR;
+    } else {
+      process.env.NAKAMA_CONFIG_DIR = previous;
+    }
+  }
+}
+
 describe("cli-config", () => {
   test("saves and loads profile_id", async () => {
-    const configDir = await mkdtemp(join(tmpdir(), "nakama-cli-"));
-    const previous = process.env.NAKAMA_CONFIG_DIR;
-    process.env.NAKAMA_CONFIG_DIR = configDir;
-
-    try {
+    await withCliConfigDir(async () => {
       await saveCliProfileId("super_bot");
       expect(await loadSavedCliProfileId()).toBe("super_bot");
 
       const raw = await readFile(getCliConfigPath(), "utf8");
       expect(raw).toContain("profile_id=super_bot");
-    } finally {
-      if (previous === undefined) {
-        delete process.env.NAKAMA_CONFIG_DIR;
-      } else {
-        process.env.NAKAMA_CONFIG_DIR = previous;
-      }
-    }
+    });
+  });
+
+  test("ignores unknown keys when loading cli.ini", async () => {
+    await withCliConfigDir(async () => {
+      const path = getCliConfigPath();
+      await writeFile(
+        path,
+        [
+          "# Nakama CLI",
+          "profile_id=super_bot",
+          "evil=injected",
+          "org_id=org_123",
+          "another=payload",
+          "",
+        ].join("\n"),
+        { mode: 0o600 }
+      );
+
+      expect(await loadSavedCliProfileId()).toBe("super_bot");
+      expect(await loadSavedCliOrgId()).toBe("org_123");
+
+      await saveCliOrgId("org_123");
+      const raw = await readFile(path, "utf8");
+      expect(raw).toContain("profile_id=super_bot");
+      expect(raw).toContain("org_id=org_123");
+      expect(raw).not.toContain("evil");
+      expect(raw).not.toContain("another");
+      expect(raw).not.toContain("injected");
+      expect(raw).not.toContain("payload");
+    });
   });
 });

--- a/apps/cli/src/cli-config.ts
+++ b/apps/cli/src/cli-config.ts
@@ -1,6 +1,8 @@
 import { join } from "node:path";
 import { getUserConfigDir, readTextOrNull, writeTextFile } from "@nakama/core";
 
+const CLI_CONFIG_KEYS = new Set(["org_id", "profile_id"]);
+
 export function getCliConfigPath(): string {
   return join(getUserConfigDir(), "cli.ini");
 }
@@ -84,6 +86,11 @@ function parseIni(raw: string): Record<string, string> {
     }
 
     const key = trimmed.slice(0, separator).trim();
+
+    if (!CLI_CONFIG_KEYS.has(key)) {
+      continue;
+    }
+
     const value = trimmed.slice(separator + 1).trim();
     values[key] = value;
   }


### PR DESCRIPTION
## Summary

`parseIni` for `~/.nakama/cli.ini` only accepts `org_id` / `profile_id` — unknown keys are dropped on load (#611).

**Before:** any `key=value` line entered the parsed dict and could ride along on later saves.
**After:** `CLI_CONFIG_KEYS` allowlist in `parseIni`; unknown keys skipped.

Why safe:
1. Write path already only emits `org_id` / `profile_id`
2. File mode still 0o600 via `writeTextFile`
3. Known keys still load/save unchanged

Only re-add keys if a new CLI setting is intentionally stored in `cli.ini`.

## Test plan
- [x] `bun test apps/cli/src/cli-config.test.ts` (2 pass)
- [ ] Write a junk key into `cli.ini`, run a CLI command that saves config — junk key gone, profile/org intact

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
