### PR TITLE
fix(cli): cache macOS theme defaults (#548)

### DIFF
--- a/apps/cli/src/styled-text.test.ts
+++ b/apps/cli/src/styled-text.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  clearMacOsThemeSessionCache,
+  detectMacOsTheme,
+  getCliStatePath,
+} from "./styled-text";
+
+describe("detectMacOsTheme", () => {
+  let configDir = "";
+  let previousConfigDir: string | undefined;
+
+  afterEach(async () => {
+    clearMacOsThemeSessionCache();
+    if (previousConfigDir === undefined) {
+      delete process.env.NAKAMA_CONFIG_DIR;
+    } else {
+      process.env.NAKAMA_CONFIG_DIR = previousConfigDir;
+    }
+    if (configDir) {
+      await rm(configDir, { force: true, recursive: true });
+      configDir = "";
+    }
+  });
+
+  async function withTempConfigDir(): Promise<void> {
+    configDir = await mkdtemp(join(tmpdir(), "nakama-cli-theme-"));
+    previousConfigDir = process.env.NAKAMA_CONFIG_DIR;
+    process.env.NAKAMA_CONFIG_DIR = configDir;
+    clearMacOsThemeSessionCache();
+  }
+
+  test("reads defaults once and caches by prefs mtime", async () => {
+    await withTempConfigDir();
+    let reads = 0;
+
+    const first = await detectMacOsTheme({
+      prefsMtimeMs: () => 1000,
+      readDefaults: () => {
+        reads += 1;
+        return "dark";
+      },
+    });
+    expect(first).toBe("dark");
+    expect(reads).toBe(1);
+
+    const raw = await readFile(getCliStatePath(), "utf8");
+    expect(JSON.parse(raw)).toEqual({
+      macosTheme: "dark",
+      macosThemePrefsMtimeMs: 1000,
+    });
+
+    clearMacOsThemeSessionCache();
+    const second = await detectMacOsTheme({
+      prefsMtimeMs: () => 1000,
+      readDefaults: () => {
+        reads += 1;
+        return "light";
+      },
+    });
+    expect(second).toBe("dark");
+    expect(reads).toBe(1);
+  });
+
+  test("re-reads defaults when prefs mtime changes", async () => {
+    await withTempConfigDir();
+    let reads = 0;
+
+    await detectMacOsTheme({
+      prefsMtimeMs: () => 1000,
+      readDefaults: () => {
+        reads += 1;
+        return "dark";
+      },
+    });
+
+    clearMacOsThemeSessionCache();
+    const next = await detectMacOsTheme({
+      prefsMtimeMs: () => 2000,
+      readDefaults: () => {
+        reads += 1;
+        return "light";
+      },
+    });
+    expect(next).toBe("light");
+    expect(reads).toBe(2);
+
+    const raw = await readFile(getCliStatePath(), "utf8");
+    expect(JSON.parse(raw)).toEqual({
+      macosTheme: "light",
+      macosThemePrefsMtimeMs: 2000,
+    });
+  });
+
+  test("uses in-memory session cache without re-reading disk or defaults", async () => {
+    await withTempConfigDir();
+    let reads = 0;
+
+    await detectMacOsTheme({
+      prefsMtimeMs: () => 1000,
+      readDefaults: () => {
+        reads += 1;
+        return "dark";
+      },
+    });
+
+    const again = await detectMacOsTheme({
+      prefsMtimeMs: () => {
+        throw new Error("prefs should not be read again in-session");
+      },
+      readDefaults: () => {
+        reads += 1;
+        return "light";
+      },
+    });
+    expect(again).toBe("dark");
+    expect(reads).toBe(1);
+  });
+
+  test("calls defaults when prefs mtime is unavailable", async () => {
+    await withTempConfigDir();
+    let reads = 0;
+
+    const theme = await detectMacOsTheme({
+      prefsMtimeMs: () => null,
+      readDefaults: () => {
+        reads += 1;
+        return "light";
+      },
+    });
+    expect(theme).toBe("light");
+    expect(reads).toBe(1);
+
+    const raw = await readFile(getCliStatePath(), "utf8");
+    expect(JSON.parse(raw)).toEqual({ macosTheme: "light" });
+  });
+});

