### PR TITLE
fix(setup): validate the admin before creating the organization

### DIFF
--- a/apps/server/src/http/app.test.ts
+++ b/apps/server/src/http/app.test.ts
@@ -802,6 +802,30 @@ describe("createHonoApp", () => {
     });
   }
 
+  test("a rejected setup leaves no organization behind", async () => {
+    const options = createServerOptions();
+    const app = createHonoApp(options);
+    const setup = (email: string) =>
+      app.fetch(
+        new Request("http://localhost:4310/v1/auth/setup", {
+          body: JSON.stringify(
+            buildSetupAuthBody(email, {
+              organization: { name: "Acme", slug: "acme" },
+            })
+          ),
+          headers: { "Content-Type": "application/json" },
+          method: "POST",
+        })
+      );
+
+    expect((await setup("not-an-email")).status).toBe(400);
+    expect(await options.databaseAdapter.listOrganizations()).toHaveLength(0);
+
+    // The org used to be committed before the admin was validated, so the
+    // retry lost the slug it had just taken.
+    expect((await setup("admin@example.com")).status).toBe(201);
+  });
+
   test("logout clears both Secure and non-Secure session cookies", async () => {
     const options = createServerOptions();
     const app = createHonoApp(options);

--- a/apps/server/src/services/org-service.ts
+++ b/apps/server/src/services/org-service.ts
@@ -471,11 +471,8 @@ export class OrgService {
       passwordHash: string;
     };
   }): Promise<{ user: StoredUserRecord; organization: OrganizationSummary }> {
-    const organization = await this.insertOrganization({
-      name: input.organization.name,
-      slug: input.organization.slug,
-    });
-
+    // Validate before the insert: a rejected admin used to leave the org behind,
+    // and the retry then failed on the slug it had just taken.
     const name = input.admin.name.trim();
     const email = normalizeEmail(input.admin.email);
     const phone = normalizeOptionalPhone(input.admin.phone);
@@ -487,6 +484,11 @@ export class OrgService {
     if (!EMAIL_PATTERN.test(email)) {
       throw new NakamaApiError("A valid email address is required.", 400);
     }
+
+    const organization = await this.insertOrganization({
+      name: input.organization.name,
+      slug: input.organization.slug,
+    });
 
     const now = new Date().toISOString();
     const user: StoredUserRecord = {


### PR DESCRIPTION
## Summary

Item (a) of the batch, which turned out to be reachable without any race.

**Before:** `bootstrapInitialSetup` inserted the organization, then validated the admin name and email. A typo in the email returned 400 with the org already committed. `countHumanUsers` stayed at zero so setup was still open, but the retry hit `Organization slug already exists.` and first run could not be completed with the name the operator picked.

```
first attempt: 400
orgs left behind: [ "acme" ]
retry: 409 {"error":"Organization slug already exists."}
```

**After:** the two checks run before the insert. Same input:

```
first attempt: 400
orgs left behind: []
retry: 201
```

Why safe: nothing in `insertOrganization` depends on the user, and it already does its own name and slug validation, so the only change is which check runs first.

## Test plan

- [x] `bun run test` across all workspaces: **2759 pass, 0 fail**, exit 0
- [x] The new case watched failing with the reorder reverted: `Expected length: 0  Received length: 1`

## The rest of the batch

- **(b) import size caps** belongs to #357, which is open, `priority: high`, and covers request body limits for the whole server. This issue's own text says the two should be folded together, and a cap that only guards two routes while `unzipSync` still expands everything in memory is the wrong half of it.
- **(c) avatar endpoint** is already fixed: `GET /v1/profiles/{id}/avatar` is out of `PUBLIC_ROUTES` and the handler resolves the org from the session.
- **(d) client-controlled origin** is already fixed: PR #712 made the configured `NAKAMA_WEB_PUBLIC_URL` win over caller headers, and PR #772 stopped an `Origin` header writing that stored value.

The residual on (a) is two simultaneous first-run setups: the loser now fails on the `user_admin` primary key with the org already inserted. Closing that needs a transaction across the two writes, which the sqlite adapter cannot express around `await`, so it is left out rather than half done.

Refs #361, which stays open for (b).
