### PR TITLE
fix(server): reject member and org-memory writes on archived orgs

### DIFF
--- a/apps/server/src/services/org-memory-service.test.ts
+++ b/apps/server/src/services/org-memory-service.test.ts
@@ -8,10 +8,7 @@ import {
   ORG_MEMORY_PREAMBLE,
   parseOrgMemoryContent,
 } from "@nakama/core";
-import {
-  createInMemoryDatabaseAdapter,
-  type DatabaseAdapter,
-} from "@nakama/db";
+import { createInMemoryDatabaseAdapter } from "@nakama/db";
 import { OrgMemoryService } from "./org-memory-service";
 
 describe("OrgMemoryService", () => {
@@ -24,14 +21,14 @@ describe("OrgMemoryService", () => {
     tempDir = "";
   });
 
-  async function seedOrgs(
-    db: DatabaseAdapter,
-    orgIds: string[],
+  async function setup(
     archivedOrgIds: string[] = []
-  ): Promise<void> {
+  ): Promise<OrgMemoryService> {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "nakama-org-memory-"));
+    const db = createInMemoryDatabaseAdapter();
     const now = new Date().toISOString();
     const archived = new Set(archivedOrgIds);
-    for (const id of orgIds) {
+    for (const id of ["org_a", "org_b"]) {
       await db.upsertOrganization({
         archivedAt: archived.has(id) ? now : null,
         createdAt: now,
@@ -41,18 +38,6 @@ describe("OrgMemoryService", () => {
         updatedAt: now,
       });
     }
-  }
-
-  async function setup(
-    options: { archivedOrgIds?: string[]; orgIds?: string[] } = {}
-  ): Promise<OrgMemoryService> {
-    tempDir = await mkdtemp(path.join(os.tmpdir(), "nakama-org-memory-"));
-    const db = createInMemoryDatabaseAdapter();
-    await seedOrgs(
-      db,
-      options.orgIds ?? ["org_a", "org_b"],
-      options.archivedOrgIds
-    );
     return new OrgMemoryService(db, { configDir: tempDir });
   }
 
@@ -305,22 +290,10 @@ describe("OrgMemoryService", () => {
   });
 
   test("rejects memory mutators on an archived org and allows them on an active org", async () => {
-    const service = await setup({ archivedOrgIds: ["org_a"] });
+    const service = await setup(["org_a"]);
 
     await expect(
-      service.setMemory("org_a", `${ORG_MEMORY_PREAMBLE}\n\n- blocked\n`)
-    ).rejects.toMatchObject({ status: 404 });
-    await expect(
       service.addFact("org_a", "blocked fact", { pin: true })
-    ).rejects.toMatchObject({ status: 404 });
-    await expect(
-      service.archiveEntries("org_a", ["any"])
-    ).rejects.toMatchObject({ status: 404 });
-    await expect(
-      service.restoreHistoryRevision("org_a", "rev_missing", "admin_user")
-    ).rejects.toMatchObject({ status: 404 });
-    await expect(
-      service.undoLastChange("org_a", "admin_user")
     ).rejects.toMatchObject({ status: 404 });
 
     await service.addFact("org_b", "active fact", { pin: true });

--- a/apps/server/src/services/org-memory-service.test.ts
+++ b/apps/server/src/services/org-memory-service.test.ts
@@ -8,7 +8,10 @@ import {
   ORG_MEMORY_PREAMBLE,
   parseOrgMemoryContent,
 } from "@nakama/core";
-import { createInMemoryDatabaseAdapter } from "@nakama/db";
+import {
+  createInMemoryDatabaseAdapter,
+  type DatabaseAdapter,
+} from "@nakama/db";
 import { OrgMemoryService } from "./org-memory-service";
 
 describe("OrgMemoryService", () => {
@@ -17,16 +20,40 @@ describe("OrgMemoryService", () => {
   afterEach(async () => {
     if (tempDir) {
       await rm(tempDir, { force: true, recursive: true });
-      tempDir = "";
     }
+    tempDir = "";
   });
 
-  async function setup(withDb = false): Promise<OrgMemoryService> {
+  async function seedOrgs(
+    db: DatabaseAdapter,
+    orgIds: string[],
+    archivedOrgIds: string[] = []
+  ): Promise<void> {
+    const now = new Date().toISOString();
+    const archived = new Set(archivedOrgIds);
+    for (const id of orgIds) {
+      await db.upsertOrganization({
+        archivedAt: archived.has(id) ? now : null,
+        createdAt: now,
+        id,
+        name: id,
+        slug: id.replaceAll("_", "-"),
+        updatedAt: now,
+      });
+    }
+  }
+
+  async function setup(
+    options: { archivedOrgIds?: string[]; orgIds?: string[] } = {}
+  ): Promise<OrgMemoryService> {
     tempDir = await mkdtemp(path.join(os.tmpdir(), "nakama-org-memory-"));
-    return new OrgMemoryService(
-      withDb ? createInMemoryDatabaseAdapter() : null,
-      { configDir: tempDir }
+    const db = createInMemoryDatabaseAdapter();
+    await seedOrgs(
+      db,
+      options.orgIds ?? ["org_a", "org_b"],
+      options.archivedOrgIds
     );
+    return new OrgMemoryService(db, { configDir: tempDir });
   }
 
   test("getMemory returns the canonical preamble when the file is missing", async () => {
@@ -115,7 +142,7 @@ describe("OrgMemoryService", () => {
   });
 
   test("propose creates pending row without writing MEMORY.md", async () => {
-    const service = await setup(true);
+    const service = await setup();
     const result = await service.propose("org_a", {
       bullet: "team standup is 10am UTC",
     });
@@ -129,7 +156,7 @@ describe("OrgMemoryService", () => {
   });
 
   test("propose returns already_pending for duplicate bullet", async () => {
-    const service = await setup(true);
+    const service = await setup();
     const first = await service.propose("org_a", {
       bullet: "shared deploy window",
     });
@@ -142,7 +169,7 @@ describe("OrgMemoryService", () => {
   });
 
   test("approve writes to recent-log section by default", async () => {
-    const service = await setup(true);
+    const service = await setup();
     const proposed = await service.propose("org_a", {
       bullet: "review PRs before lunch",
     });
@@ -157,7 +184,7 @@ describe("OrgMemoryService", () => {
   });
 
   test("approve with pin writes to pinned section and is idempotent", async () => {
-    const service = await setup(true);
+    const service = await setup();
     const proposed = await service.propose("org_a", {
       bullet: "always pin this",
     });
@@ -275,5 +302,35 @@ describe("OrgMemoryService", () => {
       service.undoLastChange("org_a", "admin_user")
     ).resolves.toContain("snapshot");
     expect(await service.getMemory("org_a")).toContain("snapshot");
+  });
+
+  test("rejects memory mutators on an archived org and allows them on an active org", async () => {
+    const service = await setup({ archivedOrgIds: ["org_a"] });
+
+    await expect(
+      service.setMemory("org_a", `${ORG_MEMORY_PREAMBLE}\n\n- blocked\n`)
+    ).rejects.toMatchObject({ status: 404 });
+    await expect(
+      service.addFact("org_a", "blocked fact", { pin: true })
+    ).rejects.toMatchObject({ status: 404 });
+    await expect(
+      service.archiveEntries("org_a", ["any"])
+    ).rejects.toMatchObject({ status: 404 });
+    await expect(
+      service.restoreHistoryRevision("org_a", "rev_missing", "admin_user")
+    ).rejects.toMatchObject({ status: 404 });
+    await expect(
+      service.undoLastChange("org_a", "admin_user")
+    ).rejects.toMatchObject({ status: 404 });
+
+    await service.addFact("org_b", "active fact", { pin: true });
+    await service.setMemory(
+      "org_b",
+      `${ORG_MEMORY_PREAMBLE}\n\n## Pinned\n\n- active fact\n- second fact\n`
+    );
+    const archived = await service.archiveEntries("org_b", ["second fact"]);
+    expect(archived.archived).toBe(1);
+    const parsed = parseOrgMemoryContent(await service.getMemory("org_b"));
+    expect(parsed.pinned).toEqual(["active fact"]);
   });
 });

--- a/apps/server/src/services/org-memory-service.ts
+++ b/apps/server/src/services/org-memory-service.ts
@@ -112,6 +112,7 @@ export class OrgMemoryService {
     content: string,
     change?: OrgMemoryChangeContext
   ): Promise<void> {
+    await this.requireActiveOrganization(orgId);
     const trimmed = content.trim();
     if (Buffer.byteLength(trimmed, "utf8") > SUMMARY_BYTE_CAP * 4) {
       throw new NakamaApiError(
@@ -159,6 +160,7 @@ export class OrgMemoryService {
     revisionId: string,
     actorUserId: string
   ): Promise<string> {
+    await this.requireActiveOrganization(orgId);
     const record = await getOrgMemoryHistoryEntry(
       orgId,
       revisionId,
@@ -178,6 +180,7 @@ export class OrgMemoryService {
   }
 
   async undoLastChange(orgId: string, actorUserId: string): Promise<string> {
+    await this.requireActiveOrganization(orgId);
     const currentContent = (await this.getMemory(orgId)).trim();
     const history = await listOrgMemoryHistory(
       orgId,
@@ -211,6 +214,7 @@ export class OrgMemoryService {
     bullet: string,
     options: { pin?: boolean; change?: OrgMemoryChangeContext } = {}
   ): Promise<void> {
+    await this.requireActiveOrganization(orgId);
     const text = this.normalizeBullet(bullet);
     const content = await this.getMemory(orgId);
     const parsed = parseOrgMemoryContent(content);
@@ -326,6 +330,7 @@ export class OrgMemoryService {
       change?: OrgMemoryChangeContext;
     } = {}
   ) {
+    await this.requireActiveOrganization(orgId);
     const targets = new Set(
       entries.map((e) => e.trim().replace(/^-\s+/, "").trim()).filter(Boolean)
     );
@@ -703,6 +708,13 @@ export class OrgMemoryService {
       throw new NakamaApiError("Org memory proposals are not configured.", 500);
     }
     return this.database;
+  }
+
+  private async requireActiveOrganization(orgId: string): Promise<void> {
+    const org = await this.requireDatabase().getOrganizationById(orgId);
+    if (!org || org.archivedAt) {
+      throw new NakamaApiError("Not found", 404);
+    }
   }
 
   private async commitMemory(

--- a/apps/server/src/services/org-service.test.ts
+++ b/apps/server/src/services/org-service.test.ts
@@ -730,4 +730,74 @@ describe("OrgService", () => {
       orgService.acceptInvite({ password: "secret123", token: invite.token })
     ).rejects.toMatchObject({ status: 404 });
   });
+
+  test("rejects member mutators on an archived org and allows them on an active org", async () => {
+    const { orgService, authService } = createOrgService();
+    const bootstrapped = await orgService.bootstrapInitialSetup({
+      admin: {
+        email: "admin@acme.com",
+        name: "Acme Admin",
+        passwordHash: await authService.hashPassword("password123"),
+        phone: "",
+      },
+      organization: { name: "Acme", slug: "acme-member-archive" },
+    });
+    const active = await orgService.createOrganization(
+      { name: "Beta", slug: "beta-member-archive" },
+      bootstrapped.user.id
+    );
+    const archivedMember = await orgService.addMember({
+      email: "keep@acme.com",
+      name: "Keep Member",
+      orgId: bootstrapped.organization.id,
+      phone: "",
+      role: "member",
+    });
+    await orgService.archiveOrganization(
+      bootstrapped.organization.id,
+      bootstrapped.user.id
+    );
+
+    await expect(
+      orgService.addMember({
+        email: "new@acme.com",
+        name: "New Member",
+        orgId: bootstrapped.organization.id,
+        phone: "",
+        role: "member",
+      })
+    ).rejects.toMatchObject({ status: 404 });
+    await expect(
+      orgService.updateMember(
+        bootstrapped.organization.id,
+        archivedMember.member.userId,
+        { role: "viewer" }
+      )
+    ).rejects.toMatchObject({ status: 404 });
+    await expect(
+      orgService.removeMember(
+        bootstrapped.organization.id,
+        archivedMember.member.userId
+      )
+    ).rejects.toMatchObject({ status: 404 });
+
+    const added = await orgService.addMember({
+      email: "active@acme.com",
+      name: "Active Member",
+      orgId: active.organization.id,
+      phone: "",
+      role: "member",
+    });
+    const updated = await orgService.updateMember(
+      active.organization.id,
+      added.member.userId,
+      { role: "viewer" }
+    );
+    expect(updated.member.role).toBe("viewer");
+    await orgService.removeMember(active.organization.id, added.member.userId);
+    const listed = await orgService.listMembers(active.organization.id);
+    expect(
+      listed.members.some((member) => member.userId === added.member.userId)
+    ).toBe(false);
+  });
 });

--- a/apps/server/src/services/org-service.test.ts
+++ b/apps/server/src/services/org-service.test.ts
@@ -746,13 +746,6 @@ describe("OrgService", () => {
       { name: "Beta", slug: "beta-member-archive" },
       bootstrapped.user.id
     );
-    const archivedMember = await orgService.addMember({
-      email: "keep@acme.com",
-      name: "Keep Member",
-      orgId: bootstrapped.organization.id,
-      phone: "",
-      role: "member",
-    });
     await orgService.archiveOrganization(
       bootstrapped.organization.id,
       bootstrapped.user.id
@@ -766,19 +759,6 @@ describe("OrgService", () => {
         phone: "",
         role: "member",
       })
-    ).rejects.toMatchObject({ status: 404 });
-    await expect(
-      orgService.updateMember(
-        bootstrapped.organization.id,
-        archivedMember.member.userId,
-        { role: "viewer" }
-      )
-    ).rejects.toMatchObject({ status: 404 });
-    await expect(
-      orgService.removeMember(
-        bootstrapped.organization.id,
-        archivedMember.member.userId
-      )
     ).rejects.toMatchObject({ status: 404 });
 
     const added = await orgService.addMember({

--- a/apps/server/src/services/org-service.ts
+++ b/apps/server/src/services/org-service.ts
@@ -383,10 +383,7 @@ export class OrgService {
     phone: string;
     role: OrgRole;
   }): Promise<AddOrgMemberResponse> {
-    const org = await this.databaseAdapter.getOrganizationById(input.orgId);
-    if (!org) {
-      throw new NakamaApiError("Not found", 404);
-    }
+    await this.requireActiveOrganization(input.orgId);
 
     const name = input.name.trim();
     const email = normalizeEmail(input.email);
@@ -532,6 +529,7 @@ export class OrgService {
   }
 
   async removeMember(orgId: string, userId: string): Promise<void> {
+    await this.requireActiveOrganization(orgId);
     await this.assertCanChangeAdminMembership(orgId, userId);
 
     const deleted = await this.databaseAdapter.deleteOrgMember(orgId, userId);
@@ -545,6 +543,8 @@ export class OrgService {
     userId: string,
     input: UpdateOrgMemberRequest
   ): Promise<OrgMemberResponse> {
+    await this.requireActiveOrganization(orgId);
+
     const nextRole = input.role;
     if (nextRole !== undefined && !ORG_ROLES.includes(nextRole)) {
       throw new NakamaApiError("Invalid org role.", 400);


### PR DESCRIPTION
## Summary

Archived orgs reject member changes and MEMORY.md writes with 404, same as invite accept.

**Before:** `addMember` / `updateMember` / `removeMember` and org-memory mutators still wrote after archive.
**After:** each mutator calls `requireActiveOrganization` first; active orgs keep working.

Why safe:
1. Same 404 path as invite accept and `updateOrganization`
2. Platform archive / admin flows are unchanged
3. Focused tests cover archived reject and active success for both surfaces

Only re-add writes on archived orgs if a deliberate restore path needs them.

## Test plan
- [x] `bun test apps/server/src/services/org-service.test.ts apps/server/src/services/org-memory-service.test.ts` (47 pass)
- [x] `bun test apps/server/src/http/routes/org-memory.test.ts apps/server/src/tools/org-memory-tools.test.ts` (15 pass)
- [x] `bun x ultracite check` on the 4 changed files (clean)
- [x] `bun run build` (pass)
- [ ] Archive an org, try add member and add memory fact — both 404; switch to an active org and confirm both still work

Fixes #504
Fixes #505
