### PR TITLE
fix(orgs): guard the last admin inside the statement

### DIFF
--- a/apps/server/src/services/org-service.ts
+++ b/apps/server/src/services/org-service.ts
@@ -543,6 +543,9 @@ export class OrgService {
 
     const deleted = await this.databaseAdapter.deleteOrgMember(orgId, userId);
     if (!deleted) {
+      // The delete carries the last-admin guard, so a concurrent change between
+      // the check above and here lands here rather than emptying the org.
+      await this.assertCanChangeAdminMembership(orgId, userId);
       throw new NakamaApiError("Not found", 404);
     }
   }
@@ -589,12 +592,15 @@ export class OrgService {
     }
 
     if (member.role !== role) {
-      await this.databaseAdapter.upsertOrgMember({
-        createdAt: member.createdAt,
+      const updated = await this.databaseAdapter.updateOrgMemberRole(
         orgId,
-        role,
         userId,
-      });
+        role
+      );
+      if (!updated) {
+        await this.assertCanChangeAdminMembership(orgId, userId, role);
+        throw new NakamaApiError("Not found", 404);
+      }
     }
 
     return {

--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -1691,9 +1691,21 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
       AND o.archived_at IS NULL
     ORDER BY o.name ASC
   `);
+  // The last-admin guard lives in the statement so two concurrent removals
+  // cannot both pass a read-then-write check and leave the org with no admin.
   const deleteOrgMemberStmt = db.prepare(`
     DELETE FROM org_members
     WHERE org_id = ? AND user_id = ?
+      AND (role != 'admin'
+        OR (SELECT COUNT(*) FROM org_members
+            WHERE org_id = ? AND role = 'admin') > 1)
+  `);
+  const updateOrgMemberRoleStmt = db.prepare(`
+    UPDATE org_members SET role = ?
+    WHERE org_id = ? AND user_id = ?
+      AND (? = 'admin' OR role != 'admin'
+        OR (SELECT COUNT(*) FROM org_members
+            WHERE org_id = ? AND role = 'admin') > 1)
   `);
 
   return {
@@ -1927,7 +1939,7 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
     },
 
     async deleteOrgMember(orgId, userId) {
-      const result = deleteOrgMemberStmt.run(orgId, userId);
+      const result = deleteOrgMemberStmt.run(orgId, userId, orgId);
       return result.changes > 0;
     },
 
@@ -2814,6 +2826,17 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
 
     async updateBrowserSessionLastUsedAt(id, lastUsedAt) {
       updateBrowserSessionLastUsedAtStmt.run(lastUsedAt, id);
+    },
+
+    async updateOrgMemberRole(orgId, userId, role) {
+      const result = updateOrgMemberRoleStmt.run(
+        role,
+        orgId,
+        userId,
+        role,
+        orgId
+      );
+      return result.changes > 0;
     },
 
     async updateOrgMemoryProposalStatus(orgId, id, update) {

--- a/packages/db/src/last-org-admin.test.ts
+++ b/packages/db/src/last-org-admin.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { createSqliteMemoryAdapter } from "./adapters/sqlite";
+import type { DatabaseAdapter, OrgRole } from "./types";
+
+const NOW = "2026-08-31T00:00:00.000Z";
+
+async function seedOrgWithAdmins(
+  db: DatabaseAdapter,
+  roles: OrgRole[]
+): Promise<string[]> {
+  await db.upsertOrganization({
+    createdAt: NOW,
+    id: "org_a",
+    name: "A",
+    slug: "a",
+    updatedAt: NOW,
+  });
+
+  const userIds: string[] = [];
+  for (const [index, role] of roles.entries()) {
+    const userId = `user_${index}`;
+    await db.createUser({
+      createdAt: NOW,
+      email: `${userId}@example.com`,
+      id: userId,
+      passwordHash: "unused",
+      updatedAt: NOW,
+    });
+    await db.upsertOrgMember({
+      createdAt: NOW,
+      orgId: "org_a",
+      role,
+      userId,
+    });
+    userIds.push(userId);
+  }
+
+  return userIds;
+}
+
+async function adminCount(db: DatabaseAdapter): Promise<number> {
+  const members = await db.listOrgMembers("org_a");
+  return members.filter((member) => member.role === "admin").length;
+}
+
+// The service checks the admin count before it writes, so two concurrent
+// requests can both pass that check. These assert the guard that runs inside
+// the statement instead.
+describe("last org admin", () => {
+  test("refuses to delete the only admin", async () => {
+    const db = createSqliteMemoryAdapter();
+    const [admin] = await seedOrgWithAdmins(db, ["admin", "viewer"]);
+
+    expect(await db.deleteOrgMember("org_a", admin!)).toBe(false);
+    expect(await adminCount(db)).toBe(1);
+  });
+
+  test("refuses to demote the only admin", async () => {
+    const db = createSqliteMemoryAdapter();
+    const [admin] = await seedOrgWithAdmins(db, ["admin", "viewer"]);
+
+    expect(await db.updateOrgMemberRole("org_a", admin!, "viewer")).toBe(false);
+    expect(await adminCount(db)).toBe(1);
+  });
+
+  test("allows the change while a second admin remains", async () => {
+    const db = createSqliteMemoryAdapter();
+    const [first] = await seedOrgWithAdmins(db, ["admin", "admin"]);
+
+    expect(await db.updateOrgMemberRole("org_a", first!, "viewer")).toBe(true);
+    expect(await adminCount(db)).toBe(1);
+  });
+});

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -913,6 +913,12 @@ export interface DatabaseAdapter {
     activeOrgId: string | null
   ): Promise<void>;
   updateBrowserSessionLastUsedAt(id: string, lastUsedAt: string): Promise<void>;
+  /** False when the change would leave the org without an admin. */
+  updateOrgMemberRole(
+    orgId: string,
+    userId: string,
+    role: OrgRole
+  ): Promise<boolean>;
   updateOrgMemoryProposalStatus(
     orgId: string,
     id: string,


### PR DESCRIPTION
## Summary

Move the last-admin rule from a read-then-write check into the statements that do the write.

**Before:** `assertCanChangeAdminMembership` counts admins in one query and the delete or role change runs in another. Two concurrent removals both see two admins, both pass, and the org ends with zero. Same for two demotions, or a remove racing a demote. An org with no admin cannot be managed back without direct database access.

**After:** `deleteOrgMember` and the new `updateOrgMemberRole` each carry `AND (role != 'admin' OR (SELECT COUNT(*) ... ) > 1)`, so SQLite decides it, not the gap between two awaits.

Why safe:
1. `deleteOrgMember` has exactly one caller, `removeMember`, so the condition cannot surprise another path.
2. The service keeps its pre-check, which is what produces the right 409 message on the ordinary path. Only when the write comes back empty does it re-run the check, to tell a lost race apart from a member that is already gone.
3. Role changes used `upsertOrgMember`, which is also the insert path for adding members. That one is untouched; the guarded update is a separate method so adding a member cannot be blocked by it.

## Test plan

- [x] `bun run test` across all workspaces: **2761 pass, 0 fail**, exit 0
- [x] All three new cases watched failing against the current statements:

```
(fail) last org admin > refuses to delete the only admin      Expected: false  Received: true
(fail) last org admin > refuses to demote the only admin
(fail) last org admin > allows the change while a second admin remains
 0 pass 3 fail
```

The race itself is not tested. Two interleaved awaits do not reproduce on demand, so the tests assert the guard the race would have to get past instead.

Closes #479
