### PR TITLE
fix(web): MCP tab remove control with confirm dialog

### DIFF
--- a/apps/web/src/components/soul-tools/McpTab.tsx
+++ b/apps/web/src/components/soul-tools/McpTab.tsx
@@ -1,4 +1,5 @@
 import type { McpServerSummary } from "@nakama/core/contract";
+import { isPreinstalledMcpServerId } from "@nakama/core/mcp/preinstalled";
 import { useState } from "react";
 import { McpServerDialog } from "@/components/soul-tools/mcp-tab/McpServerDialog";
 import {
@@ -6,6 +7,16 @@ import {
   McpServersSection,
 } from "@/components/soul-tools/mcp-tab/McpServersSection";
 import { McpServerToolsDialog } from "@/components/soul-tools/mcp-tab/McpServerToolsDialog";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Spinner } from "@/components/ui/spinner";
 import { useMcpServersQuery } from "@/hooks/use-app-queries";
 import {
   useConnectMcpServerMutation,
@@ -27,6 +38,9 @@ export function McpTab({ embedded = false }: { embedded?: boolean } = {}) {
   const [createOpen, setCreateOpen] = useState(false);
   const [editServerId, setEditServerId] = useState<string | null>(null);
   const [detailServerId, setDetailServerId] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<McpServerSummary | null>(
+    null
+  );
   const editServer =
     servers.find((server) => server.id === editServerId) ?? null;
   const detailServer =
@@ -41,24 +55,30 @@ export function McpTab({ embedded = false }: { embedded?: boolean } = {}) {
     syncMutation.isPending;
   const errorMessage = actionError ?? (error ? formatError(error) : null);
 
-  async function handleDelete(server: McpServerSummary) {
-    if ((server.assignedProfileCount ?? 0) > 0) {
+  function requestDelete(server: McpServerSummary) {
+    if (
+      isPreinstalledMcpServerId(server.id) ||
+      (server.assignedProfileCount ?? 0) > 0
+    ) {
       return;
     }
 
-    if (
-      !window.confirm(
-        `Delete MCP server "${server.name}"? This cannot be undone.`
-      )
-    ) {
+    setDeleteTarget(server);
+  }
+
+  async function confirmDelete() {
+    if (!deleteTarget) {
       return;
     }
 
     setActionError(null);
 
     try {
-      await deleteMutation.mutateAsync(server.id);
-      setDetailServerId((current) => (current === server.id ? null : current));
+      await deleteMutation.mutateAsync(deleteTarget.id);
+      setDetailServerId((current) =>
+        current === deleteTarget.id ? null : current
+      );
+      setDeleteTarget(null);
     } catch (err) {
       setActionError(formatError(err));
     }
@@ -103,7 +123,7 @@ export function McpTab({ embedded = false }: { embedded?: boolean } = {}) {
         embedded={embedded}
         onAddServer={() => setCreateOpen(true)}
         onConnect={(serverId) => void handleConnect(serverId)}
-        onDelete={(server) => void handleDelete(server)}
+        onDelete={requestDelete}
         onEdit={setEditServerId}
         onSync={(serverId) => void handleSync(serverId)}
         onViewTools={setDetailServerId}
@@ -183,6 +203,51 @@ export function McpTab({ embedded = false }: { embedded?: boolean } = {}) {
         open={editServerId !== null}
         server={editServer}
       />
+
+      <Dialog
+        onOpenChange={(open) => {
+          if (!(open || deleteMutation.isPending)) {
+            setDeleteTarget(null);
+          }
+        }}
+        open={deleteTarget !== null}
+      >
+        <DialogContent className="gap-6 p-6 sm:max-w-md">
+          <DialogHeader className="gap-3">
+            <DialogTitle>Delete MCP server?</DialogTitle>
+            <DialogDescription>
+              Remove{" "}
+              {deleteTarget?.name
+                ? `"${deleteTarget.name}"`
+                : "this MCP server"}
+              . This cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+
+          <DialogFooter className="mx-0 mb-0 gap-2 border-0 bg-transparent p-0 sm:flex-row sm:justify-end">
+            <Button
+              disabled={deleteMutation.isPending}
+              onClick={() => setDeleteTarget(null)}
+              type="button"
+              variant="outline"
+            >
+              Cancel
+            </Button>
+            <Button
+              disabled={deleteMutation.isPending}
+              onClick={() => void confirmDelete()}
+              type="button"
+              variant="destructive"
+            >
+              {deleteMutation.isPending ? (
+                <Spinner className="size-4" />
+              ) : (
+                "Delete"
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/apps/web/src/components/soul-tools/mcp-tab/McpServersSection.tsx
+++ b/apps/web/src/components/soul-tools/mcp-tab/McpServersSection.tsx
@@ -1,5 +1,4 @@
 import type { McpServerSummary } from "@nakama/core/contract";
-import { isPreinstalledMcpServerId } from "@nakama/core/mcp/preinstalled";
 import {
   Add01Icon,
   Delete02Icon,
@@ -10,6 +9,7 @@ import {
   RefreshIcon,
 } from "hugeicons-react";
 import { McpToolLabels } from "@/components/soul-tools/McpToolList";
+import { mcpServerDeleteBlockReason } from "@/components/soul-tools/mcp-tab/mcp-server-delete-block-reason";
 import { sectionClass } from "@/components/soul-tools/mcp-tab/shared";
 import { Button } from "@/components/ui/button";
 import {
@@ -44,24 +44,6 @@ export function McpPageState({
       {message}
     </div>
   );
-}
-
-function mcpServerDeleteBlockReason(server: McpServerSummary): string | null {
-  if (isPreinstalledMcpServerId(server.id)) {
-    return "Preinstalled MCP servers cannot be deleted.";
-  }
-
-  const assignedProfileCount = server.assignedProfileCount ?? 0;
-
-  if (assignedProfileCount === 1) {
-    return "Assigned to 1 profile. Unassign on the Profiles page before deleting.";
-  }
-
-  if (assignedProfileCount > 1) {
-    return `Assigned to ${assignedProfileCount} profiles. Unassign on the Profiles page before deleting.`;
-  }
-
-  return null;
 }
 
 function McpServerDeleteButton({
@@ -309,5 +291,3 @@ export function McpServersSection({
     </section>
   );
 }
-
-export { mcpServerDeleteBlockReason };

--- a/apps/web/src/components/soul-tools/mcp-tab/McpServersSection.tsx
+++ b/apps/web/src/components/soul-tools/mcp-tab/McpServersSection.tsx
@@ -46,6 +46,71 @@ export function McpPageState({
   );
 }
 
+function mcpServerDeleteBlockReason(server: McpServerSummary): string | null {
+  if (isPreinstalledMcpServerId(server.id)) {
+    return "Preinstalled MCP servers cannot be deleted.";
+  }
+
+  const assignedProfileCount = server.assignedProfileCount ?? 0;
+
+  if (assignedProfileCount === 1) {
+    return "Assigned to 1 profile. Unassign on the Profiles page before deleting.";
+  }
+
+  if (assignedProfileCount > 1) {
+    return `Assigned to ${assignedProfileCount} profiles. Unassign on the Profiles page before deleting.`;
+  }
+
+  return null;
+}
+
+function McpServerDeleteButton({
+  server,
+  busy,
+  onDelete,
+}: {
+  server: McpServerSummary;
+  busy: boolean;
+  onDelete: () => void;
+}) {
+  const deleteBlockReason = mcpServerDeleteBlockReason(server);
+  const label = `Delete ${server.name}`;
+
+  if (deleteBlockReason) {
+    return (
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              aria-label={label}
+              disabled
+              size="icon-sm"
+              type="button"
+              variant="ghost"
+            />
+          }
+        >
+          <Delete02Icon aria-hidden className="size-4" />
+        </TooltipTrigger>
+        <TooltipContent side="left">{deleteBlockReason}</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Button
+      aria-label={label}
+      disabled={busy}
+      onClick={onDelete}
+      size="icon-sm"
+      type="button"
+      variant="ghost"
+    >
+      <Delete02Icon aria-hidden className="size-4" />
+    </Button>
+  );
+}
+
 function McpServerActions({
   server,
   busy,
@@ -63,14 +128,7 @@ function McpServerActions({
   onSync: () => void;
   onDelete: () => void;
 }) {
-  const assignedProfileCount = server.assignedProfileCount ?? 0;
-  const preinstalled = isPreinstalledMcpServerId(server.id);
-  const deleteBlocked = preinstalled || assignedProfileCount > 0;
-  const deleteTooltip = preinstalled
-    ? "Preinstalled MCP servers cannot be deleted."
-    : assignedProfileCount === 1
-      ? "Assigned to 1 profile. Unassign on the Profiles page before deleting."
-      : `Assigned to ${assignedProfileCount} profiles. Unassign on the Profiles page before deleting.`;
+  const deleteBlockReason = mcpServerDeleteBlockReason(server);
 
   return (
     <div className="flex shrink-0 items-center gap-1">
@@ -83,6 +141,8 @@ function McpServerActions({
       >
         <EyeIcon aria-hidden className="size-4" />
       </Button>
+
+      <McpServerDeleteButton busy={busy} onDelete={onDelete} server={server} />
 
       <DropdownMenu>
         <DropdownMenuTrigger
@@ -113,7 +173,7 @@ function McpServerActions({
             <RefreshIcon aria-hidden />
             Sync tools
           </DropdownMenuItem>
-          {deleteBlocked ? (
+          {deleteBlockReason ? (
             <Tooltip>
               <TooltipTrigger
                 render={
@@ -123,7 +183,7 @@ function McpServerActions({
                   </DropdownMenuItem>
                 }
               />
-              <TooltipContent side="left">{deleteTooltip}</TooltipContent>
+              <TooltipContent side="left">{deleteBlockReason}</TooltipContent>
             </Tooltip>
           ) : (
             <DropdownMenuItem
@@ -249,3 +309,5 @@ export function McpServersSection({
     </section>
   );
 }
+
+export { mcpServerDeleteBlockReason };

--- a/apps/web/src/components/soul-tools/mcp-tab/mcp-server-delete-block-reason.test.ts
+++ b/apps/web/src/components/soul-tools/mcp-tab/mcp-server-delete-block-reason.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { McpServerSummary } from "@nakama/core/contract";
 import { PREINSTALLED_MCP_SERVER_IDS } from "@nakama/core/mcp/preinstalled";
-import { mcpServerDeleteBlockReason } from "./McpServersSection";
+import { mcpServerDeleteBlockReason } from "./mcp-server-delete-block-reason";
 
 function summary(
   overrides: Partial<McpServerSummary> & Pick<McpServerSummary, "id" | "name">

--- a/apps/web/src/components/soul-tools/mcp-tab/mcp-server-delete-block-reason.test.ts
+++ b/apps/web/src/components/soul-tools/mcp-tab/mcp-server-delete-block-reason.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import type { McpServerSummary } from "@nakama/core/contract";
+import { PREINSTALLED_MCP_SERVER_IDS } from "@nakama/core/mcp/preinstalled";
+import { mcpServerDeleteBlockReason } from "./McpServersSection";
+
+function summary(
+  overrides: Partial<McpServerSummary> & Pick<McpServerSummary, "id" | "name">
+): McpServerSummary {
+  return {
+    assignedProfileCount: 0,
+    enabled: true,
+    lastError: null,
+    status: "disconnected",
+    toolCount: 0,
+    transport: "http",
+    ...overrides,
+  };
+}
+
+describe("mcpServerDeleteBlockReason", () => {
+  test("allows delete for unassigned custom servers", () => {
+    expect(
+      mcpServerDeleteBlockReason(
+        summary({ id: "mcp_custom_qa", name: "QA-probe" })
+      )
+    ).toBeNull();
+  });
+
+  test("blocks preinstalled servers", () => {
+    expect(
+      mcpServerDeleteBlockReason(
+        summary({
+          id: PREINSTALLED_MCP_SERVER_IDS.firecrawl,
+          name: "firecrawl",
+        })
+      )
+    ).toBe("Preinstalled MCP servers cannot be deleted.");
+  });
+
+  test("blocks servers assigned to profiles", () => {
+    expect(
+      mcpServerDeleteBlockReason(
+        summary({
+          assignedProfileCount: 1,
+          id: "mcp_custom_qa",
+          name: "QA-probe",
+        })
+      )
+    ).toBe(
+      "Assigned to 1 profile. Unassign on the Profiles page before deleting."
+    );
+
+    expect(
+      mcpServerDeleteBlockReason(
+        summary({
+          assignedProfileCount: 3,
+          id: "mcp_custom_qa",
+          name: "QA-probe",
+        })
+      )
+    ).toBe(
+      "Assigned to 3 profiles. Unassign on the Profiles page before deleting."
+    );
+  });
+});

--- a/apps/web/src/components/soul-tools/mcp-tab/mcp-server-delete-block-reason.ts
+++ b/apps/web/src/components/soul-tools/mcp-tab/mcp-server-delete-block-reason.ts
@@ -1,0 +1,22 @@
+import type { McpServerSummary } from "@nakama/core/contract";
+import { isPreinstalledMcpServerId } from "@nakama/core/mcp/preinstalled";
+
+export function mcpServerDeleteBlockReason(
+  server: McpServerSummary
+): string | null {
+  if (isPreinstalledMcpServerId(server.id)) {
+    return "Preinstalled MCP servers cannot be deleted.";
+  }
+
+  const assignedProfileCount = server.assignedProfileCount ?? 0;
+
+  if (assignedProfileCount === 1) {
+    return "Assigned to 1 profile. Unassign on the Profiles page before deleting.";
+  }
+
+  if (assignedProfileCount > 1) {
+    return `Assigned to ${assignedProfileCount} profiles. Unassign on the Profiles page before deleting.`;
+  }
+
+  return null;
+}

--- a/apps/web/src/context/theme-context.tsx
+++ b/apps/web/src/context/theme-context.tsx
@@ -23,10 +23,12 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     resolveTheme(getInitialTheme())
   );
   const themeRef = useRef(theme);
-  themeRef.current = theme;
 
-  const syncTheme = useCallback(() => {
-    const currentTheme = themeRef.current;
+  useEffect(() => {
+    themeRef.current = theme;
+  }, [theme]);
+
+  const syncTheme = useCallback((currentTheme: Theme) => {
     applyTheme(currentTheme);
     setResolvedTheme(resolveTheme(currentTheme));
 
@@ -38,7 +40,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   }, []);
 
   useEffect(() => {
-    syncTheme();
+    syncTheme(theme);
   }, [theme, syncTheme]);
 
   useEffect(() => {
@@ -47,7 +49,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       if (themeRef.current !== "system") {
         return;
       }
-      syncTheme();
+      syncTheme("system");
     };
     mediaQuery.addEventListener("change", handleChange);
     return () => mediaQuery.removeEventListener("change", handleChange);


### PR DESCRIPTION
## Summary

System → MCP: trash on each server row → confirm dialog → `DELETE /v1/mcp/servers/:id`. Closes #631.

**Before:** Delete only in the ⋮ menu behind `window.confirm` (easy to miss during QA cleanup).
**After:** Visible row delete + in-app confirm dialog (`McpTab` / `McpServersSection`).

Why safe:
1. Same API + guards (preinstalled / assigned still blocked)
2. Confirm is cancelable; no auto-delete
3. Server already rejects invalid deletes

Only re-add / follow up if assigned servers need force-remove from this tab.

## Test plan
- [x] `bun test apps/web/src/components/soul-tools/mcp-tab/mcp-server-delete-block-reason.test.ts` (3 pass)
- [x] `bun test apps/server/src/services/mcp-service.test.ts` (14 pass)
- [x] Browser proof: System → MCP → trash → Cancel keeps row; Confirm removes `VIDEO_PROOF_DELETE_ME`
- [ ] System → MCP: add a throwaway server → trash → confirm → row gone; Cancel leaves it

## Browser proof

1. Open System → MCP with two throwaway servers (`VIDEO_PROOF_CANCEL_KEEP`, `VIDEO_PROOF_DELETE_ME`)
2. Row trash → confirm dialog → **Cancel** → keep row still listed
3. Row trash on delete target → **Delete** → row gone; keep row remains (5 → 4 registered)

https://github.com/user-attachments/assets/08cf8bd0-a03b-4425-add9-0b33e880bb0e

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/cursor_grok_4.5-000000)
