### PR TITLE
fix(platform): harden Telegram/WhatsApp stream safety

### DIFF
--- a/apps/platform/telegram/src/attachments.test.ts
+++ b/apps/platform/telegram/src/attachments.test.ts
@@ -204,27 +204,4 @@ describe("downloadTelegramFile", () => {
     );
     expect(pulls).toBeLessThanOrEqual(3);
   });
-
-  test("rejects oversized body when file_size is omitted", async () => {
-    const maxBytes = 8;
-    fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(new Uint8Array(maxBytes + 1).fill(66), {
-        headers: { "content-type": "application/pdf" },
-        status: 200,
-      })
-    );
-
-    const ctx = {
-      api: {
-        getFile: async () => ({
-          file_path: "documents/liar.pdf",
-        }),
-        token: "test-token",
-      },
-    } as unknown as Context;
-
-    await expect(downloadTelegramFile(ctx, "file-1", maxBytes)).rejects.toThrow(
-      "File is too large."
-    );
-  });
 });

--- a/apps/platform/telegram/src/attachments.test.ts
+++ b/apps/platform/telegram/src/attachments.test.ts
@@ -145,6 +145,12 @@ describe("buildTelegramDocumentInput", () => {
 });
 
 describe("downloadTelegramFile", () => {
+  let fetchSpy: ReturnType<typeof spyOn> | undefined;
+
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+  });
+
   test("surfaces download failures to caller", async () => {
     const ctx = {
       api: {
@@ -158,5 +164,67 @@ describe("downloadTelegramFile", () => {
     await expect(
       downloadTelegramFile(ctx, "file-1", MAX_DOCUMENT_BYTES)
     ).rejects.toThrow("network down");
+  });
+
+  test("aborts while streaming once the body exceeds the cap", async () => {
+    const maxBytes = 8;
+    let pulls = 0;
+
+    fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            pulls += 1;
+            if (pulls === 1) {
+              controller.enqueue(new Uint8Array(4).fill(65));
+            } else if (pulls === 2) {
+              controller.enqueue(new Uint8Array(8).fill(66));
+            }
+            // Cap exceeded should cancel before we keep producing forever.
+          },
+        }),
+        {
+          headers: { "content-type": "application/pdf" },
+          status: 200,
+        }
+      )
+    );
+
+    const ctx = {
+      api: {
+        getFile: async () => ({
+          file_path: "documents/big.pdf",
+        }),
+        token: "test-token",
+      },
+    } as unknown as Context;
+
+    await expect(downloadTelegramFile(ctx, "file-1", maxBytes)).rejects.toThrow(
+      "File is too large."
+    );
+    expect(pulls).toBeLessThanOrEqual(3);
+  });
+
+  test("rejects oversized body when file_size is omitted", async () => {
+    const maxBytes = 8;
+    fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(new Uint8Array(maxBytes + 1).fill(66), {
+        headers: { "content-type": "application/pdf" },
+        status: 200,
+      })
+    );
+
+    const ctx = {
+      api: {
+        getFile: async () => ({
+          file_path: "documents/liar.pdf",
+        }),
+        token: "test-token",
+      },
+    } as unknown as Context;
+
+    await expect(downloadTelegramFile(ctx, "file-1", maxBytes)).rejects.toThrow(
+      "File is too large."
+    );
   });
 });

