### PR TITLE
fix(security): pin the theme bootstrap by hash and trim the password at login

### DIFF
--- a/apps/server/src/http/app.test.ts
+++ b/apps/server/src/http/app.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { loadLocalAuthToken, verifyLocalAuthToken } from "@nakama/core";
 import { createInMemoryDatabaseAdapter } from "@nakama/db";
 import { AuthService } from "../services/auth-service";
@@ -467,6 +467,70 @@ describe("createHonoApp", () => {
     const csp = response.headers.get("Content-Security-Policy") ?? "";
     expect(csp).toContain("img-src 'self' data: blob:");
     expect(csp).toContain("media-src 'self' blob:");
+  });
+
+  test("allows the theme bootstrap by hash instead of every inline script", async () => {
+    const indexHtml = await Bun.file(
+      resolve(import.meta.dir, "../../../web/index.html")
+    ).text();
+    const inlineScript = indexHtml.match(/<script>([\s\S]*?)<\/script>/)?.[1];
+    if (!inlineScript) {
+      throw new Error("apps/web/index.html no longer inlines a script");
+    }
+    const hash = new Bun.CryptoHasher("sha256")
+      .update(inlineScript)
+      .digest("base64");
+
+    const options = createServerOptions();
+    const app = createHonoApp(options);
+    const response = await app.fetch(
+      new Request("http://localhost:4310/v1/profiles", {
+        headers: { Authorization: "Bearer invalid_token" },
+      })
+    );
+
+    const scriptSrc = (response.headers.get("Content-Security-Policy") ?? "")
+      .split(";")
+      .map((directive) => directive.trim())
+      .find((directive) => directive.startsWith("script-src"));
+    expect(scriptSrc).toBe(`script-src 'self' 'sha256-${hash}'`);
+  });
+
+  test("logs in with a password that was set with surrounding whitespace", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "nakama-password-trim-"));
+    process.env.NAKAMA_CONFIG_DIR = configDir;
+
+    try {
+      const options = createServerOptions();
+      const app = createHonoApp(options);
+      await app.fetch(
+        new Request("http://localhost:4310/v1/auth/setup", {
+          body: JSON.stringify(
+            buildSetupAuthBody("padded@example.com", {
+              admin: { password: "  secret123  " },
+            })
+          ),
+          headers: { "Content-Type": "application/json" },
+          method: "POST",
+        })
+      );
+
+      const loginResponse = await app.fetch(
+        new Request("http://localhost:4310/v1/auth/login", {
+          body: JSON.stringify({
+            email: "padded@example.com",
+            password: "  secret123  ",
+          }),
+          headers: { "Content-Type": "application/json" },
+          method: "POST",
+        })
+      );
+
+      expect(loginResponse.status).toBe(200);
+    } finally {
+      delete process.env.NAKAMA_CONFIG_DIR;
+      await rm(configDir, { force: true, recursive: true });
+    }
   });
 
   test("rotates the local auth token from a browser session", async () => {

--- a/apps/server/src/http/app.ts
+++ b/apps/server/src/http/app.ts
@@ -40,6 +40,15 @@ import { registerWorkerRoutes } from "./routes/workers";
 import { errorResponse } from "./shared";
 import type { HonoApp } from "./types";
 
+/**
+ * Hash of the theme bootstrap inlined in `apps/web/index.html`, which has to run
+ * before first paint and so cannot be an external file. Editing that script
+ * changes this value; `app.test.ts` recomputes it from the file and fails when
+ * the two drift, which is the only thing keeping this constant honest.
+ */
+const THEME_BOOTSTRAP_SCRIPT_HASH =
+  "sha256-rQ5OTxagyMHDDSQ6k5wlUK8gtuYxXBrpQGqjAcYBz2w=";
+
 export function createHonoApp(options: ServerOptions) {
   const app: HonoApp = new OpenAPIHono();
 
@@ -71,7 +80,7 @@ export function createHonoApp(options: ServerOptions) {
       }
       headers.set(
         "Content-Security-Policy",
-        "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob:; font-src 'self' data:; connect-src 'self';"
+        `default-src 'self'; script-src 'self' '${THEME_BOOTSTRAP_SCRIPT_HASH}'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob:; font-src 'self' data:; connect-src 'self';`
       );
       // Only enable HSTS if the request is secure (HTTPS)
       if (new URL(c.req.url).protocol === "https:") {

--- a/apps/server/src/http/routes/auth.ts
+++ b/apps/server/src/http/routes/auth.ts
@@ -451,8 +451,10 @@ export function registerAuthRoutes(app: HonoApp, options: ServerOptions): void {
       return errorResponse("Invalid credentials", 401);
     }
 
+    // Every path that sets a password trims it first, so login has to as well
+    // or a padded password can never be typed back in.
     const valid = await authService.verifyPassword(
-      body.password,
+      body.password?.trim() ?? "",
       user.passwordHash
     );
     if (!valid) {


### PR DESCRIPTION
## Summary

Closes #359. Two of the four items in that batch are already fixed on main, so this carries the other two.

**(b) CSP.** `script-src` was `'self' 'unsafe-inline'`, which is no defence at all in an app that renders model output constantly. It now pins the theme bootstrap by `sha256-` hash and drops `'unsafe-inline'`.

**(c) Password trim.** Setup, accept-invite and change-password trim before hashing; login compared raw input, so a password set with surrounding whitespace was rejected for the exact string that created it. Login trims too now.

**Already fixed, not touched here:** (a) `/v1/tools` left `PUBLIC_ROUTES` in #736, so `handlerConfig` is no longer unauthenticated. (d) the worker log clamp already reads `Number.isFinite(parsed) ? parsed : 200`.

## Why the hash is a constant in `app.ts`

The server emits the header at runtime, so the value has to exist in the server process. The test cannot supply it. What the test does instead is recompute the hash from `apps/web/index.html` and compare, so the constant cannot drift silently: edit that script and the test goes red carrying the value to paste in.

Computing it at boot would not remove the constant either. `resolveWebDistDir` returns `null` whenever `apps/web/dist` is absent, which is every dev run and every server-only run, and this CSP goes on every response including API JSON. That design still needs a hardcoded fallback, and buys boot-time file I/O and a new failure mode for it.

The guard has one limit worth naming rather than hiding. The test hashes the source file; the browser hashes `dist/index.html`. They are byte-identical today and this PR checked that, but if Vite ever started transforming inline scripts the two would diverge and the test would stay green. Closing that would mean reading `dist` in the test, and CI runs `bun run test` without building the web app first.

Why safe:
1. Moving the script to an external file needs no hash at all and the repo forbids it: `lint/performance/noSyncScripts` rejects the render-blocking tag a theme bootstrap needs, and `defer` would paint first.
2. `style-src 'unsafe-inline'` is untouched. Only `script-src` was in scope.
3. No account is locked out by the trim. Every path that writes a hash has trimmed since `a41e3bf2`, and change-password already trims the current password, so a padded hash older than that is unusable today either way.

## Test plan

- [x] Two cases in `app.test.ts`, both watched red first. CSP: expected the hash, received `script-src 'self' 'unsafe-inline'`. Login: expected 200, received 401.
- [x] Drift check: edited the inline script and the CSP test went red, expected `sha256-q6gZzN...` against the committed `sha256-rQ5OTx...`.
- [x] `bun run --cwd apps/web build`, then hashed `dist/index.html` and the source: both `sha256-rQ5OTxagyMHDDSQ6k5wlUK8gtuYxXBrpQGqjAcYBz2w=`.
- [x] `bun run test` across every workspace, 0 fail.
- [ ] Not checked in a browser: the script is unchanged and still inline, so first paint behaves as before, but I did not watch it render.
