### PR TITLE
fix(server): preserve usage totals during reload

### DIFF
--- a/apps/server/src/services/llm-usage-tracker.test.ts
+++ b/apps/server/src/services/llm-usage-tracker.test.ts
@@ -62,19 +62,13 @@ describe("LlmUsageTracker", () => {
   test("waits for an in-flight record before reloading", async () => {
     const db = createInMemoryDatabaseAdapter();
     const incrementStats = db.incrementLlmUsageStats.bind(db);
-    const incrementStatsByModel = db.incrementLlmUsageStatsByModel.bind(db);
     const persistGate = Promise.withResolvers<void>();
     const persistStarted = Promise.withResolvers<void>();
-    const persistFinished = Promise.withResolvers<void>();
 
     db.incrementLlmUsageStats = async (delta, trackedSince) => {
       persistStarted.resolve();
       await persistGate.promise;
       await incrementStats(delta, trackedSince);
-    };
-    db.incrementLlmUsageStatsByModel = async (modelId, delta, trackedSince) => {
-      await incrementStatsByModel(modelId, delta, trackedSince);
-      persistFinished.resolve();
     };
 
     const tracker = await LlmUsageTracker.create(db);
@@ -82,9 +76,8 @@ describe("LlmUsageTracker", () => {
     await persistStarted.promise;
 
     const reload = tracker.reloadFromDatabase();
-    await Promise.resolve();
     persistGate.resolve();
-    await Promise.all([reload, persistFinished.promise]);
+    await reload;
 
     expect(tracker.getStats().requestCount).toBe(1);
     expect(tracker.getStatsByModel()).toHaveLength(1);

--- a/apps/server/src/services/llm-usage-tracker.test.ts
+++ b/apps/server/src/services/llm-usage-tracker.test.ts
@@ -58,4 +58,88 @@ describe("LlmUsageTracker", () => {
       },
     ]);
   });
+
+  test("waits for an in-flight record before reloading", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const incrementStats = db.incrementLlmUsageStats.bind(db);
+    const incrementStatsByModel = db.incrementLlmUsageStatsByModel.bind(db);
+    const persistGate = Promise.withResolvers<void>();
+    const persistStarted = Promise.withResolvers<void>();
+    const persistFinished = Promise.withResolvers<void>();
+
+    db.incrementLlmUsageStats = async (delta, trackedSince) => {
+      persistStarted.resolve();
+      await persistGate.promise;
+      await incrementStats(delta, trackedSince);
+    };
+    db.incrementLlmUsageStatsByModel = async (modelId, delta, trackedSince) => {
+      await incrementStatsByModel(modelId, delta, trackedSince);
+      persistFinished.resolve();
+    };
+
+    const tracker = await LlmUsageTracker.create(db);
+    tracker.record("gpt-4o", 100, 50);
+    await persistStarted.promise;
+
+    const reload = tracker.reloadFromDatabase();
+    await Promise.resolve();
+    persistGate.resolve();
+    await Promise.all([reload, persistFinished.promise]);
+
+    expect(tracker.getStats().requestCount).toBe(1);
+    expect(tracker.getStatsByModel()).toHaveLength(1);
+  });
+
+  test("retries a reload when a record arrives during the database read", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    await db.incrementLlmUsageStats(
+      {
+        estimatedCostUsd: 0.02,
+        inputTokens: 200,
+        outputTokens: 100,
+        requestCount: 2,
+      },
+      "2026-06-05T00:00:00.000Z"
+    );
+    const tracker = await LlmUsageTracker.create(db);
+    const getStats = db.getLlmUsageStats.bind(db);
+    const readGate = Promise.withResolvers<void>();
+    const readStarted = Promise.withResolvers<void>();
+    let readCount = 0;
+    let pauseNextRead = true;
+
+    db.getLlmUsageStats = async () => {
+      readCount += 1;
+      const snapshot = await getStats();
+      if (pauseNextRead) {
+        pauseNextRead = false;
+        readStarted.resolve();
+        await readGate.promise;
+      }
+      return snapshot;
+    };
+
+    const reload = tracker.reloadFromDatabase();
+    await readStarted.promise;
+    tracker.record("gpt-4o", 100, 50);
+    readGate.resolve();
+    await reload;
+
+    expect(tracker.getStats()).toMatchObject({
+      inputTokens: 300,
+      outputTokens: 150,
+      requestCount: 3,
+      totalTokens: 450,
+    });
+    expect(readCount).toBe(2);
+    expect(tracker.getStatsByModel()).toMatchObject([
+      {
+        inputTokens: 100,
+        modelId: "gpt-4o",
+        outputTokens: 50,
+        requestCount: 1,
+        totalTokens: 150,
+      },
+    ]);
+  });
 });