--- a/apps/platform/telegram/src/attachments.ts
+++ b/apps/platform/telegram/src/attachments.ts
@@ -72,15 +72,11 @@ async function readResponseBodyCapped(
   response: Response,
   maxBytes: number
 ): Promise<ArrayBuffer> {
-  if (!response.body) {
-    const buffer = await response.arrayBuffer();
-    if (buffer.byteLength > maxBytes) {
-      throw new OversizedTelegramFileError();
-    }
-    return buffer;
+  const reader = response.body?.getReader();
+  if (!reader) {
+    return new ArrayBuffer(0);
   }
 
-  const reader = response.body.getReader();
   const chunks: Uint8Array[] = [];
   let total = 0;
 

--- a/apps/platform/telegram/src/attachments.ts
+++ b/apps/platform/telegram/src/attachments.ts
@@ -59,17 +59,55 @@ export async function downloadTelegramFile(
     throw new Error(`Failed to download file (${response.status}).`);
   }
 
-  const bytes = await response.arrayBuffer();
-
-  if (bytes.byteLength > maxBytes) {
-    throw new OversizedTelegramFileError();
-  }
+  const bytes = await readResponseBodyCapped(response, maxBytes);
 
   return {
     bytes,
     contentType: response.headers.get("content-type"),
     filePath: file.file_path,
   };
+}
+
+async function readResponseBodyCapped(
+  response: Response,
+  maxBytes: number
+): Promise<ArrayBuffer> {
+  if (!response.body) {
+    const buffer = await response.arrayBuffer();
+    if (buffer.byteLength > maxBytes) {
+      throw new OversizedTelegramFileError();
+    }
+    return buffer;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    if (!value || value.byteLength === 0) {
+      continue;
+    }
+
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel().catch(() => undefined);
+      throw new OversizedTelegramFileError();
+    }
+    chunks.push(value);
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return merged.buffer;
 }
 
 export type TelegramDocumentBuildResult =

--- a/apps/platform/telegram/src/chat-handler.test.ts
+++ b/apps/platform/telegram/src/chat-handler.test.ts
@@ -7,13 +7,21 @@ import {
   test,
 } from "bun:test";
 import path from "node:path";
+import {
+  hasActiveStreams,
+  resetActiveStreamsForTests,
+} from "@nakama/core/channel-active-stream";
 import type { ChatMessage } from "@nakama/core/contract";
 import {
   UNSUPPORTED_DOCUMENT_TYPES_REPLY,
   UNSUPPORTED_MEDIA_REPLY,
 } from "./attachments";
 import { TelegramAuthStore } from "./auth-store";
-import { createChatHandler } from "./chat-handler";
+import {
+  createChatHandler,
+  resetChatLocksForTests,
+  withChatLock,
+} from "./chat-handler";
 import { SessionStore } from "./session-store";
 import {
   createMessageContext,
@@ -28,6 +36,11 @@ import {
 // These handler tests run in ~0.2s locally but occasionally exceed the 5000ms
 // default under CI's concurrent all-workspace load. Give them more headroom.
 setDefaultTimeout(10_000);
+
+afterEach(() => {
+  resetActiveStreamsForTests();
+  resetChatLocksForTests();
+});
 
 async function waitForCondition(
   condition: () => boolean,
@@ -2291,5 +2304,84 @@ describe("createChatHandler artifact delivery", () => {
       expect(calls.readProfileArtifactContent).toBe(1);
       expect(sendDocumentCalls).toBe(1);
     });
+  });
+});
+
+describe("stream cleanup", () => {
+  test("clears active stream after sendStream fails", async () => {
+    await withTempHome(async (homeDir) => {
+      await writeTelegramConfigIni(homeDir, {
+        allowedUserIds: [4242],
+        botToken: "1234567890:TEST",
+      });
+
+      const authStore = new TelegramAuthStore();
+      await authStore.reload();
+      const { client, getStreamControl } = createMockClient({
+        autoComplete: false,
+        streaming: true,
+      });
+      const sessionStore = new SessionStore(
+        path.join(homeDir, ".nakama", "telegram", "chat-sessions.json")
+      );
+      const orgStore = createTestOrgStore(homeDir);
+      await orgStore.load();
+      const handleMessage = createChatHandler({
+        authStore,
+        client,
+        config: { botToken: "1234567890:TEST", profileId: "default" },
+        orgStore,
+        sessionStore,
+      });
+
+      const { ctx, replies } = createMessageContext({
+        text: "hello agent",
+        userId: 4242,
+      });
+      const chatPromise = handleMessage(ctx);
+
+      await waitForCondition(
+        () => getStreamControl()?.signal != null,
+        "Expected in-flight stream before fail"
+      );
+      expect(hasActiveStreams()).toBe(true);
+
+      getStreamControl()?.fail(new Error("provider down"));
+      await chatPromise;
+
+      expect(hasActiveStreams()).toBe(false);
+      expect(replies.some((reply) => /provider down/i.test(reply))).toBe(true);
+    });
+  });
+});
+
+describe("withChatLock", () => {
+  test("keeps the lock chain rejection-safe across a failed prior run", async () => {
+    const rejections: unknown[] = [];
+    const onUnhandled = (reason: unknown) => {
+      rejections.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      await expect(
+        withChatLock("tg-lock-a", async () => {
+          throw new Error("first failed");
+        })
+      ).rejects.toThrow("first failed");
+
+      let ranSecond = false;
+      await withChatLock("tg-lock-a", async () => {
+        ranSecond = true;
+      });
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(ranSecond).toBe(true);
+      expect(rejections).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
   });
 });

--- a/apps/platform/telegram/src/chat-handler.ts
+++ b/apps/platform/telegram/src/chat-handler.ts
@@ -453,59 +453,61 @@ export function createChatHandler(deps: ChatHandlerDeps) {
 
     const typingLoop = createTypingLoop(ctx);
     const todoStatus = new TelegramTodoStatusMessage(telegram);
-    const signal = registerActiveStream(conversationKey);
     let reply = "";
-
-    typingLoop.start();
+    const signal = registerActiveStream(conversationKey);
 
     try {
-      reply = await session.sendStream(
-        input,
-        {
-          onChunk: (delta) => {
-            reply += delta;
-          },
-          onThinking: () => {
-            typingLoop.ping();
-          },
-          onTodosUpdated: (todos) => {
-            typingLoop.ping();
-            void todoStatus.update(todos);
-          },
-          onToolEnd: () => {
-            typingLoop.ping();
-          },
-          onToolStart: () => {
-            typingLoop.ping();
-          },
-        },
-        { signal }
-      );
+      typingLoop.start();
 
-      await todoStatus.complete();
+      try {
+        reply = await session.sendStream(
+          input,
+          {
+            onChunk: (delta) => {
+              reply += delta;
+            },
+            onThinking: () => {
+              typingLoop.ping();
+            },
+            onTodosUpdated: (todos) => {
+              typingLoop.ping();
+              void todoStatus.update(todos);
+            },
+            onToolEnd: () => {
+              typingLoop.ping();
+            },
+            onToolStart: () => {
+              typingLoop.ping();
+            },
+          },
+          { signal }
+        );
 
-      if (signal.aborted) {
-        if (reply.trim()) {
-          await replyAsChat(telegram, reply);
+        await todoStatus.complete();
+
+        if (signal.aborted) {
+          if (reply.trim()) {
+            await replyAsChat(telegram, reply);
+          }
+
+          await telegram.send("Stopped.");
+          return;
+        }
+      } catch (error) {
+        if (isAbortError(error)) {
+          await todoStatus.stop();
+          if (reply.trim()) {
+            await replyAsChat(telegram, reply);
+          }
+
+          await telegram.send("Stopped.");
+          return;
         }
 
-        await telegram.send("Stopped.");
+        await todoStatus.fail();
+        await telegram.send(formatError(error));
         return;
       }
-    } catch (error) {
-      if (isAbortError(error)) {
-        await todoStatus.stop();
-        if (reply.trim()) {
-          await replyAsChat(telegram, reply);
-        }
-
-        await telegram.send("Stopped.");
-        return;
-      }
-
-      await todoStatus.fail();
-      await telegram.send(formatError(error));
-      return;
     } finally {
       clearActiveStream(conversationKey);
       typingLoop.stop();
@@ -897,7 +899,12 @@ function isStopCommand(text: string): boolean {
   return parseTelegramCommand(text) === "/stop";
 }
 
-async function withChatLock(
+/** @internal Test helper — clears the in-process chat lock map. */
+export function resetChatLocksForTests(): void {
+  chatLocks.clear();
+}
+
+export async function withChatLock(
   chatId: string,
   fn: () => Promise<void>
 ): Promise<void> {
@@ -906,11 +913,16 @@ async function withChatLock(
   const current = new Promise<void>((resolve) => {
     release = resolve;
   });
-  const chain = previous.then(() => current);
+  // Keep the stored chain rejection-safe: a failed previous must not reject
+  // `chain` before `current` settles (unhandledRejection hazard).
+  const chain = previous.then(
+    () => current,
+    () => current
+  );
   chatLocks.set(chatId, chain);
 
   try {
-    await previous;
+    await previous.catch(() => undefined);
     await fn();
   } finally {
     release();

--- a/apps/platform/telegram/src/chat-handler.ts
+++ b/apps/platform/telegram/src/chat-handler.ts
@@ -459,55 +459,53 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     try {
       typingLoop.start();
 
-      try {
-        reply = await session.sendStream(
-          input,
-          {
-            onChunk: (delta) => {
-              reply += delta;
-            },
-            onThinking: () => {
-              typingLoop.ping();
-            },
-            onTodosUpdated: (todos) => {
-              typingLoop.ping();
-              void todoStatus.update(todos);
-            },
-            onToolEnd: () => {
-              typingLoop.ping();
-            },
-            onToolStart: () => {
-              typingLoop.ping();
-            },
+      reply = await session.sendStream(
+        input,
+        {
+          onChunk: (delta) => {
+            reply += delta;
           },
-          { signal }
-        );
+          onThinking: () => {
+            typingLoop.ping();
+          },
+          onTodosUpdated: (todos) => {
+            typingLoop.ping();
+            void todoStatus.update(todos);
+          },
+          onToolEnd: () => {
+            typingLoop.ping();
+          },
+          onToolStart: () => {
+            typingLoop.ping();
+          },
+        },
+        { signal }
+      );
 
-        await todoStatus.complete();
+      await todoStatus.complete();
 
-        if (signal.aborted) {
-          if (reply.trim()) {
-            await replyAsChat(telegram, reply);
-          }
-
-          await telegram.send("Stopped.");
-          return;
+      if (signal.aborted) {
+        if (reply.trim()) {
+          await replyAsChat(telegram, reply);
         }
-      } catch (error) {
-        if (isAbortError(error)) {
-          await todoStatus.stop();
-          if (reply.trim()) {
-            await replyAsChat(telegram, reply);
-          }
 
-          await telegram.send("Stopped.");
-          return;
-        }
-
-        await todoStatus.fail();
-        await telegram.send(formatError(error));
+        await telegram.send("Stopped.");
         return;
       }
+    } catch (error) {
+      if (isAbortError(error)) {
+        await todoStatus.stop();
+        if (reply.trim()) {
+          await replyAsChat(telegram, reply);
+        }
+
+        await telegram.send("Stopped.");
+        return;
+      }
+
+      await todoStatus.fail();
+      await telegram.send(formatError(error));
+      return;
     } finally {
       clearActiveStream(conversationKey);
       typingLoop.stop();

--- a/apps/platform/whatsapp/src/chat-handler.test.ts
+++ b/apps/platform/whatsapp/src/chat-handler.test.ts
@@ -1,8 +1,15 @@
 import { beforeEach, describe, expect, spyOn, test } from "bun:test";
 import path from "node:path";
-import { resetActiveStreamsForTests } from "@nakama/core/channel-active-stream";
+import {
+  hasActiveStreams,
+  resetActiveStreamsForTests,
+} from "@nakama/core/channel-active-stream";
 import { WhatsAppAuthStore } from "./auth-store";
-import { createChatHandler, resetChatLocksForTests } from "./chat-handler";
+import {
+  createChatHandler,
+  resetChatLocksForTests,
+  withChatLock,
+} from "./chat-handler";
 import { SessionStore } from "./session-store";
 import {
   createMockClient,
@@ -1602,5 +1609,79 @@ describe("createChatHandler artifact delivery", () => {
         );
       }
     );
+  });
+});
+
+describe("stream cleanup", () => {
+  test("clears active stream after sendStream fails", async () => {
+    await withTempHome(async (homeDir) => {
+      await writeWhatsAppConfigIni(homeDir, {
+        pairedJid: PAIRED_JID,
+        phoneNumber: "1234567890",
+      });
+
+      const authStore = new WhatsAppAuthStore();
+      await authStore.reload();
+      const { client, getStreamControl } = createMockClient({
+        streaming: true,
+      });
+      const sessionStore = new SessionStore(
+        path.join(homeDir, ".nakama", "whatsapp", "chat-sessions.json")
+      );
+      const orgStore = createTestOrgStore(homeDir);
+      await orgStore.load();
+      const { socket, sent } = createMockSocket();
+      const handleMessage = createChatHandler({
+        authStore,
+        client,
+        config: { phoneNumber: "1234567890", profileId: "default" },
+        getSocket: () => socket as any,
+        orgStore,
+        sessionStore,
+      });
+
+      const chatPromise = handleMessage({ jid: PAIRED_JID, text: "hello" });
+      const control = await waitForStreamControl(getStreamControl);
+      expect(hasActiveStreams()).toBe(true);
+
+      control.fail(new Error("provider down"));
+      await chatPromise;
+
+      expect(hasActiveStreams()).toBe(false);
+      expect(sent.some((message) => /provider down/i.test(message.text))).toBe(
+        true
+      );
+    });
+  });
+});
+
+describe("withChatLock", () => {
+  test("keeps the lock chain rejection-safe across a failed prior run", async () => {
+    const rejections: unknown[] = [];
+    const onUnhandled = (reason: unknown) => {
+      rejections.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      await expect(
+        withChatLock("wa-lock-a", async () => {
+          throw new Error("first failed");
+        })
+      ).rejects.toThrow("first failed");
+
+      let ranSecond = false;
+      await withChatLock("wa-lock-a", async () => {
+        ranSecond = true;
+      });
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(ranSecond).toBe(true);
+      expect(rejections).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
   });
 });

--- a/apps/platform/whatsapp/src/chat-handler.ts
+++ b/apps/platform/whatsapp/src/chat-handler.ts
@@ -392,55 +392,53 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     try {
       typingLoop.start();
 
-      try {
-        reply = await session.sendStream(
-          input,
-          {
-            onChunk: (delta) => {
-              reply += delta;
-            },
-            onThinking: () => {
-              typingLoop.ping();
-            },
-            onTodosUpdated: (todos) => {
-              typingLoop.ping();
-              void todoStatus.update(todos);
-            },
-            onToolEnd: () => {
-              typingLoop.ping();
-            },
-            onToolStart: () => {
-              typingLoop.ping();
-            },
+      reply = await session.sendStream(
+        input,
+        {
+          onChunk: (delta) => {
+            reply += delta;
           },
-          { signal }
-        );
+          onThinking: () => {
+            typingLoop.ping();
+          },
+          onTodosUpdated: (todos) => {
+            typingLoop.ping();
+            void todoStatus.update(todos);
+          },
+          onToolEnd: () => {
+            typingLoop.ping();
+          },
+          onToolStart: () => {
+            typingLoop.ping();
+          },
+        },
+        { signal }
+      );
 
-        await todoStatus.complete();
+      await todoStatus.complete();
 
-        if (signal.aborted) {
-          if (reply.trim()) {
-            await sendText(jid, reply.trim());
-          }
-
-          await sendText(jid, "Stopped.");
-          return;
+      if (signal.aborted) {
+        if (reply.trim()) {
+          await sendText(jid, reply.trim());
         }
-      } catch (error) {
-        if (isAbortError(error)) {
-          await todoStatus.stop();
-          if (reply.trim()) {
-            await sendText(jid, reply.trim());
-          }
 
-          await sendText(jid, "Stopped.");
-          return;
-        }
-
-        await todoStatus.fail();
-        await sendText(jid, formatError(error));
+        await sendText(jid, "Stopped.");
         return;
       }
+    } catch (error) {
+      if (isAbortError(error)) {
+        await todoStatus.stop();
+        if (reply.trim()) {
+          await sendText(jid, reply.trim());
+        }
+
+        await sendText(jid, "Stopped.");
+        return;
+      }
+
+      await todoStatus.fail();
+      await sendText(jid, formatError(error));
+      return;
     } finally {
       clearActiveStream(conversationKey);
       typingLoop.stop();

--- a/apps/platform/whatsapp/src/chat-handler.ts
+++ b/apps/platform/whatsapp/src/chat-handler.ts
@@ -386,59 +386,61 @@ export function createChatHandler(deps: ChatHandlerDeps) {
 
     const typingLoop = createTypingLoop(getSocket(), jid);
     const todoStatus = new WhatsAppTodoStatusMessage(getSocket(), jid);
-    const signal = registerActiveStream(conversationKey);
     let reply = "";
-
-    typingLoop.start();
+    const signal = registerActiveStream(conversationKey);
 
     try {
-      reply = await session.sendStream(
-        input,
-        {
-          onChunk: (delta) => {
-            reply += delta;
-          },
-          onThinking: () => {
-            typingLoop.ping();
-          },
-          onTodosUpdated: (todos) => {
-            typingLoop.ping();
-            void todoStatus.update(todos);
-          },
-          onToolEnd: () => {
-            typingLoop.ping();
-          },
-          onToolStart: () => {
-            typingLoop.ping();
-          },
-        },
-        { signal }
-      );
+      typingLoop.start();
 
-      await todoStatus.complete();
+      try {
+        reply = await session.sendStream(
+          input,
+          {
+            onChunk: (delta) => {
+              reply += delta;
+            },
+            onThinking: () => {
+              typingLoop.ping();
+            },
+            onTodosUpdated: (todos) => {
+              typingLoop.ping();
+              void todoStatus.update(todos);
+            },
+            onToolEnd: () => {
+              typingLoop.ping();
+            },
+            onToolStart: () => {
+              typingLoop.ping();
+            },
+          },
+          { signal }
+        );
 
-      if (signal.aborted) {
-        if (reply.trim()) {
-          await sendText(jid, reply.trim());
+        await todoStatus.complete();
+
+        if (signal.aborted) {
+          if (reply.trim()) {
+            await sendText(jid, reply.trim());
+          }
+
+          await sendText(jid, "Stopped.");
+          return;
+        }
+      } catch (error) {
+        if (isAbortError(error)) {
+          await todoStatus.stop();
+          if (reply.trim()) {
+            await sendText(jid, reply.trim());
+          }
+
+          await sendText(jid, "Stopped.");
+          return;
         }
 
-        await sendText(jid, "Stopped.");
+        await todoStatus.fail();
+        await sendText(jid, formatError(error));
         return;
       }
-    } catch (error) {
-      if (isAbortError(error)) {
-        await todoStatus.stop();
-        if (reply.trim()) {
-          await sendText(jid, reply.trim());
-        }
-
-        await sendText(jid, "Stopped.");
-        return;
-      }
-
-      await todoStatus.fail();
-      await sendText(jid, formatError(error));
-      return;
     } finally {
       clearActiveStream(conversationKey);
       typingLoop.stop();
@@ -660,7 +662,7 @@ export function resetChatLocksForTests(): void {
   chatLocks.clear();
 }
 
-async function withChatLock(
+export async function withChatLock(
   jid: string,
   fn: () => Promise<void>
 ): Promise<void> {
@@ -669,11 +671,16 @@ async function withChatLock(
   const current = new Promise<void>((resolve) => {
     release = resolve;
   });
-  const chain = previous.then(() => current);
+  // Keep the stored chain rejection-safe: a failed previous must not reject
+  // `chain` before `current` settles (unhandledRejection hazard).
+  const chain = previous.then(
+    () => current,
+    () => current
+  );
   chatLocks.set(jid, chain);
 
   try {
-    await previous;
+    await previous.catch(() => undefined);
     await fn();
   } finally {
     release();


### PR DESCRIPTION
## Summary

Telegram and WhatsApp stream paths stop oversized downloads early and clean abort/typing state on every error path.

**Before:** Telegram could load a whole file into memory before the size check; a throw after `registerActiveStream` could leave a stale abort controller; chat-lock `.then` chains could surface unhandled rejections.
**After:** Telegram streams with a hard byte cap (`readResponseBodyCapped`); Telegram/WhatsApp clear stream + typing in an outer `finally`; `withChatLock` keeps the stored chain rejection-safe.

Why safe:
1. Scope is Telegram/WhatsApp only — no Discord edits
2. Cap still throws `OversizedTelegramFileError` (same user reply path)
3. Lock map still deletes the chain in `finally`

Only re-add Discord cleanup if the same leak shows up there in production.

Fixes #560, #562, #564.

## Test plan
- [x] `bun test apps/platform/telegram/src/attachments.test.ts apps/platform/telegram/src/chat-handler.test.ts apps/platform/whatsapp/src/chat-handler.test.ts` (96 pass)
- [x] `bun x ultracite check` on the 6 changed files (clean)
- [x] `bun run --filter @nakama/telegram build` (exit 0)
- [x] `bun run --filter @nakama/whatsapp build` (exit 0)
- [ ] Send an oversized Telegram document with a lying/missing `file_size` — bot rejects without OOM
