### PR TITLE
fix(server): force kill trapped bash processes

### DIFF
--- a/apps/server/src/tools/bash.test.ts
+++ b/apps/server/src/tools/bash.test.ts
@@ -15,6 +15,30 @@ import path from "node:path";
 import { PathGuardError } from "@nakama/core";
 import { runBash } from "./bash";
 
+async function waitForPositivePid(pidPath: string): Promise<number> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    try {
+      const pid = Number((await readFile(pidPath, "utf8")).trim());
+      if (Number.isInteger(pid) && pid > 0) {
+        return pid;
+      }
+    } catch {
+      // The shell has not created the PID file yet.
+    }
+    await Bun.sleep(10);
+  }
+  return 0;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 describe("bash tool", () => {
   let workspaceRoot = "";
 
@@ -44,9 +68,78 @@ describe("bash tool", () => {
 
     setTimeout(() => controller.abort(), 50);
 
-    await expect(pending).rejects.toThrow();
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
     expect(Date.now() - startedAt).toBeLessThan(5000);
   });
+
+  test("force kills a shell that traps SIGTERM after cancellation", async () => {
+    workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "nakama-bash-"));
+    const pidPath = path.join(workspaceRoot, "trapped.pid");
+    const controller = new AbortController();
+    const pending = runBash(
+      {
+        command:
+          "trap '' TERM; echo $$ > trapped.pid; while :; do sleep 1; done",
+      },
+      {
+        orgId: "org_test",
+        profileId: "profile_test",
+        signal: controller.signal,
+      },
+      { workspaceRoot }
+    );
+
+    const childPid = await waitForPositivePid(pidPath);
+
+    controller.abort();
+    await expect(pending).rejects.toThrow();
+    expect(childPid).toBeGreaterThan(0);
+
+    let survivedAbort = true;
+    const forceKillDeadline = Date.now() + 6500;
+    while (Date.now() < forceKillDeadline) {
+      if (!isProcessAlive(childPid)) {
+        survivedAbort = false;
+        break;
+      }
+      await Bun.sleep(25);
+    }
+
+    if (survivedAbort) {
+      process.kill(childPid, "SIGKILL");
+    }
+    expect(survivedAbort).toBe(false);
+  }, 10_000);
+
+  test("force kills a shell that traps SIGTERM after timeout", async () => {
+    workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "nakama-bash-"));
+    const pidPath = path.join(workspaceRoot, "trapped.pid");
+    const pending = runBash(
+      {
+        command:
+          "trap '' TERM; echo $$ > trapped.pid; while :; do sleep 1; done",
+        timeoutMs: 1000,
+      },
+      { orgId: "org_test", profileId: "profile_test" },
+      { workspaceRoot }
+    );
+
+    const childPid = await waitForPositivePid(pidPath);
+    const result = await Promise.race([
+      pending,
+      Bun.sleep(7500).then(() => null),
+    ]);
+
+    if (result === null && childPid > 0) {
+      process.kill(childPid, "SIGKILL");
+      await pending;
+    }
+
+    expect(childPid).toBeGreaterThan(0);
+    expect(result).not.toBeNull();
+    expect(result?.timedOut).toBe(true);
+    expect(isProcessAlive(childPid)).toBe(false);
+  }, 10_000);
 
   test("runs commands in the profile workspace by default", async () => {
     workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "nakama-bash-"));

--- a/apps/server/src/tools/bash.test.ts
+++ b/apps/server/src/tools/bash.test.ts
@@ -111,36 +111,6 @@ describe("bash tool", () => {
     expect(survivedAbort).toBe(false);
   }, 10_000);
 
-  test("force kills a shell that traps SIGTERM after timeout", async () => {
-    workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "nakama-bash-"));
-    const pidPath = path.join(workspaceRoot, "trapped.pid");
-    const pending = runBash(
-      {
-        command:
-          "trap '' TERM; echo $$ > trapped.pid; while :; do sleep 1; done",
-        timeoutMs: 1000,
-      },
-      { orgId: "org_test", profileId: "profile_test" },
-      { workspaceRoot }
-    );
-
-    const childPid = await waitForPositivePid(pidPath);
-    const result = await Promise.race([
-      pending,
-      Bun.sleep(7500).then(() => null),
-    ]);
-
-    if (result === null && childPid > 0) {
-      process.kill(childPid, "SIGKILL");
-      await pending;
-    }
-
-    expect(childPid).toBeGreaterThan(0);
-    expect(result).not.toBeNull();
-    expect(result?.timedOut).toBe(true);
-    expect(isProcessAlive(childPid)).toBe(false);
-  }, 10_000);
-
   test("runs commands in the profile workspace by default", async () => {
     workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "nakama-bash-"));
 

