### PR TITLE
fix(agent): stop counting a reasoning trace Gemini never replays

### DIFF
--- a/apps/server/src/providers/compaction-thinking-estimate.test.ts
+++ b/apps/server/src/providers/compaction-thinking-estimate.test.ts
@@ -4,7 +4,9 @@ import type { ChatMessage, ProviderClient } from "@nakama/core";
 import {
   compactHistory,
   estimateHistoryTokens,
+  providerReplaysThinking,
 } from "../../../../packages/agent/src/history-compaction";
+import { createGeminiProvider, toGeminiContents } from "./gemini";
 import { createOpenAIProvider, toOpenAIMessages } from "./openai";
 
 const j = (value: unknown) => JSON.stringify(value);
@@ -70,9 +72,10 @@ async function chatCompletionsTurn(): Promise<ChatMessage> {
 describe("history token estimate on the chat-completions path", () => {
   test("does not under-count a turn whose reasoning is replayed", async () => {
     const assistant = await chatCompletionsTurn();
+    const replays = providerReplaysThinking("deepseek");
     const estimated =
-      estimateHistoryTokens([USER, assistant], "", []) -
-      estimateHistoryTokens([USER], "", []);
+      estimateHistoryTokens([USER, assistant], "", [], replays) -
+      estimateHistoryTokens([USER], "", [], replays);
     const sent =
       estimateTokens(j(await toOpenAIMessages("", [USER, assistant]))) -
       estimateTokens(j(await toOpenAIMessages("", [USER])));
@@ -129,5 +132,115 @@ describe("history token estimate on the chat-completions path", () => {
       alreadyOverflowed: true,
       summarizeCalls: 1,
     });
+  });
+});
+
+// The Gemini parser keeps thought parts as message.thinking, but
+// toGeminiAssistantParts never sends them back.
+async function geminiTurn(): Promise<ChatMessage> {
+  const body = JSON.stringify({
+    candidates: [
+      {
+        content: {
+          parts: [{ text: REASONING, thought: true }, { text: "Answer." }],
+          role: "model",
+        },
+        finishReason: "STOP",
+      },
+    ],
+  });
+  const fetchMock = mock(
+    async () =>
+      new Response(body, {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      })
+  );
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+  try {
+    const provider = createGeminiProvider({
+      apiKey: "k",
+      model: "gemini-3-pro",
+    });
+    const result = await provider.generateChat({
+      messages: [USER],
+      system: "",
+    });
+
+    return result.assistantMessage;
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+describe("history token estimate on the Gemini path", () => {
+  test("does not over-count a trace the Gemini mapper drops", async () => {
+    const assistant = await geminiTurn();
+
+    const replays = providerReplaysThinking("gemini");
+    const estimated =
+      estimateHistoryTokens([USER, assistant], "", [], replays) -
+      estimateHistoryTokens([USER], "", [], replays);
+    const sent =
+      estimateTokens(j(await toGeminiContents([USER, assistant]))) -
+      estimateTokens(j(await toGeminiContents([USER])));
+
+    expect({
+      estimated,
+      sent,
+      withinTenPercent: estimated / sent <= 1.1,
+    }).toEqual({
+      estimated,
+      sent,
+      withinTenPercent: true,
+    });
+  });
+
+  // Eight turns is what it takes for the trace alone to push the estimate over
+  // the window: counted, this history reads 945 against a usable 900 and is
+  // summarized; uncounted it reads 105.
+  test("does not summarize a Gemini history on a trace it never sends", async () => {
+    const history: ChatMessage[] = [];
+
+    for (let turn = 0; turn < 8; turn += 1) {
+      history.push({ content: `turn ${turn}`, role: "user" });
+      history.push(await geminiTurn());
+    }
+
+    let summarizeCalls = 0;
+    const provider: ProviderClient = {
+      generateChat() {
+        summarizeCalls += 1;
+        return Promise.resolve({
+          assistantMessage: { content: "summary", role: "assistant" },
+          content: "summary",
+          toolCalls: [],
+        });
+      },
+      generateText() {
+        return Promise.resolve({ content: "summary" });
+      },
+      name: "gemini",
+      streamChat(input, handlers) {
+        handlers.onChunk("summary");
+        return this.generateChat(input);
+      },
+    };
+
+    const sent = estimateTokens(j(await toGeminiContents(history)));
+    const result = await compactHistory({
+      compaction: { contextWindow: 1000, maxOutputTokens: 100 },
+      history,
+      provider,
+      systemPrompt: "",
+    });
+
+    expect({
+      action: result.action,
+      stillFitsTheWindow: sent < 900,
+      summarizeCalls,
+    }).toEqual({ action: "none", stillFitsTheWindow: true, summarizeCalls: 0 });
   });
 });

--- a/packages/agent/src/chat-context-usage.test.ts
+++ b/packages/agent/src/chat-context-usage.test.ts
@@ -2,6 +2,65 @@ import { describe, expect, test } from "bun:test";
 import type { ChatCompletionResult, ProviderClient } from "@nakama/core";
 import { createAgentHarness } from "./index";
 
+const REASONING = "r".repeat(400);
+
+function providerReplayingThinking(
+  name: ProviderClient["name"]
+): ProviderClient {
+  const assistantMessage = {
+    content: "Hello",
+    role: "assistant" as const,
+    thinking: REASONING,
+  };
+
+  return {
+    async generateChat() {
+      return { assistantMessage, content: "Hello", toolCalls: [] };
+    },
+    async generateText() {
+      return { content: "unused" };
+    },
+    name,
+    async streamChat(_input, handlers) {
+      handlers.onChunk("Hello");
+      return { assistantMessage, content: "Hello", toolCalls: [] };
+    },
+  };
+}
+
+async function usedTokensFor(name: ProviderClient["name"]): Promise<number> {
+  const harness = createAgentHarness({
+    provider: providerReplayingThinking(name),
+  });
+  const session = harness.createChatSession({
+    compaction: { contextWindow: 100_000, maxOutputTokens: 8000 },
+    enableToolLoop: false,
+  });
+
+  // The estimate for a turn is taken before its own reply lands, so the trace
+  // only reaches the history the turn after it was produced.
+  await session.send("hi");
+  await session.send("again");
+
+  return session.getContextUsage()?.usedTokens ?? 0;
+}
+
+function usedTokensFromInitialHistory(name: ProviderClient["name"]): number {
+  const harness = createAgentHarness({
+    provider: providerReplayingThinking(name),
+  });
+  const session = harness.createChatSession({
+    compaction: { contextWindow: 100_000, maxOutputTokens: 8000 },
+    enableToolLoop: false,
+    initialHistory: [
+      { content: "hi", role: "user" },
+      { content: "Hello", role: "assistant", thinking: REASONING },
+    ],
+  });
+
+  return session.getContextUsage()?.usedTokens ?? 0;
+}
+
 function providerReturning(
   usage?: ChatCompletionResult["usage"]
 ): ProviderClient {
@@ -85,5 +144,29 @@ describe("chat context usage", () => {
     expect(usage?.source).toBe("estimate");
     expect(usage?.usableContextTokens).toBe(80_000);
     expect(usage?.usedTokens).toBeGreaterThan(100);
+  });
+
+  // toGeminiAssistantParts never sends the trace back, so counting it here
+  // would report context the model was never given.
+  test("leaves the reasoning trace out of a Gemini estimate", async () => {
+    const gemini = await usedTokensFor("gemini");
+    const replayer = await usedTokensFor("openai");
+
+    expect({
+      differenceIsTheTrace:
+        replayer - gemini === Math.ceil(REASONING.length / 4),
+      geminiIsSmaller: gemini < replayer,
+    }).toEqual({ differenceIsTheTrace: true, geminiIsSmaller: true });
+  });
+
+  test("leaves it out of a Gemini estimate taken before any turn", () => {
+    const gemini = usedTokensFromInitialHistory("gemini");
+    const replayer = usedTokensFromInitialHistory("openai");
+
+    expect({
+      differenceIsTheTrace:
+        replayer - gemini === Math.ceil(REASONING.length / 4),
+      geminiIsSmaller: gemini < replayer,
+    }).toEqual({ differenceIsTheTrace: true, geminiIsSmaller: true });
   });
 });

--- a/packages/agent/src/chat.ts
+++ b/packages/agent/src/chat.ts
@@ -42,6 +42,7 @@ import {
   type CompactionConfig,
   compactHistory,
   estimateHistoryTokens,
+  providerReplaysThinking,
   usableContextTokens,
 } from "./history-compaction";
 import {
@@ -225,7 +226,10 @@ export function createAgentChatSession(
     const usedTokens = estimateHistoryTokens(
       history,
       `${systemPrompt}\n\n${dateLine}`,
-      llmToolsForEstimate()
+      llmToolsForEstimate(),
+      dependencies.provider
+        ? providerReplaysThinking(dependencies.provider.name)
+        : true
     );
 
     return buildContextUsage(usedTokens, "estimate");
@@ -521,7 +525,8 @@ async function runConversation(
       estimateHistoryTokens(
         history,
         `${systemPrompt}\n\nToday is ${formatCurrentDate()}.`,
-        llmTools
+        llmTools,
+        providerReplaysThinking(provider.name)
       );
     onContextUsage?.(
       usedTokens,

--- a/packages/agent/src/history-compaction.ts
+++ b/packages/agent/src/history-compaction.ts
@@ -82,12 +82,8 @@ function estimateTokens(text: string): number {
 // Gemini is the only provider whose mapper never replays the reasoning trace:
 // toGeminiAssistantParts sends content and toolCalls only, because replaying a
 // thought needs the thoughtSignature the parser drops. See #768.
-const PROVIDERS_THAT_DROP_THINKING: ReadonlySet<ProviderName> = new Set([
-  "gemini",
-]);
-
 export function providerReplaysThinking(provider: ProviderName): boolean {
-  return !PROVIDERS_THAT_DROP_THINKING.has(provider);
+  return provider !== "gemini";
 }
 
 function estimateMessageTokens(

--- a/packages/agent/src/history-compaction.ts
+++ b/packages/agent/src/history-compaction.ts
@@ -3,6 +3,7 @@ import type {
   CompactionResponse,
   LlmToolDefinition,
   ProviderClient,
+  ProviderName,
 } from "@nakama/core";
 import {
   estimateUserContentTokens,
@@ -78,7 +79,21 @@ function estimateTokens(text: string): number {
   return Math.ceil(text.length / TOKEN_ESTIMATE_RATIO);
 }
 
-function estimateMessageTokens(messages: readonly ChatMessage[]): number {
+// Gemini is the only provider whose mapper never replays the reasoning trace:
+// toGeminiAssistantParts sends content and toolCalls only, because replaying a
+// thought needs the thoughtSignature the parser drops. See #768.
+const PROVIDERS_THAT_DROP_THINKING: ReadonlySet<ProviderName> = new Set([
+  "gemini",
+]);
+
+export function providerReplaysThinking(provider: ProviderName): boolean {
+  return !PROVIDERS_THAT_DROP_THINKING.has(provider);
+}
+
+function estimateMessageTokens(
+  messages: readonly ChatMessage[],
+  replaysThinking: boolean
+): number {
   let total = 0;
 
   for (const message of messages) {
@@ -100,7 +115,9 @@ function estimateMessageTokens(messages: readonly ChatMessage[]): number {
         total += estimateTokens(message.content);
 
         // The chat-completions mapper replays this trace as reasoning_content.
-        if (message.thinking) {
+        // Anthropic and Responses carry it inside providerContent, counted
+        // above, and their parsers set that whenever a trace is present.
+        if (replaysThinking && message.thinking) {
           total += estimateTokens(message.thinking);
         }
 
@@ -121,11 +138,12 @@ function estimateMessageTokens(messages: readonly ChatMessage[]): number {
 export function estimateHistoryTokens(
   messages: readonly ChatMessage[],
   systemPrompt: string,
-  tools?: LlmToolDefinition[]
+  tools?: LlmToolDefinition[],
+  replaysThinking = true
 ): number {
   return (
     estimateTokens(systemPrompt) +
-    estimateMessageTokens(messages) +
+    estimateMessageTokens(messages, replaysThinking) +
     estimateTokens(JSON.stringify(tools ?? []))
   );
 }
@@ -303,7 +321,8 @@ export async function compactHistory(
   const usedTokens = estimateHistoryTokens(
     input.history,
     input.systemPrompt,
-    input.tools
+    input.tools,
+    providerReplaysThinking(input.provider.name)
   );
   const overflow = isOverflow(usedTokens, input.compaction);
   const shouldSummarize = input.force === true || overflow;


### PR DESCRIPTION
## Summary

A Gemini chat keeps the context the model was actually given, instead of one inflated by a reasoning trace Gemini never receives.

**Before:** #774 made `estimateMessageTokens` count `message.thinking` whenever `providerContent` is absent. That is right for the chat-completions mapper and wrong for Gemini: one turn holding 419 characters of reasoning was scored at 116 tokens against the 11 tokens Gemini is sent, and eight such turns read 945 against a usable 900, so the history is summarized on a trace the model never saw.
**After:** the count is gated on the provider, so the same turn scores 11 (`packages/agent/src/history-compaction.ts`). The chat-completions path is untouched and still scores 116.

Why safe:
1. `toGeminiAssistantParts` sends `content` and `toolCalls` only, and Gemini never sets `providerContent`, so its trace reaches nothing on the wire. Replaying a thought needs the `thoughtSignature` the parser drops.
2. Gemini is the only provider that needs the gate. The other 15 names in `ProviderName` reach `toOpenAIMessages`, which replays the trace as `reasoning_content`, or `toAnthropicMessages` and `toResponsesInput`, which carry it inside `providerContent` and are counted verbatim a branch earlier.
3. `bun run test` 2762 pass, 0 fail across all 11 workspaces, against 2758 on `2d4f2c07`; the 4 new tests are the difference. `bun run check` and `bun run knip` clean, and the `tsc --noEmit` error set is unchanged.

Only re-add the trace for Gemini if a future `thoughtSignature` round trip makes `toGeminiAssistantParts` send it back.

## Test plan
- [x] `bun test packages/agent/src/chat-context-usage.test.ts apps/server/src/providers/compaction-thinking-estimate.test.ts` (9 pass)
- [x] `bun run test` (2762 pass, 0 fail)
- [x] Seven mutations, two rounds with the same result: these tests catch all seven, the tests on `main` catch one
- [ ] Run a reasoning-heavy Gemini chat past the point compaction used to fire and watch the context number stay put

Refs #768
