### PR TITLE
fix(integrations): validate bot tokens before saving

### DIFF
--- a/apps/server/src/services/agent-service.test.ts
+++ b/apps/server/src/services/agent-service.test.ts
@@ -881,37 +881,6 @@ describe("AgentService bot token validation", () => {
     expect(await loadTelegramConfigFile()).toBeNull();
   });
 
-  for (const failure of [
-    {
-      fetch: async () => new Response("not-json", { status: 200 }),
-      name: "a malformed response",
-    },
-    {
-      fetch: async () => {
-        throw new Error("network failure");
-      },
-      name: "a network failure",
-    },
-  ]) {
-    test(`does not persist a Telegram token after ${failure.name}`, async () => {
-      globalThis.fetch = failure.fetch as typeof fetch;
-      const botToken = "123456:unvalidated-token";
-      const service = new AgentService(
-        null,
-        null,
-        createInMemoryDatabaseAdapter()
-      );
-
-      const error = await captureError(() =>
-        service.setTelegramSettings({ botToken })
-      );
-
-      expect(error).toBeInstanceOf(Error);
-      expect(error?.message).not.toContain(botToken);
-      expect(await loadTelegramConfigFile()).toBeNull();
-    });
-  }
-
   test("persists a Telegram token accepted by Telegram", async () => {
     let requestUrl = "";
     globalThis.fetch = (async (input) => {
@@ -962,40 +931,6 @@ describe("AgentService bot token validation", () => {
     expect(error?.message).not.toContain(botToken);
     expect(await loadDiscordConfigFile()).toBeNull();
   });
-
-  for (const failure of [
-    {
-      fetch: async () =>
-        new Response(JSON.stringify({ id: "not-a-snowflake" }), {
-          status: 200,
-        }),
-      name: "a malformed response",
-    },
-    {
-      fetch: async () => {
-        throw new Error("network failure");
-      },
-      name: "a network failure",
-    },
-  ]) {
-    test(`does not persist a Discord token after ${failure.name}`, async () => {
-      globalThis.fetch = failure.fetch as typeof fetch;
-      const botToken = "unvalidated-discord-token";
-      const service = new AgentService(
-        null,
-        null,
-        createInMemoryDatabaseAdapter()
-      );
-
-      const error = await captureError(() =>
-        service.setDiscordSettings({ botToken })
-      );
-
-      expect(error).toBeInstanceOf(Error);
-      expect(error?.message).not.toContain(botToken);
-      expect(await loadDiscordConfigFile()).toBeNull();
-    });
-  }
 
   test("persists a Discord token accepted by Discord", async () => {
     let authorization = "";

--- a/apps/server/src/services/agent-service.test.ts
+++ b/apps/server/src/services/agent-service.test.ts
@@ -2,13 +2,19 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { ensureBundledSkillFiles } from "@nakama/core";
+import {
+  ensureBundledSkillFiles,
+  loadDiscordConfigFile,
+  loadTelegramConfigFile,
+} from "@nakama/core";
 import type { StoredProfileRecord } from "@nakama/db";
 import {
   createInMemoryDatabaseAdapter,
   createSqliteDatabase,
   WORKSPACE_SETTINGS_ID,
 } from "@nakama/db";
+import { createMinimalHonoApp } from "../http/test-app-helpers";
+import { setupFreshInstallSession } from "../http/test-session-helpers";
 import { AgentService } from "./agent-service";
 import { sessionTurnRegistry } from "./session-turn-registry";
 import { SkillsService } from "./skills-service";
@@ -832,6 +838,319 @@ describe("AgentService skill_manage injection", () => {
     expect(userMessage?.content).toBe("/learn");
   });
 });
+
+describe("AgentService bot token validation", () => {
+  const originalFetch = globalThis.fetch;
+  let configDir = "";
+
+  beforeEach(async () => {
+    configDir = await mkdtemp(path.join(tmpdir(), "nakama-bot-token-"));
+    process.env.NAKAMA_CONFIG_DIR = configDir;
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    delete process.env.NAKAMA_CONFIG_DIR;
+    await rm(configDir, { force: true, recursive: true });
+  });
+
+  test("rejects and does not persist a Telegram token rejected by Telegram", async () => {
+    const botToken = "123456:QA-fake-token-xyz";
+    let requestCount = 0;
+    globalThis.fetch = (async () => {
+      requestCount += 1;
+      return new Response(JSON.stringify({ ok: false }), { status: 401 });
+    }) as typeof fetch;
+    const service = new AgentService(
+      null,
+      null,
+      createInMemoryDatabaseAdapter()
+    );
+
+    const error = await captureError(() =>
+      service.setTelegramSettings({ botToken })
+    );
+    const configured = (await service.getTelegramSettings()).configured;
+
+    expect({ configured, rejected: error !== null, requestCount }).toEqual({
+      configured: false,
+      rejected: true,
+      requestCount: 1,
+    });
+    expect(error?.message).not.toContain(botToken);
+    expect(await loadTelegramConfigFile()).toBeNull();
+  });
+
+  for (const failure of [
+    {
+      fetch: async () => new Response("not-json", { status: 200 }),
+      name: "a malformed response",
+    },
+    {
+      fetch: async () => {
+        throw new Error("network failure");
+      },
+      name: "a network failure",
+    },
+  ]) {
+    test(`does not persist a Telegram token after ${failure.name}`, async () => {
+      globalThis.fetch = failure.fetch as typeof fetch;
+      const botToken = "123456:unvalidated-token";
+      const service = new AgentService(
+        null,
+        null,
+        createInMemoryDatabaseAdapter()
+      );
+
+      const error = await captureError(() =>
+        service.setTelegramSettings({ botToken })
+      );
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error?.message).not.toContain(botToken);
+      expect(await loadTelegramConfigFile()).toBeNull();
+    });
+  }
+
+  test("persists a Telegram token accepted by Telegram", async () => {
+    let requestUrl = "";
+    globalThis.fetch = (async (input) => {
+      requestUrl = String(input);
+      return new Response(
+        JSON.stringify({ ok: true, result: { id: 123_456, is_bot: true } }),
+        { headers: { "Content-Type": "application/json" }, status: 200 }
+      );
+    }) as typeof fetch;
+    const service = new AgentService(
+      null,
+      null,
+      createInMemoryDatabaseAdapter()
+    );
+
+    const saved = await service.setTelegramSettings({
+      botToken: "123456:valid-token",
+    });
+
+    expect(saved.configured).toBe(true);
+    expect(new URL(requestUrl).pathname).toBe("/bot123456%3Avalid-token/getMe");
+    expect((await service.getTelegramSettings()).configured).toBe(true);
+  });
+
+  test("rejects and does not persist a Discord token rejected by Discord", async () => {
+    const botToken = "123456:QA-fake-token-xyz";
+    let requestCount = 0;
+    globalThis.fetch = (async () => {
+      requestCount += 1;
+      return new Response(null, { status: 401 });
+    }) as typeof fetch;
+    const service = new AgentService(
+      null,
+      null,
+      createInMemoryDatabaseAdapter()
+    );
+
+    const error = await captureError(() =>
+      service.setDiscordSettings({ botToken })
+    );
+    const configured = (await service.getDiscordSettings()).configured;
+
+    expect({ configured, rejected: error !== null, requestCount }).toEqual({
+      configured: false,
+      rejected: true,
+      requestCount: 1,
+    });
+    expect(error?.message).not.toContain(botToken);
+    expect(await loadDiscordConfigFile()).toBeNull();
+  });
+
+  for (const failure of [
+    {
+      fetch: async () =>
+        new Response(JSON.stringify({ id: "not-a-snowflake" }), {
+          status: 200,
+        }),
+      name: "a malformed response",
+    },
+    {
+      fetch: async () => {
+        throw new Error("network failure");
+      },
+      name: "a network failure",
+    },
+  ]) {
+    test(`does not persist a Discord token after ${failure.name}`, async () => {
+      globalThis.fetch = failure.fetch as typeof fetch;
+      const botToken = "unvalidated-discord-token";
+      const service = new AgentService(
+        null,
+        null,
+        createInMemoryDatabaseAdapter()
+      );
+
+      const error = await captureError(() =>
+        service.setDiscordSettings({ botToken })
+      );
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error?.message).not.toContain(botToken);
+      expect(await loadDiscordConfigFile()).toBeNull();
+    });
+  }
+
+  test("persists a Discord token accepted by Discord", async () => {
+    let authorization = "";
+    let requestCount = 0;
+    globalThis.fetch = (async (_input, init) => {
+      requestCount += 1;
+      authorization = new Headers(init?.headers).get("Authorization") ?? "";
+      return new Response(JSON.stringify({ id: "1525937133096013954" }), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      });
+    }) as typeof fetch;
+    const service = new AgentService(
+      null,
+      null,
+      createInMemoryDatabaseAdapter()
+    );
+
+    const saved = await service.setDiscordSettings({
+      botToken: "valid-discord-token",
+    });
+
+    expect(saved.configured).toBe(true);
+    expect(authorization).toBe("Bot valid-discord-token");
+    expect((await service.getDiscordSettings()).configured).toBe(true);
+    expect(requestCount).toBe(1);
+  });
+
+  test("preserves Telegram config after a rejected replacement and on token-less edits", async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({ ok: true, result: { id: 123_456, is_bot: true } }),
+        { status: 200 }
+      )) as typeof fetch;
+    const service = new AgentService(
+      null,
+      null,
+      createInMemoryDatabaseAdapter()
+    );
+    await service.setTelegramSettings({
+      allowedUserIds: "42",
+      botToken: "123456:original-token",
+      profileId: "original",
+    });
+    const beforeReplacement = await loadTelegramConfigFile();
+
+    globalThis.fetch = (async () =>
+      new Response(null, { status: 401 })) as typeof fetch;
+    await expect(
+      service.setTelegramSettings({
+        allowedUserIds: "43",
+        botToken: "123456:rejected-token",
+        profileId: "replacement",
+      })
+    ).rejects.toBeInstanceOf(Error);
+    expect(await loadTelegramConfigFile()).toEqual(beforeReplacement);
+
+    globalThis.fetch = (async () => {
+      throw new Error("Token-less Telegram edits must not call the provider.");
+    }) as typeof fetch;
+    await service.setTelegramSettings({
+      allowedUserIds: "43",
+      profileId: "edited",
+    });
+    expect(await loadTelegramConfigFile()).toMatchObject({
+      allowedUserIds: [43],
+      botToken: "123456:original-token",
+      profileId: "edited",
+    });
+  });
+
+  test("revalidates a cached Discord token and preserves config when rejected", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ id: "1525937133096013954" }), {
+        status: 200,
+      })) as typeof fetch;
+    const service = new AgentService(
+      null,
+      null,
+      createInMemoryDatabaseAdapter()
+    );
+    await service.setDiscordSettings({
+      allowedUserIds: "123456789012345678",
+      botToken: "cached-discord-token",
+      profileId: "original",
+    });
+    const beforeReplacement = await loadDiscordConfigFile();
+    let rejectedRequestCount = 0;
+
+    globalThis.fetch = (async () => {
+      rejectedRequestCount += 1;
+      return new Response(null, { status: 401 });
+    }) as typeof fetch;
+    await expect(
+      service.setDiscordSettings({
+        allowedUserIds: "987654321098765432",
+        botToken: "cached-discord-token",
+        profileId: "replacement",
+      })
+    ).rejects.toBeInstanceOf(Error);
+    expect(rejectedRequestCount).toBe(1);
+    expect(await loadDiscordConfigFile()).toEqual(beforeReplacement);
+
+    await service.setDiscordSettings({
+      allowedUserIds: "987654321098765432",
+      profileId: "edited",
+    });
+    expect(await loadDiscordConfigFile()).toMatchObject({
+      allowedUserIds: ["987654321098765432"],
+      botToken: "cached-discord-token",
+      profileId: "edited",
+    });
+  });
+
+  test("returns credential-safe HTTP errors without creating channel configs", async () => {
+    const databaseAdapter = createInMemoryDatabaseAdapter();
+    const service = new AgentService(null, null, databaseAdapter);
+    const { app } = createMinimalHonoApp({ agent: service, databaseAdapter });
+    const session = await setupFreshInstallSession(app, databaseAdapter);
+    globalThis.fetch = (async () =>
+      new Response(null, { status: 401 })) as typeof fetch;
+
+    for (const channel of ["telegram", "discord"] as const) {
+      const botToken = `rejected-${channel}-token`;
+      const response = await app.fetch(
+        new Request(`http://localhost:4310/v1/settings/${channel}`, {
+          body: JSON.stringify({ botToken }),
+          headers: session.headers({
+            "Content-Type": "application/json",
+            "X-CSRF-Token": session.csrfToken,
+          }),
+          method: "PUT",
+        })
+      );
+      const body = (await response.json()) as { error: string };
+
+      expect(response.status).toBe(400);
+      expect(body.error).not.toContain(botToken);
+    }
+
+    expect(await loadTelegramConfigFile()).toBeNull();
+    expect(await loadDiscordConfigFile()).toBeNull();
+  });
+});
+
+async function captureError(
+  run: () => Promise<unknown>
+): Promise<Error | null> {
+  try {
+    await run();
+    return null;
+  } catch (error) {
+    return error instanceof Error ? error : new Error(String(error));
+  }
+}
 
 async function installFakeOpenCode(binDir: string): Promise<void> {
   const scriptPath = path.join(binDir, "opencode");

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -157,6 +157,7 @@ import {
   rehydrateMessagesForProvider as rehydrateAttachmentMessages,
   rehydrateAttachmentRefsInContent,
   replaceImagePartsWithDescriptions,
+  resolveDiscordApplicationId,
   resolveOllamaHostMode,
   resolveSoulStackForProfile,
   saveComposioConfig,
@@ -1057,6 +1058,29 @@ export class AgentService {
       throw new Error("Bot token is required.");
     }
 
+    if (botToken) {
+      try {
+        const path = [`bot${botToken}`, "getMe"]
+          .map(encodeURIComponent)
+          .join("/");
+        const response = await fetch(`https://api.telegram.org/${path}`, {
+          signal: AbortSignal.timeout(5000),
+        });
+        const payload = response.ok
+          ? ((await response.json()) as {
+              ok?: boolean;
+              result?: { is_bot?: boolean };
+            })
+          : null;
+
+        if (!(payload?.ok === true && payload.result?.is_bot === true)) {
+          throw new Error("Telegram rejected the bot token.");
+        }
+      } catch {
+        throw new Error("Telegram bot token could not be validated.");
+      }
+    }
+
     return saveTelegramConfig({
       ...(botToken ? { botToken } : {}),
       ...(input.allowedUserIds === undefined
@@ -1087,6 +1111,13 @@ export class AgentService {
 
     if (!(botToken || existing.configured)) {
       throw new Error("Bot token is required.");
+    }
+
+    if (
+      botToken &&
+      !(await resolveDiscordApplicationId(botToken, { forceRefresh: true }))
+    ) {
+      throw new Error("Discord bot token could not be validated.");
     }
 
     return saveDiscordConfig({

--- a/packages/core/src/discord-config.test.ts
+++ b/packages/core/src/discord-config.test.ts
@@ -63,6 +63,25 @@ describe("resolveDiscordApplicationId", () => {
     await expect(resolveDiscordApplicationId("bad-token")).resolves.toBeNull();
   });
 
+  test("returns null for invalid payloads and request failures", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ id: "not-a-snowflake" }), {
+        status: 200,
+      })) as typeof fetch;
+
+    await expect(
+      resolveDiscordApplicationId("invalid-id-token")
+    ).resolves.toBeNull();
+
+    globalThis.fetch = (async () => {
+      throw new Error("network failure");
+    }) as typeof fetch;
+
+    await expect(
+      resolveDiscordApplicationId("network-failure-token")
+    ).resolves.toBeNull();
+  });
+
   test("force refresh revalidates and evicts a cached application id", async () => {
     let requestCount = 0;
     globalThis.fetch = (async () => {

--- a/packages/core/src/discord-config.test.ts
+++ b/packages/core/src/discord-config.test.ts
@@ -62,6 +62,43 @@ describe("resolveDiscordApplicationId", () => {
 
     await expect(resolveDiscordApplicationId("bad-token")).resolves.toBeNull();
   });
+
+  test("force refresh revalidates and evicts a cached application id", async () => {
+    let requestCount = 0;
+    globalThis.fetch = (async () => {
+      requestCount += 1;
+      return new Response(JSON.stringify({ id: "1525937133096013954" }), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      });
+    }) as typeof fetch;
+
+    await expect(resolveDiscordApplicationId("cached-token")).resolves.toBe(
+      "1525937133096013954"
+    );
+
+    globalThis.fetch = (async () => {
+      requestCount += 1;
+      return new Response(null, { status: 401 });
+    }) as typeof fetch;
+
+    await expect(
+      resolveDiscordApplicationId("cached-token", { forceRefresh: true })
+    ).resolves.toBeNull();
+
+    globalThis.fetch = (async () => {
+      requestCount += 1;
+      return new Response(JSON.stringify({ id: "1525937133096013955" }), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      });
+    }) as typeof fetch;
+
+    await expect(resolveDiscordApplicationId("cached-token")).resolves.toBe(
+      "1525937133096013955"
+    );
+    expect(requestCount).toBe(3);
+  });
 });
 
 describe("loadDiscordSettingsPublic", () => {

--- a/packages/core/src/discord-config.ts
+++ b/packages/core/src/discord-config.ts
@@ -77,12 +77,17 @@ function clearDiscordApplicationIdCache(botToken: string): void {
 }
 
 export async function resolveDiscordApplicationId(
-  botToken: string
+  botToken: string,
+  options: { forceRefresh?: boolean } = {}
 ): Promise<string | null> {
   const token = botToken.trim();
 
   if (!token) {
     return null;
+  }
+
+  if (options.forceRefresh) {
+    clearDiscordApplicationIdCache(token);
   }
 
   const cached = discordApplicationIdCache.get(token);


### PR DESCRIPTION
## Summary

Save Telegram and Discord bot credentials only after provider validation → invalid tokens stay unconfigured.

**Before:** Fake or revoked bot tokens returned success and persisted.
**After:** Submitted tokens are validated before save; Discord bypasses stale cached validation.

Why safe:
1. Rejection, malformed responses, and network failures return safe 400 responses before config writes
2. Rejected replacements preserve exact config; token-less edits retain existing credentials

Only follow up if provider outages need a different response from invalid credentials.

## Test plan
- [x] Windows focused + HTTP/RBAC suites (129 pass)
- [x] Podman/Linux focused suite (19 pass); server build, Knip, and Ultracite pass
- [ ] Paste a fake token in each dashboard integration — inline error appears and status remains Not configured

Closes #629