### PR TITLE
fix(whatsapp): clear old listeners and wait for socket end

### DIFF
--- a/apps/platform/whatsapp/src/index.ts
+++ b/apps/platform/whatsapp/src/index.ts
@@ -34,7 +34,7 @@ void installErrorTrackingSink();
 
 let spawnedChild: Bun.Subprocess | null = null;
 let socketHandle: {
-  stop: () => void;
+  stop: () => void | Promise<void>;
   socket: {
     sendMessage: (jid: string, content: { text: string }) => Promise<unknown>;
   } | null;
@@ -52,14 +52,14 @@ function persistWorkerHeartbeat(): void {
 }
 
 registerProcessLifecycleLogging();
-registerCleanupHandlers(() => {
+registerCleanupHandlers(async () => {
   outboundServer?.stop();
-  socketHandle?.stop();
+  await socketHandle?.stop();
   if (heartbeatTimer) {
     clearInterval(heartbeatTimer);
   }
-  void clearWhatsAppWorkerHeartbeat();
-  void clearWhatsAppQrCode();
+  await clearWhatsAppWorkerHeartbeat();
+  await clearWhatsAppQrCode();
   if (hasActiveStreams()) {
     console.warn(
       "Leaving the spawned Nakama server running so in-flight agent turns can finish; the next worker start will reuse it."
@@ -174,12 +174,17 @@ try {
   process.exit(1);
 }
 
-function registerCleanupHandlers(cleanup: () => void): void {
+function registerCleanupHandlers(cleanup: () => void | Promise<void>): void {
   for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
     process.on(signal, () => {
       console.log(`WhatsApp worker received ${signal}. Shutting down.`);
-      cleanup();
-      process.exit(0);
+      void (async () => {
+        try {
+          await cleanup();
+        } finally {
+          process.exit(0);
+        }
+      })();
     });
   }
 }

--- a/apps/platform/whatsapp/src/socket.test.ts
+++ b/apps/platform/whatsapp/src/socket.test.ts
@@ -170,11 +170,15 @@ describe("WhatsApp socket reconnect", () => {
   });
 
   test("clears old-socket listeners on reconnect so upserts cannot leak", async () => {
-    const handle = await createWhatsAppSocket({ onMessage: async () => {} });
+    const received: string[] = [];
+    const handle = await createWhatsAppSocket({
+      onMessage: async (data) => {
+        received.push(data.text);
+      },
+    });
     await handle.start();
 
     const oldSocket = sockets[0];
-    expect(oldSocket).toBeDefined();
     expect(oldSocket?.ev.listenerCount("messages.upsert")).toBe(1);
 
     emit(0, TIMEOUT_CLOSE);
@@ -184,21 +188,6 @@ describe("WhatsApp socket reconnect", () => {
     expect(oldSocket?.ev.listenerCount("messages.upsert")).toBe(0);
     expect(oldSocket?.ev.listenerCount("connection.update")).toBe(0);
     expect(sockets[1]?.ev.listenerCount("messages.upsert")).toBe(1);
-  });
-
-  test("does not dispatch duplicate inbound messages from a retired socket", async () => {
-    const received: string[] = [];
-    const handle = await createWhatsAppSocket({
-      onMessage: async (data) => {
-        received.push(data.text);
-      },
-    });
-    await handle.start();
-
-    emit(0, TIMEOUT_CLOSE);
-    await flush();
-
-    expect(createSocket).toHaveBeenCalledTimes(2);
 
     sockets[0]?.ev.emit("messages.upsert", SAMPLE_UPSERT);
     await flush();
@@ -228,19 +217,10 @@ describe("WhatsApp socket reconnect", () => {
 
     endResolvers[0]?.();
     await stopPromise;
+    await flush();
 
     expect(stopDone).toBe(true);
     expect(endOrder).toEqual(["end:1", "stop-done"]);
-  });
-
-  test("stop does not start a reconnect after end emits close", async () => {
-    const handle = await createWhatsAppSocket({ onMessage: async () => {} });
-    await handle.start();
-
-    endResolvers[0]?.();
-    await handle.stop();
-    await flush();
-
     expect(createSocket).toHaveBeenCalledTimes(1);
     expect(delays).toEqual([]);
   });

--- a/apps/platform/whatsapp/src/socket.test.ts
+++ b/apps/platform/whatsapp/src/socket.test.ts
@@ -18,16 +18,29 @@ const sockets: Array<{
   ev: EventEmitter;
 }> = [];
 const delays: number[] = [];
+const endOrder: string[] = [];
+let endResolvers: Array<() => void> = [];
+
 const createSocket = mock(() => {
   const ev = new EventEmitter();
+  let endResolve: (() => void) | null = null;
+  const endPromise = new Promise<void>((resolve) => {
+    endResolve = resolve;
+  });
+  endResolvers.push(() => {
+    endResolve?.();
+  });
+
   const socket = {
     end: mock(() => {
+      endOrder.push(`end:${sockets.length}`);
       ev.emit("connection.update", {
         connection: "close",
         lastDisconnect: {
           error: { message: "ended", output: { statusCode: 428 } },
         },
       });
+      return endPromise;
     }),
     ev,
   };
@@ -67,6 +80,22 @@ const LOGGED_OUT_CLOSE = {
   },
 };
 
+const SAMPLE_UPSERT = {
+  messages: [
+    {
+      key: {
+        fromMe: false,
+        id: "msg-1",
+        remoteJid: "6281379292556@s.whatsapp.net",
+      },
+      message: {
+        conversation: "hello from whatsapp",
+      },
+    },
+  ],
+  type: "notify" as const,
+};
+
 describe("WhatsApp socket reconnect", () => {
   let logSpy: ReturnType<typeof spyOn>;
   let timeoutSpy: ReturnType<typeof spyOn>;
@@ -76,6 +105,8 @@ describe("WhatsApp socket reconnect", () => {
   beforeEach(async () => {
     sockets.length = 0;
     delays.length = 0;
+    endOrder.length = 0;
+    endResolvers = [];
     createSocket.mockClear();
     previousConfigDir = process.env.NAKAMA_CONFIG_DIR;
     tempConfigDir = await mkdtemp(join(tmpdir(), "nakama-wa-socket-"));
@@ -132,6 +163,82 @@ describe("WhatsApp socket reconnect", () => {
     await handle.start();
 
     emit(0, LOGGED_OUT_CLOSE);
+    await flush();
+
+    expect(createSocket).toHaveBeenCalledTimes(1);
+    expect(delays).toEqual([]);
+  });
+
+  test("clears old-socket listeners on reconnect so upserts cannot leak", async () => {
+    const handle = await createWhatsAppSocket({ onMessage: async () => {} });
+    await handle.start();
+
+    const oldSocket = sockets[0];
+    expect(oldSocket).toBeDefined();
+    expect(oldSocket?.ev.listenerCount("messages.upsert")).toBe(1);
+
+    emit(0, TIMEOUT_CLOSE);
+    await flush();
+
+    expect(createSocket).toHaveBeenCalledTimes(2);
+    expect(oldSocket?.ev.listenerCount("messages.upsert")).toBe(0);
+    expect(oldSocket?.ev.listenerCount("connection.update")).toBe(0);
+    expect(sockets[1]?.ev.listenerCount("messages.upsert")).toBe(1);
+  });
+
+  test("does not dispatch duplicate inbound messages from a retired socket", async () => {
+    const received: string[] = [];
+    const handle = await createWhatsAppSocket({
+      onMessage: async (data) => {
+        received.push(data.text);
+      },
+    });
+    await handle.start();
+
+    emit(0, TIMEOUT_CLOSE);
+    await flush();
+
+    expect(createSocket).toHaveBeenCalledTimes(2);
+
+    sockets[0]?.ev.emit("messages.upsert", SAMPLE_UPSERT);
+    await flush();
+    expect(received).toEqual([]);
+
+    sockets[1]?.ev.emit("messages.upsert", SAMPLE_UPSERT);
+    await flush();
+    expect(received).toEqual(["hello from whatsapp"]);
+  });
+
+  test("awaits socket.end during stop before returning", async () => {
+    const handle = await createWhatsAppSocket({ onMessage: async () => {} });
+    await handle.start();
+
+    expect(endResolvers).toHaveLength(1);
+
+    let stopDone = false;
+    const stopPromise = handle.stop().then(() => {
+      stopDone = true;
+      endOrder.push("stop-done");
+    });
+
+    await flush();
+    expect(stopDone).toBe(false);
+    expect(sockets[0]?.end).toHaveBeenCalled();
+    expect(sockets[0]?.ev.listenerCount("messages.upsert")).toBe(0);
+
+    endResolvers[0]?.();
+    await stopPromise;
+
+    expect(stopDone).toBe(true);
+    expect(endOrder).toEqual(["end:1", "stop-done"]);
+  });
+
+  test("stop does not start a reconnect after end emits close", async () => {
+    const handle = await createWhatsAppSocket({ onMessage: async () => {} });
+    await handle.start();
+
+    endResolvers[0]?.();
+    await handle.stop();
     await flush();
 
     expect(createSocket).toHaveBeenCalledTimes(1);

--- a/apps/platform/whatsapp/src/socket.ts
+++ b/apps/platform/whatsapp/src/socket.ts
@@ -56,7 +56,7 @@ export async function createWhatsAppSocket(
       const myGen = ++generation;
       const previous = socket;
       socket = null;
-      retireSocket(previous);
+      void retireSocket(previous);
 
       const next = makeWASocket({
         auth: state,
@@ -73,7 +73,7 @@ export async function createWhatsAppSocket(
       });
 
       if (myGen !== generation || stopped) {
-        retireSocket(next);
+        void retireSocket(next);
         return;
       }
 
@@ -205,26 +205,21 @@ export async function createWhatsAppSocket(
       generation += 1;
       const current = socket;
       socket = null;
-      if (!current) {
-        return;
-      }
-
-      // Strip listeners first so end()'s close emit cannot re-enter reconnect.
-      current.ev.removeAllListeners();
-      await Promise.resolve(current.end(undefined));
+      await retireSocket(current);
     },
   };
 
   return handle;
 }
 
-function retireSocket(target: WASocket | null | undefined): void {
+function retireSocket(target: WASocket | null | undefined): Promise<void> {
   if (!target) {
-    return;
+    return Promise.resolve();
   }
 
+  // Strip listeners first so end()'s close emit cannot re-enter reconnect.
   target.ev.removeAllListeners();
-  target.end(undefined);
+  return Promise.resolve(target.end(undefined));
 }
 
 function isSupportedUpsertType(type: string): boolean {

--- a/apps/platform/whatsapp/src/socket.ts
+++ b/apps/platform/whatsapp/src/socket.ts
@@ -27,7 +27,7 @@ export interface WhatsAppSocketDeps {
 export interface WhatsAppSocketHandle {
   socket: WASocket | null;
   start: () => Promise<void>;
-  stop: () => void;
+  stop: () => Promise<void>;
 }
 
 export async function createWhatsAppSocket(
@@ -56,7 +56,7 @@ export async function createWhatsAppSocket(
       const myGen = ++generation;
       const previous = socket;
       socket = null;
-      previous?.end(undefined);
+      retireSocket(previous);
 
       const next = makeWASocket({
         auth: state,
@@ -73,7 +73,7 @@ export async function createWhatsAppSocket(
       });
 
       if (myGen !== generation || stopped) {
-        next.end(undefined);
+        retireSocket(next);
         return;
       }
 
@@ -100,6 +100,9 @@ export async function createWhatsAppSocket(
 
         if (connection === "close") {
           generation += 1;
+          // Drop listeners before reconnect so buffered Baileys events on this
+          // socket cannot dispatch after the next generation is bound.
+          next.ev.removeAllListeners();
           deps.onDisconnected?.();
           const statusCode = lastDisconnect?.error?.message
             ? (lastDisconnect.error as { output?: { statusCode?: number } })
@@ -135,6 +138,10 @@ export async function createWhatsAppSocket(
       next.ev.on("creds.update", saveCreds);
 
       next.ev.on("messages.upsert", async (m) => {
+        if (myGen !== generation || stopped) {
+          return;
+        }
+
         console.log(
           `WhatsApp messages.upsert type=${m.type} count=${m.messages.length}`
         );
@@ -173,6 +180,10 @@ export async function createWhatsAppSocket(
             continue;
           }
 
+          if (myGen !== generation || stopped) {
+            return;
+          }
+
           console.log(
             `WhatsApp message received id=${msg.key.id ?? "-"} jid=${maskWhatsAppJid(inbound.jid)} textBytes=${Buffer.byteLength(inbound.text, "utf8")}`
           );
@@ -189,17 +200,31 @@ export async function createWhatsAppSocket(
         }
       });
     },
-    stop() {
+    async stop() {
       stopped = true;
       generation += 1;
-      if (socket) {
-        socket.end(undefined);
-        socket = null;
+      const current = socket;
+      socket = null;
+      if (!current) {
+        return;
       }
+
+      // Strip listeners first so end()'s close emit cannot re-enter reconnect.
+      current.ev.removeAllListeners();
+      await Promise.resolve(current.end(undefined));
     },
   };
 
   return handle;
+}
+
+function retireSocket(target: WASocket | null | undefined): void {
+  if (!target) {
+    return;
+  }
+
+  target.ev.removeAllListeners();
+  target.end(undefined);
 }
 
 function isSupportedUpsertType(type: string): boolean {


### PR DESCRIPTION
## Summary

WhatsApp reconnect no longer keeps old listeners, and worker shutdown waits for `socket.end` before exit. Fixes #485 and #489.

**Before:** Reconnect left `messages.upsert` on the old socket, so one inbound message could run twice. Stop called `end` and then exited at once, so auth state could stay half-written.
**After:** Each reconnect and stop clears listeners, gates upserts by generation, and `stop()` awaits `socket.end` before cleanup finishes.

Why safe:
1. Reconnect path and backoff stay the same; only listener cleanup and generation checks are new.
2. Stop still sets `stopped` and bumps generation first, so a close emit cannot start reconnect.
3. Unit tests cover listener clear, duplicate upsert, and stop/end order.

Only re-add / follow up if live Baileys still delivers upserts after `removeAllListeners`, or if auth still looks stale after restart (Baileys `end()` is sync and does not wait for the WebSocket close flush).

## Test plan
- [x] `bun test apps/platform/whatsapp/src/socket.test.ts` (8 pass)
- [x] `bun test apps/platform/whatsapp/src/` (87 pass)
- [x] `bun run --cwd apps/platform/whatsapp build` (ok)
- [x] `bun x ultracite check` on the three changed files (ok)
- [ ] Restart a paired WhatsApp worker once — one inbound chat message, no double reply; stop with SIGTERM and start again without a forced re-pair
