### PR TITLE
fix(knowledge-base): dedupe duplicate uploads (#627)

### DIFF
--- a/apps/server/src/http/routes/profiles.ts
+++ b/apps/server/src/http/routes/profiles.ts
@@ -821,9 +821,15 @@ export function registerProfileRoutes(
     const orgId = requireActiveOrgIdFromContext(c);
     const profileId = decodeURIComponent(c.req.param("profileId"));
     const body = await readJson<UploadKnowledgeBaseRequest>(c.req.raw);
+    const result = await agent.uploadKnowledgeBaseDocument(
+      orgId,
+      profileId,
+      body.document,
+      body.onDuplicate
+    );
     return json<UploadKnowledgeBaseResponse>(
-      await agent.uploadKnowledgeBaseDocument(orgId, profileId, body.document),
-      201
+      result,
+      result.outcome === "created" ? 201 : 200
     );
   });
 

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -44,6 +44,7 @@ import type {
   InitSoulResponse,
   InitUserContextResponse,
   InstallSkillRequest,
+  KnowledgeBaseDuplicateAction,
   ListArtifactsOptions,
   ListArtifactsResponse,
   ListKnowledgeBaseResponse,
@@ -2789,12 +2790,14 @@ export class AgentService {
   async uploadKnowledgeBaseDocument(
     orgId: string,
     profileId: string,
-    document: DocumentAttachment
+    document: DocumentAttachment,
+    onDuplicate?: KnowledgeBaseDuplicateAction
   ): Promise<UploadKnowledgeBaseResponse> {
     return this.profileService.uploadKnowledgeBaseDocument(
       orgId,
       profileId,
-      document
+      document,
+      onDuplicate
     );
   }
 

--- a/apps/server/src/services/profile-service.test.ts
+++ b/apps/server/src/services/profile-service.test.ts
@@ -599,6 +599,7 @@ describe("profile service knowledge base", () => {
     );
 
     expect(uploaded.document.status).toBe("ready");
+    expect(uploaded.outcome).toBe("created");
     expect(uploaded.profileId).toBe(profileId);
 
     const listed = await service.listKnowledgeBase(ORG_ID, profileId);
@@ -614,6 +615,42 @@ describe("profile service knowledge base", () => {
 
     const afterDelete = await service.listKnowledgeBase(ORG_ID, profileId);
     expect(afterDelete.documents).toHaveLength(0);
+  });
+
+  test("rejects duplicate knowledge base uploads with 409 and supports replace", async () => {
+    tempConfigDir = await mkdtemp(path.join(os.tmpdir(), "nakama-profile-kb-"));
+    process.env.NAKAMA_CONFIG_DIR = tempConfigDir;
+
+    const service = new ProfileService(createInMemoryDatabaseAdapter());
+    const created = await service.createProfile(ORG_ID, { name: "KB Bot" });
+    const profileId = created.profile.id;
+    const attachment = {
+      data: Buffer.from("project fact", "utf8").toString("base64"),
+      filename: "notes.txt",
+      mediaType: "text/plain",
+    };
+
+    const first = await service.uploadKnowledgeBaseDocument(
+      ORG_ID,
+      profileId,
+      attachment
+    );
+
+    await expect(
+      service.uploadKnowledgeBaseDocument(ORG_ID, profileId, attachment)
+    ).rejects.toMatchObject({ status: 409 });
+
+    const replaced = await service.uploadKnowledgeBaseDocument(
+      ORG_ID,
+      profileId,
+      attachment,
+      "replace"
+    );
+    expect(replaced.outcome).toBe("replaced");
+    expect(replaced.document.id).not.toBe(first.document.id);
+
+    const listed = await service.listKnowledgeBase(ORG_ID, profileId);
+    expect(listed.documents).toHaveLength(1);
   });
 
   test("readKnowledgeBaseDocument returns preview text and download bytes", async () => {

--- a/apps/server/src/services/profile-service.ts
+++ b/apps/server/src/services/profile-service.ts
@@ -10,6 +10,7 @@ import type {
   DocumentAttachment,
   ImageAttachment,
   JsonSchema,
+  KnowledgeBaseDuplicateAction,
   ListKnowledgeBaseResponse,
   ListProfilesResponse,
   ListToolsResponse,
@@ -30,6 +31,7 @@ import {
   getProfileSoulDir,
   hasProfileAvatar,
   initSoulDirectory,
+  KnowledgeBaseDuplicateError,
   listKnowledgeBaseDocuments,
   listKnowledgeBaseSources,
   NakamaApiError,
@@ -627,7 +629,8 @@ export class ProfileService {
   async uploadKnowledgeBaseDocument(
     orgId: string,
     profileId: string,
-    document: DocumentAttachment
+    document: DocumentAttachment,
+    onDuplicate?: KnowledgeBaseDuplicateAction
   ): Promise<UploadKnowledgeBaseResponse> {
     await this.requireProfile(orgId, profileId);
 
@@ -635,10 +638,19 @@ export class ProfileService {
       const uploaded = await persistKnowledgeBaseDocument(
         orgId,
         profileId,
-        document
+        document,
+        { onDuplicate }
       );
-      return { document: uploaded, profileId };
+      return {
+        document: uploaded.document,
+        outcome: uploaded.outcome,
+        profileId,
+      };
     } catch (error) {
+      if (error instanceof KnowledgeBaseDuplicateError) {
+        throw new NakamaApiError(error.message, 409);
+      }
+
       const message =
         error instanceof Error
           ? error.message

--- a/apps/server/src/services/profile-service.ts
+++ b/apps/server/src/services/profile-service.ts
@@ -639,7 +639,7 @@ export class ProfileService {
         orgId,
         profileId,
         document,
-        { onDuplicate }
+        onDuplicate
       );
       return {
         document: uploaded.document,

--- a/apps/web/src/components/soul-tools/KnowledgeTab.tsx
+++ b/apps/web/src/components/soul-tools/KnowledgeTab.tsx
@@ -80,44 +80,65 @@ export function KnowledgeTab({ profileId }: { profileId: string | null }) {
 
     setError(null);
 
-    for (const file of Array.from(files)) {
-      if (!isKnowledgeBaseFile(file)) {
-        setError(
-          `Unsupported file type: ${file.name}. Allowed: txt, md, csv, pdf.`
-        );
-        continue;
+    const candidates = Array.from(files).filter((file) => {
+      if (isKnowledgeBaseFile(file)) {
+        return true;
+      }
+      setError(
+        `Unsupported file type: ${file.name}. Allowed: txt, md, csv, pdf.`
+      );
+      return false;
+    });
+
+    const prepared = await Promise.all(
+      candidates.map(async (file) => ({
+        document: await fileToDocumentAttachment(file),
+        file,
+      }))
+    );
+
+    // Sequential: one duplicate dialog at a time; hard errors stop the batch.
+    const uploadNext = async (index: number): Promise<void> => {
+      const item = prepared[index];
+      if (!item) {
+        return;
+      }
+
+      const { document, file } = item;
+      if (!document) {
+        setError(`Failed to read file: ${file.name}`);
+        return uploadNext(index + 1);
       }
 
       try {
-        const document = await fileToDocumentAttachment(file);
-        if (!document) {
-          setError(`Failed to read file: ${file.name}`);
-          continue;
+        await uploadMutation.mutateAsync({ document, profileId });
+      } catch (err) {
+        if (!(err instanceof NakamaApiError && err.status === 409)) {
+          setError(formatError(err));
+          return;
+        }
+
+        const decision = await askDuplicateDecision(file.name);
+        if (decision === "skip") {
+          return uploadNext(index + 1);
         }
 
         try {
-          await uploadMutation.mutateAsync({ document, profileId });
-        } catch (err) {
-          if (!(err instanceof NakamaApiError && err.status === 409)) {
-            throw err;
-          }
-
-          const decision = await askDuplicateDecision(file.name);
-          if (decision === "skip") {
-            continue;
-          }
-
           await uploadMutation.mutateAsync({
             document,
             onDuplicate: "replace",
             profileId,
           });
+        } catch (replaceErr) {
+          setError(formatError(replaceErr));
+          return;
         }
-      } catch (err) {
-        setError(formatError(err));
-        break;
       }
-    }
+
+      return uploadNext(index + 1);
+    };
+
+    await uploadNext(0);
 
     if (fileInputRef.current) {
       fileInputRef.current.value = "";

--- a/apps/web/src/components/soul-tools/KnowledgeTab.tsx
+++ b/apps/web/src/components/soul-tools/KnowledgeTab.tsx
@@ -1,3 +1,4 @@
+import { NakamaApiError } from "@nakama/core/api-error";
 import type { KnowledgeBaseDocument } from "@nakama/core/contract";
 import { useEffect, useRef, useState } from "react";
 import { KnowledgeTabPanel } from "@/components/soul-tools/knowledge-tab-panel";
@@ -23,6 +24,13 @@ import {
   isKnowledgeBaseFile,
 } from "@/lib/knowledge-base-files";
 
+type DuplicateDecision = "skip" | "replace" | "cancel";
+
+type DuplicatePrompt = {
+  filename: string;
+  resolve: (decision: DuplicateDecision) => void;
+};
+
 export function KnowledgeTab({ profileId }: { profileId: string | null }) {
   const { data: profiles = [], error: profilesError } = useProfilesQuery();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -36,6 +44,8 @@ export function KnowledgeTab({ profileId }: { profileId: string | null }) {
   const [error, setError] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] =
     useState<KnowledgeBaseDocument | null>(null);
+  const [duplicatePrompt, setDuplicatePrompt] =
+    useState<DuplicatePrompt | null>(null);
 
   const selectedProfile =
     profiles.find((profile) => profile.id === profileId) ?? null;
@@ -45,7 +55,10 @@ export function KnowledgeTab({ profileId }: { profileId: string | null }) {
     (document) => document.status === "ready"
   ).length;
   const loading = knowledgeLoading && !knowledgeBase;
-  const busy = uploadMutation.isPending || deleteMutation.isPending;
+  const busy =
+    uploadMutation.isPending ||
+    deleteMutation.isPending ||
+    duplicatePrompt !== null;
 
   useEffect(() => {
     const queryError = profilesError ?? knowledgeError;
@@ -54,6 +67,12 @@ export function KnowledgeTab({ profileId }: { profileId: string | null }) {
     }
   }, [profilesError, knowledgeError]);
 
+  function askDuplicateDecision(filename: string): Promise<DuplicateDecision> {
+    return new Promise((resolve) => {
+      setDuplicatePrompt({ filename, resolve });
+    });
+  }
+
   async function handleUpload(files: FileList | null) {
     if (!(profileId && files?.length)) {
       return;
@@ -61,28 +80,44 @@ export function KnowledgeTab({ profileId }: { profileId: string | null }) {
 
     setError(null);
 
-    await Promise.all(
-      Array.from(files).map(async (file) => {
-        if (!isKnowledgeBaseFile(file)) {
-          setError(
-            `Unsupported file type: ${file.name}. Allowed: txt, md, csv, pdf.`
-          );
-          return;
+    for (const file of Array.from(files)) {
+      if (!isKnowledgeBaseFile(file)) {
+        setError(
+          `Unsupported file type: ${file.name}. Allowed: txt, md, csv, pdf.`
+        );
+        continue;
+      }
+
+      try {
+        const document = await fileToDocumentAttachment(file);
+        if (!document) {
+          setError(`Failed to read file: ${file.name}`);
+          continue;
         }
 
         try {
-          const document = await fileToDocumentAttachment(file);
-          if (!document) {
-            setError(`Failed to read file: ${file.name}`);
-            return;
-          }
-
           await uploadMutation.mutateAsync({ document, profileId });
         } catch (err) {
-          setError(formatError(err));
+          if (!(err instanceof NakamaApiError && err.status === 409)) {
+            throw err;
+          }
+
+          const decision = await askDuplicateDecision(file.name);
+          if (decision === "cancel" || decision === "skip") {
+            continue;
+          }
+
+          await uploadMutation.mutateAsync({
+            document,
+            onDuplicate: "replace",
+            profileId,
+          });
         }
-      })
-    );
+      } catch (err) {
+        setError(formatError(err));
+        break;
+      }
+    }
 
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
@@ -172,6 +207,56 @@ export function KnowledgeTab({ profileId }: { profileId: string | null }) {
             >
               {deleteMutation.isPending ? <Spinner className="size-4" /> : null}
               Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        onOpenChange={(open) => {
+          if (!open && duplicatePrompt) {
+            duplicatePrompt.resolve("cancel");
+            setDuplicatePrompt(null);
+          }
+        }}
+        open={duplicatePrompt !== null}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Duplicate document</DialogTitle>
+            <DialogDescription>
+              {duplicatePrompt?.filename} is already in this knowledge base.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              onClick={() => {
+                duplicatePrompt?.resolve("cancel");
+                setDuplicatePrompt(null);
+              }}
+              type="button"
+              variant="outline"
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={() => {
+                duplicatePrompt?.resolve("skip");
+                setDuplicatePrompt(null);
+              }}
+              type="button"
+              variant="outline"
+            >
+              Skip
+            </Button>
+            <Button
+              onClick={() => {
+                duplicatePrompt?.resolve("replace");
+                setDuplicatePrompt(null);
+              }}
+              type="button"
+            >
+              Replace
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/web/src/components/soul-tools/KnowledgeTab.tsx
+++ b/apps/web/src/components/soul-tools/KnowledgeTab.tsx
@@ -24,7 +24,7 @@ import {
   isKnowledgeBaseFile,
 } from "@/lib/knowledge-base-files";
 
-type DuplicateDecision = "skip" | "replace" | "cancel";
+type DuplicateDecision = "skip" | "replace";
 
 type DuplicatePrompt = {
   filename: string;
@@ -103,7 +103,7 @@ export function KnowledgeTab({ profileId }: { profileId: string | null }) {
           }
 
           const decision = await askDuplicateDecision(file.name);
-          if (decision === "cancel" || decision === "skip") {
+          if (decision === "skip") {
             continue;
           }
 
@@ -215,7 +215,7 @@ export function KnowledgeTab({ profileId }: { profileId: string | null }) {
       <Dialog
         onOpenChange={(open) => {
           if (!open && duplicatePrompt) {
-            duplicatePrompt.resolve("cancel");
+            duplicatePrompt.resolve("skip");
             setDuplicatePrompt(null);
           }
         }}
@@ -229,16 +229,6 @@ export function KnowledgeTab({ profileId }: { profileId: string | null }) {
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button
-              onClick={() => {
-                duplicatePrompt?.resolve("cancel");
-                setDuplicatePrompt(null);
-              }}
-              type="button"
-              variant="outline"
-            >
-              Cancel
-            </Button>
             <Button
               onClick={() => {
                 duplicatePrompt?.resolve("skip");

--- a/apps/web/src/hooks/use-resource-mutations.ts
+++ b/apps/web/src/hooks/use-resource-mutations.ts
@@ -4,6 +4,7 @@ import type {
   CreateProfileRequest,
   DocumentAttachment,
   ImageAttachment,
+  KnowledgeBaseDuplicateAction,
   SoulStackFiles,
   UpdateProfileRequest,
   UpdateSessionRequest,
@@ -766,10 +767,12 @@ export function useUploadKnowledgeBaseDocumentMutation() {
     mutationFn: ({
       profileId,
       document,
+      onDuplicate,
     }: {
       profileId: string;
       document: DocumentAttachment;
-    }) => client.uploadKnowledgeBaseDocument(profileId, document),
+      onDuplicate?: KnowledgeBaseDuplicateAction;
+    }) => client.uploadKnowledgeBaseDocument(profileId, document, onDuplicate),
     onSuccess: async (_data, variables) => {
       await queryClient.invalidateQueries({
         queryKey: queryKeys.knowledgeBase.profile(variables.profileId),

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -64,6 +64,7 @@ import type {
   InitUserContextResponse,
   InstallSkillRequest,
   InviteOrgMemberRequest,
+  KnowledgeBaseDuplicateAction,
   ListArtifactsResponse,
   ListAutomationRunsResponse,
   ListAutomationsResponse,
@@ -1119,12 +1120,16 @@ export class NakamaClient {
 
   async uploadKnowledgeBaseDocument(
     profileId: string,
-    document: DocumentAttachment
+    document: DocumentAttachment,
+    onDuplicate?: KnowledgeBaseDuplicateAction
   ): Promise<UploadKnowledgeBaseResponse> {
     return this.request<UploadKnowledgeBaseResponse>(
       `/v1/profiles/${encodeURIComponent(profileId)}/knowledge-base`,
       {
-        body: JSON.stringify({ document } satisfies UploadKnowledgeBaseRequest),
+        body: JSON.stringify({
+          document,
+          ...(onDuplicate ? { onDuplicate } : {}),
+        } satisfies UploadKnowledgeBaseRequest),
         method: "POST",
       }
     );

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -1984,7 +1984,13 @@ export interface PublicArtifactShareResponse {
 
 export type KnowledgeBaseDocumentStatus = "ready" | "failed";
 
+export type KnowledgeBaseDuplicateAction = "error" | "skip" | "replace";
+
+export type KnowledgeBaseUploadOutcome = "created" | "skipped" | "replaced";
+
 export interface KnowledgeBaseDocument {
+  /** SHA-256 hex of the stored file bytes. Optional on legacy manifests. */
+  contentHash?: string;
   error?: string;
   filename: string;
   id: string;
@@ -2012,10 +2018,13 @@ export interface ListKnowledgeBaseResponse {
 
 export interface UploadKnowledgeBaseRequest {
   document: DocumentAttachment;
+  /** Default `error` — reject duplicates so clients can warn / choose skip or replace. */
+  onDuplicate?: KnowledgeBaseDuplicateAction;
 }
 
 export interface UploadKnowledgeBaseResponse {
   document: KnowledgeBaseDocument;
+  outcome: KnowledgeBaseUploadOutcome;
   profileId: string;
 }
 

--- a/packages/core/src/knowledge-base/store.test.ts
+++ b/packages/core/src/knowledge-base/store.test.ts
@@ -122,7 +122,7 @@ describe("knowledge base store", () => {
       ORG_ID,
       profileId,
       attachment,
-      { onDuplicate: "skip" }
+      "skip"
     );
     expect(skipped.outcome).toBe("skipped");
     expect(skipped.document.id).toBe(first.document.id);
@@ -141,7 +141,7 @@ describe("knowledge base store", () => {
       ORG_ID,
       profileId,
       attachment,
-      { onDuplicate: "replace" }
+      "replace"
     );
     expect(replaced.outcome).toBe("replaced");
     expect(replaced.document.id).not.toBe(first.document.id);

--- a/packages/core/src/knowledge-base/store.test.ts
+++ b/packages/core/src/knowledge-base/store.test.ts
@@ -9,6 +9,7 @@ import {
 } from "./paths";
 import {
   deleteKnowledgeBaseDocument,
+  KnowledgeBaseDuplicateError,
   listKnowledgeBaseDocuments,
   readKnowledgeBaseDocumentContent,
   uploadKnowledgeBaseDocument,
@@ -56,15 +57,17 @@ describe("knowledge base store", () => {
       mediaType: "text/plain",
     });
 
-    expect(uploaded.status).toBe("ready");
-    expect(uploaded.filename).toBe("notes.txt");
+    expect(uploaded.outcome).toBe("created");
+    expect(uploaded.document.status).toBe("ready");
+    expect(uploaded.document.filename).toBe("notes.txt");
+    expect(uploaded.document.contentHash).toMatch(/^[a-f0-9]{64}$/);
 
     const listed = await listKnowledgeBaseDocuments(ORG_ID, profileId);
     expect(listed).toHaveLength(1);
-    expect(listed[0]?.id).toBe(uploaded.id);
+    expect(listed[0]?.id).toBe(uploaded.document.id);
 
     const extracted = await readFile(
-      getKnowledgeBaseExtractedPath(ORG_ID, profileId, uploaded.id),
+      getKnowledgeBaseExtractedPath(ORG_ID, profileId, uploaded.document.id),
       "utf8"
     );
     expect(extracted).toContain("# source: notes.txt");
@@ -74,24 +77,106 @@ describe("knowledge base store", () => {
       getKnowledgeBaseManifestPath(ORG_ID, profileId),
       "utf8"
     );
-    expect(manifest).toContain(uploaded.id);
+    expect(manifest).toContain(uploaded.document.id);
 
     const storedPath = getKnowledgeBaseStoredDocumentPath(
       ORG_ID,
       profileId,
-      uploaded.id,
-      uploaded.filename
+      uploaded.document.id,
+      uploaded.document.filename
     );
-    expect(storedPath).toContain(uploaded.id);
+    expect(storedPath).toContain(uploaded.document.id);
     expect(await readFile(storedPath, "utf8")).toContain("needle in haystack");
 
     const deleted = await deleteKnowledgeBaseDocument(
       ORG_ID,
       profileId,
-      uploaded.id
+      uploaded.document.id
     );
     expect(deleted).toBe(true);
     expect(await listKnowledgeBaseDocuments(ORG_ID, profileId)).toHaveLength(0);
+  });
+
+  test("rejects duplicate uploads by default and supports skip/replace", async () => {
+    const profileId = "profile_kb_dedupe";
+    await setupProfile(profileId);
+
+    const attachment = {
+      data: Buffer.from("same bytes", "utf8").toString("base64"),
+      filename: "notes.txt",
+      mediaType: "text/plain",
+    };
+
+    const first = await uploadKnowledgeBaseDocument(
+      ORG_ID,
+      profileId,
+      attachment
+    );
+    expect(first.outcome).toBe("created");
+
+    await expect(
+      uploadKnowledgeBaseDocument(ORG_ID, profileId, attachment)
+    ).rejects.toBeInstanceOf(KnowledgeBaseDuplicateError);
+
+    const skipped = await uploadKnowledgeBaseDocument(
+      ORG_ID,
+      profileId,
+      attachment,
+      { onDuplicate: "skip" }
+    );
+    expect(skipped.outcome).toBe("skipped");
+    expect(skipped.document.id).toBe(first.document.id);
+    expect(await listKnowledgeBaseDocuments(ORG_ID, profileId)).toHaveLength(1);
+
+    const renamedSameBytes = {
+      data: attachment.data,
+      filename: "copy.txt",
+      mediaType: "text/plain",
+    };
+    await expect(
+      uploadKnowledgeBaseDocument(ORG_ID, profileId, renamedSameBytes)
+    ).rejects.toMatchObject({ match: "content_hash" });
+
+    const replaced = await uploadKnowledgeBaseDocument(
+      ORG_ID,
+      profileId,
+      attachment,
+      { onDuplicate: "replace" }
+    );
+    expect(replaced.outcome).toBe("replaced");
+    expect(replaced.document.id).not.toBe(first.document.id);
+
+    const listed = await listKnowledgeBaseDocuments(ORG_ID, profileId);
+    expect(listed).toHaveLength(1);
+    expect(listed[0]?.id).toBe(replaced.document.id);
+  });
+
+  test("detects duplicates by name and size when content hash is missing", async () => {
+    const profileId = "profile_kb_name_size";
+    await setupProfile(profileId);
+
+    const first = await uploadKnowledgeBaseDocument(ORG_ID, profileId, {
+      data: Buffer.from("legacy body", "utf8").toString("base64"),
+      filename: "legacy.txt",
+      mediaType: "text/plain",
+    });
+
+    const manifestPath = getKnowledgeBaseManifestPath(ORG_ID, profileId);
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as {
+      documents: Array<Record<string, unknown>>;
+    };
+    delete manifest.documents[0]?.contentHash;
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+    await expect(
+      uploadKnowledgeBaseDocument(ORG_ID, profileId, {
+        data: Buffer.from("xxxxxxxxxxx", "utf8").toString("base64"),
+        filename: "legacy.txt",
+        mediaType: "text/plain",
+      })
+    ).rejects.toMatchObject({ match: "name_size" });
+
+    expect(first.document.filename).toBe("legacy.txt");
   });
 
   test("rejects unsupported document types", async () => {
@@ -217,7 +302,7 @@ describe("knowledge base store", () => {
     const preview = await readKnowledgeBaseDocumentContent(
       ORG_ID,
       profileId,
-      uploaded.id,
+      uploaded.document.id,
       { render: "text" }
     );
     expect(preview.contentType).toBe("text/plain");
@@ -227,7 +312,7 @@ describe("knowledge base store", () => {
     const download = await readKnowledgeBaseDocumentContent(
       ORG_ID,
       profileId,
-      uploaded.id
+      uploaded.document.id
     );
     expect(download.contentType).toBe("text/plain");
     expect(download.bytes.toString("utf8")).toBe("needle in haystack");

--- a/packages/core/src/knowledge-base/store.ts
+++ b/packages/core/src/knowledge-base/store.ts
@@ -55,17 +55,9 @@ export class KnowledgeBaseDuplicateError extends Error {
   }
 }
 
-export interface UploadKnowledgeBaseDocumentOptions {
-  onDuplicate?: KnowledgeBaseDuplicateAction;
-}
-
 export interface UploadKnowledgeBaseDocumentResult {
   document: KnowledgeBaseDocument;
   outcome: KnowledgeBaseUploadOutcome;
-}
-
-function hashDocumentBytes(bytes: Buffer): string {
-  return createHash("sha256").update(bytes).digest("hex");
 }
 
 function findDuplicateDocument(
@@ -76,9 +68,7 @@ function findDuplicateDocument(
   match: KnowledgeBaseDuplicateMatch;
 } | null {
   const byHash = documents.find(
-    (document) =>
-      typeof document.contentHash === "string" &&
-      document.contentHash === candidate.contentHash
+    (document) => document.contentHash === candidate.contentHash
   );
   if (byHash) {
     return { document: byHash, match: "content_hash" };
@@ -252,7 +242,7 @@ export async function uploadKnowledgeBaseDocument(
   orgId: string,
   profileId: string,
   attachment: DocumentAttachment,
-  options: UploadKnowledgeBaseDocumentOptions = {}
+  onDuplicate: KnowledgeBaseDuplicateAction = "error"
 ): Promise<UploadKnowledgeBaseDocumentResult> {
   const filename = attachment.filename.trim();
 
@@ -285,8 +275,7 @@ export async function uploadKnowledgeBaseDocument(
 
   await ensureKnowledgeBaseDirs(orgId, profileId);
 
-  const contentHash = hashDocumentBytes(bytes);
-  const onDuplicate = options.onDuplicate ?? "error";
+  const contentHash = createHash("sha256").update(bytes).digest("hex");
   let outcome: KnowledgeBaseUploadOutcome = "created";
 
   const existingManifest = await readManifest(orgId, profileId);

--- a/packages/core/src/knowledge-base/store.ts
+++ b/packages/core/src/knowledge-base/store.ts
@@ -1,6 +1,12 @@
+import { createHash } from "node:crypto";
 import { readdir, rename, rm } from "node:fs/promises";
 import { join } from "node:path";
-import type { DocumentAttachment, KnowledgeBaseDocument } from "../contract";
+import type {
+  DocumentAttachment,
+  KnowledgeBaseDocument,
+  KnowledgeBaseDuplicateAction,
+  KnowledgeBaseUploadOutcome,
+} from "../contract";
 import {
   ensureDir,
   pathExists,
@@ -28,6 +34,66 @@ import {
 
 interface KnowledgeBaseManifest {
   documents: KnowledgeBaseDocument[];
+}
+
+export type KnowledgeBaseDuplicateMatch = "content_hash" | "name_size";
+
+export class KnowledgeBaseDuplicateError extends Error {
+  readonly existing: KnowledgeBaseDocument;
+  readonly match: KnowledgeBaseDuplicateMatch;
+
+  constructor(
+    existing: KnowledgeBaseDocument,
+    match: KnowledgeBaseDuplicateMatch
+  ) {
+    super(
+      `Duplicate knowledge base document: ${existing.filename} (matched by ${match === "content_hash" ? "content hash" : "name and size"}).`
+    );
+    this.name = "KnowledgeBaseDuplicateError";
+    this.existing = existing;
+    this.match = match;
+  }
+}
+
+export interface UploadKnowledgeBaseDocumentOptions {
+  onDuplicate?: KnowledgeBaseDuplicateAction;
+}
+
+export interface UploadKnowledgeBaseDocumentResult {
+  document: KnowledgeBaseDocument;
+  outcome: KnowledgeBaseUploadOutcome;
+}
+
+function hashDocumentBytes(bytes: Buffer): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function findDuplicateDocument(
+  documents: KnowledgeBaseDocument[],
+  candidate: { contentHash: string; filename: string; sizeBytes: number }
+): {
+  document: KnowledgeBaseDocument;
+  match: KnowledgeBaseDuplicateMatch;
+} | null {
+  const byHash = documents.find(
+    (document) =>
+      typeof document.contentHash === "string" &&
+      document.contentHash === candidate.contentHash
+  );
+  if (byHash) {
+    return { document: byHash, match: "content_hash" };
+  }
+
+  const byNameSize = documents.find(
+    (document) =>
+      document.filename === candidate.filename &&
+      document.sizeBytes === candidate.sizeBytes
+  );
+  if (byNameSize) {
+    return { document: byNameSize, match: "name_size" };
+  }
+
+  return null;
 }
 
 async function migrateLegacyKnowledgeBaseDir(
@@ -185,8 +251,9 @@ export async function listKnowledgeBaseDocuments(
 export async function uploadKnowledgeBaseDocument(
   orgId: string,
   profileId: string,
-  attachment: DocumentAttachment
-): Promise<KnowledgeBaseDocument> {
+  attachment: DocumentAttachment,
+  options: UploadKnowledgeBaseDocumentOptions = {}
+): Promise<UploadKnowledgeBaseDocumentResult> {
   const filename = attachment.filename.trim();
 
   if (!filename) {
@@ -217,6 +284,40 @@ export async function uploadKnowledgeBaseDocument(
   }
 
   await ensureKnowledgeBaseDirs(orgId, profileId);
+
+  const contentHash = hashDocumentBytes(bytes);
+  const onDuplicate = options.onDuplicate ?? "error";
+  let outcome: KnowledgeBaseUploadOutcome = "created";
+
+  const existingManifest = await readManifest(orgId, profileId);
+  const duplicate = findDuplicateDocument(existingManifest.documents, {
+    contentHash,
+    filename,
+    sizeBytes: bytes.length,
+  });
+
+  if (duplicate) {
+    if (onDuplicate === "skip") {
+      return { document: duplicate.document, outcome: "skipped" };
+    }
+
+    if (onDuplicate === "error") {
+      throw new KnowledgeBaseDuplicateError(
+        duplicate.document,
+        duplicate.match
+      );
+    }
+
+    const removed = await deleteKnowledgeBaseDocument(
+      orgId,
+      profileId,
+      duplicate.document.id
+    );
+    if (!removed) {
+      throw new Error("Failed to replace existing knowledge base document.");
+    }
+    outcome = "replaced";
+  }
 
   const documentId = createId("kb");
   const uploadedAt = new Date().toISOString();
@@ -258,6 +359,7 @@ export async function uploadKnowledgeBaseDocument(
   }
 
   const document: KnowledgeBaseDocument = {
+    contentHash,
     filename,
     id: documentId,
     mediaType,
@@ -271,7 +373,7 @@ export async function uploadKnowledgeBaseDocument(
   manifest.documents.push(document);
   await writeManifest(orgId, profileId, manifest);
 
-  return document;
+  return { document, outcome };
 }
 
 export async function deleteKnowledgeBaseDocument(


### PR DESCRIPTION
## Summary

Re-uploading the same knowledge base file warns and offers Skip / Replace instead of creating a silent second entry.

**Before:** identical upload → second document, duplicated search chunks.
**After:** content-hash or name+size match → 409 by default; `onDuplicate: skip|replace`; Knowledge tab dialog.

Why safe:
1. Default stays reject (`error`) — no silent skip for API clients
2. `contentHash` is optional on legacy manifests; name+size still catches re-uploads
3. Replace deletes the old doc then writes one new entry

Only re-open if concurrent uploads of the same file race past the manifest check.

## Test plan
- [x] `bun test packages/core/src/knowledge-base/store.test.ts apps/server/src/services/profile-service.test.ts` (41 pass)
- [ ] Upload the same file twice on Knowledge tab — dialog → Skip keeps one; Replace keeps one updated

Closes #627
