### PR TITLE
fix(platform): clear worker heartbeats on startup failure

### DIFF
--- a/apps/platform/discord/src/index.ts
+++ b/apps/platform/discord/src/index.ts
@@ -149,7 +149,13 @@ try {
     clearInterval(heartbeatTimer);
     heartbeatTimer = null;
   }
-  void clearDiscordWorkerHeartbeat();
+  try {
+    await clientStop?.();
+  } catch {
+    // Destroy best-effort on fatal path.
+  }
+  // Await before exit — void + process.exit can leave a stale heartbeat file.
+  await clearDiscordWorkerHeartbeat();
   stopSpawnedServer(spawnedChild);
   process.exit(1);
 }

--- a/apps/platform/discord/src/index.ts
+++ b/apps/platform/discord/src/index.ts
@@ -125,6 +125,7 @@ try {
   );
   console.log(`Bot: ${discord.user.tag}`);
 
+  // Assign before heartbeat so failure paths can always destroy the client.
   clientStop = async () => {
     await discord.destroy();
   };
@@ -144,6 +145,11 @@ try {
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error);
   console.error(message);
+  if (heartbeatTimer) {
+    clearInterval(heartbeatTimer);
+    heartbeatTimer = null;
+  }
+  void clearDiscordWorkerHeartbeat();
   stopSpawnedServer(spawnedChild);
   process.exit(1);
 }

--- a/apps/platform/telegram/src/index.ts
+++ b/apps/platform/telegram/src/index.ts
@@ -140,7 +140,9 @@ try {
     heartbeatTimer = null;
   }
   botStop?.();
-  void clearTelegramWorkerHeartbeat();
+  // Await before exit — void + process.exit can leave a stale heartbeat file.
+  await clearTelegramWorkerHeartbeat();
+  stopSpawnedServer(spawnedChild);
   process.exit(1);
 } finally {
   stopSpawnedServer(spawnedChild);

--- a/apps/platform/telegram/src/index.ts
+++ b/apps/platform/telegram/src/index.ts
@@ -119,6 +119,7 @@ try {
     `Paired users: ${paired} · Pending handshake: ${pendingHandshake}`
   );
 
+  // Assign before start/heartbeat so failure paths can always stop the bot.
   botStop = () => bot.stop();
 
   await writeTelegramWorkerHeartbeat();
@@ -134,6 +135,12 @@ try {
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error);
   console.error(message);
+  if (heartbeatTimer) {
+    clearInterval(heartbeatTimer);
+    heartbeatTimer = null;
+  }
+  botStop?.();
+  void clearTelegramWorkerHeartbeat();
   process.exit(1);
 } finally {
   stopSpawnedServer(spawnedChild);

--- a/apps/platform/whatsapp/src/index.ts
+++ b/apps/platform/whatsapp/src/index.ts
@@ -175,8 +175,14 @@ try {
     heartbeatTimer = null;
   }
   outboundServer?.stop();
-  void clearWhatsAppWorkerHeartbeat();
-  void clearWhatsAppQrCode();
+  try {
+    await socketHandle?.stop();
+  } catch {
+    // Socket stop best-effort on fatal path.
+  }
+  // Await before exit — void + process.exit can leave a stale heartbeat/QR file.
+  await clearWhatsAppWorkerHeartbeat();
+  await clearWhatsAppQrCode();
   stopSpawnedServer(spawnedChild);
   process.exit(1);
 }

--- a/apps/platform/whatsapp/src/index.ts
+++ b/apps/platform/whatsapp/src/index.ts
@@ -170,6 +170,13 @@ try {
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error);
   console.error(message);
+  if (heartbeatTimer) {
+    clearInterval(heartbeatTimer);
+    heartbeatTimer = null;
+  }
+  outboundServer?.stop();
+  void clearWhatsAppWorkerHeartbeat();
+  void clearWhatsAppQrCode();
   stopSpawnedServer(spawnedChild);
   process.exit(1);
 }


### PR DESCRIPTION
## Summary

Worker startup failure clears the heartbeat interval and awaits heartbeat-file removal before exit → no latent timer / stale “alive” marker blocking the next start.

**Before:** Telegram/Discord/WhatsApp catch paths exited without clearing the timer (and used `void clear*` + `process.exit`, which could race the async delete).
**After:** catch clears the timer, stops the client/socket when present, awaits heartbeat (and WhatsApp QR) clear, then exits.

Why safe:
1. Signal cleanup handlers already cleared timers on SIGINT/TERM; this mirrors that on throw
2. Awaiting clear before exit matches the file-delete contract (`store.clear` is async)
3. Success path unchanged (long-running start still owns the interval)

Only revisit if a worker should stay up after a partial start and keep heartbeating.

## Test plan
- [x] Diff review across three workers’ catch paths (timer + await clear + client/socket stop)
- [x] `bun test packages/core/src/{worker-heartbeat,telegram-worker,discord-worker}.test.ts` (12 pass)
- [x] `bun build` of telegram/discord/whatsapp `index.ts` entrypoints succeeds

Closes #557