--- a/apps/cli/src/styled-text.ts
+++ b/apps/cli/src/styled-text.ts
@@ -1,4 +1,8 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
+import { statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { getUserConfigDir, readTextOrNull, writeTextFile } from "@nakama/core";
 import { visibleLength } from "./text-measure";
 
 export type NamedColor = "default" | "cyan" | "yellow" | "red" | "green";
@@ -22,6 +26,18 @@ export interface StyledLine {
   segments: StyledSegment[];
 }
 
+/** Persistable CLI runtime hints under `~/.nakama/cli-state.json`. */
+export interface CliState {
+  macosTheme?: Theme;
+  /** mtimeMs of `~/Library/Preferences/.GlobalPreferences.plist` when cached. */
+  macosThemePrefsMtimeMs?: number;
+}
+
+export type DetectMacOsThemeOptions = {
+  prefsMtimeMs?: () => number | null;
+  readDefaults?: () => Theme;
+};
+
 const COLOR_CODES: Record<NamedColor, string> = {
   cyan: "36",
   default: "39",
@@ -39,24 +55,120 @@ const BACKGROUND_CODES: Record<Theme, Record<NamedBackgroundColor, string>> = {
   },
 };
 
+const DEFAULTS_TIMEOUT_MS = 500;
+
 let currentTheme: Theme = "dark";
+let sessionMacOsTheme: Theme | undefined;
 
 export function setTheme(theme: Theme): void {
   currentTheme = theme;
 }
 
+export function getCliStatePath(): string {
+  return join(getUserConfigDir(), "cli-state.json");
+}
+
+export function clearMacOsThemeSessionCache(): void {
+  sessionMacOsTheme = undefined;
+}
+
+function globalPreferencesPath(): string {
+  return join(homedir(), "Library/Preferences/.GlobalPreferences.plist");
+}
+
+function readGlobalPreferencesMtimeMs(): number | null {
+  try {
+    return statSync(globalPreferencesPath()).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+function readMacOsThemeFromDefaults(): Theme {
+  try {
+    // execFile (no shell) + SIGKILL on timeout — avoids orphaned shell children
+    execFileSync("defaults", ["read", "-g", "AppleInterfaceStyle"], {
+      encoding: "utf8",
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: DEFAULTS_TIMEOUT_MS,
+    });
+    return "dark";
+  } catch {
+    return "light";
+  }
+}
+
+async function loadCliState(): Promise<CliState> {
+  const raw = await readTextOrNull(getCliStatePath());
+  if (raw === null) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return parsed as CliState;
+  } catch {
+    return {};
+  }
+}
+
+async function saveMacOsThemeCache(
+  theme: Theme,
+  prefsMtimeMs: number | null
+): Promise<void> {
+  const state = await loadCliState();
+  state.macosTheme = theme;
+  if (prefsMtimeMs == null) {
+    delete state.macosThemePrefsMtimeMs;
+  } else {
+    state.macosThemePrefsMtimeMs = prefsMtimeMs;
+  }
+  await writeTextFile(getCliStatePath(), `${JSON.stringify(state)}\n`, {
+    ensureDir: getUserConfigDir(),
+  });
+}
+
+/**
+ * macOS appearance via `defaults`, cached in cli-state.json keyed by
+ * GlobalPreferences mtime so each CLI process does not re-fork.
+ */
+export async function detectMacOsTheme(
+  options: DetectMacOsThemeOptions = {}
+): Promise<Theme> {
+  if (sessionMacOsTheme) {
+    return sessionMacOsTheme;
+  }
+
+  const prefsMtimeMs = (options.prefsMtimeMs ?? readGlobalPreferencesMtimeMs)();
+  const state = await loadCliState();
+  const cached = state.macosTheme;
+  if (
+    (cached === "dark" || cached === "light") &&
+    prefsMtimeMs != null &&
+    state.macosThemePrefsMtimeMs === prefsMtimeMs
+  ) {
+    sessionMacOsTheme = cached;
+    return cached;
+  }
+
+  const theme = (options.readDefaults ?? readMacOsThemeFromDefaults)();
+  sessionMacOsTheme = theme;
+  try {
+    await saveMacOsThemeCache(theme, prefsMtimeMs);
+  } catch {
+    // Cache write is best-effort; theme detection must still succeed.
+  }
+  return theme;
+}
+
 export async function detectTheme(): Promise<Theme | null> {
   // macOS system appearance — most reliable for Apple terminals
   if (process.platform === "darwin") {
-    try {
-      execSync("defaults read -g AppleInterfaceStyle 2>/dev/null", {
-        encoding: "utf8",
-        timeout: 500,
-      });
-      return "dark";
-    } catch {
-      return "light";
-    }
+    return detectMacOsTheme();
   }
 
   // Many terminals set this: "0;15" = dark bg light fg, "15;0" = light bg dark fg


### PR DESCRIPTION
## Summary

macOS CLI startups reuse a cached AppleInterfaceStyle from `cli-state.json` instead of forking `defaults` every time.

**Before:** every `nakama` start ran `defaults read -g AppleInterfaceStyle` (shell + 500ms timeout; orphan risk).
**After:** `detectMacOsTheme` hits disk cache keyed by GlobalPreferences mtime; miss uses `execFileSync` + `SIGKILL`.

Why safe:
1. Cache invalidates when appearance prefs file mtime changes
2. No shell — timeout kills `defaults` directly
3. Cache write is best-effort; detection still returns a theme

Only re-add / follow up if theme flips without touching GlobalPreferences mtime (rare).

## Test plan
- [x] `bun test apps/cli/src/styled-text.test.ts` (4 pass)
- [ ] On macOS: run `nakama` twice with same appearance — second start should not spawn `defaults` (or confirm `cli-state.json` has `macosTheme` + matching mtime)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/Cursor_Grok_4.5-000000)
