### PR TITLE
fix(server): set the public web URL from the body only

### DIFF
--- a/apps/server/src/http/routes/system.ts
+++ b/apps/server/src/http/routes/system.ts
@@ -5,7 +5,6 @@ import { BUILTIN_TOOL_IDS } from "@nakama/core/tools/protected";
 import {
   getWebPublicUrlSettings,
   persistWebPublicUrl,
-  resolveRequestClientOrigin,
 } from "../../services/composio-callback-url";
 import type { ServerOptions } from "../context";
 import { requireOrgAdminFromContext } from "../org-guards";
@@ -207,10 +206,10 @@ export function registerSystemRoutes(
   app.put("/v1/system/web-public-url", async (c) => {
     requireOrgAdminFromContext(c);
     const body = await readJson<UpdateWebPublicUrlRequest>(c.req.raw);
-    const webPublicUrl = resolveRequestClientOrigin(
-      c.req.raw,
-      body.webPublicUrl
-    );
+    // Only the body sets this. Falling back to Origin/Referer would let a header
+    // pin the base an OAuth code is delivered to, which is what #712 took away
+    // from the read path.
+    const webPublicUrl = body.webPublicUrl?.trim();
 
     if (!webPublicUrl) {
       return errorResponse("webPublicUrl is required.", 400);

--- a/apps/server/src/http/web-public-url.test.ts
+++ b/apps/server/src/http/web-public-url.test.ts
@@ -61,6 +61,33 @@ describe("web public url settings", () => {
         webPublicUrl: string | null;
       };
       expect(afterSave.webPublicUrl).toBe("https://app.example.com/setup");
+
+      // An Origin header must not be able to repoint the OAuth callback base.
+      const headerAttempt = await app.fetch(
+        new Request("http://localhost:4310/v1/system/web-public-url", {
+          body: JSON.stringify({}),
+          headers: session.headers(
+            {
+              "Content-Type": "application/json",
+              Origin: "https://evil.example",
+              "X-CSRF-Token": session.csrfToken,
+            },
+            session.orgId
+          ),
+          method: "PUT",
+        })
+      );
+      expect(headerAttempt.status).toBe(400);
+
+      const afterAttempt = await app.fetch(
+        new Request("http://localhost:4310/v1/system/web-public-url", {
+          headers: session.headers({}, session.orgId),
+        })
+      );
+      expect(
+        ((await afterAttempt.json()) as { webPublicUrl: string | null })
+          .webPublicUrl
+      ).toBe("https://app.example.com/setup");
     } finally {
       if (previousConfigDir === undefined) {
         delete process.env.NAKAMA_CONFIG_DIR;


### PR DESCRIPTION
## Summary

Refs #478. `PUT /v1/system/web-public-url` now takes the value from the body only. It used to fall back to the request's `Origin`, then `Referer`, so a PUT with an empty body pinned the deployment-wide OAuth callback base to whatever host the caller named.

**Before:** `{}` with `Origin: https://evil.example` returned `200 {"webPublicUrl":"https://evil.example"}`, and the `GET` after it confirmed the value persisted.
**After:** the same request returns `400 webPublicUrl is required.` and the stored URL is untouched.

Why safe:
1. No caller loses anything. `client.updateWebPublicUrl` always sends the field, the settings form blocks an empty value client-side, and its "Use current" button already puts `window.location.origin` in the body.
2. Trailing slashes are still trimmed. `persistWebPublicUrl` calls `normalizeBaseUrl`, which is `trim().replace(/\/+$/, "")`.
3. `resolveRequestClientOrigin` keeps its other three callers in `artifact-shares.ts`, `sessions.ts` and setup in `auth.ts`, which all legitimately want a request-derived origin. The explicit setter is the one that should not.

Only follow up if setup should stop pinning the operator's origin as well (`auth.ts:396`), which runs once on a fresh install.

This does not close #478. Whether workspace-global config should require platform admin instead of org admin, across all seventeen routes at that level, is still your call. This is the half that needs no decision: #712 stopped headers winning on the read path, and this route still let a header write the value that now wins.

## Test plan

- [x] New case in `web-public-url.test.ts`, watched red against the unfixed handler: `Expected: 400, Received: 200`, and a probe run showed it had stored `https://evil.example`.
- [x] `bun run test` across every workspace.
