### PR TITLE
fix(security): close the login CSRF and HSTS gaps, drop a dead header

### DIFF
--- a/apps/server/src/app.test.ts
+++ b/apps/server/src/app.test.ts
@@ -202,6 +202,7 @@ describe("browser session auth", () => {
           email: "admin@example.com",
           password: "password123",
         }),
+        headers: { "Content-Type": "application/json" },
         method: "POST",
       })
     );
@@ -338,6 +339,7 @@ describe("browser session auth", () => {
           email: "member@example.com",
           password: "password123",
         }),
+        headers: { "Content-Type": "application/json" },
         method: "POST",
       })
     );

--- a/apps/server/src/http/app.test.ts
+++ b/apps/server/src/http/app.test.ts
@@ -826,6 +826,41 @@ describe("createHonoApp", () => {
     expect((await setup("admin@example.com")).status).toBe(201);
   });
 
+  test("sends HSTS behind a TLS terminator", async () => {
+    const app = createHonoApp(createServerOptions());
+
+    const response = await app.fetch(
+      new Request("http://localhost:4310/health", {
+        headers: { "X-Forwarded-Proto": "https" },
+      })
+    );
+
+    expect(response.headers.get("Strict-Transport-Security")).toContain(
+      "max-age="
+    );
+  });
+
+  test("login rejects a body that is not application/json", async () => {
+    const options = createServerOptions();
+    const app = createHonoApp(options);
+    await setupFreshInstallSession(app, options.databaseAdapter);
+
+    // A cross-site form can send text/plain without a CORS preflight, which is
+    // how a page logs a victim into an account it controls.
+    const response = await app.fetch(
+      new Request("http://localhost:4310/v1/auth/login", {
+        body: JSON.stringify({
+          email: "admin@example.com",
+          password: "password123",
+        }),
+        headers: { "Content-Type": "text/plain;charset=UTF-8" },
+        method: "POST",
+      })
+    );
+
+    expect(response.status).toBe(415);
+  });
+
   test("logout clears both Secure and non-Secure session cookies", async () => {
     const options = createServerOptions();
     const app = createHonoApp(options);
@@ -1185,6 +1220,7 @@ describe("createHonoApp", () => {
             email: "noorg@example.com",
             password: "password123",
           }),
+          headers: { "Content-Type": "application/json" },
           method: "POST",
         })
       );
@@ -1309,6 +1345,7 @@ describe("createHonoApp", () => {
             email: "platform@example.com",
             password: "password123",
           }),
+          headers: { "Content-Type": "application/json" },
           method: "POST",
         })
       );
@@ -1348,6 +1385,7 @@ describe("createHonoApp", () => {
             email: "admin@acme.com",
             password: created.adminMember.temporaryPassword,
           }),
+          headers: { "Content-Type": "application/json" },
           method: "POST",
         })
       );

--- a/apps/server/src/http/app.ts
+++ b/apps/server/src/http/app.ts
@@ -37,7 +37,7 @@ import { registerTokenOptimizationRoutes } from "./routes/token-optimization";
 import { registerToolRoutes } from "./routes/tools";
 import { registerUserContextRoutes } from "./routes/user-context";
 import { registerWorkerRoutes } from "./routes/workers";
-import { errorResponse } from "./shared";
+import { errorResponse, isSecureRequest } from "./shared";
 import type { HonoApp } from "./types";
 
 /**
@@ -73,7 +73,6 @@ export function createHonoApp(options: ServerOptions) {
       const headers = new Headers(response.headers);
       headers.set("X-Content-Type-Options", "nosniff");
       headers.set("X-Frame-Options", "DENY");
-      headers.set("X-XSS-Protection", "1; mode=block");
       // Only set Referrer-Policy if it's not already set
       if (!headers.has("Referrer-Policy")) {
         headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
@@ -82,8 +81,8 @@ export function createHonoApp(options: ServerOptions) {
         "Content-Security-Policy",
         `default-src 'self'; script-src 'self' '${THEME_BOOTSTRAP_SCRIPT_HASH}'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob:; font-src 'self' data:; connect-src 'self';`
       );
-      // Only enable HSTS if the request is secure (HTTPS)
-      if (new URL(c.req.url).protocol === "https:") {
+      // Also true behind a TLS terminator, which is where HSTS matters most.
+      if (isSecureRequest(c.req.raw)) {
         headers.set(
           "Strict-Transport-Security",
           "max-age=31536000; includeSubDomains"

--- a/apps/server/src/http/org-invites.test.ts
+++ b/apps/server/src/http/org-invites.test.ts
@@ -61,6 +61,7 @@ describe("direct org member provisioning", () => {
           email: "admin@acme.com",
           password: created.adminMember.temporaryPassword,
         }),
+        headers: { "Content-Type": "application/json" },
         method: "POST",
       })
     );
@@ -116,6 +117,7 @@ describe("direct org member provisioning", () => {
           email: "admin@acme.com",
           password: created.adminMember.temporaryPassword,
         }),
+        headers: { "Content-Type": "application/json" },
         method: "POST",
       })
     );
@@ -156,6 +158,7 @@ describe("direct org member provisioning", () => {
           email: "member@acme.com",
           password: added.temporaryPassword,
         }),
+        headers: { "Content-Type": "application/json" },
         method: "POST",
       })
     );
@@ -189,6 +192,7 @@ describe("direct org member provisioning", () => {
           email: "member@acme.com",
           password: "member-new-password",
         }),
+        headers: { "Content-Type": "application/json" },
         method: "POST",
       })
     );

--- a/apps/server/src/http/platform-orgs.test.ts
+++ b/apps/server/src/http/platform-orgs.test.ts
@@ -132,6 +132,7 @@ describe("platform org routes", () => {
           email: "admin@acme.com",
           password: created.adminMember.temporaryPassword,
         }),
+        headers: { "Content-Type": "application/json" },
         method: "POST",
       })
     );
@@ -273,6 +274,7 @@ describe("platform org routes", () => {
           email: "admin@acme.com",
           password: created.adminMember.temporaryPassword,
         }),
+        headers: { "Content-Type": "application/json" },
         method: "POST",
       })
     );

--- a/apps/server/src/http/routes/auth.ts
+++ b/apps/server/src/http/routes/auth.ts
@@ -24,6 +24,7 @@ import {
 } from "../org-guards";
 import {
   assertBrowserCsrf,
+  assertJsonRequest,
   authenticateRequest,
   clearBrowserSessionCookies,
   createBrowserSessionResponse,
@@ -444,6 +445,8 @@ export function registerAuthRoutes(app: HonoApp, options: ServerOptions): void {
     if (!(authService && databaseAdapter && orgService)) {
       return errorResponse("Authentication not configured", 500);
     }
+
+    assertJsonRequest(c.req.raw);
 
     const body = await readJson<{ email: string; password: string }>(c.req.raw);
     const user = await databaseAdapter.getUserByEmail(body.email);

--- a/apps/server/src/http/routes/data-portability.test.ts
+++ b/apps/server/src/http/routes/data-portability.test.ts
@@ -173,6 +173,7 @@ describe("data portability routes", () => {
     };
     const loginResponse = await app.fetch(
       new Request("http://localhost:4310/v1/auth/login", {
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           email: "admin@acme.test",
           password: created.adminMember.temporaryPassword,

--- a/apps/server/src/http/shared.ts
+++ b/apps/server/src/http/shared.ts
@@ -108,7 +108,7 @@ function isMutatingMethod(method: string): boolean {
  * X-Forwarded-Proto can upgrade http backends behind TLS terminators, but must
  * never downgrade an https request URL (spoofed/forwarded "http").
  */
