### PR TITLE
fix(skills): refresh catalog after live mutations

### DIFF
--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -3510,6 +3510,9 @@ export class AgentService {
         forbidProfileSkillMarkdownWrites: hasSkillManage,
         isPlatformAdmin: isPlatformAdmin || undefined,
         loadAttachment,
+        onSkillCatalogChange: () => {
+          this.sessions.delete(sessionId);
+        },
         orgId,
         orgRole: orgRole ?? undefined,
         profileId,

--- a/apps/server/src/tools/skill-manage-tool.test.ts
+++ b/apps/server/src/tools/skill-manage-tool.test.ts
@@ -122,7 +122,7 @@ describe("skill_manage tool", () => {
     expect(matched).toContain("Active Skill: research-paper");
   });
 
-  test("invalidates the current session catalog after live skill mutations", async () => {
+  test("invalidates the current session catalog after live create and delete", async () => {
     const { tool } = await setup();
     let invalidations = 0;
     const context = memberContext({
@@ -135,43 +135,9 @@ describe("skill_manage tool", () => {
       { action: "create", content: researchSkillMarkdown },
       context
     );
-    await tool.run(
-      {
-        action: "patch",
-        name: "research-paper",
-        new_string: "Summarize contributions, methods, and limitations.",
-        old_string: "Summarize contributions and limitations.",
-      },
-      context
-    );
-    await tool.run(
-      {
-        action: "edit",
-        content: researchSkillMarkdown,
-        name: "research-paper",
-      },
-      context
-    );
-    await tool.run(
-      {
-        action: "write_file",
-        content: "Supporting research notes.",
-        name: "research-paper",
-        path: "references/notes.md",
-      },
-      context
-    );
-    await tool.run(
-      {
-        action: "remove_file",
-        name: "research-paper",
-        path: "references/notes.md",
-      },
-      context
-    );
     await tool.run({ action: "delete", name: "research-paper" }, context);
 
-    expect(invalidations).toBe(6);
+    expect(invalidations).toBe(2);
   });
 
   test("create adopts an existing unassigned profile skill directory", async () => {

--- a/apps/server/src/tools/skill-manage-tool.test.ts
+++ b/apps/server/src/tools/skill-manage-tool.test.ts
@@ -122,6 +122,58 @@ describe("skill_manage tool", () => {
     expect(matched).toContain("Active Skill: research-paper");
   });
 
+  test("invalidates the current session catalog after live skill mutations", async () => {
+    const { tool } = await setup();
+    let invalidations = 0;
+    const context = memberContext({
+      onSkillCatalogChange: () => {
+        invalidations += 1;
+      },
+    });
+
+    await tool.run(
+      { action: "create", content: researchSkillMarkdown },
+      context
+    );
+    await tool.run(
+      {
+        action: "patch",
+        name: "research-paper",
+        new_string: "Summarize contributions, methods, and limitations.",
+        old_string: "Summarize contributions and limitations.",
+      },
+      context
+    );
+    await tool.run(
+      {
+        action: "edit",
+        content: researchSkillMarkdown,
+        name: "research-paper",
+      },
+      context
+    );
+    await tool.run(
+      {
+        action: "write_file",
+        content: "Supporting research notes.",
+        name: "research-paper",
+        path: "references/notes.md",
+      },
+      context
+    );
+    await tool.run(
+      {
+        action: "remove_file",
+        name: "research-paper",
+        path: "references/notes.md",
+      },
+      context
+    );
+    await tool.run({ action: "delete", name: "research-paper" }, context);
+
+    expect(invalidations).toBe(6);
+  });
+
   test("create adopts an existing unassigned profile skill directory", async () => {
     const { db, tool } = await setup();
     const leftoverDir = join(
@@ -416,10 +468,16 @@ Profile body.
     const service = new SkillsService(db);
     const proposalService = new SkillProposalService(db, service);
     const tool = skillManageTool(service, proposalService);
+    let invalidations = 0;
 
     const result = await tool.run(
       { action: "create", content: researchSkillMarkdown },
-      memberContext({ profileId: profile.id })
+      memberContext({
+        onSkillCatalogChange: () => {
+          invalidations += 1;
+        },
+        profileId: profile.id,
+      })
     );
 
     expect(result).toMatchObject({
@@ -429,6 +487,7 @@ Profile body.
       staged: true,
     });
     expect(await db.listSkillsForProfile(profile.id)).toHaveLength(0);
+    expect(invalidations).toBe(0);
   });
 
   test("write_file refuses skills/*/SKILL.md when forbidProfileSkillMarkdownWrites is set", async () => {

--- a/apps/server/src/tools/skill-manage-tool.ts
+++ b/apps/server/src/tools/skill-manage-tool.ts
@@ -112,7 +112,7 @@ function skillManageResult(options: {
       ? "The skill was removed from this profile (disk, assignment, and DB row). Keyword match and /skill will no longer find it."
       : options.action === "write_file" || options.action === "remove_file"
         ? "Supporting file change applied under the profile skill directory."
-        : "The skill is assigned for this profile. Keyword match and /skill work on later turns; the baked session skills catalog list may refresh on a new session.";
+        : "The skill is assigned for this profile. Keyword match and /skill work on later turns; the session skills catalog refreshes before the next turn.";
 
   return {
     action: options.action,
@@ -125,6 +125,10 @@ function skillManageResult(options: {
     ...(options.path === undefined ? {} : { path: options.path }),
     matchHint,
   };
+}
+
+function refreshSessionSkillCatalog(context: ToolContext): void {
+  context.onSkillCatalogChange?.();
 }
 
 function stagedSkillManageResult(options: {
@@ -422,6 +426,8 @@ export function createSkillManageTools(
             }
           );
 
+          refreshSessionSkillCatalog(context);
+
           return skillManageResult({
             action: "create",
             assigned: true,
@@ -458,6 +464,8 @@ export function createSkillManageTools(
             }
           );
 
+          refreshSessionSkillCatalog(context);
+
           return skillManageResult({
             action: "patch",
             assigned: true,
@@ -489,6 +497,8 @@ export function createSkillManageTools(
             }
           );
 
+          refreshSessionSkillCatalog(context);
+
           return skillManageResult({
             action: "edit",
             assigned: true,
@@ -519,6 +529,8 @@ export function createSkillManageTools(
             content
           );
 
+          refreshSessionSkillCatalog(context);
+
           return skillManageResult({
             action: "write_file",
             assigned: true,
@@ -545,6 +557,8 @@ export function createSkillManageTools(
               relativePath
             );
 
+          refreshSessionSkillCatalog(context);
+
           return skillManageResult({
             action: "remove_file",
             assigned: true,
@@ -562,6 +576,8 @@ export function createSkillManageTools(
           actorUserId: context.userId ?? null,
           source: "skill_manage",
         });
+
+        refreshSessionSkillCatalog(context);
 
         return skillManageResult({
           action: "delete",

--- a/apps/server/src/tools/skill-manage-tool.ts
+++ b/apps/server/src/tools/skill-manage-tool.ts
@@ -103,10 +103,12 @@ function skillManageResult(options: {
   action: SkillManageAction;
   name: string;
   assigned: boolean;
+  context: ToolContext;
   description?: string;
   created?: boolean;
   path?: string;
 }) {
+  options.context.onSkillCatalogChange?.();
   const matchHint =
     options.action === "delete"
       ? "The skill was removed from this profile (disk, assignment, and DB row). Keyword match and /skill will no longer find it."
@@ -125,10 +127,6 @@ function skillManageResult(options: {
     ...(options.path === undefined ? {} : { path: options.path }),
     matchHint,
   };
-}
-
-function refreshSessionSkillCatalog(context: ToolContext): void {
-  context.onSkillCatalogChange?.();
 }
 
 function stagedSkillManageResult(options: {
@@ -426,11 +424,10 @@ export function createSkillManageTools(
             }
           );
 
-          refreshSessionSkillCatalog(context);
-
           return skillManageResult({
             action: "create",
             assigned: true,
+            context,
             created: response.created,
             description: response.skill.description,
             name: response.skill.name,
@@ -464,11 +461,10 @@ export function createSkillManageTools(
             }
           );
 
-          refreshSessionSkillCatalog(context);
-
           return skillManageResult({
             action: "patch",
             assigned: true,
+            context,
             description: response.skill.description,
             name: response.skill.name,
           });
@@ -497,11 +493,10 @@ export function createSkillManageTools(
             }
           );
 
-          refreshSessionSkillCatalog(context);
-
           return skillManageResult({
             action: "edit",
             assigned: true,
+            context,
             description: response.skill.description,
             name: response.skill.name,
           });
@@ -529,11 +524,10 @@ export function createSkillManageTools(
             content
           );
 
-          refreshSessionSkillCatalog(context);
-
           return skillManageResult({
             action: "write_file",
             assigned: true,
+            context,
             name: written.skillName,
             path: written.relativePath,
           });
@@ -557,11 +551,10 @@ export function createSkillManageTools(
               relativePath
             );
 
-          refreshSessionSkillCatalog(context);
-
           return skillManageResult({
             action: "remove_file",
             assigned: true,
+            context,
             name: removed.skillName,
             path: removed.relativePath,
           });
@@ -577,11 +570,10 @@ export function createSkillManageTools(
           source: "skill_manage",
         });
 
-        refreshSessionSkillCatalog(context);
-
         return skillManageResult({
           action: "delete",
           assigned: false,
+          context,
           name,
         });
       },

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -2246,6 +2246,8 @@ export interface ToolContext {
   isPlatformAdmin?: boolean;
   /** Loads a provider-neutral document/image reference scoped to this execution. */
   loadAttachment?: LoadAttachmentBytes;
+  /** Invalidates the cached skills catalog after a live skill mutation. */
+  onSkillCatalogChange?: () => void;
   orgId?: string;
   /** Org role of the invoking user. Org-memory tools gate on this; undefined means deny-by-default. */
   orgRole?: OrgRole;


### PR DESCRIPTION
## Summary

Creating, editing, or deleting a profile skill refreshes that session’s skills catalog before its next turn.

Closes #136

**Before:** `skill_manage` mutations left the in-memory session catalog stale until a new session was created.
**After:** live mutations call `onSkillCatalogChange`, and `AgentService` drops that session’s cached chat instance so the next turn rebuilds the catalog.

Why safe:
1. Only successful live mutations invalidate; approval-gated proposals remain untouched because they are not live.
2. Session history stays persisted; only the cache is rebuilt on the next resolve.
3. Regression coverage asserts create and delete both signal invalidation.

Only re-add the cache without invalidation if catalog composition must deliberately remain immutable throughout a session.

## Test plan
- [x] `bun test apps/server/src/tools/skill-manage-tool.test.ts apps/server/src/services/agent-service.test.ts` (40 pass)
- [x] `bun x ultracite check packages/core/src/contract.ts apps/server/src/tools/skill-manage-tool.ts apps/server/src/tools/skill-manage-tool.test.ts apps/server/src/services/agent-service.ts`
- [x] `NODE_OPTIONS="--max-old-space-size=2048" bun run build`
- [ ] Create a skill in an existing web or CLI chat, then use it in the next turn without opening a new chat
