### PR TITLE
fix(agent): keep tool results when distillToolResult throws

### DIFF
--- a/packages/agent/src/tool-loop.test.ts
+++ b/packages/agent/src/tool-loop.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import type { ToolDefinition } from "@nakama/core";
+import * as core from "@nakama/core";
 import { canRunToolCallsInParallel, executeToolCall } from "./tool-loop";
 
 const sampleTool: ToolDefinition = {
@@ -77,5 +78,29 @@ describe("tool-loop", () => {
     });
 
     expect(result).toEqual({ error: "boom" });
+  });
+
+  test("executeToolCall returns raw result when distillToolResult throws", async () => {
+    const payload = { message: "kept" };
+    const spy = spyOn(core, "distillToolResult").mockImplementation(
+      async () => {
+        throw new Error("omni unavailable");
+      }
+    );
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => undefined);
+
+    try {
+      const result = await executeToolCall([sampleTool], {
+        arguments: payload,
+        id: "call_4",
+        name: "sample",
+      });
+
+      expect(result).toEqual(payload);
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/packages/agent/src/tool-loop.ts
+++ b/packages/agent/src/tool-loop.ts
@@ -1,9 +1,5 @@
-import {
-  distillToolResult,
-  type ToolCall,
-  type ToolContext,
-  type ToolDefinition,
-} from "@nakama/core";
+import type { ToolCall, ToolContext, ToolDefinition } from "@nakama/core";
+import * as core from "@nakama/core";
 
 export function findTool(
   tools: ToolDefinition[],
@@ -41,7 +37,17 @@ export async function executeToolCall(
     // The single place every tool result passes through, so the optimiser is
     // wired once rather than per tool. It returns `result` untouched unless it
     // is enabled, recognises the tool, and produces something strictly shorter.
-    return await distillToolResult(call.name, result, context);
+    try {
+      return await core.distillToolResult(call.name, result, context);
+    } catch (error) {
+      // Distillation is best-effort: never replace a successful tool result with
+      // an optimiser failure (same shape as a tool-runtime error).
+      console.warn(
+        `distillToolResult failed for ${call.name}; returning raw result:`,
+        error instanceof Error ? error.message : error
+      );
+      return result;
+    }
   } catch (error) {
     return {
       error: error instanceof Error ? error.message : String(error),


### PR DESCRIPTION
## Summary

Successful tool runs keep their result even when OMNI distillation throws → the model no longer sees a fake tool `{ error }`.

**Before:** `tool.run` and `distillToolResult` shared one `catch`, so optimiser failures looked like tool failures.
**After:** nested catch returns the raw result and `console.warn`s (`executeToolCall` in `packages/agent/src/tool-loop.ts`).

Why safe:
1. Distillation is already fail-open inside OMNI; this only covers unexpected throws
2. Tool-runtime failures still return `{ error: message }` unchanged
3. Covered by a spy-based unit test that forces `distillToolResult` to throw

Only re-add collapsing into `{ error }` if operators need distillation outages to abort the turn.

## Test plan
- [x] `bun test packages/agent/src/tool-loop.test.ts` (4 pass)
- [x] Forced distill throw via spy — `executeToolCall` returns raw payload, warns, does not `{ error }`

Closes #595
