### PR TITLE
fix(cli): harden input, send queue, and atomic config writes

### DIFF
--- a/apps/cli/src/chat.test.ts
+++ b/apps/cli/src/chat.test.ts
@@ -5,11 +5,13 @@ import type {
   ProfileSummary,
 } from "@nakama/core";
 import {
+  createDebouncedEscAbortHandler,
   disableRawModeIfActive,
   formatErrorLines,
   formatStatusLines,
   isEscInterruptKey,
   needsTrailingStreamNewline,
+  runCleanupThenExit,
 } from "./chat";
 
 describe("needsTrailingStreamNewline", () => {
@@ -96,6 +98,68 @@ describe("isEscInterruptKey", () => {
   });
 });
 
+describe("createDebouncedEscAbortHandler", () => {
+  test("does not abort bare ESC when more input arrives in the window", async () => {
+    let aborted = 0;
+    const handler = createDebouncedEscAbortHandler(() => {
+      aborted += 1;
+    }, 30);
+
+    handler.onData("\u001b");
+    handler.onData("[A");
+    await Bun.sleep(50);
+
+    expect(aborted).toBe(0);
+    handler.dispose();
+  });
+
+  test("aborts after a quiet window on bare ESC", async () => {
+    let aborted = 0;
+    const handler = createDebouncedEscAbortHandler(() => {
+      aborted += 1;
+    }, 20);
+
+    handler.onData("\u001b");
+    await Bun.sleep(40);
+
+    expect(aborted).toBe(1);
+    handler.dispose();
+  });
+});
+
+describe("runCleanupThenExit", () => {
+  test("awaits cleanup before exit", async () => {
+    const order: string[] = [];
+
+    await runCleanupThenExit(
+      async () => {
+        await Bun.sleep(5);
+        order.push("cleanup");
+      },
+      () => {
+        order.push("exit");
+      }
+    );
+
+    expect(order).toEqual(["cleanup", "exit"]);
+  });
+
+  test("exits even when cleanup throws", async () => {
+    const order: string[] = [];
+
+    await runCleanupThenExit(
+      async () => {
+        order.push("cleanup");
+        throw new Error("cleanup failed");
+      },
+      () => {
+        order.push("exit");
+      }
+    );
+
+    expect(order).toEqual(["cleanup", "exit"]);
+  });
+});
 describe("disableRawModeIfActive", () => {
   test("skips setRawMode when stdin is not a TTY", () => {
     const calls: boolean[] = [];

--- a/apps/cli/src/chat.ts
+++ b/apps/cli/src/chat.ts
@@ -283,12 +283,6 @@ async function runStickyChat(
       let current: PendingMessage | undefined = message;
 
       while (current && !exiting) {
-        if (isStreaming) {
-          queue.push(current);
-          syncPendingMessages();
-          return;
-        }
-
         try {
           await runOneSend(current);
         } catch (error) {

--- a/apps/cli/src/chat.ts
+++ b/apps/cli/src/chat.ts
@@ -45,7 +45,7 @@ import { ThinkingIndicator } from "./thinking-indicator";
 const HELP_TEXT = `${formatSlashCommands()}\n\n@/path/to/image.png [message]   attach an image from file\n/paste                            attach image from clipboard (recommended)\nCtrl+V / Cmd+V (empty paste)      attach image when terminal supports it\nPageUp/PageDown                   scroll conversation history\nHome/End                          jump to oldest/newest visible history`;
 
 /** Debounce bare ESC so alt-prefix / slow paste chunks do not abort. */
-export const ESC_ABORT_DEBOUNCE_MS = 50;
+const ESC_ABORT_DEBOUNCE_MS = 50;
 
 interface RunChatOptions {
   channel: AgentChannel;

--- a/apps/cli/src/chat.ts
+++ b/apps/cli/src/chat.ts
@@ -24,7 +24,7 @@ import {
   resolveSuggestions,
 } from "./commands";
 import { mergeSendInput, parseImageLine } from "./image-input";
-import type { PendingMessage } from "./message-queue";
+import { createSerializedQueue, type PendingMessage } from "./message-queue";
 import { PersistentPrompt } from "./persistent-prompt";
 import {
   type CliProfileOptions,
@@ -43,6 +43,9 @@ import { TerminalRenderer } from "./terminal-renderer";
 import { ThinkingIndicator } from "./thinking-indicator";
 
 const HELP_TEXT = `${formatSlashCommands()}\n\n@/path/to/image.png [message]   attach an image from file\n/paste                            attach image from clipboard (recommended)\nCtrl+V / Cmd+V (empty paste)      attach image when terminal supports it\nPageUp/PageDown                   scroll conversation history\nHome/End                          jump to oldest/newest visible history`;
+
+/** Debounce bare ESC so alt-prefix / slow paste chunks do not abort. */
+export const ESC_ABORT_DEBOUNCE_MS = 50;
 
 interface RunChatOptions {
   channel: AgentChannel;
@@ -148,6 +151,7 @@ async function runStickyChat(
   let modelsCache: ModelsResponse | null = null;
   let profilesCache: ProfileSummary[] = [];
   const queue: PendingMessage[] = [];
+  const sendQueue = createSerializedQueue();
   const thinkingIndicator = new ThinkingIndicator();
   let prompt: PersistentPrompt | null = null;
   thinkingIndicator.setRenderer(renderer);
@@ -234,45 +238,31 @@ async function runStickyChat(
     }
   }
 
-  async function drainQueue(): Promise<void> {
-    if (isStreaming || exiting) {
-      return;
-    }
-
-    const next = queue.shift();
-
-    if (!next) {
-      syncPendingMessages();
-      return;
-    }
-
-    syncPendingMessages();
-    await startSend(next);
-  }
-
-  async function startSend(message: PendingMessage): Promise<void> {
+  async function runOneSend(message: PendingMessage): Promise<void> {
     isStreaming = true;
     abortController = new AbortController();
-    renderer.beginStream();
-
-    if (!message.echoed) {
-      renderer.appendUserMessage(message.line, { placement: "scroll" });
-    }
 
     let aborted = false;
     let caught: unknown;
 
     try {
-      const result = await sendMessageStream(message.sendInput);
-      aborted = result.aborted;
-    } catch (error) {
-      caught = error;
+      renderer.beginStream();
+
+      if (!message.echoed) {
+        renderer.appendUserMessage(message.line, { placement: "scroll" });
+      }
+
+      try {
+        const result = await sendMessageStream(message.sendInput);
+        aborted = result.aborted;
+      } catch (error) {
+        caught = error;
+      }
     } finally {
       isStreaming = false;
       abortController = null;
       thinkingIndicator.stop();
       renderer.endStream();
-      await drainQueue();
     }
 
     // Post-stream output — the stream buffer is now flushed into the VirtualMessageList,
@@ -282,6 +272,35 @@ async function runStickyChat(
     } else if (aborted) {
       renderer.appendOutputLine(styledLine("[stopped]", { dim: true }));
     }
+  }
+
+  async function startSend(message: PendingMessage): Promise<void> {
+    await sendQueue.enqueue(async () => {
+      if (exiting) {
+        return;
+      }
+
+      let current: PendingMessage | undefined = message;
+
+      while (current && !exiting) {
+        if (isStreaming) {
+          queue.push(current);
+          syncPendingMessages();
+          return;
+        }
+
+        try {
+          await runOneSend(current);
+        } catch (error) {
+          isStreaming = false;
+          abortController = null;
+          writeError(error);
+        }
+
+        current = queue.shift();
+        syncPendingMessages();
+      }
+    });
   }
 
   async function handleChatMessage(
@@ -1155,8 +1174,63 @@ export function disableRawModeIfActive(
   }
 }
 
+/** Await cleanup, then exit. Used by CLI signal handlers. */
+export async function runCleanupThenExit(
+  cleanup: () => void | Promise<void>,
+  exitProcess: (code: number) => void = (code) => {
+    process.exit(code);
+  }
+): Promise<void> {
+  try {
+    await cleanup();
+  } catch {
+    // Always exit after cleanup attempt.
+  } finally {
+    exitProcess(0);
+  }
+}
+
 export function isEscInterruptKey(key: string): boolean {
   return key === "\u001b";
+}
+
+/**
+ * Bare ESC only aborts after a quiet window. Extra bytes cancel the abort
+ * (alt-prefix, CSI, or slow paste fragments).
+ */
+export function createDebouncedEscAbortHandler(
+  onAbort: () => void,
+  debounceMs = ESC_ABORT_DEBOUNCE_MS
+): {
+  onData: (chunk: Buffer | string) => void;
+  dispose: () => void;
+} {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const clearPending = (): void => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  return {
+    dispose: clearPending,
+    onData(chunk: Buffer | string): void {
+      const key = String(chunk);
+
+      if (isEscInterruptKey(key)) {
+        clearPending();
+        timer = setTimeout(() => {
+          timer = null;
+          onAbort();
+        }, debounceMs);
+        return;
+      }
+
+      clearPending();
+    },
+  };
 }
 
 function startEscAbortListener(onAbort: () => void): () => void {
@@ -1166,20 +1240,16 @@ function startEscAbortListener(onAbort: () => void): () => void {
 
   const stdin = process.stdin;
   const wasRaw = stdin.isRaw;
-
-  function onData(chunk: Buffer | string): void {
-    if (isEscInterruptKey(String(chunk))) {
-      onAbort();
-    }
-  }
+  const handler = createDebouncedEscAbortHandler(onAbort);
 
   stdin.setEncoding("utf8");
   stdin.setRawMode(true);
   stdin.resume();
-  stdin.on("data", onData);
+  stdin.on("data", handler.onData);
 
   return () => {
-    stdin.off("data", onData);
+    handler.dispose();
+    stdin.off("data", handler.onData);
 
     if (!wasRaw) {
       disableRawModeIfActive(stdin);

--- a/apps/cli/src/cli-layout.test.ts
+++ b/apps/cli/src/cli-layout.test.ts
@@ -3,7 +3,6 @@ import {
   createSerializedQueue,
   formatPendingDisplayLines,
   formatPendingSummary,
-  runRejectionSafeDrain,
 } from "./message-queue";
 import { plainLine, styledLine, styledLineText } from "./styled-text";
 import { TerminalLayout } from "./terminal-layout";
@@ -56,24 +55,6 @@ describe("createSerializedQueue", () => {
     await expect(first).rejects.toThrow("fail");
     await second;
     expect(order).toEqual(["a", "b"]);
-  });
-});
-
-describe("runRejectionSafeDrain", () => {
-  test("resets streaming when drain throws", async () => {
-    let streaming = true;
-
-    await runRejectionSafeDrain({
-      drain: async () => {
-        streaming = true;
-        throw new Error("drain failed");
-      },
-      setStreaming: (value) => {
-        streaming = value;
-      },
-    });
-
-    expect(streaming).toBe(false);
   });
 });
 

--- a/apps/cli/src/cli-layout.test.ts
+++ b/apps/cli/src/cli-layout.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import {
+  createSerializedQueue,
   formatPendingDisplayLines,
   formatPendingSummary,
+  runRejectionSafeDrain,
 } from "./message-queue";
 import { plainLine, styledLine, styledLineText } from "./styled-text";
 import { TerminalLayout } from "./terminal-layout";
@@ -19,6 +21,59 @@ describe("formatPendingSummary", () => {
         },
       })
     ).toBe("[image]");
+  });
+});
+
+describe("createSerializedQueue", () => {
+  test("runs tasks one after another", async () => {
+    const queue = createSerializedQueue();
+    const order: number[] = [];
+
+    const first = queue.enqueue(async () => {
+      await Bun.sleep(20);
+      order.push(1);
+    });
+    const second = queue.enqueue(async () => {
+      order.push(2);
+    });
+
+    await Promise.all([first, second]);
+    expect(order).toEqual([1, 2]);
+  });
+
+  test("continues after a rejected task", async () => {
+    const queue = createSerializedQueue();
+    const order: string[] = [];
+
+    const first = queue.enqueue(async () => {
+      order.push("a");
+      throw new Error("fail");
+    });
+    const second = queue.enqueue(async () => {
+      order.push("b");
+    });
+
+    await expect(first).rejects.toThrow("fail");
+    await second;
+    expect(order).toEqual(["a", "b"]);
+  });
+});
+
+describe("runRejectionSafeDrain", () => {
+  test("resets streaming when drain throws", async () => {
+    let streaming = true;
+
+    await runRejectionSafeDrain({
+      drain: async () => {
+        streaming = true;
+        throw new Error("drain failed");
+      },
+      setStreaming: (value) => {
+        streaming = value;
+      },
+    });
+
+    expect(streaming).toBe(false);
   });
 });
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -4,7 +4,7 @@ import {
   stopSpawnedServer,
 } from "@nakama/core/ensure-server";
 import { loadLocalAuthToken } from "@nakama/core/local-auth";
-import { runChat } from "./chat";
+import { runChat, runCleanupThenExit } from "./chat";
 import { parseCliOrgArgs, resolveCliOrgId } from "./org";
 import { parseCliProfileArgs } from "./profile";
 import {
@@ -55,7 +55,7 @@ async function resolveTheme(): Promise<Theme> {
 let spawnedChild: Bun.Subprocess | null = null;
 const abortController = new AbortController();
 
-registerCleanupHandlers(() => {
+registerCleanupHandlers(async () => {
   abortController.abort();
   stopSpawnedServer(spawnedChild);
 });
@@ -119,11 +119,17 @@ try {
 
 process.exit(0);
 
-function registerCleanupHandlers(cleanup: () => void): void {
+function registerCleanupHandlers(cleanup: () => void | Promise<void>): void {
+  let exiting = false;
+
   for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
     process.on(signal, () => {
-      cleanup();
-      process.exit(0);
+      if (exiting) {
+        return;
+      }
+
+      exiting = true;
+      void runCleanupThenExit(cleanup);
     });
   }
 }

--- a/apps/cli/src/message-queue.ts
+++ b/apps/cli/src/message-queue.ts
@@ -59,3 +59,40 @@ export function formatPendingDisplayLines(
 
   return lines;
 }
+
+/**
+ * Serialize async work so each task runs after the prior one settles.
+ * Prior rejection does not block the next task.
+ */
+export function createSerializedQueue(): {
+  enqueue(task: () => Promise<void>): Promise<void>;
+} {
+  let tail: Promise<void> = Promise.resolve();
+
+  return {
+    enqueue(task: () => Promise<void>): Promise<void> {
+      const run = tail.then(task, task);
+      tail = run.then(
+        () => undefined,
+        () => undefined
+      );
+      return run;
+    },
+  };
+}
+
+/**
+ * Clear streaming state, then drain. If drain throws, force streaming off.
+ */
+export async function runRejectionSafeDrain(options: {
+  setStreaming: (value: boolean) => void;
+  drain: () => Promise<void>;
+}): Promise<void> {
+  options.setStreaming(false);
+
+  try {
+    await options.drain();
+  } catch {
+    options.setStreaming(false);
+  }
+}

--- a/apps/cli/src/message-queue.ts
+++ b/apps/cli/src/message-queue.ts
@@ -80,19 +80,3 @@ export function createSerializedQueue(): {
     },
   };
 }
-
-/**
- * Clear streaming state, then drain. If drain throws, force streaming off.
- */
-export async function runRejectionSafeDrain(options: {
-  setStreaming: (value: boolean) => void;
-  drain: () => Promise<void>;
-}): Promise<void> {
-  options.setStreaming(false);
-
-  try {
-    await options.drain();
-  } catch {
-    options.setStreaming(false);
-  }
-}

--- a/apps/cli/src/persistent-prompt.test.ts
+++ b/apps/cli/src/persistent-prompt.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import type { PromptSuggestion } from "./commands";
-import { PersistentPrompt } from "./persistent-prompt";
+import {
+  MAX_BRACKETED_PASTE_BYTES,
+  PersistentPrompt,
+} from "./persistent-prompt";
 import type { PromptLineResult } from "./prompt";
 import type { TerminalInput } from "./terminal-input";
 import type { ComposerState, TerminalRenderer } from "./terminal-renderer";
@@ -14,8 +17,17 @@ class FakeRenderer implements Pick<TerminalRenderer, "setComposerState"> {
 }
 
 class FakeTerminalInput {
-  onInput(): () => void {
-    return () => {};
+  private listener: ((chunk: string) => void) | null = null;
+
+  onInput(listener: (chunk: string) => void): () => void {
+    this.listener = listener;
+    return () => {
+      this.listener = null;
+    };
+  }
+
+  emit(chunk: string): void {
+    this.listener?.(chunk);
   }
 }
 
@@ -23,6 +35,9 @@ describe("PersistentPrompt", () => {
   const prompts: PersistentPrompt[] = [];
   let stdoutWriteSpy: ReturnType<
     typeof spyOn<typeof process.stdout, "write">
+  > | null = null;
+  let stderrWriteSpy: ReturnType<
+    typeof spyOn<typeof process.stderr, "write">
   > | null = null;
 
   afterEach(() => {
@@ -33,6 +48,8 @@ describe("PersistentPrompt", () => {
     prompts.length = 0;
     stdoutWriteSpy?.mockRestore();
     stdoutWriteSpy = null;
+    stderrWriteSpy?.mockRestore();
+    stderrWriteSpy = null;
   });
 
   test("prefill renders suggestions for the inserted value", () => {
@@ -71,5 +88,39 @@ describe("PersistentPrompt", () => {
       ],
       value: "/model ",
     });
+  });
+
+  test("drops bracketed paste when the buffer exceeds the byte cap", () => {
+    stdoutWriteSpy = spyOn(process.stdout, "write").mockImplementation(
+      () => true
+    );
+    const stderrChunks: string[] = [];
+    stderrWriteSpy = spyOn(process.stderr, "write").mockImplementation(((
+      chunk: string | Uint8Array
+    ) => {
+      stderrChunks.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write);
+
+    const renderer = new FakeRenderer();
+    const terminalInput = new FakeTerminalInput();
+    const prompt = new PersistentPrompt({
+      onCancel: () => {},
+      onSubmit: () => {},
+      renderer,
+      terminalInput: terminalInput as unknown as TerminalInput,
+    });
+
+    prompts.push(prompt);
+    prompt.start();
+    prompt.prefill("keep-me");
+
+    terminalInput.emit(`\x1b[200~${"a".repeat(MAX_BRACKETED_PASTE_BYTES + 1)}`);
+
+    expect(renderer.state?.value).toBe("keep-me");
+    expect(stderrChunks.join("")).toContain("256 KB");
+
+    terminalInput.emit("!");
+    expect(renderer.state?.value).toBe("keep-me!");
   });
 });

--- a/apps/cli/src/persistent-prompt.ts
+++ b/apps/cli/src/persistent-prompt.ts
@@ -11,6 +11,8 @@ const BRACKETED_PASTE_END = "\x1b[201~";
 
 const BLINK_INTERVAL_MS = 530;
 const MAX_VISIBLE_SUGGESTIONS = 8;
+/** Cap bracketed-paste accumulation so a missing end sequence cannot grow forever. */
+export const MAX_BRACKETED_PASTE_BYTES = 256 * 1024;
 
 export interface PersistentPromptOptions {
   getSuggestions?: (input: string) => PromptSuggestion[];
@@ -201,6 +203,31 @@ export class PersistentPrompt {
     this.queueClipboardAttach();
   }
 
+  private dropBracketedPasteOverflow(): void {
+    this.inBracketedPaste = false;
+    this.pasteBuffer = "";
+    this.startBlink();
+    this.notifyClipboard(
+      "Paste dropped: content exceeded the 256 KB bracketed-paste limit."
+    );
+  }
+
+  private appendBracketedPaste(chunk: string): void {
+    this.pasteBuffer += chunk;
+
+    const endIndex = this.pasteBuffer.indexOf(BRACKETED_PASTE_END);
+
+    if (endIndex >= 0) {
+      const pasted = this.pasteBuffer.slice(0, endIndex);
+      this.finishBracketedPaste(pasted);
+      return;
+    }
+
+    if (this.pasteBuffer.length > MAX_BRACKETED_PASTE_BYTES) {
+      this.dropBracketedPasteOverflow();
+    }
+  }
+
   private applySuggestion(
     suggestion: PromptSuggestion,
     submitAfter = false
@@ -262,15 +289,7 @@ export class PersistentPrompt {
     }
 
     if (this.inBracketedPaste) {
-      this.pasteBuffer += key;
-
-      const endIndex = this.pasteBuffer.indexOf(BRACKETED_PASTE_END);
-
-      if (endIndex >= 0) {
-        const pasted = this.pasteBuffer.slice(0, endIndex);
-        this.finishBracketedPaste(pasted);
-      }
-
+      this.appendBracketedPaste(key);
       return;
     }
 
@@ -284,15 +303,10 @@ export class PersistentPrompt {
       }
 
       this.inBracketedPaste = true;
-      this.pasteBuffer = key.slice(startIndex + BRACKETED_PASTE_START.length);
-
-      const endIndex = this.pasteBuffer.indexOf(BRACKETED_PASTE_END);
-
-      if (endIndex >= 0) {
-        const pasted = this.pasteBuffer.slice(0, endIndex);
-        this.finishBracketedPaste(pasted);
-      }
-
+      this.pasteBuffer = "";
+      this.appendBracketedPaste(
+        key.slice(startIndex + BRACKETED_PASTE_START.length)
+      );
       return;
     }
 

--- a/apps/cli/src/terminal-input.ts
+++ b/apps/cli/src/terminal-input.ts
@@ -69,6 +69,27 @@ export function isMouseEventReport(chunk: string): boolean {
   return MOUSE_EVENT_REPORT.test(chunk);
 }
 
+/** True when more bytes may still complete a valid ESC sequence. */
+export function isIncompleteEscapeSequence(pending: string): boolean {
+  if (pending === "\x1b" || pending === "\x1b[" || pending === "\x1b(") {
+    return true;
+  }
+
+  if (/^\x1b\[[0-9;]*$/.test(pending)) {
+    return true;
+  }
+
+  if (/^\x1b\[<\d*(?:;\d*){0,2}$/.test(pending)) {
+    return true;
+  }
+
+  if (pending.startsWith("\x1b]") && !/(?:\x07|\x1b\\)$/.test(pending)) {
+    return true;
+  }
+
+  return false;
+}
+
 export function consumeTerminalInput(buffer: string): {
   events: string[];
   pending: string;
@@ -95,7 +116,14 @@ export function consumeTerminalInput(buffer: string): {
       );
 
       if (!match) {
-        break;
+        if (isIncompleteEscapeSequence(pending)) {
+          break;
+        }
+
+        // Malformed ESC: emit bare ESC so pending can drain.
+        events.push("\x1b");
+        pending = pending.slice(1);
+        continue;
       }
 
       const sequence = match[0];

--- a/apps/cli/src/terminal-screen.test.ts
+++ b/apps/cli/src/terminal-screen.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   consumeTerminalInput,
+  isIncompleteEscapeSequence,
   isMouseEventReport,
   isTerminalResponse,
   stripCursorPositionReports,
@@ -52,5 +53,28 @@ describe("consumeTerminalInput", () => {
 
     expect(consumed.events).toEqual(["a", "\x1b[<64;12;8M", "b"]);
     expect(consumed.pending).toBe("");
+  });
+
+  test("holds incomplete ESC sequences in pending", () => {
+    expect(consumeTerminalInput("\x1b").pending).toBe("\x1b");
+    expect(consumeTerminalInput("\x1b[").pending).toBe("\x1b[");
+    expect(consumeTerminalInput("\x1b[12").pending).toBe("\x1b[12");
+  });
+
+  test("recovers from malformed ESC instead of leaking pending", () => {
+    const consumed = consumeTerminalInput("\x1bxmore");
+
+    expect(consumed.events).toEqual(["\x1b", "x", "m", "o", "r", "e"]);
+    expect(consumed.pending).toBe("");
+  });
+});
+
+describe("isIncompleteEscapeSequence", () => {
+  test("treats CSI and OSC prefixes as incomplete", () => {
+    expect(isIncompleteEscapeSequence("\x1b")).toBe(true);
+    expect(isIncompleteEscapeSequence("\x1b[")).toBe(true);
+    expect(isIncompleteEscapeSequence("\x1b[1;2")).toBe(true);
+    expect(isIncompleteEscapeSequence("\x1b]0;title")).toBe(true);
+    expect(isIncompleteEscapeSequence("\x1bx")).toBe(false);
   });
 });

--- a/packages/core/src/fs.test.ts
+++ b/packages/core/src/fs.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { chmod, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { writeTextFile } from "./fs";
+import { pathExists, readText, writeTextFile } from "./fs";
 
 const temporaryDirectories: string[] = [];
 
@@ -49,5 +49,19 @@ describe("writeTextFile permissions", () => {
     await writeTextFile(path, "new", { chmod: false, mode: 0o640 });
 
     expect(await modeOf(path)).toBe(0o666);
+  });
+});
+
+describe("writeTextFile atomic replace", () => {
+  test("replaces the target and removes the temp file", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "nakama-fs-atomic-"));
+    temporaryDirectories.push(directory);
+    const path = join(directory, "cli.ini");
+
+    await writeTextFile(path, "profile_id=one\n");
+    await writeTextFile(path, "profile_id=two\n");
+
+    expect(await readText(path)).toBe("profile_id=two\n");
+    expect(await pathExists(`${path}.tmp`)).toBe(false);
   });
 });

--- a/packages/core/src/fs.ts
+++ b/packages/core/src/fs.ts
@@ -3,8 +3,11 @@ import {
   access,
   chmod,
   mkdir,
+  open,
   readdir,
   readFile,
+  rename,
+  stat,
   unlink,
   writeFile,
 } from "node:fs/promises";
@@ -69,10 +72,32 @@ export async function writeTextFile(
   const mode = options.mode ?? PRIVATE_FILE_MODE;
   const directory = options.ensureDir ?? dirname(path);
   await ensureDir(directory, options.ensureDirMode ?? PRIVATE_DIR_MODE);
-  await writeFile(path, content, { encoding: "utf8", mode });
+
+  let preserveMode: number | undefined;
+  if (options.chmod === false && (await pathExists(path))) {
+    // biome-ignore lint/suspicious/noBitwiseOperators: permission bits are stored in st_mode.
+    preserveMode = (await stat(path)).mode & 0o777;
+  }
+
+  const tempPath = `${path}.tmp`;
+  await writeFile(tempPath, content, {
+    encoding: "utf8",
+    mode: preserveMode ?? mode,
+  });
+
+  const handle = await open(tempPath, "r+");
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+
+  await rename(tempPath, path);
 
   if (options.chmod ?? true) {
     await chmod(path, mode);
+  } else if (preserveMode !== undefined) {
+    await chmod(path, preserveMode);
   }
 }
 


### PR DESCRIPTION
## Summary

CLI paste, ESC abort, send queue, shutdown, and config writes no longer wedge, false-abort, race, or corrupt on crash.

**Before:** Unbounded paste buffer, leaked ESC pending, bare ESC aborted streams, parallel sends / leaked `isStreaming`, signal exit skipped awaitable cleanup, and non-atomic `cli.ini` / auth-token writes.
**After:** 256 KB paste cap, malformed ESC drain, debounced ESC abort, serialized rejection-safe sends, await cleanup then exit, `writeTextFile` via temp + fsync + rename.

Why safe:
1. Input and send paths stay local to the CLI; no API contract change
2. Atomic write keeps prior `chmod: false` mode behavior
3. Focused regression tests cover each bug class

Only re-add immediate bare-ESC abort if operators need zero-latency stream cancel without a quiet window.

Fixes #540 #541 #542 #614 #612 #620 #544

## Test plan
- [x] `bun test apps/cli/src/chat.test.ts apps/cli/src/terminal-screen.test.ts apps/cli/src/persistent-prompt.test.ts apps/cli/src/cli-layout.test.ts packages/core/src/fs.test.ts apps/cli/src/cli-config.test.ts` (57 pass)
- [x] `bun x ultracite check` on changed files (pass)
- [x] `bun run --filter @nakama/cli build` and `bun run --filter @nakama/core build` (pass)
- [ ] Paste a large unfinished bracketed paste in sticky CLI — prompt stays usable after the 256 KB drop notice
