### PR TITLE
test(server): assert the local-token gate on internal routes

### DIFF
--- a/apps/server/src/http/routes/internal-automations.test.ts
+++ b/apps/server/src/http/routes/internal-automations.test.ts
@@ -6,6 +6,7 @@ import { AutomationService } from "../../services/automation-service";
 import { OrgService } from "../../services/org-service";
 import { createHonoApp } from "../app";
 import { seedLocalClientUser } from "../test-org-helpers";
+import { setupFreshInstallSession } from "../test-session-helpers";
 
 const PROFILE_ID = "profile_default";
 const ORG_ID = "org_default";
@@ -98,15 +99,33 @@ describe("internal automation routes", () => {
     });
   });
 
-  test("rejects schedule list without local-token auth", async () => {
+  // The auth middleware already 401s an unauthenticated caller, so the only thing
+  // the route's local-token check does is keep a signed-in browser session out.
+  test("keeps a browser session out of the internal automation endpoints", async () => {
     const options = createServerOptions();
     const app = createHonoApp(options);
-
-    const response = await app.fetch(
-      new Request("http://localhost:4310/v1/internal/automations/schedules")
+    const session = await setupFreshInstallSession(
+      app,
+      options.databaseAdapter
     );
 
-    expect(response.status).toBe(401);
+    const schedules = await app.fetch(
+      new Request("http://localhost:4310/v1/internal/automations/schedules", {
+        headers: session.headers(),
+      })
+    );
+    expect(schedules.status).toBe(401);
+
+    const run = await app.fetch(
+      new Request(
+        `http://localhost:4310/v1/internal/automations/automation_1/run?orgId=${session.orgId}`,
+        {
+          headers: session.headers({ "X-CSRF-Token": session.csrfToken }),
+          method: "POST",
+        }
+      )
+    );
+    expect(run.status).toBe(401);
   });
 
   test("runs automation via internal endpoint for the owning org", async () => {

--- a/apps/server/src/http/routes/internal-curator.test.ts
+++ b/apps/server/src/http/routes/internal-curator.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import { loadLocalAuthToken } from "@nakama/core";
+import { createInMemoryDatabaseAdapter } from "@nakama/db";
+import { AuthService } from "../../services/auth-service";
+import { OrgService } from "../../services/org-service";
+import { createHonoApp } from "../app";
+import { seedLocalClientUser } from "../test-org-helpers";
+import { setupFreshInstallSession } from "../test-session-helpers";
+
+const ORG_ID = "org_default";
+
+function createServerOptions() {
+  const databaseAdapter = createInMemoryDatabaseAdapter();
+  const authService = new AuthService();
+
+  return {
+    agent: {} as any,
+    authService,
+    automationService: {} as any,
+    databaseAdapter,
+    mcpService: {} as any,
+    orgService: new OrgService(databaseAdapter, authService),
+    skillCuratorService: {} as any,
+    systemStatus: {} as any,
+    taskService: {} as any,
+    webDistDir: null,
+    workerManager: {} as any,
+  };
+}
+
+async function seedCuratorOrg(
+  db: ReturnType<typeof createInMemoryDatabaseAdapter>
+): Promise<void> {
+  const now = new Date().toISOString();
+  await db.upsertOrganization({
+    createdAt: now,
+    id: ORG_ID,
+    name: "Default Org",
+    skillsCuratorEnabled: true,
+    slug: "default-org",
+    updatedAt: now,
+  });
+}
+
+describe("internal curator routes", () => {
+  test("lists curator orgs for local-token auth", async () => {
+    const options = createServerOptions();
+    await seedCuratorOrg(options.databaseAdapter);
+    await seedLocalClientUser(options.databaseAdapter);
+
+    const app = createHonoApp(options);
+    const token = await loadLocalAuthToken();
+
+    const response = await app.fetch(
+      new Request("http://localhost:4310/v1/internal/curator/orgs", {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.orgs).toEqual([
+      { id: ORG_ID, skillsCuratorEnabled: true, skillsCuratorLastRunAt: null },
+    ]);
+  });
+
+  // The auth middleware already 401s an unauthenticated caller, so the only thing
+  // the route's local-token check does is keep a signed-in browser session out.
+  // Both cases below fail if that check is removed.
+  test("keeps a browser session out of the curator endpoints", async () => {
+    const options = createServerOptions();
+    const app = createHonoApp(options);
+    const session = await setupFreshInstallSession(
+      app,
+      options.databaseAdapter
+    );
+
+    const list = await app.fetch(
+      new Request("http://localhost:4310/v1/internal/curator/orgs", {
+        headers: session.headers(),
+      })
+    );
+    expect(list.status).toBe(401);
+
+    const run = await app.fetch(
+      new Request(
+        `http://localhost:4310/v1/internal/curator/orgs/${session.orgId}/run`,
+        {
+          body: JSON.stringify({ trigger: "schedule" }),
+          headers: session.headers({
+            "Content-Type": "application/json",
+            "X-CSRF-Token": session.csrfToken,
+          }),
+          method: "POST",
+        }
+      )
+    );
+    expect(run.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary

Give the internal routes a test that fails when their `local-token` gate is removed.

**Before:** `internal-curator.ts` had no test file at all, and `internal-automations.test.ts` asserted that an unauthenticated fetch returns 401. That 401 comes from the auth middleware (`auth-middleware.ts:31`), which runs before the route, so both gates could be deleted and the suite stayed green.

**After:** both files assert the case the gate is actually for, a signed-in browser session. Without the gate, an org admin's session gets 200 and the full list of orgs on the install.

Why safe:
1. Test files only. No production code in the diff.
2. Uses `setupFreshInstallSession`, the same helper the other route tests use.

## Test plan

- [x] `bun run test` across all workspaces: **2760 pass, 0 fail**, exit 0
- [x] Each new assertion watched failing with the guard deleted, then passing with it back:

```
# gate removed from internal-curator.ts
expect(list.status).toBe(401)   Expected: 401   Received: 200
(fail) internal curator routes > keeps a browser session out of the curator endpoints
 1 pass 1 fail

# gate removed from internal-automations.ts
expect(schedules.status).toBe(401)   Expected: 401   Received: 200
(fail) internal automation routes > keeps a browser session out of the internal automation endpoints
 9 pass 1 fail

# both gates restored
 12 pass 0 fail   Ran 12 tests across 2 files
```

Closes #791
