### PR TITLE
fix(cli): busy feedback when blocking chat drops input

### DIFF
--- a/apps/cli/src/chat.test.ts
+++ b/apps/cli/src/chat.test.ts
@@ -5,7 +5,9 @@ import type {
   ProfileSummary,
 } from "@nakama/core";
 import {
+  BUSY_DROP_WARN_AT,
   disableRawModeIfActive,
+  formatBusyDropLine,
   formatErrorLines,
   formatStatusLines,
   isEscInterruptKey,
@@ -24,6 +26,22 @@ describe("needsTrailingStreamNewline", () => {
   test("skips the newline when the stream already ended with one", () => {
     expect(needsTrailingStreamNewline("Hello.\n")).toBe(false);
     expect(needsTrailingStreamNewline("Hello.\r\n")).toBe(false);
+  });
+});
+
+describe("formatBusyDropLine", () => {
+  test("shows a short busy marker before the warn threshold", () => {
+    expect(formatBusyDropLine(1)).toBe("[busy]");
+    expect(formatBusyDropLine(BUSY_DROP_WARN_AT - 1)).toBe("[busy]");
+  });
+
+  test("includes the drop count once the warn threshold is reached", () => {
+    expect(formatBusyDropLine(BUSY_DROP_WARN_AT)).toBe(
+      `[busy] ignored input (${BUSY_DROP_WARN_AT} while processing)`
+    );
+    expect(formatBusyDropLine(BUSY_DROP_WARN_AT + 2)).toBe(
+      `[busy] ignored input (${BUSY_DROP_WARN_AT + 2} while processing)`
+    );
   });
 });
 

--- a/apps/cli/src/chat.test.ts
+++ b/apps/cli/src/chat.test.ts
@@ -5,7 +5,6 @@ import type {
   ProfileSummary,
 } from "@nakama/core";
 import {
-  BUSY_DROP_WARN_AT,
   disableRawModeIfActive,
   formatBusyDropLine,
   formatErrorLines,
@@ -32,15 +31,15 @@ describe("needsTrailingStreamNewline", () => {
 describe("formatBusyDropLine", () => {
   test("shows a short busy marker before the warn threshold", () => {
     expect(formatBusyDropLine(1)).toBe("[busy]");
-    expect(formatBusyDropLine(BUSY_DROP_WARN_AT - 1)).toBe("[busy]");
+    expect(formatBusyDropLine(2)).toBe("[busy]");
   });
 
   test("includes the drop count once the warn threshold is reached", () => {
-    expect(formatBusyDropLine(BUSY_DROP_WARN_AT)).toBe(
-      `[busy] ignored input (${BUSY_DROP_WARN_AT} while processing)`
+    expect(formatBusyDropLine(3)).toBe(
+      "[busy] ignored input (3 while processing)"
     );
-    expect(formatBusyDropLine(BUSY_DROP_WARN_AT + 2)).toBe(
-      `[busy] ignored input (${BUSY_DROP_WARN_AT + 2} while processing)`
+    expect(formatBusyDropLine(5)).toBe(
+      "[busy] ignored input (5 while processing)"
     );
   });
 });

--- a/apps/cli/src/chat.ts
+++ b/apps/cli/src/chat.ts
@@ -56,6 +56,18 @@ export function needsTrailingStreamNewline(lastChunk: string | null): boolean {
   return lastChunk === null || !lastChunk.endsWith("\n");
 }
 
+/** Drop count at which busy feedback includes how many inputs were ignored. */
+export const BUSY_DROP_WARN_AT = 3;
+
+/** Plain-text busy feedback when input arrives while a reply is still processing. */
+export function formatBusyDropLine(dropCount: number): string {
+  if (dropCount >= BUSY_DROP_WARN_AT) {
+    return `[busy] ignored input (${dropCount} while processing)`;
+  }
+
+  return "[busy]";
+}
+
 export async function runChat(options: RunChatOptions): Promise<void> {
   const startup = await resolveStartupProfile(options.client, {
     profileId: options.profileId,
@@ -851,6 +863,7 @@ async function runBlockingChat(context: ChatContext): Promise<void> {
   const session = context.session;
   const currentProfileId = context.currentProfileId;
   let processing = false;
+  let busyDrops = 0;
   let modelsCache: ModelsResponse | null = null;
   let profilesCache: ProfileSummary[] = [];
 
@@ -972,6 +985,10 @@ async function runBlockingChat(context: ChatContext): Promise<void> {
       }
 
       if (processing) {
+        busyDrops += 1;
+        process.stdout.write(
+          `\x1b[2m${formatBusyDropLine(busyDrops)}\x1b[0m\n`
+        );
         continue;
       }
 
@@ -994,6 +1011,7 @@ async function runBlockingChat(context: ChatContext): Promise<void> {
       }
 
       processing = true;
+      busyDrops = 0;
 
       let sendInput: SendMessageInput;
 
@@ -1016,6 +1034,7 @@ async function runBlockingChat(context: ChatContext): Promise<void> {
         printError(error);
       } finally {
         processing = false;
+        busyDrops = 0;
       }
     }
   } finally {

--- a/apps/cli/src/chat.ts
+++ b/apps/cli/src/chat.ts
@@ -56,12 +56,8 @@ export function needsTrailingStreamNewline(lastChunk: string | null): boolean {
   return lastChunk === null || !lastChunk.endsWith("\n");
 }
 
-/** Drop count at which busy feedback includes how many inputs were ignored. */
-export const BUSY_DROP_WARN_AT = 3;
-
-/** Plain-text busy feedback when input arrives while a reply is still processing. */
 export function formatBusyDropLine(dropCount: number): string {
-  if (dropCount >= BUSY_DROP_WARN_AT) {
+  if (dropCount >= 3) {
     return `[busy] ignored input (${dropCount} while processing)`;
   }
 
@@ -1011,7 +1007,6 @@ async function runBlockingChat(context: ChatContext): Promise<void> {
       }
 
       processing = true;
-      busyDrops = 0;
 
       let sendInput: SendMessageInput;
 


### PR DESCRIPTION
## Summary

Blocking CLI chat prints dim `[busy]` (with a drop count after 3) when input arrives while a reply is still processing — no more silent drops.

**Before:** `processing === true` → `continue` with zero feedback.
**After:** same drop, but `formatBusyDropLine` writes `[busy]` / `[busy] ignored input (N while processing)`.

Why safe:
1. Only the blocking path feedback; sticky TTY queue unchanged
2. Counter resets when a send starts/finishes
3. Behavior stays drop-not-queue (issue allowed either)

Only re-add a queue if non-TTY users need deferred sends during stuck streams.

## Test plan
- [x] `bun test apps/cli/src/chat.test.ts` (14 pass)
- [ ] Pipe two lines into non-TTY chat while a long reply is in flight — second line shows `[busy]`

Closes #613
