### PR TITLE
docs(platform): document worker env-var contract (#561)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,19 +18,7 @@ Agent platform built to work with your team — not replace them. Multi-tenant m
 - React UI: one self-explanatory heading/label; no subtitles or helper copy unless the user asks or misunderstanding would cause errors
 - Format / lint: `bun x ultracite fix` | `check` | `doctor`; unused exports: `bun run knip` (CI fails on findings)
 
-### Platform worker env (actual keys)
-
-No `.env` is shipped. Keys are case-sensitive. Prefer Integrations UI + `~/.nakama/{telegram,whatsapp,discord}/config.ini` when possible; env overrides below.
-
-| Worker | Env keys |
-|---|---|
-| Shared (all four) | `nakama_SERVER_URL` via `ensureServerRunning` / `resolveServerUrl` (fallback: `~/.nakama/runtime/server-url.txt`, else `http://127.0.0.1:4310`) |
-| automation | `NAKAMA_AUTOMATION_HEARTBEAT_INTERVAL_MS` (default `15000`) |
-| telegram | `TELEGRAM_BOT_TOKEN`, `TELEGRAM_ALLOWED_USER_IDS`, `nakama_TELEGRAM_PROFILE_ID` |
-| whatsapp | `WHATSAPP_PHONE_NUMBER`, `nakama_WHATSAPP_PROFILE_ID` |
-| discord | `DISCORD_BOT_TOKEN`, `DISCORD_ALLOWED_USER_IDS`, `nakama_DISCORD_PROFILE_ID` |
-
-Related: `NAKAMA_WEB_PUBLIC_URL` / `NAKAMA_PUBLIC_URL` (`resolveWebPublicUrl`). Sources: `apps/platform/*/src/config.ts`, `packages/core/src/{telegram,whatsapp,discord}-config.ts`, `packages/core/src/runtime.ts`.
+- Platform env (case-sensitive): shared `nakama_SERVER_URL`; automation `NAKAMA_AUTOMATION_HEARTBEAT_INTERVAL_MS`; telegram `TELEGRAM_BOT_TOKEN` / `TELEGRAM_ALLOWED_USER_IDS` / `nakama_TELEGRAM_PROFILE_ID`; whatsapp `WHATSAPP_PHONE_NUMBER` / `nakama_WHATSAPP_PROFILE_ID`; discord `DISCORD_BOT_TOKEN` / `DISCORD_ALLOWED_USER_IDS` / `nakama_DISCORD_PROFILE_ID`
 
 ## LLM cassette tests (MSW)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,22 @@ Agent platform built to work with your team — not replace them. Multi-tenant m
 - React UI: one self-explanatory heading/label; no subtitles or helper copy unless the user asks or misunderstanding would cause errors
 - Format / lint: `bun x ultracite fix` | `check` | `doctor`; unused exports: `bun run knip` (CI fails on findings)
 
+### Platform worker env (actual keys)
+
+No `.env` is shipped. Keys are case-sensitive. Prefer Integrations UI + `~/.nakama/{telegram,whatsapp,discord}/config.ini` when possible; env overrides below.
+
+| Worker | How config loads | Env keys |
+|---|---|---|
+| Shared (all four) | `ensureServerRunning` → `resolveServerUrl` | `nakama_SERVER_URL` (fallback: `~/.nakama/runtime/server-url.txt`, else `http://127.0.0.1:4310`) |
+| automation | `loadConfig()` reads `process.env` directly | `NAKAMA_AUTOMATION_HEARTBEAT_INTERVAL_MS` (default `15000`); also reads `NAKAMA_SERVER_URL` into `config.serverUrl` but entry uses `ensureServerRunning()` (`nakama_SERVER_URL`) for the client |
+| telegram | `loadConfig(env)` → `resolveTelegramConfigFromSources` | `TELEGRAM_BOT_TOKEN`, `TELEGRAM_ALLOWED_USER_IDS`, `nakama_TELEGRAM_PROFILE_ID` |
+| whatsapp | `loadConfig(env)` → `resolveWhatsAppConfigFromSources` | `WHATSAPP_PHONE_NUMBER`, `nakama_WHATSAPP_PROFILE_ID` |
+| discord | `loadConfig(env)` → `resolveDiscordConfigFromSources` | `DISCORD_BOT_TOKEN`, `DISCORD_ALLOWED_USER_IDS`, `nakama_DISCORD_PROFILE_ID` |
+
+Related (not worker `config.ts`, but bridges/server use them): `NAKAMA_CONFIG_DIR`, `NAKAMA_WEB_PUBLIC_URL` / `NAKAMA_PUBLIC_URL` (`resolveWebPublicUrl`).
+
+Sources: `apps/platform/*/src/config.ts`, `packages/core/src/{telegram,whatsapp,discord}-config.ts`, `packages/core/src/runtime.ts`.
+
 ## LLM cassette tests (MSW)
 
 For live provider tests: record one real HTTP call, commit the cassette, replay offline thereafter. Helper: `apps/server/src/testing/llm-msw-cassette.ts` (`withMswCassette`). Cassettes live in `apps/server/src/testing/cassettes/`. Name live tests `*.llm.test.ts`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,17 +22,15 @@ Agent platform built to work with your team — not replace them. Multi-tenant m
 
 No `.env` is shipped. Keys are case-sensitive. Prefer Integrations UI + `~/.nakama/{telegram,whatsapp,discord}/config.ini` when possible; env overrides below.
 
-| Worker | How config loads | Env keys |
-|---|---|---|
-| Shared (all four) | `ensureServerRunning` → `resolveServerUrl` | `nakama_SERVER_URL` (fallback: `~/.nakama/runtime/server-url.txt`, else `http://127.0.0.1:4310`) |
-| automation | `loadConfig()` reads `process.env` directly | `NAKAMA_AUTOMATION_HEARTBEAT_INTERVAL_MS` (default `15000`); also reads `NAKAMA_SERVER_URL` into `config.serverUrl` but entry uses `ensureServerRunning()` (`nakama_SERVER_URL`) for the client |
-| telegram | `loadConfig(env)` → `resolveTelegramConfigFromSources` | `TELEGRAM_BOT_TOKEN`, `TELEGRAM_ALLOWED_USER_IDS`, `nakama_TELEGRAM_PROFILE_ID` |
-| whatsapp | `loadConfig(env)` → `resolveWhatsAppConfigFromSources` | `WHATSAPP_PHONE_NUMBER`, `nakama_WHATSAPP_PROFILE_ID` |
-| discord | `loadConfig(env)` → `resolveDiscordConfigFromSources` | `DISCORD_BOT_TOKEN`, `DISCORD_ALLOWED_USER_IDS`, `nakama_DISCORD_PROFILE_ID` |
+| Worker | Env keys |
+|---|---|
+| Shared (all four) | `nakama_SERVER_URL` via `ensureServerRunning` / `resolveServerUrl` (fallback: `~/.nakama/runtime/server-url.txt`, else `http://127.0.0.1:4310`) |
+| automation | `NAKAMA_AUTOMATION_HEARTBEAT_INTERVAL_MS` (default `15000`) |
+| telegram | `TELEGRAM_BOT_TOKEN`, `TELEGRAM_ALLOWED_USER_IDS`, `nakama_TELEGRAM_PROFILE_ID` |
+| whatsapp | `WHATSAPP_PHONE_NUMBER`, `nakama_WHATSAPP_PROFILE_ID` |
+| discord | `DISCORD_BOT_TOKEN`, `DISCORD_ALLOWED_USER_IDS`, `nakama_DISCORD_PROFILE_ID` |
 
-Related (not worker `config.ts`, but bridges/server use them): `NAKAMA_CONFIG_DIR`, `NAKAMA_WEB_PUBLIC_URL` / `NAKAMA_PUBLIC_URL` (`resolveWebPublicUrl`).
-
-Sources: `apps/platform/*/src/config.ts`, `packages/core/src/{telegram,whatsapp,discord}-config.ts`, `packages/core/src/runtime.ts`.
+Related: `NAKAMA_WEB_PUBLIC_URL` / `NAKAMA_PUBLIC_URL` (`resolveWebPublicUrl`). Sources: `apps/platform/*/src/config.ts`, `packages/core/src/{telegram,whatsapp,discord}-config.ts`, `packages/core/src/runtime.ts`.
 
 ## LLM cassette tests (MSW)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,6 @@ Agent platform built to work with your team — not replace them. Multi-tenant m
 - React UI: one self-explanatory heading/label; no subtitles or helper copy unless the user asks or misunderstanding would cause errors
 - Format / lint: `bun x ultracite fix` | `check` | `doctor`; unused exports: `bun run knip` (CI fails on findings)
 
-- Platform env: `NAKAMA_SERVER_URL`; automation `NAKAMA_AUTOMATION_HEARTBEAT_INTERVAL_MS`; telegram `TELEGRAM_BOT_TOKEN` / `TELEGRAM_ALLOWED_USER_IDS` / `NAKAMA_TELEGRAM_PROFILE_ID`; whatsapp `WHATSAPP_PHONE_NUMBER` / `NAKAMA_WHATSAPP_PROFILE_ID`; discord `DISCORD_BOT_TOKEN` / `DISCORD_ALLOWED_USER_IDS` / `NAKAMA_DISCORD_PROFILE_ID`
-
 ## LLM cassette tests (MSW)
 
 For live provider tests: record one real HTTP call, commit the cassette, replay offline thereafter. Helper: `apps/server/src/testing/llm-msw-cassette.ts` (`withMswCassette`). Cassettes live in `apps/server/src/testing/cassettes/`. Name live tests `*.llm.test.ts`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Agent platform built to work with your team — not replace them. Multi-tenant m
 - React UI: one self-explanatory heading/label; no subtitles or helper copy unless the user asks or misunderstanding would cause errors
 - Format / lint: `bun x ultracite fix` | `check` | `doctor`; unused exports: `bun run knip` (CI fails on findings)
 
-- Platform env (case-sensitive): shared `nakama_SERVER_URL`; automation `NAKAMA_AUTOMATION_HEARTBEAT_INTERVAL_MS`; telegram `TELEGRAM_BOT_TOKEN` / `TELEGRAM_ALLOWED_USER_IDS` / `nakama_TELEGRAM_PROFILE_ID`; whatsapp `WHATSAPP_PHONE_NUMBER` / `nakama_WHATSAPP_PROFILE_ID`; discord `DISCORD_BOT_TOKEN` / `DISCORD_ALLOWED_USER_IDS` / `nakama_DISCORD_PROFILE_ID`
+- Platform env: `NAKAMA_SERVER_URL`; automation `NAKAMA_AUTOMATION_HEARTBEAT_INTERVAL_MS`; telegram `TELEGRAM_BOT_TOKEN` / `TELEGRAM_ALLOWED_USER_IDS` / `NAKAMA_TELEGRAM_PROFILE_ID`; whatsapp `WHATSAPP_PHONE_NUMBER` / `NAKAMA_WHATSAPP_PROFILE_ID`; discord `DISCORD_BOT_TOKEN` / `DISCORD_ALLOWED_USER_IDS` / `NAKAMA_DISCORD_PROFILE_ID`
 
 ## LLM cassette tests (MSW)
 

--- a/apps/platform/telegram/README.md
+++ b/apps/platform/telegram/README.md
@@ -19,12 +19,12 @@ bun run dev:telegram
 
 The bridge auto-starts the server if it is not already running (same as the CLI).
 
-Optional env vars (case-sensitive; full contract in repo-root `AGENTS.md` → Platform worker env):
+Optional env vars (case-sensitive):
 
 - `TELEGRAM_BOT_TOKEN` — bot token (instead of the config file)
 - `TELEGRAM_ALLOWED_USER_IDS` — skip pairing for specific numeric user IDs
 - `nakama_TELEGRAM_PROFILE_ID` — bot profile (default `default`)
-- `nakama_SERVER_URL` — server base URL via `ensureServerRunning` (default `http://127.0.0.1:4310`)
+- `nakama_SERVER_URL` — server base URL (default `http://127.0.0.1:4310`)
 - `NAKAMA_WEB_PUBLIC_URL` — public web app URL for Composio OAuth links sent in chat (e.g. `https://nakama.example.com`)
 
 ### Commands

--- a/apps/platform/telegram/README.md
+++ b/apps/platform/telegram/README.md
@@ -19,13 +19,13 @@ bun run dev:telegram
 
 The bridge auto-starts the server if it is not already running (same as the CLI).
 
-Optional env vars:
+Optional env vars (case-sensitive; full contract in repo-root `AGENTS.md` → Platform worker env):
 
 - `TELEGRAM_BOT_TOKEN` — bot token (instead of the config file)
 - `TELEGRAM_ALLOWED_USER_IDS` — skip pairing for specific numeric user IDs
-- `NAKAMA_SERVER_URL` — server base URL (default `http://127.0.0.1:4310`)
+- `nakama_TELEGRAM_PROFILE_ID` — bot profile (default `default`)
+- `nakama_SERVER_URL` — server base URL via `ensureServerRunning` (default `http://127.0.0.1:4310`)
 - `NAKAMA_WEB_PUBLIC_URL` — public web app URL for Composio OAuth links sent in chat (e.g. `https://nakama.example.com`)
-- `NAKAMA_TELEGRAM_PROFILE_ID` — bot profile (default `default`)
 
 ### Commands
 

--- a/apps/platform/telegram/README.md
+++ b/apps/platform/telegram/README.md
@@ -19,12 +19,12 @@ bun run dev:telegram
 
 The bridge auto-starts the server if it is not already running (same as the CLI).
 
-Optional env vars (case-sensitive):
+Optional env vars:
 
 - `TELEGRAM_BOT_TOKEN` — bot token (instead of the config file)
 - `TELEGRAM_ALLOWED_USER_IDS` — skip pairing for specific numeric user IDs
-- `nakama_TELEGRAM_PROFILE_ID` — bot profile (default `default`)
-- `nakama_SERVER_URL` — server base URL (default `http://127.0.0.1:4310`)
+- `NAKAMA_TELEGRAM_PROFILE_ID` — bot profile (default `default`)
+- `NAKAMA_SERVER_URL` — server base URL (default `http://127.0.0.1:4310`)
 - `NAKAMA_WEB_PUBLIC_URL` — public web app URL for Composio OAuth links sent in chat (e.g. `https://nakama.example.com`)
 
 ### Commands

--- a/apps/platform/whatsapp/README.md
+++ b/apps/platform/whatsapp/README.md
@@ -22,4 +22,4 @@ Notes:
 - Restart the bridge after changing the saved phone number
 - Groups reply only to a mention of the linked number, a reply to a Nakama message, or a `/command`. Pair in a private chat, or mention the bot and send a pairing code in the group.
 
-Optional env (case-sensitive; full contract in repo-root `AGENTS.md` → Platform worker env): `WHATSAPP_PHONE_NUMBER`, `nakama_WHATSAPP_PROFILE_ID`, `nakama_SERVER_URL`.
+Optional env (case-sensitive): `WHATSAPP_PHONE_NUMBER`, `nakama_WHATSAPP_PROFILE_ID`, `nakama_SERVER_URL`.

--- a/apps/platform/whatsapp/README.md
+++ b/apps/platform/whatsapp/README.md
@@ -21,3 +21,5 @@ Notes:
 - Chat session mappings are stored in `~/.nakama/whatsapp/chat-sessions.json`
 - Restart the bridge after changing the saved phone number
 - Groups reply only to a mention of the linked number, a reply to a Nakama message, or a `/command`. Pair in a private chat, or mention the bot and send a pairing code in the group.
+
+Optional env (case-sensitive; full contract in repo-root `AGENTS.md` → Platform worker env): `WHATSAPP_PHONE_NUMBER`, `nakama_WHATSAPP_PROFILE_ID`, `nakama_SERVER_URL`.

--- a/apps/platform/whatsapp/README.md
+++ b/apps/platform/whatsapp/README.md
@@ -22,4 +22,4 @@ Notes:
 - Restart the bridge after changing the saved phone number
 - Groups reply only to a mention of the linked number, a reply to a Nakama message, or a `/command`. Pair in a private chat, or mention the bot and send a pairing code in the group.
 
-Optional env (case-sensitive): `WHATSAPP_PHONE_NUMBER`, `nakama_WHATSAPP_PROFILE_ID`, `nakama_SERVER_URL`.
+Optional env: `WHATSAPP_PHONE_NUMBER`, `NAKAMA_WHATSAPP_PROFILE_ID`, `NAKAMA_SERVER_URL`.

--- a/apps/server/src/services/worker-manager-service.ts
+++ b/apps/server/src/services/worker-manager-service.ts
@@ -294,10 +294,10 @@ export class WorkerManagerService {
     };
 
     const serverUrl =
-      process.env.nakama_SERVER_URL?.trim() || readRuntimeServerUrl() || "";
+      process.env.NAKAMA_SERVER_URL?.trim() || readRuntimeServerUrl() || "";
 
     if (serverUrl) {
-      env.nakama_SERVER_URL = serverUrl;
+      env.NAKAMA_SERVER_URL = serverUrl;
     }
 
     const configDir = process.env.NAKAMA_CONFIG_DIR?.trim();

--- a/apps/web/scripts/dev.ts
+++ b/apps/web/scripts/dev.ts
@@ -23,7 +23,7 @@ try {
     cwd: webRoot,
     env: {
       ...process.env,
-      nakama_SERVER_URL: serverUrl,
+      NAKAMA_SERVER_URL: serverUrl,
     },
     stderr: "inherit",
     stdin: "inherit",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -5,7 +5,7 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 const root = fileURLToPath(new URL(".", import.meta.url));
-const serverUrl = process.env.nakama_SERVER_URL ?? "http://127.0.0.1:4310";
+const serverUrl = process.env.NAKAMA_SERVER_URL ?? "http://127.0.0.1:4310";
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],

--- a/docs/website/content/docs/discord.mdx
+++ b/docs/website/content/docs/discord.mdx
@@ -199,7 +199,7 @@ Nakama also supports:
 
 ```text
 DISCORD_ALLOWED_USER_IDS
-nakama_DISCORD_PROFILE_ID
+NAKAMA_DISCORD_PROFILE_ID
 ```
 
 Override the config root with `NAKAMA_CONFIG_DIR` when needed.

--- a/docs/website/scripts/capture-automation-profile-select-screenshots.sh
+++ b/docs/website/scripts/capture-automation-profile-select-screenshots.sh
@@ -133,7 +133,7 @@ start_seeded_stack() {
 
   (
     cd "$root/apps/web"
-    nakama_SERVER_URL="$api" bun x vite --host 127.0.0.1 --port "$web_port" --strictPort \
+    NAKAMA_SERVER_URL="$api" bun x vite --host 127.0.0.1 --port "$web_port" --strictPort \
       >"$web_log" 2>&1
   ) &
   if [[ "$prefix" == "AFTER" ]]; then

--- a/packages/core/src/discord-config.ts
+++ b/packages/core/src/discord-config.ts
@@ -375,7 +375,7 @@ export function resolveDiscordConfigFromSources(options: {
     handshakeCode: file?.handshakeCode ?? null,
     pairedUserIds: file?.pairedUserIds ?? [],
     profileId:
-      env.nakama_DISCORD_PROFILE_ID?.trim() ||
+      env.NAKAMA_DISCORD_PROFILE_ID?.trim() ||
       file?.profileId?.trim() ||
       DEFAULT_DISCORD_PROFILE_ID,
   };

--- a/packages/core/src/local-auth.test.ts
+++ b/packages/core/src/local-auth.test.ts
@@ -25,7 +25,7 @@ describe("loadLocalAuthToken", () => {
     }
 
     delete process.env.NAKAMA_CONFIG_DIR;
-    delete process.env.nakama_LOCAL_AUTH_TOKEN;
+    delete process.env.NAKAMA_LOCAL_AUTH_TOKEN;
   });
 
   test("generates a token when none is configured", async () => {
@@ -85,7 +85,7 @@ describe("loadLocalAuthToken", () => {
   });
 
   test("prefers env token for production-style setup", async () => {
-    process.env.nakama_LOCAL_AUTH_TOKEN = "tc_local_from_env";
+    process.env.NAKAMA_LOCAL_AUTH_TOKEN = "tc_local_from_env";
     await expect(loadLocalAuthToken()).resolves.toBe("tc_local_from_env");
     await expect(verifyLocalAuthToken("tc_local_from_env")).resolves.toEqual({
       email: "local-client@nakama.internal",
@@ -109,7 +109,7 @@ describe("loadLocalAuthToken", () => {
   });
 
   test("rotateLocalAuthToken refuses when the token comes from env", async () => {
-    process.env.nakama_LOCAL_AUTH_TOKEN = "tc_local_from_env";
+    process.env.NAKAMA_LOCAL_AUTH_TOKEN = "tc_local_from_env";
     await expect(rotateLocalAuthToken()).rejects.toBeInstanceOf(
       LocalAuthTokenManagedExternallyError
     );

--- a/packages/core/src/local-auth.ts
+++ b/packages/core/src/local-auth.ts
@@ -79,7 +79,7 @@ function compareTokenHash(token: string, expectedHashHex: string): boolean {
 }
 
 export async function resolveLocalAuthToken(): Promise<string> {
-  const envToken = process.env.nakama_LOCAL_AUTH_TOKEN?.trim();
+  const envToken = process.env.NAKAMA_LOCAL_AUTH_TOKEN?.trim();
   if (envToken) {
     return envToken;
   }
@@ -122,7 +122,7 @@ export async function loadLocalAuthToken(
 }
 
 export async function rotateLocalAuthToken(): Promise<string> {
-  if (process.env.nakama_LOCAL_AUTH_TOKEN?.trim()) {
+  if (process.env.NAKAMA_LOCAL_AUTH_TOKEN?.trim()) {
     throw new LocalAuthTokenManagedExternallyError();
   }
 
@@ -145,7 +145,7 @@ export async function verifyLocalAuthToken(
     return null;
   }
 
-  const envToken = process.env.nakama_LOCAL_AUTH_TOKEN?.trim();
+  const envToken = process.env.NAKAMA_LOCAL_AUTH_TOKEN?.trim();
   if (envToken) {
     return compareTokenHash(token, hashLocalAuthToken(envToken))
       ? { email: LOCAL_CLIENT_EMAIL }

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -50,7 +50,7 @@ export function resolveServerUrl(
   env: Record<string, string | undefined> = process.env
 ): string {
   return normalizeBaseUrl(
-    env.nakama_SERVER_URL?.trim() ||
+    env.NAKAMA_SERVER_URL?.trim() ||
       readRuntimeServerUrl() ||
       DEFAULT_SERVER_URL
   );

--- a/packages/core/src/telegram-config.ts
+++ b/packages/core/src/telegram-config.ts
@@ -240,7 +240,7 @@ export function resolveTelegramConfigFromSources(options: {
     handshakeCode: file?.handshakeCode ?? null,
     pairedUserIds: file?.pairedUserIds ?? [],
     profileId:
-      env.nakama_TELEGRAM_PROFILE_ID?.trim() ||
+      env.NAKAMA_TELEGRAM_PROFILE_ID?.trim() ||
       file?.profileId?.trim() ||
       DEFAULT_TELEGRAM_PROFILE_ID,
   };

--- a/packages/core/src/whatsapp-config.ts
+++ b/packages/core/src/whatsapp-config.ts
@@ -535,7 +535,7 @@ export function resolveWhatsAppConfigFromSources(options: {
     phoneNumber:
       env.WHATSAPP_PHONE_NUMBER?.trim() || file?.phoneNumber?.trim() || "",
     profileId:
-      env.nakama_WHATSAPP_PROFILE_ID?.trim() ||
+      env.NAKAMA_WHATSAPP_PROFILE_ID?.trim() ||
       file?.profileId?.trim() ||
       DEFAULT_WHATSAPP_PROFILE_ID,
   };

--- a/scripts/agent-ui-harness.sh
+++ b/scripts/agent-ui-harness.sh
@@ -291,7 +291,7 @@ EOF
   fi
 
   web_pid="$(
-    export nakama_SERVER_URL="$api_url"
+    export NAKAMA_SERVER_URL="$api_url"
     spawn_detached "$ROOT/apps/web" "$web_log" \
       bun --no-env-file x vite --host 127.0.0.1 --port "$web_port" --strictPort
   )"


### PR DESCRIPTION
## Summary

Document the real platform-worker env keys in `AGENTS.md` (and align Telegram/WhatsApp READMEs) so operators stop guessing `NAKAMA_*` vs `nakama_*`.

**Before:** Env contract undocumented; Telegram README listed `NAKAMA_SERVER_URL` / `NAKAMA_TELEGRAM_PROFILE_ID` which the code does not read.
**After:** Single table of actual keys — automation direct reads vs `resolve*ConfigFromSources` / `nakama_SERVER_URL`.

Why safe:
1. Docs-only; no runtime change
2. Keys copied from `config.ts` + `resolve*ConfigFromSources` + `resolveServerUrl`
3. Closes the operator-ergonomics gap called out in #561

Only re-add / follow up if we later normalize `nakama_*` → `NAKAMA_*` in code (separate change).

## Test plan
- [x] Cross-checked keys against `apps/platform/*/src/config.ts`, `packages/core/src/{telegram,whatsapp,discord}-config.ts`, `packages/core/src/runtime.ts`
- [ ] Skim `AGENTS.md` → Platform worker env table; set one listed key and confirm it matches a worker you run

Closes #561
