### PR TITLE
fix(web): stop echoing invalid session timestamps in the UI

### DIFF
--- a/apps/web/src/lib/chat-history.test.ts
+++ b/apps/web/src/lib/chat-history.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import type { ChatMessage, SessionMessageMeta } from "@nakama/core/contract";
 import { extractTurnArtifacts } from "./chat-artifacts";
-import { chatMessagesToListItems } from "./chat-history";
+import {
+  chatMessagesToListItems,
+  formatSessionRelativeTime,
+  formatSessionTimestamp,
+} from "./chat-history";
 
 const tinyPngBase64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
@@ -413,5 +417,21 @@ describe("chatMessagesToListItems", () => {
     const items = chatMessagesToListItems(messages);
 
     expect(items.filter((item) => item.tool === "web_search")).toHaveLength(0);
+  });
+});
+
+describe("formatSessionTimestamp", () => {
+  test("formats a valid ISO timestamp", () => {
+    const formatted = formatSessionTimestamp("2026-06-14T10:00:00.000Z");
+    expect(formatted).not.toBe("Unknown time");
+    expect(formatted.length).toBeGreaterThan(0);
+  });
+
+  test("does not echo invalid or attacker-controlled date strings", () => {
+    expect(formatSessionTimestamp("not-a-date")).toBe("Unknown time");
+    expect(formatSessionTimestamp("<img src=x onerror=alert(1)>")).toBe(
+      "Unknown time"
+    );
+    expect(formatSessionRelativeTime("totally-bogus")).toBe("Unknown time");
   });
 });

--- a/apps/web/src/lib/chat-history.ts
+++ b/apps/web/src/lib/chat-history.ts
@@ -550,7 +550,8 @@ export function formatSessionTimestamp(value: string): string {
   const date = new Date(value);
 
   if (Number.isNaN(date.getTime())) {
-    return value;
+    // Never echo unparsed input into the UI (session startedAt is API-controlled).
+    return "Unknown time";
   }
 
   return date.toLocaleString(undefined, {
@@ -573,7 +574,7 @@ function formatRelativeTime(value: string, tense: "past" | "future"): string {
   const date = new Date(value);
 
   if (Number.isNaN(date.getTime())) {
-    return value;
+    return "Unknown time";
   }
 
   const deltaMs =


### PR DESCRIPTION
## Summary

Invalid session timestamps render a fixed `Unknown time` label → API-controlled junk strings no longer appear in chat/history UI.

**Before:** `formatSessionTimestamp` / relative helpers returned the raw `value` when `Date` was invalid.
**After:** both paths return `Unknown time` (`apps/web/src/lib/chat-history.ts`).

Why safe:
1. React already escaped text; this removes the inconsistent attacker-echo path
2. Valid ISO timestamps still use `toLocaleString` / relative formatting
3. Unit tests cover valid + malicious invalid inputs (including relative helper)

Only add a debug tooltip with the raw value if operators need to inspect corrupt `startedAt` fields in-product.

## Test plan
- [x] `bun test apps/web/src/lib/chat-history.test.ts` (11 pass)
- [x] Invalid / XSS-like strings assert `Unknown time` for absolute + relative formatters (covers history sidebar label path)

Closes #585