--- a/apps/server/src/tools/bash.ts
+++ b/apps/server/src/tools/bash.ts
@@ -23,6 +23,7 @@ import {
 const DEFAULT_TIMEOUT_MS = 30_000;
 const MAX_TIMEOUT_MS = 30 * 60_000;
 const MAX_OUTPUT_CHARS = 32_000;
+const SIGKILL_GRACE_MS = 5000;
 /** In-memory capture for coding-agent runs before summarize / keep-tail. */
 const CODING_AGENT_MAX_CAPTURE_CHARS = 5_000_000;
 /** Keep the newest N coding-agent logs; prune the rest after each write. */
@@ -146,9 +147,6 @@ function runShellCommand(
     const child = spawn("/bin/bash", ["-lc", command], {
       cwd,
       env: mergeCodingAgentSpawnEnv(process.env, envOverrides),
-      // SIGTERMs the shell when the turn is cancelled, so a stopped chat does not
-      // leave an ffmpeg or coding-agent run holding the session turn open.
-      signal: options.signal,
       stdio: ["ignore", "pipe", "pipe"],
     });
 
@@ -157,10 +155,44 @@ function runShellCommand(
     let timedOut = false;
     let stdoutOverflow = false;
     let stderrOverflow = false;
+    let killTimeoutId: ReturnType<typeof setTimeout> | null = null;
+    let abortHandled = false;
+
+    const scheduleForcedKill = () => {
+      if (killTimeoutId) {
+        return;
+      }
+
+      killTimeoutId = setTimeout(() => {
+        killTimeoutId = null;
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // already exited
+        }
+      }, SIGKILL_GRACE_MS);
+      killTimeoutId.unref();
+    };
+
+    const onAbort = () => {
+      if (abortHandled) {
+        return;
+      }
+      abortHandled = true;
+      child.kill("SIGTERM");
+      scheduleForcedKill();
+      reject(new DOMException("The operation was aborted", "AbortError"));
+    };
+
+    options.signal?.addEventListener("abort", onAbort, { once: true });
+    if (options.signal?.aborted) {
+      onAbort();
+    }
 
     const timeoutId = setTimeout(() => {
       timedOut = true;
       child.kill("SIGTERM");
+      scheduleForcedKill();
     }, timeoutMs);
 
     child.stdout?.on("data", (chunk: Buffer | string) => {
@@ -187,11 +219,17 @@ function runShellCommand(
 
     child.on("error", (error) => {
       clearTimeout(timeoutId);
+      options.signal?.removeEventListener("abort", onAbort);
       reject(error);
     });
 
     child.on("close", (exitCode) => {
       clearTimeout(timeoutId);
+      if (killTimeoutId) {
+        clearTimeout(killTimeoutId);
+        killTimeoutId = null;
+      }
+      options.signal?.removeEventListener("abort", onAbort);
 
       void finalizeCodingAgentOutput({
         codingAgentMode: options.codingAgentMode,


### PR DESCRIPTION
## Summary

Cancel a Bash tool run → its direct process exits even when it traps SIGTERM.

**Before:** Abort rejected the turn, but a SIGTERM-trapping shell or agent process could survive indefinitely.
**After:** `runShellCommand` sends SIGTERM, waits five seconds, then escalates to SIGKILL while preserving prompt `AbortError` rejection.

Why safe:
1. The retained child handle owns escalation; `close` clears the kill timer and abort listener
2. The real-shell cancellation regression covers the shared escalation path without a duplicate timeout case

Only follow up with process-group termination if independently forked descendants must be killed too.

Closes #526

## Test plan
- [x] `bun test apps/server/src/tools/bash.test.ts` in Podman (12 pass)
- [x] Server build, Ultracite, and Knip in Podman
- [ ] Cancel a real coding-agent CLI run that traps SIGTERM — the direct process exits after the grace period