### PR TITLE
chore(github): keep the help wanted label in sync with open PRs

### DIFF
--- a/.github/workflows/help-wanted.yml
+++ b/.github/workflows/help-wanted.yml
@@ -1,0 +1,62 @@
+# Keeps the `help wanted` label honest. The label marks an issue as up for grabs,
+# so it has to come off the moment someone starts, or two people build the same fix.
+name: Help wanted
+
+# pull_request_target, because a fork PR gets a read-only token and this needs to
+# write labels. Safe here only because nothing checks out or runs the PR's code.
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, closed]
+
+permissions:
+  issues: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync the label on every issue this PR declares
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          MERGED: ${{ github.event.pull_request.merged }}
+          ACTION: ${{ github.event.action }}
+        run: |
+          set -euo pipefail
+
+          # GitHub's own issue linking, not a regex over the body, so the workflow
+          # agrees with the "Closes #N" GitHub already shows on the PR.
+          linked=$(gh api graphql -f query='
+            query($owner: String!, $repo: String!, $pr: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $pr) {
+                  closingIssuesReferences(first: 20) { nodes { number } }
+                }
+              }
+            }' \
+            -F owner="${REPO%/*}" -F repo="${REPO#*/}" -F pr="$PR" \
+            --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[].number')
+
+          for n in $linked; do
+            if [ "$ACTION" = closed ]; then
+              # A merged PR closes the issue, so there is nothing to hand back.
+              if [ "$MERGED" = true ]; then continue; fi
+
+              # Abandoned work frees the issue again, but only if it still meets the
+              # bar for the label: open, nobody assigned, and sized to one PR.
+              eligible=$(gh api "repos/$REPO/issues/$n" --jq '
+                select(.state == "open" and .assignee == null
+                       and ([.labels[].name] | index("stage: now"))) | .number')
+              if [ -z "$eligible" ]; then continue; fi
+
+              gh api -X POST "repos/$REPO/issues/$n/labels" \
+                -f 'labels[]=help wanted' >/dev/null
+              echo "restored help wanted on #$n"
+            else
+              # 404s when the label was never there, which is the common case.
+              gh api -X DELETE "repos/$REPO/issues/$n/labels/help%20wanted" \
+                >/dev/null 2>&1 || true
+              echo "cleared help wanted on #$n"
+            fi
+          done


### PR DESCRIPTION
## Summary

Closes #769. A PR that declares `Closes #N` takes `help wanted` off #N when it opens, and hands the label back if that PR is closed unmerged.

**Before:** the label went onto 74 open issues on 2026-08-30 and nothing removes it, so it points a second contributor at work already in flight. A PR closed unmerged leaves its issue unlabelled and off the board even though it is free again.
**After:** the label follows GitHub's own issue linking in both directions, with no manual step.

Why safe:
1. The workflow holds `issues: write` and nothing else.
2. `pull_request_target` is what lets a fork PR write labels at all. It is sound here only because nothing checks out or runs the PR's code, so an untrusted branch has no path into the runner.
3. Linked issues come from `closingIssuesReferences`, not a regex over the body, so this cannot disagree with the `Closes #N` GitHub already shows.
4. Restoring re-checks the bar rather than assuming it: open, unassigned, `stage: now`.

Only follow up if the label should cover `stage: next` too; that is one string in the filter.

This only sees links a PR declares. #756 closes the substance of #554 without naming it, and no automation catches that.

## Test plan

- [x] Ran the `run:` block verbatim against the live repo with both mutating `gh` calls stubbed. Nothing was written, `help wanted` still sits on 74 issues.
- [x] `opened`, linked `547 100 17` → cleared on all three. Closed unmerged, same three → restored `#547` only, since `#100` is `stage: next` and `#17` is `stage: later`.
- [x] Closed merged → no label work. A PR with no declared link (#742) resolved to an empty list and did nothing.
- [x] `bun run test` across every workspace, exit 0, 0 failures.
