### PR TITLE
fix(db): run each migration step in its own transaction

### DIFF
--- a/packages/db/src/migrate.test.ts
+++ b/packages/db/src/migrate.test.ts
@@ -324,6 +324,50 @@ describe("coding-delegation skill rename migration", () => {
       db.close();
     }
   });
+
+  test("rolls back the whole merge when one legacy row fails to delete", () => {
+    const db = new Database(":memory:");
+
+    try {
+      migrateDatabase(db);
+
+      db.exec(`
+        INSERT INTO profiles (id, name, system_prompt, model, is_super, created_at, updated_at)
+        VALUES ('super_bot', 'Super Bot', '', NULL, 1, '2026-06-19T00:00:00.000Z', '2026-06-19T00:00:00.000Z');
+
+        INSERT INTO skills (
+          id, name, description, source_path, has_tool,
+          disable_model_invocation, enabled, created_at, updated_at
+        ) VALUES
+          ('skill_legacy_a', 'coding-delegation', 'Legacy A', '/tmp/a/coding-delegation/SKILL.md', 0, 0, 1, '2026-06-19T00:00:00.000Z', '2026-06-19T00:00:00.000Z'),
+          ('skill_legacy_b', 'coding-delegation', 'Legacy B', '/tmp/b/coding-delegation/SKILL.md', 0, 0, 1, '2026-06-19T00:00:00.000Z', '2026-06-19T00:00:00.000Z'),
+          ('skill_canonical', 'coding-agent', 'Coding agent', '/tmp/c/coding-agent/SKILL.md', 0, 0, 1, '2026-06-19T00:00:00.000Z', '2026-06-19T00:00:00.000Z');
+
+        -- The merge deletes legacy rows one at a time, so aborting on the
+        -- second one leaves the first already gone unless the step is atomic.
+        CREATE TRIGGER fail_second_legacy_delete
+        BEFORE DELETE ON skills
+        WHEN OLD.id = 'skill_legacy_b'
+        BEGIN
+          SELECT RAISE(ABORT, 'forced migration failure');
+        END;
+      `);
+
+      expect(() => migrateDatabase(db)).toThrow();
+
+      const remaining = db
+        .prepare(
+          "SELECT id FROM skills WHERE name = 'coding-delegation' ORDER BY id"
+        )
+        .all() as Array<{ id: string }>;
+      expect(remaining).toEqual([
+        { id: "skill_legacy_a" },
+        { id: "skill_legacy_b" },
+      ]);
+    } finally {
+      db.close();
+    }
+  });
 });
 
 describe("install-wide name uniqueness", () => {

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -7,39 +7,49 @@ export function migrateDatabase(db: Database): void {
   const schemaPath = resolveSchemaPath();
   const sql = readFileSync(schemaPath, "utf8");
 
+  // Each step runs in its own transaction so a failure cannot leave one half
+  // applied. They deliberately do not share a single outer transaction: the
+  // schema sets `PRAGMA foreign_keys`, and migrateLegacyProfileIds toggles it
+  // and opens its own BEGIN, both of which SQLite ignores or rejects inside a
+  // transaction. Stopping between steps is safe because every step is
+  // idempotent and this runs on every open.
+  const atomic = (step: (database: Database) => void): void => {
+    db.transaction(() => step(db))();
+  };
+
   db.exec(sql);
-  migrateProfilesTable(db);
-  migrateAutomationsTable(db);
-  migrateTasksTable(db);
-  migrateSessionsTable(db);
-  migrateMcpTables(db);
-  migrateSkillsTables(db);
-  migrateUsersTable(db);
-  migrateOrgTables(db);
-  migrateOrgMemoryProposalsTable(db);
-  migrateSkillProposalsTable(db);
-  migrateSkillSuggestionsTable(db);
-  migrateSkillsWriteApprovalColumns(db);
-  migrateSkillsPostTurnReviewColumns(db);
-  migrateSkillsCuratorColumns(db);
-  migrateSkillsCuratorConsolidateColumns(db);
-  migrateOrganizationArchivedAt(db);
-  migrateSkillUsageTables(db);
-  migrateTenantOrgScope(db);
-  migrateSkillOrgIds(db);
-  migrateProfileOrgColumns(db);
-  migrateBrowserSessionsTable(db);
+  atomic(migrateProfilesTable);
+  atomic(migrateAutomationsTable);
+  atomic(migrateTasksTable);
+  atomic(migrateSessionsTable);
+  atomic(migrateMcpTables);
+  atomic(migrateSkillsTables);
+  atomic(migrateUsersTable);
+  atomic(migrateOrgTables);
+  atomic(migrateOrgMemoryProposalsTable);
+  atomic(migrateSkillProposalsTable);
+  atomic(migrateSkillSuggestionsTable);
+  atomic(migrateSkillsWriteApprovalColumns);
+  atomic(migrateSkillsPostTurnReviewColumns);
+  atomic(migrateSkillsCuratorColumns);
+  atomic(migrateSkillsCuratorConsolidateColumns);
+  atomic(migrateOrganizationArchivedAt);
+  atomic(migrateSkillUsageTables);
+  atomic(migrateTenantOrgScope);
+  atomic(migrateSkillOrgIds);
+  atomic(migrateProfileOrgColumns);
+  atomic(migrateBrowserSessionsTable);
   migrateLegacyProfileIds(db);
-  migrateCodingDelegationSkillName(db);
-  migrateWorkspaceSettingsTable(db);
-  migrateLlmUsageModelStatsTable(db);
-  migrateToolOutputSavingsTable(db);
-  migrateLlmTurnUsageTable(db);
-  migrateAttachmentsTable(db);
-  migrateAutomationRunsTable(db);
-  migrateAutomationRunReadStateTable(db);
-  migrateComposioTables(db);
-  migrateComposioUserConnections(db);
+  atomic(migrateCodingDelegationSkillName);
+  atomic(migrateWorkspaceSettingsTable);
+  atomic(migrateLlmUsageModelStatsTable);
+  atomic(migrateToolOutputSavingsTable);
+  atomic(migrateLlmTurnUsageTable);
+  atomic(migrateAttachmentsTable);
+  atomic(migrateAutomationRunsTable);
+  atomic(migrateAutomationRunReadStateTable);
+  atomic(migrateComposioTables);
+  atomic(migrateComposioUserConnections);
 }
 
 export function resolveSchemaPath(


### PR DESCRIPTION
## Summary

Closes #536. Every migration step now runs inside its own transaction, so a failure cannot leave one half applied.

**Before:** the merge in `migrateCodingDelegationSkillName` deletes legacy skill rows one at a time. Abort on the second and the first is already gone: `skill_legacy_a` deleted, `skill_legacy_b` still there.
**After:** the same abort leaves both rows untouched.

Why safe:
1. `migrateLegacyProfileIds` is deliberately not wrapped. It runs `PRAGMA foreign_keys = OFF` and opens its own `BEGIN`, and both are dead inside a transaction. Measured: `PRAGMA foreign_keys = OFF` inside `db.transaction` leaves the value at `1`, outside it goes to `0`. Its own rollback already covers it.
2. `db.exec(schema.sql)` stays outside for the same reason. Line 1 of the schema is `PRAGMA foreign_keys = ON`.
3. `migrateProfileOrgColumns` already had a transaction. Bun nests through savepoints, and the existing "rolls back profile org backfill" test still passes.
4. Stopping between steps stays safe: every step is idempotent and `migrateDatabase` runs on every open (`adapters/sqlite.ts:430`, `441`, `461`), so an interrupted run finishes on the next boot.

The issue title asks for one transaction around all of it. That is not reachable while point 1 holds, and the Fix line in the issue already asks for the per-step version, which is what this does.

## Test plan

- [x] New case in `migrate.test.ts` using the `RAISE(ABORT)` trigger pattern the neighbouring rollback test already uses. Watched red against the unfixed migrate: expected both legacy rows, received only `skill_legacy_b`.
- [x] `bun test packages/db/src/migrate.test.ts`, 21 pass 0 fail.
- [x] `bun run test` across every workspace.