-function isSecureCookieRequest(request: Request): boolean {
+export function isSecureRequest(request: Request): boolean {
   const forwardedProto = request.headers
     .get("x-forwarded-proto")
     ?.split(",")[0]
@@ -262,7 +262,7 @@ function applyBrowserSessionCookies(
   const cookieBase = {
     path: "/",
     sameSite: "Lax" as const,
-    secure: isSecureCookieRequest(request),
+    secure: isSecureRequest(request),
   };
 
   appendSetCookie(
@@ -350,6 +350,23 @@ export function clearBrowserSessionCookies(headers: Headers): void {
         secure,
       })
     );
+  }
+}
+
+/**
+ * A cross-site form can POST text/plain without a CORS preflight, which is how a
+ * malicious page can log a victim into an attacker's account. Requiring JSON
+ * forces the preflight, and nothing here answers one.
+ */
+export function assertJsonRequest(request: Request): void {
+  const contentType = request.headers
+    .get("content-type")
+    ?.split(";")[0]
+    ?.trim()
+    .toLowerCase();
+
+  if (contentType !== "application/json") {
+    throw new NakamaApiError("Content-Type must be application/json.", 415);
   }
 }
 

--- a/apps/server/src/http/test-session-helpers.ts
+++ b/apps/server/src/http/test-session-helpers.ts
@@ -121,6 +121,7 @@ export async function loginPlatformAdminSession(
   const response = await app.fetch(
     new Request("http://localhost:4310/v1/auth/login", {
       body: JSON.stringify({ email, password }),
+      headers: { "Content-Type": "application/json" },
       method: "POST",
     })
   );
@@ -138,6 +139,7 @@ export async function loginUserSession(
   const response = await app.fetch(
     new Request("http://localhost:4310/v1/auth/login", {
       body: JSON.stringify({ email, password }),
+      headers: { "Content-Type": "application/json" },
       method: "POST",
     })
   );


### PR DESCRIPTION
## Summary

Three of the six items in the batch. Part (a) is left to @muafa7, who claimed it on the issue before this was opened. Two more need no code, see the bottom.

**Before:**
- `POST /v1/auth/login` accepted `text/plain`, which a cross-site form sends with no CORS preflight. A local PoC logged a victim in and got session cookies back: status 200, `nakama_session` minted.
- HSTS was gated on the request URL protocol while cookie code already honoured `X-Forwarded-Proto`, so the header was silently dropped behind a TLS terminator.
- `X-XSS-Protection` is a no-op in current browsers.

**After:** `application/json` required on login (415 otherwise), one `isSecureRequest` used by both cookies and HSTS, dead header gone.

Why safe:
1. The client already sets `Content-Type: application/json` for every body (`client.ts:2496`), so the web UI and CLI are unaffected. The test churn is test requests that had been sending no content type at all.
2. Setup and accept-invite keep taking any content type on purpose: setup is 409-gated once an admin exists, accept-invite needs a valid token, so neither carries the login vector.

## Test plan

- [x] `bun run test` across all workspaces: **2760 pass, 0 fail**, exit 0
- [x] Both new tests watched failing with their fix reverted:

```
(fail) createHonoApp > sends HSTS behind a TLS terminator
(fail) createHonoApp > login rejects a body that is not application/json
  Expected: 415   Received: 200
```

## The two items with no code here

- **(e) WhatsApp outbound server** is already authenticated: `outbound-server.ts` mints a token before the port opens and returns 401 on mismatch.
- **(f) platform admin membership** is a product call, not a defect. `profiles.mdx:186` already documents that platform admins need an active org context, a platform admin can add themselves to any org, and #478 declined the same shape of change as inconsistent with the other seventeen routes.

Refs #374, which stays open for (a) and (f).
