### PR TITLE
fix(web): confirm LLM provider remove in-app

### DIFF
--- a/apps/web/src/components/settings/provider-instance-card.tsx
+++ b/apps/web/src/components/settings/provider-instance-card.tsx
@@ -18,6 +18,7 @@ import { ShortlistBrowseProviderModelFields } from "@/components/ShortlistBrowse
 import {
   ProviderCompatibleEditDialog,
   ProviderManageModelsDialog,
+  ProviderRemoveDialog,
   ProviderReplaceKeyDialog,
 } from "@/components/settings/provider-instance-dialogs";
 import { useProviderInstanceCard } from "@/components/settings/use-provider-instance-card";
@@ -89,7 +90,6 @@ export function ProviderInstanceCard({
   const card = useProviderInstanceCard({
     catalog,
     instance,
-    isSole,
     onDelete,
     onError,
     onUpdate,
@@ -153,13 +153,22 @@ export function ProviderInstanceCard({
               destructive
               disabled={card.busy}
               label="Remove"
-              onClick={() => void card.handleDelete()}
+              onClick={() => card.setDeleteOpen(true)}
             >
               <Delete02Icon className="size-3.5" />
             </ProviderActionButton>
           </div>
         </td>
       </tr>
+
+      <ProviderRemoveDialog
+        busy={card.busy}
+        instance={instance}
+        isSole={isSole}
+        onConfirm={() => void card.handleDelete()}
+        onOpenChange={card.setDeleteOpen}
+        open={card.deleteOpen}
+      />
 
       <ProviderReplaceKeyDialog
         apiKey={card.apiKey}

--- a/apps/web/src/components/settings/provider-instance-card.tsx
+++ b/apps/web/src/components/settings/provider-instance-card.tsx
@@ -163,8 +163,8 @@ export function ProviderInstanceCard({
 
       <ProviderRemoveDialog
         busy={card.busy}
-        instance={instance}
         isSole={isSole}
+        label={instance.label}
         onConfirm={() => void card.handleDelete()}
         onOpenChange={card.setDeleteOpen}
         open={card.deleteOpen}

--- a/apps/web/src/components/settings/provider-instance-dialogs.tsx
+++ b/apps/web/src/components/settings/provider-instance-dialogs.tsx
@@ -228,6 +228,65 @@ export function ProviderCompatibleEditDialog({
   );
 }
 
+export function ProviderRemoveDialog({
+  open,
+  instance,
+  isSole,
+  busy,
+  onOpenChange,
+  onConfirm,
+}: {
+  open: boolean;
+  instance: ProviderInstanceSummary;
+  isSole: boolean;
+  busy: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <Dialog
+      onOpenChange={(nextOpen) => {
+        if (!(nextOpen || busy)) {
+          onOpenChange(false);
+        }
+      }}
+      open={open}
+    >
+      <DialogContent className="gap-6 p-6 sm:max-w-md">
+        <DialogHeader className="gap-3">
+          <DialogTitle className="text-balance">Remove provider?</DialogTitle>
+          <DialogDescription className="text-pretty">
+            {isSole ? "This is your only LLM provider. " : null}
+            Models using{" "}
+            <span className="font-medium text-foreground">
+              {instance.label}
+            </span>{" "}
+            will stop working. This cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="mx-0 mb-0 gap-2 border-0 bg-transparent p-0 sm:flex-row sm:justify-end">
+          <Button
+            disabled={busy}
+            onClick={() => onOpenChange(false)}
+            type="button"
+            variant="outline"
+          >
+            Cancel
+          </Button>
+          <Button
+            disabled={busy}
+            onClick={onConfirm}
+            type="button"
+            variant="destructive"
+          >
+            {busy ? <Spinner className="size-4" /> : "Remove"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 export function ProviderManageModelsDialog({
   open,
   busy,

--- a/apps/web/src/components/settings/provider-instance-dialogs.tsx
+++ b/apps/web/src/components/settings/provider-instance-dialogs.tsx
@@ -230,14 +230,14 @@ export function ProviderCompatibleEditDialog({
 
 export function ProviderRemoveDialog({
   open,
-  instance,
+  label,
   isSole,
   busy,
   onOpenChange,
   onConfirm,
 }: {
   open: boolean;
-  instance: ProviderInstanceSummary;
+  label: string;
   isSole: boolean;
   busy: boolean;
   onOpenChange: (open: boolean) => void;
@@ -252,19 +252,15 @@ export function ProviderRemoveDialog({
       }}
       open={open}
     >
-      <DialogContent className="gap-6 p-6 sm:max-w-md">
-        <DialogHeader className="gap-3">
-          <DialogTitle className="text-balance">Remove provider?</DialogTitle>
-          <DialogDescription className="text-pretty">
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Remove provider?</DialogTitle>
+          <DialogDescription>
             {isSole ? "This is your only LLM provider. " : null}
-            Models using{" "}
-            <span className="font-medium text-foreground">
-              {instance.label}
-            </span>{" "}
-            will stop working. This cannot be undone.
+            Models using {label} will stop working. This cannot be undone.
           </DialogDescription>
         </DialogHeader>
-        <DialogFooter className="mx-0 mb-0 gap-2 border-0 bg-transparent p-0 sm:flex-row sm:justify-end">
+        <DialogFooter>
           <Button
             disabled={busy}
             onClick={() => onOpenChange(false)}

--- a/apps/web/src/components/settings/use-provider-instance-card.ts
+++ b/apps/web/src/components/settings/use-provider-instance-card.ts
@@ -36,7 +36,6 @@ export function useProviderInstanceCard({
   onUpdate,
   onDelete,
   onError,
-  isSole = false,
 }: {
   instance: ProviderInstanceSummary;
   catalog: ProviderModelOption[];
@@ -46,11 +45,11 @@ export function useProviderInstanceCard({
   ) => Promise<void>;
   onDelete: (providerId: string) => Promise<void>;
   onError: (error: string | null) => void;
-  isSole?: boolean;
 }) {
   const [replaceKeyOpen, setReplaceKeyOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
   const [manageOpen, setManageOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
   const [busy, setBusy] = useState(false);
   const [dialogError, setDialogError] = useState<string | null>(null);
   const [apiKey, setApiKey] = useState("");
@@ -162,19 +161,12 @@ export function useProviderInstanceCard({
   };
 
   const handleDelete = async () => {
-    if (
-      !window.confirm(
-        `${isSole ? "This is your only/default LLM provider. " : ""}Remove ${instance.label} (${instance.type})? Models using this provider will stop working. This cannot be undone.`
-      )
-    ) {
-      return;
-    }
-
     setBusy(true);
     onError(null);
 
     try {
       await onDelete(instance.id);
+      setDeleteOpen(false);
     } catch (error) {
       onError(formatError(error));
     } finally {
@@ -245,6 +237,7 @@ export function useProviderInstanceCard({
     apiKey,
     busy,
     catalogModelsForType,
+    deleteOpen,
     dialogError,
     editBaseUrl,
     editLabel,
@@ -268,6 +261,7 @@ export function useProviderInstanceCard({
     saveCompatible,
     saveManageModels,
     setApiKey,
+    setDeleteOpen,
     setEditBaseUrl,
     setEditLabel,
     setEditOpen,


### PR DESCRIPTION
## Summary

Settings → Remove on an LLM provider opens an in-app dialog, then deletes only after you click Remove.

**Before:** `window.confirm` in `handleDelete`.
**After:** `ProviderRemoveDialog` (same Dialog pattern as profile/chat deletes).

Why safe:
1. `onDelete` still runs only after the destructive button
2. Overlay/Cancel cannot close the dialog while the request is in flight
3. Failed delete leaves the dialog open so you can retry

Only revisit if a failed delete should dismiss the dialog instead of staying open.

## Test plan
- [x] `bun x ultracite check` on the 3 files (clean)
- [x] agent-browser on seeded Settings: Remove → "Remove provider?"; Cancel leaves the Ollama row
- [ ] Settings → trash on a provider → dialog, not a browser confirm; Cancel leaves the row
