### PR TITLE
fix(web): persistent Retry after failed chat turns (#630)

### DIFF
--- a/apps/web/src/components/chat/assistant-tool-group.shared.ts
+++ b/apps/web/src/components/chat/assistant-tool-group.shared.ts
@@ -84,5 +84,6 @@ function hasThinkingContent(message: ChatListItem): boolean {
 
 function hasAssistantText(message: ChatListItem): boolean {
   // Empty streaming bubbles are handled by the awaiting-model placeholder, not as text.
-  return Boolean(message.content.trim());
+  // Failed markers always render even when the error string is the only content.
+  return Boolean(message.content.trim() || message.failed);
 }

--- a/apps/web/src/components/chat/assistant-tool-group.tsx
+++ b/apps/web/src/components/chat/assistant-tool-group.tsx
@@ -95,6 +95,20 @@ function AssistantTextContent({ message }: { message: ChatListItem }) {
   const streaming = Boolean(message.streaming && !message.thinkingStreaming);
   const content = useRafCoalescedValue(message.content, streaming);
 
+  if (message.failed) {
+    return (
+      <div
+        className="flex w-full min-w-0 flex-col gap-1 rounded-lg border border-destructive/25 bg-destructive/5 px-3 py-2"
+        role="alert"
+      >
+        <span className="font-medium text-destructive text-xs">Failed</span>
+        <p className="text-destructive/90 text-sm leading-relaxed">
+          {content || "The model did not respond."}
+        </p>
+      </div>
+    );
+  }
+
   if (!streaming) {
     return <MessageResponse>{content || "…"}</MessageResponse>;
   }

--- a/apps/web/src/components/chat/assistant-tool-group.tsx
+++ b/apps/web/src/components/chat/assistant-tool-group.tsx
@@ -1,4 +1,4 @@
-import { ArrowDown01Icon, Wrench01Icon } from "hugeicons-react";
+import { ArrowDown01Icon, Rotate02Icon, Wrench01Icon } from "hugeicons-react";
 import type { ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
 import {
@@ -12,6 +12,7 @@ import { ThinkingReasoning } from "@/components/chat/ThinkingReasoning";
 import thinkingStyles from "@/components/chat/ThinkingReasoning.module.css";
 import { WebFetchToolRow } from "@/components/chat/WebFetchToolRow";
 import { WebSearchToolRow } from "@/components/chat/WebSearchToolRow";
+import { Button } from "@/components/ui/button";
 import { useRafCoalescedValue } from "@/hooks/use-raf-coalesced-value";
 import { isArtifactMetaSidecarTool } from "@/lib/chat-artifacts";
 import type { ChatListItem } from "@/lib/chat-history";
@@ -46,11 +47,15 @@ export function AssistantTurnSegmentView({
   showThinking = true,
   modelLabel,
   profileId,
+  onRetryMessage,
+  retryDisabled = false,
 }: {
   segment: AssistantTurnSegment;
   showThinking?: boolean;
   modelLabel?: string | null;
   profileId?: string | null;
+  onRetryMessage?: (message: ChatListItem) => void;
+  retryDisabled?: boolean;
 }) {
   if (segment.kind === "work") {
     return (
@@ -72,7 +77,15 @@ export function AssistantTurnSegmentView({
         {showThinking && segment.thinking ? (
           <ThinkingBlock message={segment.thinking} />
         ) : null}
-        <AssistantTextContent message={segment.message} />
+        <AssistantTextContent
+          message={segment.message}
+          onRetry={
+            segment.message.failed && onRetryMessage
+              ? () => onRetryMessage(segment.message)
+              : undefined
+          }
+          retryDisabled={retryDisabled}
+        />
       </MessageContent>
     </Message>
   );
@@ -91,20 +104,43 @@ function StreamingPlainTail({ text }: { text: string }) {
   );
 }
 
-function AssistantTextContent({ message }: { message: ChatListItem }) {
+function AssistantTextContent({
+  message,
+  onRetry,
+  retryDisabled = false,
+}: {
+  message: ChatListItem;
+  onRetry?: () => void;
+  retryDisabled?: boolean;
+}) {
   const streaming = Boolean(message.streaming && !message.thinkingStreaming);
   const content = useRafCoalescedValue(message.content, streaming);
 
   if (message.failed) {
     return (
       <div
-        className="flex w-full min-w-0 flex-col gap-1 rounded-lg border border-destructive/25 bg-destructive/5 px-3 py-2"
+        className="flex w-full min-w-0 flex-col gap-2 rounded-lg border border-destructive/25 bg-destructive/5 px-3 py-2.5"
         role="alert"
       >
-        <span className="font-medium text-destructive text-xs">Failed</span>
-        <p className="text-destructive/90 text-sm leading-relaxed">
-          {content || "The model did not respond."}
-        </p>
+        <div className="flex flex-col gap-1">
+          <span className="font-medium text-destructive text-xs">Failed</span>
+          <p className="text-destructive/90 text-sm leading-relaxed">
+            {content || "The model did not respond."}
+          </p>
+        </div>
+        {onRetry ? (
+          <Button
+            className="w-fit border-destructive/30 bg-background text-destructive hover:bg-destructive/10 hover:text-destructive"
+            disabled={retryDisabled}
+            onClick={onRetry}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            <Rotate02Icon aria-hidden className="size-3.5" />
+            Retry
+          </Button>
+        ) : null}
       </div>
     );
   }

--- a/apps/web/src/components/chat/chat-message-list.tsx
+++ b/apps/web/src/components/chat/chat-message-list.tsx
@@ -358,6 +358,7 @@ function AssistantTurn({
   // Wait for the full SSE reply (tools + final summary), not the brief gap after tool_end.
   const showArtifacts = turnComplete && artifacts.length > 0;
   const showActions = !streamActive && turnComplete && anchorMessage != null;
+  const failedAnchor = Boolean(anchorMessage?.failed);
 
   return (
     <div className="group mr-auto ml-0 flex w-full max-w-full flex-col items-start justify-start gap-3">
@@ -394,6 +395,7 @@ function AssistantTurn({
       {showActions && anchorMessage ? (
         <AssistantMessageActions
           actionsDisabled={actionsDisabled}
+          alwaysVisible={failedAnchor}
           busy={branchingMessageId === anchorMessage.id}
           copyContent={assistantTurnContent(turnMessages)}
           message={anchorMessage}
@@ -474,6 +476,7 @@ function assistantTurnContent(messages: ChatListItem[]): string {
 function isBranchableAssistantMessage(message: ChatListItem): boolean {
   return (
     message.role === "assistant" &&
+    !message.failed &&
     !message.streaming &&
     typeof message.historyIndex === "number" &&
     Boolean(message.createdAt)
@@ -485,6 +488,7 @@ function AssistantMessageActions({
   copyContent,
   busy,
   actionsDisabled = false,
+  alwaysVisible = false,
   onBranchMessage,
   onRetryMessage,
 }: {
@@ -492,6 +496,7 @@ function AssistantMessageActions({
   copyContent: string;
   busy: boolean;
   actionsDisabled?: boolean;
+  alwaysVisible?: boolean;
   onBranchMessage?: (message: ChatListItem) => void;
   onRetryMessage?: (message: ChatListItem) => void;
 }) {
@@ -532,39 +537,62 @@ function AssistantMessageActions({
   const branchCreatedAt = isBranchableAssistantMessage(message)
     ? message.createdAt
     : null;
+  const isFailed = Boolean(message.failed);
+  const retryLabel = isFailed ? "Retry" : "Try again";
 
   return (
-    <div className="flex items-center gap-1 pt-1 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
-      <button
-        aria-label={copied ? "Copied" : "Copy response"}
-        className={cn(
-          "inline-flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-40",
-          copied && "text-emerald-600 dark:text-emerald-400"
-        )}
-        disabled={!copyContent.trim()}
-        onClick={() => void copyMessage()}
-        title={copied ? "Copied" : "Copy response"}
-        type="button"
-      >
-        {copied ? (
-          <CheckmarkCircle01Icon aria-hidden className="size-4" />
-        ) : (
-          <Copy01Icon aria-hidden className="size-4" />
-        )}
-      </button>
-      {onRetryMessage ? (
+    <div
+      className={cn(
+        "flex items-center gap-1 pt-1 transition-opacity",
+        alwaysVisible
+          ? "opacity-100"
+          : "opacity-0 group-focus-within:opacity-100 group-hover:opacity-100"
+      )}
+    >
+      {isFailed ? null : (
         <button
-          aria-label="Try again"
-          className="inline-flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-40"
-          disabled={busy || actionsDisabled}
-          onClick={() => onRetryMessage(message)}
-          title="Try again"
+          aria-label={copied ? "Copied" : "Copy response"}
+          className={cn(
+            "inline-flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-40",
+            copied && "text-emerald-600 dark:text-emerald-400"
+          )}
+          disabled={!copyContent.trim()}
+          onClick={() => void copyMessage()}
+          title={copied ? "Copied" : "Copy response"}
           type="button"
         >
-          <Rotate02Icon aria-hidden className="size-4" />
+          {copied ? (
+            <CheckmarkCircle01Icon aria-hidden className="size-4" />
+          ) : (
+            <Copy01Icon aria-hidden className="size-4" />
+          )}
         </button>
+      )}
+      {onRetryMessage ? (
+        isFailed ? (
+          <button
+            className="inline-flex h-8 items-center gap-1.5 rounded-full px-3 font-medium text-muted-foreground text-xs transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-40"
+            disabled={busy || actionsDisabled}
+            onClick={() => onRetryMessage(message)}
+            type="button"
+          >
+            <Rotate02Icon aria-hidden className="size-3.5" />
+            Retry
+          </button>
+        ) : (
+          <button
+            aria-label={retryLabel}
+            className="inline-flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-40"
+            disabled={busy || actionsDisabled}
+            onClick={() => onRetryMessage(message)}
+            title={retryLabel}
+            type="button"
+          >
+            <Rotate02Icon aria-hidden className="size-4" />
+          </button>
+        )
       ) : null}
-      {onBranchMessage && branchCreatedAt ? (
+      {onBranchMessage && branchCreatedAt && !isFailed ? (
         <DropdownMenu>
           <DropdownMenuTrigger
             render={

--- a/apps/web/src/components/chat/chat-message-list.tsx
+++ b/apps/web/src/components/chat/chat-message-list.tsx
@@ -358,7 +358,6 @@ function AssistantTurn({
   // Wait for the full SSE reply (tools + final summary), not the brief gap after tool_end.
   const showArtifacts = turnComplete && artifacts.length > 0;
   const showActions = !streamActive && turnComplete && anchorMessage != null;
-  const failedAnchor = Boolean(anchorMessage?.failed);
 
   return (
     <div className="group mr-auto ml-0 flex w-full max-w-full flex-col items-start justify-start gap-3">
@@ -395,7 +394,6 @@ function AssistantTurn({
       {showActions && anchorMessage ? (
         <AssistantMessageActions
           actionsDisabled={actionsDisabled}
-          alwaysVisible={failedAnchor}
           busy={branchingMessageId === anchorMessage.id}
           copyContent={assistantTurnContent(turnMessages)}
           message={anchorMessage}
@@ -488,7 +486,6 @@ function AssistantMessageActions({
   copyContent,
   busy,
   actionsDisabled = false,
-  alwaysVisible = false,
   onBranchMessage,
   onRetryMessage,
 }: {
@@ -496,7 +493,6 @@ function AssistantMessageActions({
   copyContent: string;
   busy: boolean;
   actionsDisabled?: boolean;
-  alwaysVisible?: boolean;
   onBranchMessage?: (message: ChatListItem) => void;
   onRetryMessage?: (message: ChatListItem) => void;
 }) {
@@ -538,13 +534,12 @@ function AssistantMessageActions({
     ? message.createdAt
     : null;
   const isFailed = Boolean(message.failed);
-  const retryLabel = isFailed ? "Retry" : "Try again";
 
   return (
     <div
       className={cn(
         "flex items-center gap-1 pt-1 transition-opacity",
-        alwaysVisible
+        isFailed
           ? "opacity-100"
           : "opacity-0 group-focus-within:opacity-100 group-hover:opacity-100"
       )}
@@ -569,30 +564,26 @@ function AssistantMessageActions({
         </button>
       )}
       {onRetryMessage ? (
-        isFailed ? (
-          <button
-            className="inline-flex h-8 items-center gap-1.5 rounded-full px-3 font-medium text-muted-foreground text-xs transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-40"
-            disabled={busy || actionsDisabled}
-            onClick={() => onRetryMessage(message)}
-            type="button"
-          >
-            <Rotate02Icon aria-hidden className="size-3.5" />
-            Retry
-          </button>
-        ) : (
-          <button
-            aria-label={retryLabel}
-            className="inline-flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-40"
-            disabled={busy || actionsDisabled}
-            onClick={() => onRetryMessage(message)}
-            title={retryLabel}
-            type="button"
-          >
-            <Rotate02Icon aria-hidden className="size-4" />
-          </button>
-        )
+        <button
+          aria-label={isFailed ? undefined : "Try again"}
+          className={
+            isFailed
+              ? "inline-flex h-8 items-center gap-1.5 rounded-full px-3 font-medium text-muted-foreground text-xs transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-40"
+              : "inline-flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-40"
+          }
+          disabled={busy || actionsDisabled}
+          onClick={() => onRetryMessage(message)}
+          title={isFailed ? undefined : "Try again"}
+          type="button"
+        >
+          <Rotate02Icon
+            aria-hidden
+            className={isFailed ? "size-3.5" : "size-4"}
+          />
+          {isFailed ? "Retry" : null}
+        </button>
       ) : null}
-      {onBranchMessage && branchCreatedAt && !isFailed ? (
+      {onBranchMessage && branchCreatedAt ? (
         <DropdownMenu>
           <DropdownMenuTrigger
             render={

--- a/apps/web/src/components/chat/chat-message-list.tsx
+++ b/apps/web/src/components/chat/chat-message-list.tsx
@@ -357,7 +357,13 @@ function AssistantTurn({
   const turnComplete = isAssistantTurnComplete(turnMessages);
   // Wait for the full SSE reply (tools + final summary), not the brief gap after tool_end.
   const showArtifacts = turnComplete && artifacts.length > 0;
-  const showActions = !streamActive && turnComplete && anchorMessage != null;
+  const showActions =
+    !streamActive &&
+    turnComplete &&
+    anchorMessage != null &&
+    !anchorMessage.failed;
+  const retryDisabled =
+    actionsDisabled || branchingMessageId === anchorMessage?.id;
 
   return (
     <div className="group mr-auto ml-0 flex w-full max-w-full flex-col items-start justify-start gap-3">
@@ -369,7 +375,9 @@ function AssistantTurn({
               : `text:${segment.message.id}`
           }
           modelLabel={modelLabel}
+          onRetryMessage={onRetryMessage}
           profileId={profileId}
+          retryDisabled={retryDisabled}
           segment={segment}
           showThinking={showThinking}
         />
@@ -533,54 +541,36 @@ function AssistantMessageActions({
   const branchCreatedAt = isBranchableAssistantMessage(message)
     ? message.createdAt
     : null;
-  const isFailed = Boolean(message.failed);
 
   return (
-    <div
-      className={cn(
-        "flex items-center gap-1 pt-1 transition-opacity",
-        isFailed
-          ? "opacity-100"
-          : "opacity-0 group-focus-within:opacity-100 group-hover:opacity-100"
-      )}
-    >
-      {isFailed ? null : (
-        <button
-          aria-label={copied ? "Copied" : "Copy response"}
-          className={cn(
-            "inline-flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-40",
-            copied && "text-emerald-600 dark:text-emerald-400"
-          )}
-          disabled={!copyContent.trim()}
-          onClick={() => void copyMessage()}
-          title={copied ? "Copied" : "Copy response"}
-          type="button"
-        >
-          {copied ? (
-            <CheckmarkCircle01Icon aria-hidden className="size-4" />
-          ) : (
-            <Copy01Icon aria-hidden className="size-4" />
-          )}
-        </button>
-      )}
+    <div className="flex items-center gap-1 pt-1 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
+      <button
+        aria-label={copied ? "Copied" : "Copy response"}
+        className={cn(
+          "inline-flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-40",
+          copied && "text-emerald-600 dark:text-emerald-400"
+        )}
+        disabled={!copyContent.trim()}
+        onClick={() => void copyMessage()}
+        title={copied ? "Copied" : "Copy response"}
+        type="button"
+      >
+        {copied ? (
+          <CheckmarkCircle01Icon aria-hidden className="size-4" />
+        ) : (
+          <Copy01Icon aria-hidden className="size-4" />
+        )}
+      </button>
       {onRetryMessage ? (
         <button
-          aria-label={isFailed ? undefined : "Try again"}
-          className={
-            isFailed
-              ? "inline-flex h-8 items-center gap-1.5 rounded-full px-3 font-medium text-muted-foreground text-xs transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-40"
-              : "inline-flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-40"
-          }
+          aria-label="Try again"
+          className="inline-flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-40"
           disabled={busy || actionsDisabled}
           onClick={() => onRetryMessage(message)}
-          title={isFailed ? undefined : "Try again"}
+          title="Try again"
           type="button"
         >
-          <Rotate02Icon
-            aria-hidden
-            className={isFailed ? "size-3.5" : "size-4"}
-          />
-          {isFailed ? "Retry" : null}
+          <Rotate02Icon aria-hidden className="size-4" />
         </button>
       ) : null}
       {onBranchMessage && branchCreatedAt ? (

--- a/apps/web/src/lib/chat-history.ts
+++ b/apps/web/src/lib/chat-history.ts
@@ -305,6 +305,8 @@ export interface ChatListItem {
   content: string;
   createdAt?: string;
   documents?: Array<{ filename: string; mediaType: string }>;
+  /** Client-only: turn failed (e.g. upstream 429); not part of server history. */
+  failed?: boolean;
   historyIndex?: number;
   id: string;
   imageAttachments?: Array<{
@@ -326,6 +328,66 @@ export interface ChatListItem {
   toolInputAccumulatedJson?: string;
   toolResult?: unknown;
   toolStatus?: "running" | "done";
+}
+
+/** Survives reload so a failed web turn keeps a Retry affordance. */
+export interface FailedChatTurn {
+  error: string;
+  text: string;
+}
+
+export const FAILED_CHAT_TURN_STORAGE_PREFIX = "nakama:failed-chat-turn:";
+
+export function failedChatTurnStorageKey(sessionId: string): string {
+  return `${FAILED_CHAT_TURN_STORAGE_PREFIX}${sessionId}`;
+}
+
+export function storeFailedChatTurn(
+  sessionId: string,
+  turn: FailedChatTurn
+): void {
+  if (typeof localStorage === "undefined") {
+    return;
+  }
+
+  localStorage.setItem(
+    failedChatTurnStorageKey(sessionId),
+    JSON.stringify(turn)
+  );
+}
+
+export function readFailedChatTurn(sessionId: string): FailedChatTurn | null {
+  if (typeof localStorage === "undefined") {
+    return null;
+  }
+
+  const raw = localStorage.getItem(failedChatTurnStorageKey(sessionId));
+
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<FailedChatTurn>;
+    const text = typeof parsed.text === "string" ? parsed.text : "";
+    const error = typeof parsed.error === "string" ? parsed.error.trim() : "";
+
+    if (!(text.trim() && error)) {
+      return null;
+    }
+
+    return { error, text };
+  } catch {
+    return null;
+  }
+}
+
+export function clearFailedChatTurn(sessionId: string): void {
+  if (typeof localStorage === "undefined") {
+    return;
+  }
+
+  localStorage.removeItem(failedChatTurnStorageKey(sessionId));
 }
 
 export function sessionStorageKey(profileId: string): string {

--- a/apps/web/src/lib/chat-history.ts
+++ b/apps/web/src/lib/chat-history.ts
@@ -336,11 +336,7 @@ export interface FailedChatTurn {
   text: string;
 }
 
-export const FAILED_CHAT_TURN_STORAGE_PREFIX = "nakama:failed-chat-turn:";
-
-export function failedChatTurnStorageKey(sessionId: string): string {
-  return `${FAILED_CHAT_TURN_STORAGE_PREFIX}${sessionId}`;
-}
+const FAILED_CHAT_TURN_STORAGE_PREFIX = "nakama:failed-chat-turn:";
 
 export function storeFailedChatTurn(
   sessionId: string,
@@ -351,7 +347,7 @@ export function storeFailedChatTurn(
   }
 
   localStorage.setItem(
-    failedChatTurnStorageKey(sessionId),
+    `${FAILED_CHAT_TURN_STORAGE_PREFIX}${sessionId}`,
     JSON.stringify(turn)
   );
 }
@@ -361,7 +357,9 @@ export function readFailedChatTurn(sessionId: string): FailedChatTurn | null {
     return null;
   }
 
-  const raw = localStorage.getItem(failedChatTurnStorageKey(sessionId));
+  const raw = localStorage.getItem(
+    `${FAILED_CHAT_TURN_STORAGE_PREFIX}${sessionId}`
+  );
 
   if (!raw) {
     return null;
@@ -387,7 +385,7 @@ export function clearFailedChatTurn(sessionId: string): void {
     return;
   }
 
-  localStorage.removeItem(failedChatTurnStorageKey(sessionId));
+  localStorage.removeItem(`${FAILED_CHAT_TURN_STORAGE_PREFIX}${sessionId}`);
 }
 
 export function sessionStorageKey(profileId: string): string {

--- a/apps/web/src/pages/chat/chat-page.shared.test.ts
+++ b/apps/web/src/pages/chat/chat-page.shared.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "bun:test";
+import type { ChatListItem } from "@/lib/chat-history";
+import {
+  clearFailedChatTurn,
+  readFailedChatTurn,
+  storeFailedChatTurn,
+} from "@/lib/chat-history";
+import {
+  appendFailedTurnIfNeeded,
+  findFailedRetryPrompt,
+  markStreamingTurnFailed,
+  messagesWithoutFailedTurn,
+} from "@/pages/chat/chat-page.shared";
+
+function user(
+  content: string,
+  extras: Partial<ChatListItem> = {}
+): ChatListItem {
+  return { content, id: `user-${content}`, role: "user", ...extras };
+}
+
+function assistant(
+  content: string,
+  extras: Partial<ChatListItem> = {}
+): ChatListItem {
+  return {
+    content,
+    id: `asst-${content || "empty"}`,
+    role: "assistant",
+    ...extras,
+  };
+}
+
+describe("markStreamingTurnFailed", () => {
+  test("converts a streaming assistant into a failed marker", () => {
+    const messages = [
+      user("hello"),
+      assistant("", { id: "stream", streaming: true }),
+    ];
+
+    const next = markStreamingTurnFailed(messages, "Rate limited");
+
+    expect(next).toHaveLength(2);
+    expect(next[1]).toMatchObject({
+      content: "Rate limited",
+      failed: true,
+      id: "stream",
+      streaming: false,
+    });
+  });
+
+  test("appends a failed marker when only the user message remains", () => {
+    const next = markStreamingTurnFailed([user("hello")], "Boom");
+
+    expect(next).toHaveLength(2);
+    expect(next[0]?.content).toBe("hello");
+    expect(next[1]).toMatchObject({
+      content: "Boom",
+      failed: true,
+      role: "assistant",
+    });
+  });
+});
+
+describe("appendFailedTurnIfNeeded", () => {
+  test("appends stored user + failed assistant after reload", () => {
+    const next = appendFailedTurnIfNeeded(
+      [user("earlier", { historyIndex: 0 })],
+      {
+        error: "429",
+        text: "retry me",
+      }
+    );
+
+    expect(next.map((message) => message.role)).toEqual([
+      "user",
+      "user",
+      "assistant",
+    ]);
+    expect(next[1]).toMatchObject({ content: "retry me", role: "user" });
+    expect(next[2]).toMatchObject({
+      content: "429",
+      failed: true,
+      role: "assistant",
+    });
+  });
+
+  test("is a no-op when a failed marker is already present", () => {
+    const messages = [user("retry me"), assistant("429", { failed: true })];
+
+    expect(
+      appendFailedTurnIfNeeded(messages, { error: "429", text: "retry me" })
+    ).toBe(messages);
+  });
+});
+
+describe("failed turn retry helpers", () => {
+  test("finds the prompt and strips the optimistic failed turn", () => {
+    const failed = assistant("429", { failed: true, id: "failed" });
+    const messages = [
+      user("kept", { historyIndex: 0 }),
+      user("retry me"),
+      failed,
+    ];
+
+    expect(findFailedRetryPrompt(messages, failed)?.content).toBe("retry me");
+    expect(messagesWithoutFailedTurn(messages, failed)).toEqual([
+      user("kept", { historyIndex: 0 }),
+    ]);
+  });
+
+  test("keeps a persisted user message when stripping a failed marker", () => {
+    const failed = assistant("429", { failed: true, id: "failed" });
+    const messages = [user("persisted", { historyIndex: 0 }), failed];
+
+    expect(messagesWithoutFailedTurn(messages, failed)).toEqual([
+      user("persisted", { historyIndex: 0 }),
+    ]);
+  });
+});
+
+describe("failed chat turn storage", () => {
+  function withLocalStorage<T>(run: (store: Map<string, string>) => T): T {
+    const store = new Map<string, string>();
+    const previousLocalStorage = globalThis.localStorage;
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: (key: string) => store.get(key) ?? null,
+        removeItem: (key: string) => {
+          store.delete(key);
+        },
+        setItem: (key: string, value: string) => {
+          store.set(key, value);
+        },
+      },
+    });
+
+    try {
+      return run(store);
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", {
+        configurable: true,
+        value: previousLocalStorage,
+      });
+    }
+  }
+
+  test("round-trips a failed turn and clears it", () => {
+    withLocalStorage(() => {
+      const sessionId = `session_failed_${Date.now()}`;
+      storeFailedChatTurn(sessionId, {
+        error: "Rate limit",
+        text: "hello",
+      });
+
+      expect(readFailedChatTurn(sessionId)).toEqual({
+        error: "Rate limit",
+        text: "hello",
+      });
+
+      clearFailedChatTurn(sessionId);
+      expect(readFailedChatTurn(sessionId)).toBeNull();
+    });
+  });
+
+  test("rejects malformed storage payloads", () => {
+    withLocalStorage((store) => {
+      const sessionId = `session_bad_${Date.now()}`;
+      store.set(
+        `nakama:failed-chat-turn:${sessionId}`,
+        JSON.stringify({ error: "x" })
+      );
+
+      expect(readFailedChatTurn(sessionId)).toBeNull();
+    });
+  });
+});

--- a/apps/web/src/pages/chat/chat-page.shared.ts
+++ b/apps/web/src/pages/chat/chat-page.shared.ts
@@ -36,7 +36,7 @@ export function findRetryCheckpoint(
   );
 }
 
-export function buildFailedAssistantMessage(error: string): ChatListItem {
+function buildFailedAssistantMessage(error: string): ChatListItem {
   return {
     content: error,
     failed: true,

--- a/apps/web/src/pages/chat/chat-page.shared.ts
+++ b/apps/web/src/pages/chat/chat-page.shared.ts
@@ -80,11 +80,6 @@ export function markStreamingTurnFailed(
 
   const last = next.at(-1);
 
-  if (last?.role === "assistant" && last.failed) {
-    next[next.length - 1] = { ...last, content: error, failed: true };
-    return next;
-  }
-
   if (last?.role === "user") {
     return [...next, buildFailedAssistantMessage(error)];
   }
@@ -99,16 +94,6 @@ export function appendFailedTurnIfNeeded(
 ): ChatListItem[] {
   if (messages.some((message) => message.failed)) {
     return messages;
-  }
-
-  const last = messages.at(-1);
-
-  if (
-    last?.role === "user" &&
-    last.content === failed.text &&
-    typeof last.historyIndex !== "number"
-  ) {
-    return [...messages, buildFailedAssistantMessage(failed.error)];
   }
 
   return [
@@ -134,15 +119,11 @@ export function findFailedRetryPrompt(
     return null;
   }
 
-  for (let index = failedIndex - 1; index >= 0; index -= 1) {
-    const message = messages[index];
-
-    if (message?.role === "user") {
-      return message;
-    }
-  }
-
-  return null;
+  return (
+    messages
+      .slice(0, failedIndex)
+      .findLast((message) => message.role === "user") ?? null
+  );
 }
 
 /** Drop the failed assistant + its optimistic user prompt before re-sending. */

--- a/apps/web/src/pages/chat/chat-page.shared.ts
+++ b/apps/web/src/pages/chat/chat-page.shared.ts
@@ -1,4 +1,5 @@
-import type { ChatListItem } from "@/lib/chat-history";
+import type { ChatListItem, FailedChatTurn } from "@/lib/chat-history";
+import { createClientId } from "@/lib/client-id";
 
 export function findRetryPrompt(
   messages: ChatListItem[],
@@ -33,4 +34,136 @@ export function findRetryCheckpoint(
         message.historyIndex < promptMessage.historyIndex!
     ) ?? null
   );
+}
+
+export function buildFailedAssistantMessage(error: string): ChatListItem {
+  return {
+    content: error,
+    failed: true,
+    id: createClientId(),
+    role: "assistant",
+  };
+}
+
+/** Convert a live streaming turn into a persistent failed marker. */
+export function markStreamingTurnFailed(
+  messages: ChatListItem[],
+  error: string
+): ChatListItem[] {
+  const next = messages.map((message) => {
+    if (message.role === "tool" && message.toolStatus === "running") {
+      return {
+        ...message,
+        artifactStreaming: false,
+        content: `${message.tool} stopped`,
+        toolStatus: "done" as const,
+      };
+    }
+
+    return message;
+  });
+
+  for (let index = next.length - 1; index >= 0; index -= 1) {
+    const message = next[index];
+
+    if (message?.role === "assistant" && message.streaming) {
+      next[index] = {
+        ...message,
+        content: error,
+        failed: true,
+        streaming: false,
+        thinkingStreaming: false,
+      };
+      return next;
+    }
+  }
+
+  const last = next.at(-1);
+
+  if (last?.role === "assistant" && last.failed) {
+    next[next.length - 1] = { ...last, content: error, failed: true };
+    return next;
+  }
+
+  if (last?.role === "user") {
+    return [...next, buildFailedAssistantMessage(error)];
+  }
+
+  return next;
+}
+
+/** Re-attach a stored failed turn after reload (server history rolls failed sends back). */
+export function appendFailedTurnIfNeeded(
+  messages: ChatListItem[],
+  failed: FailedChatTurn
+): ChatListItem[] {
+  if (messages.some((message) => message.failed)) {
+    return messages;
+  }
+
+  const last = messages.at(-1);
+
+  if (
+    last?.role === "user" &&
+    last.content === failed.text &&
+    typeof last.historyIndex !== "number"
+  ) {
+    return [...messages, buildFailedAssistantMessage(failed.error)];
+  }
+
+  return [
+    ...messages,
+    {
+      content: failed.text,
+      id: createClientId(),
+      role: "user",
+    },
+    buildFailedAssistantMessage(failed.error),
+  ];
+}
+
+export function findFailedRetryPrompt(
+  messages: ChatListItem[],
+  failedMessage: ChatListItem
+): ChatListItem | null {
+  const failedIndex = messages.findIndex(
+    (message) => message.id === failedMessage.id
+  );
+
+  if (failedIndex < 0) {
+    return null;
+  }
+
+  for (let index = failedIndex - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+
+    if (message?.role === "user") {
+      return message;
+    }
+  }
+
+  return null;
+}
+
+/** Drop the failed assistant + its optimistic user prompt before re-sending. */
+export function messagesWithoutFailedTurn(
+  messages: ChatListItem[],
+  failedMessage: ChatListItem
+): ChatListItem[] {
+  const failedIndex = messages.findIndex(
+    (message) => message.id === failedMessage.id
+  );
+
+  if (failedIndex < 0) {
+    return messages;
+  }
+
+  let start = failedIndex;
+  const previous = messages[failedIndex - 1];
+
+  if (previous?.role === "user" && typeof previous.historyIndex !== "number") {
+    start = failedIndex - 1;
+  }
+
+  return [...messages.slice(0, start), ...messages.slice(failedIndex + 1)];
 }

--- a/apps/web/src/pages/chat/use-chat-page.ts
+++ b/apps/web/src/pages/chat/use-chat-page.ts
@@ -42,16 +42,19 @@ import {
   buildNewChatPath,
   type ChatListItem,
   chatMessagesToListItems,
+  clearFailedChatTurn,
   consumeStoredChatDraft,
   isReadOnlySessionChannel,
   parseChatRouteParams,
   pickKnownProfileId,
+  readFailedChatTurn,
   readInitialDraftChatProfileId,
   readRequestedDraftFromNewChatSearch,
   readRequestedDraftKeyFromNewChatSearch,
   readStoredActiveChatProfileId,
   resolveDefaultProfileId,
   sessionStorageKey,
+  storeFailedChatTurn,
 } from "@/lib/chat-history";
 import {
   filePartsToDisplayDocuments,
@@ -89,8 +92,12 @@ import {
   shouldShowThinkingEffort,
 } from "@/lib/thinking-settings";
 import {
+  appendFailedTurnIfNeeded,
+  findFailedRetryPrompt,
   findRetryCheckpoint,
   findRetryPrompt,
+  markStreamingTurnFailed,
+  messagesWithoutFailedTurn,
 } from "@/pages/chat/chat-page.shared";
 
 interface SendMessageOptions {
@@ -471,6 +478,13 @@ export function useChatPage() {
         } = await client.getSessionMessages(sessionId);
         const nextSession = client.createChatSession(sessionId, channel);
         let listItems = chatMessagesToListItems(storedMessages, messageMeta);
+        const storedFailedTurn =
+          channel === "web" ? readFailedChatTurn(sessionId) : null;
+
+        if (storedFailedTurn) {
+          listItems = appendFailedTurnIfNeeded(listItems, storedFailedTurn);
+        }
+
         setProfileId(nextProfileId);
         setSessionChannel(channel);
         setSession(nextSession);
@@ -479,6 +493,7 @@ export function useChatPage() {
         setAgentTodos(todos);
         setAgentQuestionnaire(questionnaire);
         setContextUsage(nextContextUsage ?? null);
+        setError(storedFailedTurn?.error ?? null);
         syncChatUrl(nextProfileId, sessionId);
 
         if (channel === "web") {
@@ -504,9 +519,24 @@ export function useChatPage() {
             });
 
             const refreshed = await client.getSessionMessages(sessionId);
-            setMessages(
-              chatMessagesToListItems(refreshed.messages, refreshed.messageMeta)
+            let refreshedItems = chatMessagesToListItems(
+              refreshed.messages,
+              refreshed.messageMeta
             );
+            const failedAfterReconnect = readFailedChatTurn(sessionId);
+
+            if (failedAfterReconnect && !reconnected) {
+              refreshedItems = appendFailedTurnIfNeeded(
+                refreshedItems,
+                failedAfterReconnect
+              );
+              setError(failedAfterReconnect.error);
+            } else if (reconnected) {
+              clearFailedChatTurn(sessionId);
+              setError(null);
+            }
+
+            setMessages(refreshedItems);
             setAgentTodos(refreshed.todos);
             setAgentQuestionnaire(refreshed.questionnaire);
             setContextUsage(refreshed.contextUsage ?? null);
@@ -514,10 +544,6 @@ export function useChatPage() {
 
             if (reconnected) {
               setLastSuccessfulTurnAt(Date.now());
-            }
-
-            if (!(reconnected || status.active)) {
-              setError(null);
             }
           }
         }
@@ -780,6 +806,7 @@ export function useChatPage() {
           contextUsage: nextContextUsage,
           model: nextSessionModel,
         } = await client.getSessionMessages(activeSession.id);
+        clearFailedChatTurn(activeSession.id);
         setMessages(chatMessagesToListItems(storedMessages, messageMeta));
         setAgentTodos(todos);
         setAgentQuestionnaire(questionnaire);
@@ -827,9 +854,10 @@ export function useChatPage() {
         }
 
         setError(message);
-        setMessages((current) =>
-          current.filter((message) => !message.streaming)
-        );
+        if (activeSession && text.trim()) {
+          storeFailedChatTurn(activeSession.id, { error: message, text });
+        }
+        setMessages((current) => markStreamingTurnFailed(current, message));
       } finally {
         streamAbortRef.current = null;
         setCanStop(false);
@@ -904,6 +932,40 @@ export function useChatPage() {
   const handleTryAgainMessage = useCallback(
     async (message: ChatListItem) => {
       if (busy || !profileId) {
+        return;
+      }
+
+      if (message.failed) {
+        const prompt = findFailedRetryPrompt(messages, message);
+
+        if (!prompt?.content.trim()) {
+          setError("Could not find a prompt to retry.");
+          return;
+        }
+
+        if (prompt.images?.length || prompt.documents?.length) {
+          setError("Retry is available for text-only prompts.");
+          return;
+        }
+
+        setBranchingMessageId(message.id);
+        setError(null);
+
+        try {
+          if (session) {
+            clearFailedChatTurn(session.id);
+          }
+
+          await sendMessage(prompt.content, [], {
+            initialMessages: messagesWithoutFailedTurn(messages, message),
+            sessionOverride: session ?? undefined,
+          });
+        } catch (err) {
+          setError(formatError(err));
+        } finally {
+          setBranchingMessageId(null);
+        }
+
         return;
       }
 

--- a/apps/web/src/pages/chat/use-chat-page.ts
+++ b/apps/web/src/pages/chat/use-chat-page.ts
@@ -493,7 +493,7 @@ export function useChatPage() {
         setAgentTodos(todos);
         setAgentQuestionnaire(questionnaire);
         setContextUsage(nextContextUsage ?? null);
-        setError(storedFailedTurn?.error ?? null);
+        setError(null);
         syncChatUrl(nextProfileId, sessionId);
 
         if (channel === "web") {
@@ -530,7 +530,6 @@ export function useChatPage() {
                 refreshedItems,
                 failedAfterReconnect
               );
-              setError(failedAfterReconnect.error);
             } else if (reconnected) {
               clearFailedChatTurn(sessionId);
               setError(null);
@@ -853,7 +852,9 @@ export function useChatPage() {
           }
         }
 
-        setError(message);
+        // Turn failures live in the Failed bubble; composer error stays for
+        // non-turn issues (attachments, session expired, validation, etc.).
+        setError(null);
         if (activeSession && text.trim()) {
           storeFailedChatTurn(activeSession.id, { error: message, text });
         }


### PR DESCRIPTION
## Summary

Failed chat turns keep a **Failed** marker + **Retry** that re-sends the same text after reload.

**Before:** Error lived only in composer state; reload wiped the prompt and any retry path.
**After:** Client marks the turn failed, stores `{text,error}` per session in localStorage, restores on resume; Retry lives inside the Failed bubble and clears the marker on re-send. Composer banner stays for non-turn errors only.

Why safe:
1. Server history still rolls back failed sends (LLM context unchanged)
2. Storage is session-scoped and cleared on success / Retry
3. Existing “Try again” branch path untouched for successful replies

Only re-add / follow up if attachments need retry (text-only today) or cross-device persistence is required.

## Screenshot

Failed marker with in-bubble Retry after a 429:

![Failed chat turn with Retry](https://github.com/user-attachments/assets/c4cf8e2b-f306-4025-a626-0e71d5766aee)

## Test plan
- [x] `bun test apps/web/src/pages/chat/chat-page.shared.test.ts` (8 pass)
- [x] `bun x tsc -p apps/web --noEmit`
- [x] Browser: seeded failed turn shows Failed + in-bubble Retry (no composer duplicate)
- [ ] Trigger a 429 (or offline provider) on a web chat message → Failed + Retry → reload → marker still there → Retry re-sends

Closes #630
