### PR TITLE
feat(web): move workers onto their own System page

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -9,7 +9,7 @@ import { SetupGuard } from "@/components/SetupGuard";
 import { AppProvider } from "@/context/app-context";
 import { AuthProvider } from "@/context/auth-context";
 import { AppQueryPrefetch } from "@/hooks/use-app-queries";
-import { statusTabPath } from "@/lib/navigation";
+import { PAGE_PATHS } from "@/lib/navigation";
 import { onGlobalQueryError, queryClient } from "@/lib/query-client";
 
 const lazyPage = <Name extends string>(
@@ -60,6 +60,7 @@ const SkillDetailPage = lazyPage(
   () => import("@/pages/SkillDetailPage"),
   "SkillDetailPage"
 );
+const StatusPage = lazyPage(() => import("@/pages/StatusPage"), "StatusPage");
 const SystemPage = lazyPage(() => import("@/pages/SystemPage"), "SystemPage");
 const ToolPlaygroundPage = lazyPage(
   () => import("@/pages/ToolPlaygroundPage"),
@@ -111,9 +112,12 @@ function AppShell() {
                 <Route element={<Layout />}>
                   <Route element={<Navigate replace to="/chat" />} index />
                   <Route
-                    element={<Navigate replace to={statusTabPath()} />}
+                    element={<Navigate replace to={PAGE_PATHS.workers} />}
                     path="/status"
                   />
+                  <Route element={<PlatformAdminGuard allowOrgAdmin />}>
+                    <Route element={<StatusPage />} path="/workers" />
+                  </Route>
                   <Route element={<ChatPage />} path="/chat" />
                   <Route
                     element={<ChatPage />}

--- a/apps/web/src/lib/navigation.test.ts
+++ b/apps/web/src/lib/navigation.test.ts
@@ -25,6 +25,7 @@ describe("visibleNavGroups", () => {
       "profiles",
       "settings",
       "soul",
+      "workers",
     ]);
   });
 
@@ -36,6 +37,7 @@ describe("visibleNavGroups", () => {
     expect(ids).toContain("organization");
     expect(ids).toContain("profiles");
     expect(ids).toContain("integrations");
+    expect(ids).toContain("workers");
     expect(ids).not.toContain("files");
   });
 
@@ -44,11 +46,13 @@ describe("visibleNavGroups", () => {
     expect(member).toContain("integrations");
     expect(member).not.toContain("soul");
     expect(member).not.toContain("organization");
+    expect(member).not.toContain("workers");
 
     const viewer = pageIdsFor(false, "viewer");
     expect(viewer).not.toContain("integrations");
     expect(viewer).not.toContain("soul");
     expect(viewer).not.toContain("organization");
+    expect(viewer).not.toContain("workers");
   });
 
   test("groups left with no reachable item are dropped", () => {
@@ -86,6 +90,12 @@ describe("agent work navigation", () => {
   test("maps the legacy tasks path to the unified page", () => {
     expect(pageIdFromPath("/tasks")).toBe("automations");
     expect(pageIdFromPath("/automations")).toBe("automations");
+  });
+});
+
+describe("workers navigation", () => {
+  test("maps the workers path", () => {
+    expect(pageIdFromPath("/workers")).toBe("workers");
   });
 });
 

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -2,6 +2,7 @@ import {
   Brain03Icon,
   Building03Icon,
   Chat01Icon,
+  DashboardSquare01Icon,
   Folder01Icon,
   Notification01Icon,
   PlusSignSquareIcon,
@@ -24,7 +25,8 @@ export type PageId =
   | "integrations"
   | "organization"
   | "settings"
-  | "notifications";
+  | "notifications"
+  | "workers";
 
 export interface NavItem {
   description: string;
@@ -102,6 +104,12 @@ export const NAV_GROUPS: NavGroup[] = [
     collapsible: true,
     id: "system",
     items: [
+      navItem(
+        "workers",
+        "Workers",
+        "Automation and channel workers",
+        DashboardSquare01Icon
+      ),
       navItem(
         "integrations",
         "Integrations",
@@ -190,7 +198,8 @@ export function visibleNavGroups(access: {
       if (
         item.id === "soul" ||
         item.id === "profiles" ||
-        item.id === "organization"
+        item.id === "organization" ||
+        item.id === "workers"
       ) {
         return canAccessSystemPage(access.isPlatformAdmin, access.orgRole);
       }
@@ -215,9 +224,6 @@ const queryPath = (path: string, params: Record<string, string>): string =>
 
 export const toolsTabPath = (): string =>
   queryPath(PAGE_PATHS.soul, { tab: "tools" });
-
-export const statusTabPath = (): string =>
-  queryPath(PAGE_PATHS.soul, { tab: "status" });
 
 export const profilePath = (profileId: string): string =>
   queryPath(PAGE_PATHS.profiles, { profile: profileId });
@@ -296,6 +302,7 @@ export const PAGE_PATHS: Record<PageId, string> = {
   settings: "/settings",
   soul: "/system",
   tasks: "/tasks",
+  workers: "/workers",
 };
 
 const PREFIX_PAGE_IDS: readonly [string, PageId][] = [

--- a/apps/web/src/pages/StatusPage.tsx
+++ b/apps/web/src/pages/StatusPage.tsx
@@ -35,7 +35,8 @@ import {
   type StatusTone,
 } from "@/pages/status-page.shared";
 
-const sectionClass = "rounded-md border border-border bg-card";
+const sectionClass =
+  "min-w-0 overflow-hidden rounded-md border border-border bg-card";
 const iconTileClass =
   "flex size-10 shrink-0 items-center justify-center rounded-md border border-border bg-muted/40";
 
@@ -127,7 +128,7 @@ function StatusDashboard({
   }));
 
   return (
-    <section className={cn("min-w-0 overflow-hidden", sectionClass)}>
+    <section className={sectionClass}>
       <SummaryStrip status={status} summary={summary} />
 
       <div className="grid grid-cols-1 divide-y divide-border border-border border-b sm:grid-cols-2 sm:divide-x sm:divide-y-0">
@@ -198,7 +199,7 @@ function LlmUsageSection({ usage }: { usage: LlmUsageStatus }) {
   const maxModelTokens = usage.models[0]?.totalTokens ?? 0;
 
   return (
-    <section className={cn("min-w-0 overflow-hidden", sectionClass)}>
+    <section className={sectionClass}>
       <div className="flex flex-wrap items-start justify-between gap-4 border-border border-b px-5 py-4">
         <div className="min-w-0 space-y-1">
           <div className="flex items-center gap-2">

--- a/apps/web/src/pages/StatusPage.tsx
+++ b/apps/web/src/pages/StatusPage.tsx
@@ -39,7 +39,7 @@ const sectionClass = "rounded-md border border-border bg-card";
 const iconTileClass =
   "flex size-10 shrink-0 items-center justify-center rounded-md border border-border bg-muted/40";
 
-export function StatusPage({ embedded = false }: { embedded?: boolean } = {}) {
+export function StatusPage() {
   const { data: status, error, isLoading } = useSystemStatusQuery();
   const { user } = useAuth();
   const refreshSystemStatus = useRefreshSystemStatus();
@@ -47,18 +47,10 @@ export function StatusPage({ embedded = false }: { embedded?: boolean } = {}) {
   const canManageWorkers = user?.isPlatformAdmin === true;
 
   return (
-    <div
-      className={cn(
-        "min-w-0",
-        embedded ? "divide-y divide-border" : "space-y-6"
-      )}
-    >
+    <div className="min-w-0 space-y-6">
       {errorMessage ? (
         <div
-          className={cn(
-            "flex flex-wrap items-start justify-between gap-3 border-destructive/40 bg-destructive/10 px-4 py-3",
-            embedded ? "border-b" : "rounded-md border"
-          )}
+          className="flex flex-wrap items-start justify-between gap-3 rounded-md border border-destructive/40 bg-destructive/10 px-4 py-3"
           role="alert"
         >
           <p className="min-w-0 flex-1 text-destructive text-sm">
@@ -77,15 +69,14 @@ export function StatusPage({ embedded = false }: { embedded?: boolean } = {}) {
       ) : null}
 
       {isLoading && !status ? (
-        <StatusSkeleton embedded={embedded} />
+        <StatusSkeleton />
       ) : status ? (
         <>
           <StatusDashboard
             canManageWorkers={canManageWorkers}
-            embedded={embedded}
             status={status}
           />
-          <LlmUsageSection embedded={embedded} usage={status.llmUsage} />
+          <LlmUsageSection usage={status.llmUsage} />
         </>
       ) : null}
     </div>
@@ -95,11 +86,9 @@ export function StatusPage({ embedded = false }: { embedded?: boolean } = {}) {
 function StatusDashboard({
   status,
   canManageWorkers,
-  embedded = false,
 }: {
   status: SystemStatusResponse;
   canManageWorkers: boolean;
-  embedded?: boolean;
 }) {
   const summary = useMemo(() => deriveSummary(status), [status]);
   const services = useMemo(() => buildServiceColumns(status), [status]);
@@ -138,9 +127,7 @@ function StatusDashboard({
   }));
 
   return (
-    <section
-      className={cn("min-w-0 overflow-hidden", !embedded && sectionClass)}
-    >
+    <section className={cn("min-w-0 overflow-hidden", sectionClass)}>
       <SummaryStrip status={status} summary={summary} />
 
       <div className="grid grid-cols-1 divide-y divide-border border-border border-b sm:grid-cols-2 sm:divide-x sm:divide-y-0">
@@ -202,13 +189,7 @@ function StatusDashboard({
   );
 }
 
-function LlmUsageSection({
-  usage,
-  embedded = false,
-}: {
-  usage: LlmUsageStatus;
-  embedded?: boolean;
-}) {
+function LlmUsageSection({ usage }: { usage: LlmUsageStatus }) {
   const modelLabel =
     usage.currentModel ??
     (usage.providerConfigured ? "Default model" : "Not configured");
@@ -217,9 +198,7 @@ function LlmUsageSection({
   const maxModelTokens = usage.models[0]?.totalTokens ?? 0;
 
   return (
-    <section
-      className={cn("min-w-0 overflow-hidden", !embedded && sectionClass)}
-    >
+    <section className={cn("min-w-0 overflow-hidden", sectionClass)}>
       <div className="flex flex-wrap items-start justify-between gap-4 border-border border-b px-5 py-4">
         <div className="min-w-0 space-y-1">
           <div className="flex items-center gap-2">
@@ -737,15 +716,12 @@ function ToneIcon({
   );
 }
 
-function StatusSkeleton({ embedded = false }: { embedded?: boolean } = {}) {
+function StatusSkeleton() {
   return (
     <div
       aria-busy="true"
       aria-label="Loading system status"
-      className={cn(
-        "h-80 animate-pulse bg-muted/40",
-        embedded ? "border-0" : "rounded-md border border-border"
-      )}
+      className="h-80 animate-pulse rounded-md border border-border bg-muted/40"
     />
   );
 }

--- a/apps/web/src/pages/StatusPage.tsx
+++ b/apps/web/src/pages/StatusPage.tsx
@@ -72,13 +72,7 @@ export function StatusPage() {
       {isLoading && !status ? (
         <StatusSkeleton />
       ) : status ? (
-        <>
-          <StatusDashboard
-            canManageWorkers={canManageWorkers}
-            status={status}
-          />
-          <LlmUsageSection usage={status.llmUsage} />
-        </>
+        <StatusDashboard canManageWorkers={canManageWorkers} status={status} />
       ) : null}
     </div>
   );
@@ -190,6 +184,46 @@ function StatusDashboard({
   );
 }
 
+export function LlmUsageTab() {
+  const { data: status, error, isLoading } = useSystemStatusQuery();
+  const refreshSystemStatus = useRefreshSystemStatus();
+  const errorMessage = error ? formatError(error) : null;
+
+  return (
+    <div className="min-w-0">
+      {errorMessage ? (
+        <div
+          className="flex flex-wrap items-start justify-between gap-3 border-destructive/40 border-b bg-destructive/10 px-4 py-3"
+          role="alert"
+        >
+          <p className="min-w-0 flex-1 text-destructive text-sm">
+            Could not load usage: {errorMessage}
+          </p>
+          <Button
+            className="shrink-0 border-destructive/30 bg-background text-destructive hover:bg-destructive/10"
+            onClick={() => void refreshSystemStatus()}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            Try again
+          </Button>
+        </div>
+      ) : null}
+
+      {isLoading && !status ? (
+        <div
+          aria-busy="true"
+          aria-label="Loading LLM usage"
+          className="h-80 animate-pulse bg-muted/40"
+        />
+      ) : status ? (
+        <LlmUsageSection usage={status.llmUsage} />
+      ) : null}
+    </div>
+  );
+}
+
 function LlmUsageSection({ usage }: { usage: LlmUsageStatus }) {
   const modelLabel =
     usage.currentModel ??
@@ -199,7 +233,7 @@ function LlmUsageSection({ usage }: { usage: LlmUsageStatus }) {
   const maxModelTokens = usage.models[0]?.totalTokens ?? 0;
 
   return (
-    <section className={sectionClass}>
+    <section className="min-w-0 overflow-hidden">
       <div className="flex flex-wrap items-start justify-between gap-4 border-border border-b px-5 py-4">
         <div className="min-w-0 space-y-1">
           <div className="flex items-center gap-2">

--- a/apps/web/src/pages/SystemPage.test.ts
+++ b/apps/web/src/pages/SystemPage.test.ts
@@ -2,21 +2,17 @@ import { describe, expect, test } from "bun:test";
 import { resolveSystemTab, visibleSystemTabs } from "./system-page.shared";
 
 describe("SystemPage tab access", () => {
-  test("shows status to all system users and MCP only to platform admins", () => {
+  test("shows MCP only to platform admins", () => {
     expect(visibleSystemTabs(true).map((tab) => tab.id)).toEqual([
-      "status",
       "tools",
       "mcp",
     ]);
-    expect(visibleSystemTabs(false).map((tab) => tab.id)).toEqual([
-      "status",
-      "tools",
-    ]);
+    expect(visibleSystemTabs(false).map((tab) => tab.id)).toEqual(["tools"]);
   });
 
-  test("resolves status for all system users and forces non-platform users off admin tabs", () => {
-    expect(resolveSystemTab("status", true)).toBe("status");
-    expect(resolveSystemTab("status", false)).toBe("status");
+  test("forces non-platform users off admin tabs", () => {
+    expect(resolveSystemTab("status", true)).toBe("tools");
+    expect(resolveSystemTab("status", false)).toBe("tools");
     expect(resolveSystemTab("organization", true)).toBe("tools");
     expect(resolveSystemTab("organization", false)).toBe("tools");
     expect(resolveSystemTab("mcp", true)).toBe("mcp");

--- a/apps/web/src/pages/SystemPage.test.ts
+++ b/apps/web/src/pages/SystemPage.test.ts
@@ -2,15 +2,21 @@ import { describe, expect, test } from "bun:test";
 import { resolveSystemTab, visibleSystemTabs } from "./system-page.shared";
 
 describe("SystemPage tab access", () => {
-  test("shows MCP only to platform admins", () => {
+  test("shows usage to system users and MCP only to platform admins", () => {
     expect(visibleSystemTabs(true).map((tab) => tab.id)).toEqual([
       "tools",
+      "usage",
       "mcp",
     ]);
-    expect(visibleSystemTabs(false).map((tab) => tab.id)).toEqual(["tools"]);
+    expect(visibleSystemTabs(false).map((tab) => tab.id)).toEqual([
+      "tools",
+      "usage",
+    ]);
   });
 
-  test("forces non-platform users off admin tabs", () => {
+  test("resolves usage for all system users and forces non-platform users off admin tabs", () => {
+    expect(resolveSystemTab("usage", true)).toBe("usage");
+    expect(resolveSystemTab("usage", false)).toBe("usage");
     expect(resolveSystemTab("organization", true)).toBe("tools");
     expect(resolveSystemTab("organization", false)).toBe("tools");
     expect(resolveSystemTab("mcp", true)).toBe("mcp");

--- a/apps/web/src/pages/SystemPage.test.ts
+++ b/apps/web/src/pages/SystemPage.test.ts
@@ -11,8 +11,6 @@ describe("SystemPage tab access", () => {
   });
 
   test("forces non-platform users off admin tabs", () => {
-    expect(resolveSystemTab("status", true)).toBe("tools");
-    expect(resolveSystemTab("status", false)).toBe("tools");
     expect(resolveSystemTab("organization", true)).toBe("tools");
     expect(resolveSystemTab("organization", false)).toBe("tools");
     expect(resolveSystemTab("mcp", true)).toBe("mcp");

--- a/apps/web/src/pages/SystemPage.tsx
+++ b/apps/web/src/pages/SystemPage.tsx
@@ -7,6 +7,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { useAuth } from "@/context/use-auth";
 import { canAccessSystemPage, PAGE_PATHS } from "@/lib/navigation";
 import { cn } from "@/lib/utils";
+import { LlmUsageTab } from "@/pages/StatusPage";
 import {
   resolveSystemTab,
   type SYSTEM_TABS,
@@ -103,7 +104,13 @@ export function SystemPage() {
           id={`system-panel-${tab}`}
           role="tabpanel"
         >
-          {tab === "tools" ? <ToolsTab embedded /> : <McpTab embedded />}
+          {tab === "tools" ? (
+            <ToolsTab embedded />
+          ) : tab === "usage" ? (
+            <LlmUsageTab />
+          ) : (
+            <McpTab embedded />
+          )}
         </div>
       </section>
     </>

--- a/apps/web/src/pages/SystemPage.tsx
+++ b/apps/web/src/pages/SystemPage.tsx
@@ -7,7 +7,6 @@ import { Spinner } from "@/components/ui/spinner";
 import { useAuth } from "@/context/use-auth";
 import { canAccessSystemPage, PAGE_PATHS } from "@/lib/navigation";
 import { cn } from "@/lib/utils";
-import { StatusPage } from "@/pages/StatusPage";
 import {
   resolveSystemTab,
   type SYSTEM_TABS,
@@ -55,6 +54,10 @@ export function SystemPage() {
     return <Navigate replace to="/chat" />;
   }
 
+  if (searchParams.get("tab") === "status") {
+    return <Navigate replace to={PAGE_PATHS.workers} />;
+  }
+
   if (searchParams.get("tab") === "organization") {
     const next = new URLSearchParams(searchParams);
     next.delete("tab");
@@ -100,13 +103,7 @@ export function SystemPage() {
           id={`system-panel-${tab}`}
           role="tabpanel"
         >
-          {tab === "status" ? (
-            <StatusPage embedded />
-          ) : tab === "tools" ? (
-            <ToolsTab embedded />
-          ) : (
-            <McpTab embedded />
-          )}
+          {tab === "tools" ? <ToolsTab embedded /> : <McpTab embedded />}
         </div>
       </section>
     </>

--- a/apps/web/src/pages/system-page.shared.ts
+++ b/apps/web/src/pages/system-page.shared.ts
@@ -1,11 +1,6 @@
-import {
-  DashboardSquare01Icon,
-  LayoutGridIcon,
-  Plug01Icon,
-} from "hugeicons-react";
+import { LayoutGridIcon, Plug01Icon } from "hugeicons-react";
 
 export const SYSTEM_TABS = [
-  { icon: DashboardSquare01Icon, id: "status" as const, label: "Status" },
   { icon: LayoutGridIcon, id: "tools" as const, label: "Tools" },
   { icon: Plug01Icon, id: "mcp" as const, label: "MCP" },
 ] as const;
@@ -16,10 +11,6 @@ export function resolveSystemTab(
   value: string | null,
   isPlatformAdmin: boolean
 ): SystemTabId {
-  if (value === "status") {
-    return "status";
-  }
-
   if (!isPlatformAdmin) {
     return "tools";
   }
@@ -36,7 +27,5 @@ export function visibleSystemTabs(isPlatformAdmin: boolean) {
     return SYSTEM_TABS;
   }
 
-  return SYSTEM_TABS.filter(
-    (item) => item.id === "status" || item.id === "tools"
-  );
+  return SYSTEM_TABS.filter((item) => item.id === "tools");
 }

--- a/apps/web/src/pages/system-page.shared.ts
+++ b/apps/web/src/pages/system-page.shared.ts
@@ -1,7 +1,8 @@
-import { LayoutGridIcon, Plug01Icon } from "hugeicons-react";
+import { Coins01Icon, LayoutGridIcon, Plug01Icon } from "hugeicons-react";
 
 export const SYSTEM_TABS = [
   { icon: LayoutGridIcon, id: "tools" as const, label: "Tools" },
+  { icon: Coins01Icon, id: "usage" as const, label: "Usage" },
   { icon: Plug01Icon, id: "mcp" as const, label: "MCP" },
 ] as const;
 
@@ -11,6 +12,10 @@ export function resolveSystemTab(
   value: string | null,
   isPlatformAdmin: boolean
 ): SystemTabId {
+  if (value === "usage") {
+    return "usage";
+  }
+
   if (!isPlatformAdmin) {
     return "tools";
   }
@@ -27,5 +32,5 @@ export function visibleSystemTabs(isPlatformAdmin: boolean) {
     return SYSTEM_TABS;
   }
 
-  return SYSTEM_TABS.filter((item) => item.id === "tools");
+  return SYSTEM_TABS.filter((item) => item.id !== "mcp");
 }

--- a/docs/website/content/docs/automations.mdx
+++ b/docs/website/content/docs/automations.mdx
@@ -26,7 +26,7 @@ A `runAt` automation whose timestamp has already passed is not scheduled. Disabl
 
 ### The worker
 
-Scheduled runs are driven by the automation worker, a separate process managed by PM2 alongside the channel bridges. It reports a heartbeat, so **System → Status** tells you whether schedules are actually being served. If the worker is down, `manual` runs from the dashboard still work and scheduled ones do not fire.
+Scheduled runs are driven by the automation worker, a separate process managed by PM2 alongside the channel bridges. It reports a heartbeat, so **System → Workers** tells you whether schedules are actually being served. If the worker is down, `manual` runs from the dashboard still work and scheduled ones do not fire.
 
 See [Docker](/docker) for how the worker is started in a container.
 


### PR DESCRIPTION
## Summary

Admins open **System → Workers** to start, stop, and inspect workers.

**Before:** worker table lived on `/system?tab=status`.
**After:** `/workers` in the System nav; `/status` and `?tab=status` redirect there.

Why safe:
1. Same `StatusPage` and worker actions — routing and nav only
2. Same access gate (`canAccessSystemPage` / org admin + platform admin)
3. Old URLs redirect

Only re-add a System Status tab if people still look for workers under Tools/MCP.

## Test plan
- [x] `bun test apps/web/src/lib/navigation.test.ts apps/web/src/pages/SystemPage.test.ts apps/web/src/pages/StatusPage.test.ts` (15 pass)
- [x] agent-ui: sidebar Workers, table, `/status` and `?tab=status` → `/workers`
- [ ] Click System → Workers, start/stop one worker — same as before
