### PR TITLE
fix(server): validate addMember name length and control chars

### DIFF
--- a/apps/server/src/services/org-service.test.ts
+++ b/apps/server/src/services/org-service.test.ts
@@ -234,6 +234,60 @@ describe("OrgService", () => {
     expect(added.temporaryPassword).toHaveLength(12);
   });
 
+  test("rejects member names with control characters", async () => {
+    const { orgService } = createOrgService();
+    const created = await orgService.createOrganization({
+      name: "Acme",
+      slug: "acme-member-control-chars",
+    });
+
+    await expect(
+      orgService.addMember({
+        email: "control@acme.com",
+        name: "Bad\r\nName",
+        orgId: created.organization.id,
+        phone: "",
+        role: "member",
+      })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  test("rejects member names longer than 120 characters", async () => {
+    const { orgService } = createOrgService();
+    const created = await orgService.createOrganization({
+      name: "Acme",
+      slug: "acme-member-name-too-long",
+    });
+
+    await expect(
+      orgService.addMember({
+        email: "long@acme.com",
+        name: "a".repeat(121),
+        orgId: created.organization.id,
+        phone: "",
+        role: "member",
+      })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  test("rejects empty member names", async () => {
+    const { orgService } = createOrgService();
+    const created = await orgService.createOrganization({
+      name: "Acme",
+      slug: "acme-empty-member-name",
+    });
+
+    await expect(
+      orgService.addMember({
+        email: "empty@acme.com",
+        name: "   ",
+        orgId: created.organization.id,
+        phone: "",
+        role: "member",
+      })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
   test("allows changing password after provisioning", async () => {
     const { orgService } = createOrgService();
     const created = await orgService.createOrganization({

--- a/apps/server/src/services/org-service.ts
+++ b/apps/server/src/services/org-service.ts
@@ -45,6 +45,8 @@ const LAST_ORGANIZATION_MESSAGE =
 const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const PHONE_PATTERN = /^[+0-9()\-\s]{6,32}$/;
+const MAX_MEMBER_NAME_LENGTH = 120;
+const MEMBER_NAME_CONTROL_CHARS = /[\u0000-\u001F\u007F]/;
 
 export class OrgService {
   constructor(
@@ -392,9 +394,7 @@ export class OrgService {
     const email = normalizeEmail(input.email);
     const phone = normalizeOptionalPhone(input.phone);
 
-    if (!name) {
-      throw new NakamaApiError("Member name is required.", 400);
-    }
+    assertMemberName(name);
 
     if (!EMAIL_PATTERN.test(email)) {
       throw new NakamaApiError("A valid email address is required.", 400);
@@ -869,6 +869,20 @@ export class OrgService {
       orgId
     );
     await initSoulDirectory(getProfileSoulDir(orgId, superBotProfile.id));
+  }
+}
+
+function assertMemberName(name: string): void {
+  if (!name) {
+    throw new NakamaApiError("Member name is required.", 400);
+  }
+
+  if (name.length > MAX_MEMBER_NAME_LENGTH) {
+    throw new NakamaApiError("Member name is too long.", 400);
+  }
+
+  if (MEMBER_NAME_CONTROL_CHARS.test(name)) {
+    throw new NakamaApiError("Member name contains invalid characters.", 400);
   }
 }
 


### PR DESCRIPTION
## Summary

`addMember` rejects names with control chars or length > 120 → 400.

**Before:** only `trim()` + empty check — `\r\n` and huge names accepted.
**After:** `assertMemberName` — empty, >120, or `[\u0000-\u001F\u007F]` → 400.

Why safe:
1. Validation only on `addMember`; existing members unchanged
2. Happy-path names (letters/spaces) still pass
3. Tests assert status 400, not error copy

Only re-check if `updateMember` / profile rename should share the same rules (still open).

## Test plan
- [x] `bun test apps/server/src/services/org-service.test.ts` (29 pass)
- [ ] Add a member with a normal name in System → Organization → Members — still works

Closes #555
