### PR TITLE
fix(agent): history token estimate and prune copy-on-write

### DIFF
--- a/apps/server/src/providers/compaction-estimate.test.ts
+++ b/apps/server/src/providers/compaction-estimate.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, mock, test } from "bun:test";
+// estimateHistoryTokens is not exported from @nakama/agent, hence the deep path.
+import { estimateHistoryTokens } from "../../../../packages/agent/src/history-compaction";
+import { createAnthropicProvider, toAnthropicMessages } from "./anthropic";
+
+const j = (value: unknown) => JSON.stringify(value);
+const ev = (payload: { type: string }) =>
+  `event: ${payload.type}\r\ndata:${j(payload)}\r\n\r\n`;
+
+// Mirrors TOKEN_ESTIMATE_RATIO = 4 in history-compaction.ts.
+const estimateTokens = (text: string) => Math.ceil(text.length / 4);
+
+function eventStream(chunks: string[]): Response {
+  const encoder = new TextEncoder();
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(encoder.encode(chunk));
+        }
+        controller.close();
+      },
+    }),
+    { headers: { "Content-Type": "text/event-stream" }, status: 200 }
+  );
+}
+
+function streamOf(options: { text: string; thinking?: string }): string[] {
+  const chunks = [
+    'event: message_start\r\ndata:{"type":"message_start","message":{"usage":{"input_tokens":10}}}\r\n\r\n',
+  ];
+  let index = 0;
+
+  if (options.thinking) {
+    chunks.push(
+      ev({
+        content_block: { signature: "", thinking: "", type: "thinking" },
+        index,
+        type: "content_block_start",
+      }),
+      ev({
+        delta: { thinking: options.thinking, type: "thinking_delta" },
+        index,
+        type: "content_block_delta",
+      }),
+      ev({
+        delta: {
+          signature: "EqQBCgIYAhIB0aBcd1234SIG",
+          type: "signature_delta",
+        },
+        index,
+        type: "content_block_delta",
+      }),
+      ev({ index, type: "content_block_stop" })
+    );
+    index += 1;
+  }
+
+  chunks.push(
+    ev({
+      content_block: { text: "", type: "text" },
+      index,
+      type: "content_block_start",
+    }),
+    ev({
+      delta: { text: options.text, type: "text_delta" },
+      index,
+      type: "content_block_delta",
+    }),
+    ev({ index, type: "content_block_stop" }),
+    'event: message_delta\r\ndata:{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":40}}\r\n\r\n'
+  );
+
+  return chunks;
+}
+
+async function ratioFor(options: { text: string; thinking?: string }) {
+  const fetchMock = mock(async () => eventStream(streamOf(options)));
+  const provider = createAnthropicProvider({
+    apiKey: "sk-ant-test",
+    fetch: fetchMock as unknown as typeof fetch,
+    model: "claude-sonnet-4-6",
+  });
+
+  const user = { content: "invoices last quarter", role: "user" } as const;
+  const { assistantMessage } = await provider.streamChat(
+    { messages: [user], system: "s" },
+    { onChunk: () => undefined }
+  );
+
+  const estimated =
+    estimateHistoryTokens([user, assistantMessage], "", []) -
+    estimateHistoryTokens([user], "", []);
+  const sent =
+    estimateTokens(j(await toAnthropicMessages([user, assistantMessage]))) -
+    estimateTokens(j(await toAnthropicMessages([user])));
+
+  return { estimated, ratio: estimated / sent, sent };
+}
+
+const LONG_TEXT = "Here is what I found in the invoice table. ".repeat(20);
+const LONG_THINKING = "The user wants last quarter invoices. ".repeat(20);
+
+describe("history token estimate", () => {
+  test("does not over-count an assistant turn without thinking", async () => {
+    const { estimated, ratio, sent } = await ratioFor({ text: LONG_TEXT });
+    expect({ estimated, sent, within10Percent: ratio <= 1.1 }).toEqual({
+      estimated,
+      sent,
+      within10Percent: true,
+    });
+  });
+
+  test("does not under-count an assistant turn with thinking", async () => {
+    const { estimated, ratio, sent } = await ratioFor({
+      text: "Let me look that up.",
+      thinking: LONG_THINKING,
+    });
+    expect({ estimated, sent, within10Percent: ratio >= 0.9 }).toEqual({
+      estimated,
+      sent,
+      within10Percent: true,
+    });
+  });
+});