--- a/apps/server/src/services/llm-usage-tracker.ts
+++ b/apps/server/src/services/llm-usage-tracker.ts
@@ -16,30 +16,35 @@ export class LlmUsageTracker {
     Omit<LlmUsageModelStats, "totalTokens">
   >();
   private pricingContext: PricingContext = {};
+  private recordRevision = 0;
+  private readonly pendingWrites = new Set<Promise<void>>();
 
   private constructor(private readonly db?: DatabaseAdapter) {}
 
   static async create(db?: DatabaseAdapter): Promise<LlmUsageTracker> {
     const tracker = new LlmUsageTracker(db);
-    await tracker.load();
+    await tracker.loadSnapshotIfRevisionUnchanged();
     return tracker;
   }
 
-  private async load(): Promise<void> {
-    if (!this.db) {
-      return;
+  private async loadSnapshotIfRevisionUnchanged(
+    expectedRevision = this.recordRevision
+  ): Promise<boolean> {
+    const stored = (await this.db?.getLlmUsageStats()) ?? null;
+    const byModel = (await this.db?.listLlmUsageStatsByModel()) ?? [];
+
+    // Publish only a snapshot that spans no record(), otherwise reload retries
+    // after the new record's database write finishes.
+    if (expectedRevision !== this.recordRevision) {
+      return false;
     }
 
-    const stored = await this.db.getLlmUsageStats();
-    if (stored) {
-      this.requestCount = stored.requestCount;
-      this.inputTokens = stored.inputTokens;
-      this.outputTokens = stored.outputTokens;
-      this.estimatedCostUsd = stored.estimatedCostUsd;
-      this.trackedSince = stored.trackedSince;
-    }
-
-    const byModel = await this.db.listLlmUsageStatsByModel();
+    this.requestCount = stored?.requestCount ?? 0;
+    this.inputTokens = stored?.inputTokens ?? 0;
+    this.outputTokens = stored?.outputTokens ?? 0;
+    this.estimatedCostUsd = stored?.estimatedCostUsd ?? 0;
+    this.trackedSince = stored?.trackedSince ?? new Date().toISOString();
+    this.usageByModel.clear();
     for (const entry of byModel) {
       this.usageByModel.set(entry.modelId, {
         estimatedCostUsd: entry.estimatedCostUsd,
@@ -50,16 +55,22 @@ export class LlmUsageTracker {
         trackedSince: entry.trackedSince,
       });
     }
+    return true;
   }
 
   async reloadFromDatabase(): Promise<void> {
-    this.requestCount = 0;
-    this.inputTokens = 0;
-    this.outputTokens = 0;
-    this.estimatedCostUsd = 0;
-    this.trackedSince = new Date().toISOString();
-    this.usageByModel.clear();
-    await this.load();
+    while (true) {
+      const revision = this.recordRevision;
+      await Promise.all(this.pendingWrites);
+
+      if (revision !== this.recordRevision) {
+        continue;
+      }
+
+      if (await this.loadSnapshotIfRevisionUnchanged(revision)) {
+        return;
+      }
+    }
   }
 
   setPricingContext(context: PricingContext): void {
@@ -74,6 +85,7 @@ export class LlmUsageTracker {
       this.pricingContext
     );
 
+    this.recordRevision += 1;
     this.requestCount += 1;
     this.inputTokens += inputTokens;
     this.outputTokens += outputTokens;
@@ -89,7 +101,7 @@ export class LlmUsageTracker {
       trackedSince: existing?.trackedSince ?? new Date().toISOString(),
     });
 
-    void this.persist(
+    const persistence = this.persist(
       {
         estimatedCostUsd: costDelta,
         inputTokens,
@@ -98,6 +110,10 @@ export class LlmUsageTracker {
       },
       modelId
     );
+    this.pendingWrites.add(persistence);
+    void persistence.then(() => {
+      this.pendingWrites.delete(persistence);
+    });
   }
 
   private async persist(


### PR DESCRIPTION
## Summary

Within one active database generation, usage totals survive concurrent `reloadFromDatabase()` calls.

**Before:** reload could apply a pre-write snapshot and leave memory behind SQLite.
**After:** reload waits for tracked writes and retries any aggregate/per-model snapshot spanning a newer record.

Why safe:
1. `record()` stays synchronous and fire-and-forget; only reload waits
2. Deterministic tests force both race orders, and a stable revision gates snapshot publication

Only follow up if destructive restore/reopen must preserve pre-cutover writes, or aggregate/per-model usage must commit atomically.

## Test plan
- [x] `bun test apps/server/src/services/llm-usage-tracker.test.ts apps/server/src/providers/usage-tracking.test.ts apps/server/src/services/image-generation.test.ts packages/db/src/llm-usage-stats.test.ts` (24 pass on Windows; 24 pass in Podman/Linux; file-backed SQLite experiment aligned memory/disk at 1 request / 150 tokens)
- [x] `bun run --filter @nakama/server build` + targeted `bun x ultracite check` (pass)
- [ ] Invoke `reloadFromDatabase()` while a same-generation usage write is gated; memory and SQLite stay aligned

Fixes #552
