### PR TITLE
fix(web): stop pushing webPublicUrl on Setup Wizard mount

### DIFF
--- a/apps/web/src/components/setup-wizard/SetupWizard.tsx
+++ b/apps/web/src/components/setup-wizard/SetupWizard.tsx
@@ -11,7 +11,6 @@ import type {
   SetupWizardProps,
 } from "@/components/setup-wizard/setup-wizard.shared";
 import { useAppContext } from "@/context/use-app-context";
-import { client } from "@/lib/client";
 import { pathForPage } from "@/lib/navigation";
 
 export function SetupWizard({ onComplete }: SetupWizardProps) {
@@ -23,16 +22,6 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
   const [accountDraft, setAccountDraft] = useState<SetupAccountDraft | null>(
     null
   );
-
-  useEffect(() => {
-    if (typeof window === "undefined" || !window.location?.origin) {
-      return;
-    }
-
-    void client.updateWebPublicUrl(window.location.origin).catch(() => {
-      // Fresh install persists during POST /v1/auth/setup instead.
-    });
-  }, []);
 
   useEffect(() => {
     if (!userAlreadyConfigured && currentStep === 2 && !accountDraft) {


### PR DESCRIPTION
## Summary

Setup Wizard remounts no longer PUT `webPublicUrl` from a mount `useEffect` → public URL is set only during auth setup.

**Before:** every `SetupWizard` mount called `client.updateWebPublicUrl(origin)` (Strict Mode = twice).
**After:** effect removed; `auth-context` `setup()` still sends `webPublicUrl` on `POST /v1/auth/setup`.

Why safe:
1. Fresh install path already persists URL in `setup()` from `window.location.origin`
2. Settings / system UI remains the place to change URL later
3. No other call site depended on the mount side effect

Only re-add a one-shot bootstrap if installs without going through `setup()` need an origin pin.

## Test plan
- [x] Diff review: mount effect + unused `client` import gone from `SetupWizard.tsx`
- [x] Code path check: `SetupStepOrganization` → `setup()` → `auth-context` injects `webPublicUrl` from `window.location.origin`

Closes #578