--- a/packages/agent/src/history-compaction.test.ts
+++ b/packages/agent/src/history-compaction.test.ts
@@ -180,6 +180,32 @@ describe("history compaction", () => {
     );
   });
 
+  test("does not mutate shared tool message objects in place (#589)", () => {
+    const original = createToolMessage(repeat("a", 200_000));
+    const messages: ChatMessage[] = [
+      { content: "turn 1", role: "user" },
+      original,
+      { content: "done 1", role: "assistant" },
+      { content: "turn 2", role: "user" },
+      createToolMessage(repeat("b", 10_000)),
+      { content: "done 2", role: "assistant" },
+      { content: "turn 3", role: "user" },
+      createToolMessage(repeat("c", 10_000)),
+      { content: "done 3", role: "assistant" },
+      { content: "turn 4", role: "user" },
+      { content: "done 4", role: "assistant" },
+    ];
+
+    const result = pruneToolOutputs(messages, compaction);
+
+    expect(result.prunedTokens).toBeGreaterThan(0);
+    expect(original.content).toBe(repeat("a", 200_000));
+    expect(messages[1]).not.toBe(original);
+    expect(messages[1]?.role === "tool" && messages[1].content).toContain(
+      "truncated"
+    );
+  });
+
   test("selects only the head for summarization", () => {
     const messages: ChatMessage[] = [
       { content: "one", role: "user" },
@@ -292,5 +318,58 @@ describe("history compaction", () => {
     const estimate = estimateHistoryTokens(messages, "system prompt");
 
     expect(estimate).toBeGreaterThan(100);
+  });
+
+  test("counts providerContent once and keeps thinking (#340)", () => {
+    const thinking = repeat("t", 800);
+    const text = "Let me look that up.";
+    const toolCalls = [
+      {
+        arguments: { query: "invoice" },
+        id: "call_1",
+        name: "search_invoices",
+      },
+    ];
+    const providerContent = [
+      { thinking, type: "thinking" },
+      { text, type: "text" },
+      {
+        id: "call_1",
+        input: { query: "invoice" },
+        name: "search_invoices",
+        type: "tool_use",
+      },
+    ];
+    const withProvider: ChatMessage[] = [
+      {
+        content: text,
+        providerContent,
+        role: "assistant",
+        toolCalls,
+      },
+    ];
+    const withoutProvider: ChatMessage[] = [
+      {
+        content: text,
+        role: "assistant",
+        toolCalls,
+      },
+    ];
+    const empty: ChatMessage[] = [];
+
+    const withEstimate =
+      estimateHistoryTokens(withProvider, "") -
+      estimateHistoryTokens(empty, "");
+    const withoutEstimate =
+      estimateHistoryTokens(withoutProvider, "") -
+      estimateHistoryTokens(empty, "");
+    const providerOnly = Math.ceil(JSON.stringify(providerContent).length / 4);
+    const contentAndTools =
+      Math.ceil(text.length / 4) +
+      Math.ceil(JSON.stringify(toolCalls).length / 4);
+
+    expect(withEstimate).toBe(providerOnly);
+    expect(withEstimate).toBeGreaterThan(withoutEstimate);
+    expect(withoutEstimate).toBe(contentAndTools);
   });
 });

--- a/packages/agent/src/history-compaction.ts
+++ b/packages/agent/src/history-compaction.ts
@@ -278,17 +278,14 @@ export function pruneToolOutputs(
     return { prunedTokens: 0 };
   }
 
-  // Copy-on-write (#589): replace slots with new tool messages so in-flight
-  // providers that already hold the old objects keep the original content.
-  const pruneSet = new Set(pruneIndexes);
-  const nextHistory = messages.map((message, index) => {
-    if (!pruneSet.has(index) || message.role !== "tool") {
-      return message;
+  // Copy-on-write (#589): replace slots so in-flight providers keep originals.
+  for (const index of pruneIndexes) {
+    const message = messages[index];
+    if (!message || message.role !== "tool") {
+      continue;
     }
-
-    return { ...message, content: PRUNE_TRUNCATION };
-  });
-  messages.splice(0, messages.length, ...nextHistory);
+    messages[index] = { ...message, content: PRUNE_TRUNCATION };
+  }
 
   return { prunedTokens: pruned };
 }

--- a/packages/agent/src/history-compaction.ts
+++ b/packages/agent/src/history-compaction.ts
@@ -78,17 +78,6 @@ function estimateTokens(text: string): number {
   return Math.ceil(text.length / TOKEN_ESTIMATE_RATIO);
 }
 
-function stripThinkingFromProviderContent(content: unknown[]): unknown[] {
-  return content.filter((item) => {
-    if (typeof item !== "object" || item === null) {
-      return true;
-    }
-
-    const type = (item as { type?: unknown }).type;
-    return type !== "thinking" && type !== "reasoning";
-  });
-}
-
 function estimateMessageTokens(messages: readonly ChatMessage[]): number {
   let total = 0;
 
@@ -99,18 +88,20 @@ function estimateMessageTokens(messages: readonly ChatMessage[]): number {
     }
 
     if (message.role === "assistant") {
-      total += estimateTokens(message.content);
-
-      if (message.toolCalls?.length) {
-        total += estimateTokens(JSON.stringify(message.toolCalls));
-      }
-
+      // When providerContent is present it is what providers replay (#340).
+      // Count it verbatim (thinking/reasoning included) and skip content/
+      // toolCalls, which already live inside it. OpenAI tool turns can
+      // diverge slightly: Responses rebuilds function_call items from
+      // toolCalls and drops id/status; that gap is accepted deliberately
+      // rather than making the estimator provider-aware.
       if (message.providerContent?.length) {
-        total += estimateTokens(
-          JSON.stringify(
-            stripThinkingFromProviderContent(message.providerContent)
-          )
-        );
+        total += estimateTokens(JSON.stringify(message.providerContent));
+      } else {
+        total += estimateTokens(message.content);
+
+        if (message.toolCalls?.length) {
+          total += estimateTokens(JSON.stringify(message.toolCalls));
+        }
       }
 
       continue;
@@ -238,7 +229,7 @@ export function pruneToolOutputs(
 
   let total = 0;
   let pruned = 0;
-  const toPrune: Extract<ChatMessage, { role: "tool" }>[] = [];
+  const pruneIndexes: number[] = [];
   let turns = 0;
 
   for (
@@ -280,16 +271,24 @@ export function pruneToolOutputs(
     }
 
     pruned += estimate;
-    toPrune.push(message);
+    pruneIndexes.push(messageIndex);
   }
 
   if (pruned <= minimum) {
     return { prunedTokens: 0 };
   }
 
-  for (const message of toPrune) {
-    message.content = PRUNE_TRUNCATION;
-  }
+  // Copy-on-write (#589): replace slots with new tool messages so in-flight
+  // providers that already hold the old objects keep the original content.
+  const pruneSet = new Set(pruneIndexes);
+  const nextHistory = messages.map((message, index) => {
+    if (!pruneSet.has(index) || message.role !== "tool") {
+      return message;
+    }
+
+    return { ...message, content: PRUNE_TRUNCATION };
+  });
+  messages.splice(0, messages.length, ...nextHistory);
 
   return { prunedTokens: pruned };
 }


### PR DESCRIPTION
## Summary

Compaction now counts the assistant turn that providers replay, and prune no longer changes shared tool message objects mid-stream.

Fixes #340 #589

**Before:** The estimate double-counted `content`/`toolCalls` with `providerContent`, stripped thinking, and prune wrote into live message objects.
**After:** `estimateMessageTokens` counts `providerContent` once (thinking kept). `pruneToolOutputs` swaps in new tool messages.

Why safe:
1. Compaction overflow still uses the same `estimateHistoryTokens` → `isOverflow` path
2. OpenAI tool-turn gap (rebuilt `function_call`, dropped `id`/`status`) is accepted on purpose — not a provider-aware estimator
3. Prune thresholds and summarization splice behavior stay the same

Only re-add a provider-aware estimator if OpenAI tool turns drift past the measured envelope.

## Test plan
- [x] `bun test packages/agent/src/history-compaction.test.ts apps/server/src/providers/compaction-estimate.test.ts` (15 pass)
- [x] `bun run --filter @nakama/agent test` (84 pass)
- [x] `bun run --filter @nakama/agent build` (exit 0)
- [x] `bun x ultracite check` on changed files (clean)
- [ ] Open a long chat with thinking + tool output, then compact — context chip and history stay coherent
