### PR TITLE
fix(server): settle a timed-out install once the child has actually exited

### DIFF
--- a/apps/server/src/services/cli-package-install.test.ts
+++ b/apps/server/src/services/cli-package-install.test.ts
@@ -17,6 +17,28 @@ const SELF_EXITING_PLAN = {
   displayCommand: "sh -c 'printf partial; exec sleep 1'",
 };
 
+/**
+ * Ignores SIGTERM, so it only dies once the escalation lands. Exits on its own
+ * after a second, which bounds every test that uses it and lets those tests put
+ * an upper bound on the wait: passing late enough to be the self-exit is a
+ * failure, not a pass.
+ */
+const SIGTERM_IGNORING_PLAN = {
+  args: ["-c", "trap '' TERM; printf partial; sleep 1"],
+  command: "sh",
+  displayCommand: "sh -c \"trap '' TERM; printf partial; sleep 1\"",
+};
+
+/**
+ * Exits at once but leaves something holding the stdout pipe, so `close` stays
+ * outstanding long after the process itself is gone.
+ */
+const PIPE_HOLDING_PLAN = {
+  args: ["-c", "sh -c 'sleep 3' & printf 'hi\\n'; exit 0"],
+  command: "sh",
+  displayCommand: "sh -c \"sh -c 'sleep 3' & printf 'hi\\n'; exit 0\"",
+};
+
 describe("runTimedInstallCommand", () => {
   test("gives up on an installer that outlives the timeout", async () => {
     const result = await runTimedInstallCommand(STALLING_PLAN, undefined, {
@@ -67,6 +89,70 @@ describe("runTimedInstallCommand", () => {
       exitCode: 0,
       progress: ["stdout: one", "stdout: two"],
       timedOut: false,
+    });
+  });
+  test("settles only once the timed-out installer has actually exited", async () => {
+    const startedAt = performance.now();
+
+    const result = await runTimedInstallCommand(
+      SIGTERM_IGNORING_PLAN,
+      undefined,
+      {
+        sigtermGraceMs: 200,
+        timeoutMs: 50,
+      }
+    );
+    const elapsedMs = performance.now() - startedAt;
+
+    expect({
+      settledAfterTheEscalation: elapsedMs >= 250,
+      settledBeforeTheSelfExit: elapsedMs < 800,
+      timedOut: result.timedOut,
+    }).toEqual({
+      settledAfterTheEscalation: true,
+      settledBeforeTheSelfExit: true,
+      timedOut: true,
+    });
+  });
+
+  test("gives up waiting when the kill escalation has not landed yet", async () => {
+    const startedAt = performance.now();
+
+    const result = await runTimedInstallCommand(
+      SIGTERM_IGNORING_PLAN,
+      undefined,
+      {
+        settleTimeoutMs: 150,
+        sigtermGraceMs: 10_000,
+        timeoutMs: 50,
+      }
+    );
+    const elapsedMs = performance.now() - startedAt;
+
+    expect({
+      settledAfterTheSettleBound: elapsedMs >= 200,
+      settledBeforeTheSelfExit: elapsedMs < 800,
+      timedOut: result.timedOut,
+    }).toEqual({
+      settledAfterTheSettleBound: true,
+      settledBeforeTheSelfExit: true,
+      timedOut: true,
+    });
+  });
+  test("does not wait out the settle bound for a process that already exited", async () => {
+    const startedAt = performance.now();
+
+    const result = await runTimedInstallCommand(PIPE_HOLDING_PLAN, undefined, {
+      timeoutMs: 200,
+    });
+    const elapsedMs = performance.now() - startedAt;
+
+    expect({
+      settledAtTheDeadline: elapsedMs >= 200 && elapsedMs < 1200,
+      timedOut: result.timedOut,
+    }).toEqual({
+      settledAtTheDeadline: true,
+      timedOut: true,
     });
   });
 });

--- a/apps/server/src/services/cli-package-install.ts
+++ b/apps/server/src/services/cli-package-install.ts
@@ -4,6 +4,13 @@ export const CLI_SIGTERM_GRACE_MS = 2000;
 
 const CLI_INSTALL_TIMEOUT_MS = 120_000;
 
+/**
+ * Upper bound on waiting for a timed-out child to actually exit. The escalation
+ * normally lands long before this; the bound only keeps a caller from waiting
+ * forever on a process no signal can reach.
+ */
+const CLI_SETTLE_TIMEOUT_MS = 5000;
+
 export interface GlobalPackageInstallPlan {
   args: string[];
   command: string;
@@ -136,7 +143,11 @@ export async function probeCliVersion(command: string): Promise<{
 export async function runTimedInstallCommand(
   plan: GlobalPackageInstallPlan,
   onProgress?: (message: string) => void,
-  options: { timeoutMs?: number } = {}
+  options: {
+    settleTimeoutMs?: number;
+    sigtermGraceMs?: number;
+    timeoutMs?: number;
+  } = {}
 ): Promise<{
   exitCode: number | null;
   stdout: string;
@@ -145,6 +156,8 @@ export async function runTimedInstallCommand(
 }> {
   const { spawn } = await import("node:child_process");
   const timeoutMs = options.timeoutMs ?? CLI_INSTALL_TIMEOUT_MS;
+  const sigtermGraceMs = options.sigtermGraceMs ?? CLI_SIGTERM_GRACE_MS;
+  const settleTimeoutMs = options.settleTimeoutMs ?? CLI_SETTLE_TIMEOUT_MS;
 
   return new Promise((resolve) => {
     const child = spawn(plan.command, plan.args, {
@@ -154,23 +167,47 @@ export async function runTimedInstallCommand(
     let stdout = "";
     let stderr = "";
     let timedOut = false;
+    let exited = false;
     let stdoutBuffer = "";
     let stderrBuffer = "";
     let killTimeoutId: ReturnType<typeof setTimeout> | undefined;
+    let settleTimeoutId: ReturnType<typeof setTimeout> | undefined;
 
-    const timeoutId = setTimeout(() => {
-      timedOut = true;
-      child.kill("SIGTERM");
-      killTimeoutId = setTimeout(
-        () => child.kill("SIGKILL"),
-        CLI_SIGTERM_GRACE_MS
-      );
+    const clearTimers = () => {
+      clearTimeout(timeoutId);
+      clearTimeout(killTimeoutId);
+      clearTimeout(settleTimeoutId);
+    };
+
+    /**
+     * Resolving here means the deadline passed, so the exit code is not the
+     * installer's own. Waiting for the child's `exit` first is what makes the
+     * result honest: it is reported once the process is gone, not once the
+     * signal was sent.
+     */
+    const settleAsTimedOut = () => {
+      clearTimers();
       resolve({
         exitCode: null,
         stderr: stderr.trim(),
         stdout: stdout.trim(),
         timedOut,
       });
+    };
+
+    const timeoutId = setTimeout(() => {
+      timedOut = true;
+
+      // The process can already be gone with `close` still outstanding, held by
+      // whatever the installer left running. There is nothing left to wait for.
+      if (exited) {
+        settleAsTimedOut();
+        return;
+      }
+
+      child.kill("SIGTERM");
+      killTimeoutId = setTimeout(() => child.kill("SIGKILL"), sigtermGraceMs);
+      settleTimeoutId = setTimeout(settleAsTimedOut, settleTimeoutMs);
     }, timeoutMs);
 
     const emitLine = (prefix: "stdout" | "stderr", line: string) => {
@@ -216,9 +253,22 @@ export async function runTimedInstallCommand(
       stderrBuffer = flushBuffer(stderrBuffer, "stderr");
     });
 
+    /**
+     * `close` waits for the stdio pipes, which anything the installer left
+     * running can hold open indefinitely, so it is not a usable signal for a
+     * run that has already timed out. `exit` fires when the process itself is
+     * gone, which is the question the timeout path is asking.
+     */
+    child.once("exit", () => {
+      exited = true;
+
+      if (timedOut) {
+        settleAsTimedOut();
+      }
+    });
+
     child.once("error", (error) => {
-      clearTimeout(timeoutId);
-      clearTimeout(killTimeoutId);
+      clearTimers();
 
       if (stdoutBuffer.trim()) {
         emitLine("stdout", stdoutBuffer.trim());
@@ -236,8 +286,7 @@ export async function runTimedInstallCommand(
     });
 
     child.once("close", (exitCode) => {
-      clearTimeout(timeoutId);
-      clearTimeout(killTimeoutId);
+      clearTimers();
 
       if (stdoutBuffer.trim()) {
         emitLine("stdout", stdoutBuffer.trim());


### PR DESCRIPTION
## Summary

A timed-out install reports back once the installer is actually gone, instead of once the signal was sent.

**Before:** `runTimedInstallCommand` resolved inside its own timeout callback, so an installer that ignores SIGTERM was reported as finished while it was still running. Measured at 302 ms against a 300 ms deadline, and still alive 500 ms later.
**After:** the deadline signals, then waits for the child's `exit` before resolving, bounded so no caller can wait forever (`apps/server/src/services/cli-package-install.ts`).

Why safe:
1. The path that finishes in time is untouched. It still resolves on `close`, and paired runs on both trees gave the same exit code, stdout, stderr, and latency in the same single-digit millisecond band.
2. `exit`, not `close`: `close` waits for the stdio pipes, so anything the installer leaves running holds it open. Measured on `2d4f2c07`, a child that exited at 220 ms had no `close` for 6 s, and in two other cases none arrived at all. A process already gone at the deadline settles straight away rather than sitting out the bound.
3. `bun run test` 2761 pass, 0 fail across all 11 workspaces (2758 before, the 3 new tests are the difference); `bun run check` and `bun run knip` clean; the `tsc --noEmit` error set is unchanged against `2d4f2c07`.

Only follow up if installers that no signal can reach turn out to be common. That case leaves through the settle bound with `timedOut` true, which is today's outcome, five seconds later.

Refs #439

## Test plan
- [x] `bun test apps/server/src/services/cli-package-install.test.ts` (6 pass; 10 consecutive runs, no flake)
- [x] `bun run test` (2761 pass, 0 fail)
- [x] The two tests for the new wait fail on `2d4f2c07`, settling at 55 ms on the deadline; the third guards a case `2d4f2c07` already got right
- [ ] Start an agent-browser install, kill the installer's process mid-run, and the SSE stream still ends with one error event and closes once
