### PR TITLE
refactor(channels): derive the channel subsets from AGENT_CHANNELS

### DIFF
--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -101,7 +101,6 @@ import type {
   WhatsAppSettingsResponse,
 } from "@nakama/core";
 import {
-  AGENT_CHANNELS,
   apiKeyEnvVarForProvider,
   appendOrgMemorySection,
   buildErrorReport,
@@ -146,6 +145,7 @@ import {
   normalizeUserContextContent,
   type OrgRole,
   ollamaRequiresApiKey,
+  parseAgentChannel,
   parseSentryDsn,
   persistInlineAttachmentsInContent,
   readArtifactFile,
@@ -203,7 +203,10 @@ import { wrapProviderWithUsageTracking } from "../providers/usage-tracking";
 import { createAskUserQuestionTools } from "../tools/ask-user-question-tool";
 import { createOrgMemoryTools } from "../tools/org-memory-tools";
 import { createSendDiscordArtifactTools } from "../tools/send-discord-artifact-tool";
-import { createSkillManageTools } from "../tools/skill-manage-tool";
+import {
+  createSkillManageTools,
+  SKILL_MANAGE_CHANNELS,
+} from "../tools/skill-manage-tool";
 import { formatToolActivityLabel } from "../tools/sub-agent-activity";
 import {
   buildSubAgentPrompt,
@@ -3332,7 +3335,7 @@ export class AgentService {
   ): Promise<AgentChatSession> {
     await this.ensureVisionSettingsLoaded();
     const profile = await this.requireProfile(orgId, profileId);
-    const includeSkillManageTools = channel === "web" || channel === "cli";
+    const includeSkillManageTools = SKILL_MANAGE_CHANNELS[channel];
     let tools = await this.resolveProfileTools(profile, {
       includeSkillManageTools,
       userId,
@@ -3340,10 +3343,12 @@ export class AgentService {
     if (channel === "discord") {
       tools = [...tools, ...createSendDiscordArtifactTools()];
     }
-    const skillUsageContext =
-      channel === "web" || channel === "cli"
-        ? { seenCatalogSkillIds: new Set<string>(), sessionId }
-        : undefined;
+    // Same table as the tools above on purpose: a channel that can manage
+    // skills is a channel that needs the catalog to track what it has seen.
+    // Splitting them later means splitting the table, which is a visible edit.
+    const skillUsageContext = SKILL_MANAGE_CHANNELS[channel]
+      ? { seenCatalogSkillIds: new Set<string>(), sessionId }
+      : undefined;
     const { systemPrompt, soulActive } = await this.resolveProfileSystemPrompt(
       orgId,
       profileId,
@@ -3823,12 +3828,6 @@ export class AgentService {
       enabled: this.userConfig?.thinkingEnabled ?? DEFAULT_THINKING_ENABLED,
     };
   }
-}
-
-function parseAgentChannel(value: string): AgentChannel | null {
-  return AGENT_CHANNELS.includes(value as AgentChannel)
-    ? (value as AgentChannel)
-    : null;
 }
 
 function clampSubAgentTimeout(timeoutMs: number | undefined): number {

--- a/apps/server/src/services/skill-post-turn-review-service.test.ts
+++ b/apps/server/src/services/skill-post-turn-review-service.test.ts
@@ -201,55 +201,6 @@ describe("SkillPostTurnReviewService", () => {
     expect(ran).toBe(0);
   });
 
-  test("skips headless automation channel as channel_not_interactive", async () => {
-    const db = createInMemoryDatabaseAdapter();
-    const now = new Date().toISOString();
-    await db.upsertOrganization({
-      createdAt: now,
-      id: "org_1",
-      name: "Org",
-      skillsPostTurnReview: true,
-      slug: "org",
-      updatedAt: now,
-    });
-    await db.upsertProfile({
-      createdAt: now,
-      id: "profile_1",
-      isSuper: false,
-      model: null,
-      name: "Bot",
-      orgId: "org_1",
-      systemPrompt: "",
-      updatedAt: now,
-    });
-    await db.upsertSession({
-      agentQuestionnaire: null,
-      agentTodos: [],
-      channel: "automation",
-      createdAt: now,
-      id: "session_1",
-      model: null,
-      orgId: "org_1",
-      profileId: "profile_1",
-      title: null,
-      userId: "user_1",
-    });
-
-    let ran = 0;
-    const service = new SkillPostTurnReviewService(
-      db,
-      () => null,
-      async () => {
-        ran += 1;
-      }
-    );
-
-    expect(await service.runPostTurnSkillReview("session_1")).toBe(
-      "channel_not_interactive"
-    );
-    expect(ran).toBe(0);
-  });
-
   test("skips when flag disabled", async () => {
     const db = createInMemoryDatabaseAdapter();
     const now = new Date().toISOString();

--- a/apps/server/src/services/skill-post-turn-review-service.test.ts
+++ b/apps/server/src/services/skill-post-turn-review-service.test.ts
@@ -140,7 +140,7 @@ describe("evaluatePostTurnReviewTurnEligibility", () => {
 
 describe("SkillPostTurnReviewService", () => {
   test("runs runner once for eligible interactive channels when flag on and manage-skills assigned", async () => {
-    for (const channel of ["web", "discord", "telegram", "whatsapp"]) {
+    for (const channel of ["web", "cli", "discord", "telegram", "whatsapp"]) {
       const db = createInMemoryDatabaseAdapter();
       await seedEligibleTurn(db, channel);
 
@@ -156,6 +156,49 @@ describe("SkillPostTurnReviewService", () => {
       expect(await service.runPostTurnSkillReview("session_1")).toBe("ran");
       expect(ran).toBe(1);
     }
+  });
+
+  // The other half of the same table. Together these two cover all eight
+  // channels, so flipping any value in POST_TURN_REVIEW_CHANNELS fails a test
+  // rather than only shifting behaviour.
+  test("skips the non-interactive channels even when the turn is eligible", async () => {
+    for (const channel of ["automation", "task", "subagent"]) {
+      const db = createInMemoryDatabaseAdapter();
+      await seedEligibleTurn(db, channel);
+
+      let ran = 0;
+      const service = new SkillPostTurnReviewService(
+        db,
+        () => null,
+        async () => {
+          ran += 1;
+        }
+      );
+
+      expect(await service.runPostTurnSkillReview("session_1")).toBe(
+        "channel_not_interactive"
+      );
+      expect(ran).toBe(0);
+    }
+  });
+
+  test("skips a channel value that is not an agent channel at all", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    await seedEligibleTurn(db, "sms");
+
+    let ran = 0;
+    const service = new SkillPostTurnReviewService(
+      db,
+      () => null,
+      async () => {
+        ran += 1;
+      }
+    );
+
+    expect(await service.runPostTurnSkillReview("session_1")).toBe(
+      "channel_not_interactive"
+    );
+    expect(ran).toBe(0);
   });
 
   test("skips headless automation channel as channel_not_interactive", async () => {

--- a/apps/server/src/services/skill-post-turn-review-service.test.ts
+++ b/apps/server/src/services/skill-post-turn-review-service.test.ts
@@ -201,6 +201,59 @@ describe("SkillPostTurnReviewService", () => {
     expect(ran).toBe(0);
   });
 
+  // A different property from the table above: not which channels skip, but
+  // that the channel decides before anything later can claim the skip. This
+  // session would fail the manage-skills check too, so if the gate moved below
+  // it the reason would change to manage_skills_unassigned.
+  test("reports the channel before a later check can claim the skip", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const now = new Date().toISOString();
+    await db.upsertOrganization({
+      createdAt: now,
+      id: "org_1",
+      name: "Org",
+      skillsPostTurnReview: true,
+      slug: "org",
+      updatedAt: now,
+    });
+    await db.upsertProfile({
+      createdAt: now,
+      id: "profile_1",
+      isSuper: false,
+      model: null,
+      name: "Bot",
+      orgId: "org_1",
+      systemPrompt: "",
+      updatedAt: now,
+    });
+    await db.upsertSession({
+      agentQuestionnaire: null,
+      agentTodos: [],
+      channel: "automation",
+      createdAt: now,
+      id: "session_1",
+      model: null,
+      orgId: "org_1",
+      profileId: "profile_1",
+      title: null,
+      userId: "user_1",
+    });
+
+    let ran = 0;
+    const service = new SkillPostTurnReviewService(
+      db,
+      () => null,
+      async () => {
+        ran += 1;
+      }
+    );
+
+    expect(await service.runPostTurnSkillReview("session_1")).toBe(
+      "channel_not_interactive"
+    );
+    expect(ran).toBe(0);
+  });
+
   test("skips when flag disabled", async () => {
     const db = createInMemoryDatabaseAdapter();
     const now = new Date().toISOString();

--- a/apps/server/src/services/skill-post-turn-review-service.ts
+++ b/apps/server/src/services/skill-post-turn-review-service.ts
@@ -16,9 +16,10 @@ import { resolveProfileProviderSelection } from "./provider-instance-helpers";
 
 /**
  * Which channels run the post-turn skill review. Total over `AgentChannel`, so
- * a new channel fails the typecheck here and has to be decided. #213 was this
- * gate: it shipped as `channel !== "web" && channel !== "cli"`, and Discord,
- * Telegram and WhatsApp skipped the review for six days without a signal.
+ * a new channel fails the typecheck here and has to be decided. This gate is
+ * where #213 happened: `ae27f7b2` shipped it as
+ * `channel !== "web" && channel !== "cli"`, and Discord, Telegram and WhatsApp
+ * skipped the review for five days and 23 hours until `e0026ea6` (#224).
  */
 const POST_TURN_REVIEW_CHANNELS = {
   automation: false,

--- a/apps/server/src/services/skill-post-turn-review-service.ts
+++ b/apps/server/src/services/skill-post-turn-review-service.ts
@@ -3,14 +3,33 @@ import {
   type SkillPostTurnReviewOutcome,
 } from "@nakama/agent";
 import {
+  type AgentChannel,
   type ChatMessage,
   extractLatestTurnMessages,
+  parseAgentChannel,
   resolveSkillPostTurnReviewEnabled,
   type UserConfig,
 } from "@nakama/core";
 import type { DatabaseAdapter } from "@nakama/db";
 import { createProviderForInstance } from "../providers/create";
 import { resolveProfileProviderSelection } from "./provider-instance-helpers";
+
+/**
+ * Which channels run the post-turn skill review. Total over `AgentChannel`, so
+ * a new channel fails the typecheck here and has to be decided. #213 was this
+ * gate: it shipped as `channel !== "web" && channel !== "cli"`, and Discord,
+ * Telegram and WhatsApp skipped the review for six days without a signal.
+ */
+const POST_TURN_REVIEW_CHANNELS = {
+  automation: false,
+  cli: true,
+  discord: true,
+  subagent: false,
+  task: false,
+  telegram: true,
+  web: true,
+  whatsapp: true,
+} as const satisfies Record<AgentChannel, boolean>;
 
 const MIN_TOOL_CALLS_FOR_COMPLEX_TURN = 5;
 const MANAGE_SKILLS_NAME = "manage-skills";
@@ -193,15 +212,10 @@ export class SkillPostTurnReviewService {
         return "session_missing";
       }
 
-      const channel = session.channel;
-      const interactiveChannels = new Set([
-        "web",
-        "cli",
-        "discord",
-        "telegram",
-        "whatsapp",
-      ]);
-      if (!interactiveChannels.has(channel)) {
+      // The session row keeps `channel` as a string, so an unknown value is
+      // narrowed away here and skips the review exactly as it did before.
+      const channel = parseAgentChannel(session.channel);
+      if (!(channel && POST_TURN_REVIEW_CHANNELS[channel])) {
         return "channel_not_interactive";
       }
 

--- a/apps/server/src/tools/skill-manage-tool.test.ts
+++ b/apps/server/src/tools/skill-manage-tool.test.ts
@@ -380,17 +380,6 @@ Profile body.
     ).rejects.toThrow("not available during automation runs");
   });
 
-  test("refuses non-interactive channel context", async () => {
-    const { tool } = await setup();
-
-    await expect(
-      tool.run(
-        { action: "create", content: researchSkillMarkdown },
-        memberContext({ channel: "telegram" })
-      )
-    ).rejects.toThrow(/interactive web or CLI/);
-  });
-
   // The whole of SKILL_MANAGE_CHANNELS, so flipping any one value fails here
   // instead of only changing behaviour. The two allowed channels create; the
   // six others are refused before anything touches disk.

--- a/apps/server/src/tools/skill-manage-tool.test.ts
+++ b/apps/server/src/tools/skill-manage-tool.test.ts
@@ -391,6 +391,44 @@ Profile body.
     ).rejects.toThrow(/interactive web or CLI/);
   });
 
+  // The whole of SKILL_MANAGE_CHANNELS, so flipping any one value fails here
+  // instead of only changing behaviour. The two allowed channels create; the
+  // six others are refused before anything touches disk.
+  test("lets the skill-management channels through the gate", async () => {
+    for (const channel of ["web", "cli"] as const) {
+      const { tool } = await setup();
+
+      const result = await tool.run(
+        { action: "create", content: researchSkillMarkdown },
+        memberContext({ channel })
+      );
+
+      expect(result).toMatchObject({ created: true, name: "research-paper" });
+      // Each pass needs its own config dir; afterEach only removes the last.
+      await rm(configDir, { force: true, recursive: true });
+    }
+  });
+
+  test("refuses every channel outside the skill-management table", async () => {
+    const { tool } = await setup();
+
+    for (const channel of [
+      "automation",
+      "discord",
+      "subagent",
+      "task",
+      "telegram",
+      "whatsapp",
+    ] as const) {
+      await expect(
+        tool.run(
+          { action: "create", content: researchSkillMarkdown },
+          memberContext({ channel })
+        )
+      ).rejects.toThrow(/interactive web or CLI/);
+    }
+  });
+
   test("gate off creates immediately (AE1 regression)", async () => {
     const { db, tool } = await setup();
     await seedOrgProfile(db, { orgSkillsWriteApproval: false });

--- a/apps/server/src/tools/skill-manage-tool.ts
+++ b/apps/server/src/tools/skill-manage-tool.ts
@@ -1,4 +1,5 @@
 import {
+  type AgentChannel,
   parseRawProfileSkillContent,
   type ToolContext,
   type ToolDefinition,
@@ -31,6 +32,23 @@ function requireProfileId(context: ToolContext): string {
 }
 
 /**
+ * Which channels get the skill-management surface. Total over `AgentChannel`,
+ * so a new channel fails the typecheck here instead of inheriting `false` in
+ * silence. `agent-service` reads the same table when it decides whether to
+ * attach the tools, so the offer and this gate cannot drift apart.
+ */
+export const SKILL_MANAGE_CHANNELS = {
+  automation: false,
+  cli: true,
+  discord: false,
+  subagent: false,
+  task: false,
+  telegram: false,
+  web: true,
+  whatsapp: false,
+} as const satisfies Record<AgentChannel, boolean>;
+
+/**
  * Deny-by-default role gate for skill_manage. Viewers are blocked; an undefined
  * role also blocks — same pattern as org-memory tools.
  */
@@ -43,7 +61,7 @@ function requireSkillManageAccess(context: ToolContext): {
   }
 
   const channel = context.channel;
-  if (channel !== undefined && channel !== "web" && channel !== "cli") {
+  if (channel !== undefined && !SKILL_MANAGE_CHANNELS[channel]) {
     throw new Error(
       "skill_manage is only available in interactive web or CLI chat."
     );

--- a/apps/web/src/lib/chat-history.test.ts
+++ b/apps/web/src/lib/chat-history.test.ts
@@ -459,12 +459,4 @@ describe("session channel tables", () => {
 
     expect(readOnly).toEqual(["telegram", "whatsapp", "discord"]);
   });
-
-  test("every listed channel except web is read only", () => {
-    const writable = HISTORY_SESSION_CHANNELS.filter(
-      (channel) => !isReadOnlySessionChannel(channel)
-    );
-
-    expect(writable).toEqual(["web"]);
-  });
 });

--- a/apps/web/src/lib/chat-history.test.ts
+++ b/apps/web/src/lib/chat-history.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import type { ChatMessage, SessionMessageMeta } from "@nakama/core/contract";
+import { AGENT_CHANNELS } from "@nakama/core/contract";
 import { extractTurnArtifacts } from "./chat-artifacts";
 import {
   chatMessagesToListItems,
   formatSessionRelativeTime,
   formatSessionTimestamp,
+  HISTORY_SESSION_CHANNELS,
+  isReadOnlySessionChannel,
 } from "./chat-history";
 
 const tinyPngBase64 =
@@ -433,5 +436,35 @@ describe("formatSessionTimestamp", () => {
       "Unknown time"
     );
     expect(formatSessionRelativeTime("totally-bogus")).toBe("Unknown time");
+  });
+});
+
+// Both web channel tables, every channel named. Flipping one value in either
+// table fails one of these, which is what the tables are for: a channel that
+// joins AGENT_CHANNELS has to be decided rather than dropping out in silence.
+describe("session channel tables", () => {
+  test("lists the four channels that have a web history", () => {
+    expect(HISTORY_SESSION_CHANNELS).toEqual([
+      "web",
+      "telegram",
+      "whatsapp",
+      "discord",
+    ]);
+  });
+
+  test("marks the three messaging channels read only and no others", () => {
+    const readOnly = AGENT_CHANNELS.filter((channel) =>
+      isReadOnlySessionChannel(channel)
+    );
+
+    expect(readOnly).toEqual(["telegram", "whatsapp", "discord"]);
+  });
+
+  test("every listed channel except web is read only", () => {
+    const writable = HISTORY_SESSION_CHANNELS.filter(
+      (channel) => !isReadOnlySessionChannel(channel)
+    );
+
+    expect(writable).toEqual(["web"]);
   });
 });

--- a/apps/web/src/lib/chat-history.ts
+++ b/apps/web/src/lib/chat-history.ts
@@ -5,6 +5,7 @@ import type {
   ChatMessage,
   SessionMessageMeta,
 } from "@nakama/core/contract";
+import { AGENT_CHANNELS } from "@nakama/core/contract";
 import { extractThinkingFromAssistantMessage } from "@nakama/core/thinking-content";
 import {
   stripImageDescriptionsFromDisplayText,
@@ -393,17 +394,42 @@ export function sessionStorageKey(profileId: string): string {
   return `nakama:session:${profileId}`;
 }
 
-export const HISTORY_SESSION_CHANNELS = [
-  "web",
-  "telegram",
-  "whatsapp",
-  "discord",
-] as const satisfies readonly AgentChannel[];
+/**
+ * Which channels the history panel lists. Total over `AgentChannel`, so a new
+ * channel fails the typecheck here rather than dropping out of the list in
+ * silence, and the list itself is derived so the two cannot disagree.
+ */
+const HISTORY_SESSION_CHANNEL = {
+  automation: false,
+  cli: false,
+  discord: true,
+  subagent: false,
+  task: false,
+  telegram: true,
+  web: true,
+  whatsapp: true,
+} as const satisfies Record<AgentChannel, boolean>;
+
+export const HISTORY_SESSION_CHANNELS: readonly AgentChannel[] =
+  AGENT_CHANNELS.filter((channel) => HISTORY_SESSION_CHANNEL[channel]);
+
+/**
+ * Which listed channels are read only in the web UI. Separate from the list
+ * above because it is a separate decision: `web` is listed and writable.
+ */
+const READ_ONLY_SESSION_CHANNEL = {
+  automation: false,
+  cli: false,
+  discord: true,
+  subagent: false,
+  task: false,
+  telegram: true,
+  web: false,
+  whatsapp: true,
+} as const satisfies Record<AgentChannel, boolean>;
 
 export function isReadOnlySessionChannel(channel: AgentChannel): boolean {
-  return (
-    channel === "telegram" || channel === "whatsapp" || channel === "discord"
-  );
+  return READ_ONLY_SESSION_CHANNEL[channel];
 }
 
 export function formatSessionChannelLabel(channel: AgentChannel): string {

--- a/docs/website/content/docs/self-improving-skills.mdx
+++ b/docs/website/content/docs/self-improving-skills.mdx
@@ -118,7 +118,7 @@ Org admins: **System → Organization**, on the **Learn after a turn** card (nex
 
 ![Learn after a turn org switch and per-profile overrides](/screenshots/learn-after-a-turn-org.png)
 
-When enabled, after a **successful** web or CLI turn that looks complex (many tool calls, or a tool error recovery) — and only if the agent did **not** already save a skill that turn — Nakama runs a lightweight background review. Chat is not blocked while that runs. It uses an extra model call on eligible turns, so leave it off unless you want the safety net.
+When enabled, after a **successful** turn in an interactive chat (web, CLI, Discord, Telegram or WhatsApp) that looks complex (many tool calls, or a tool error recovery) — and only if the agent did **not** already save a skill that turn — Nakama runs a lightweight background review. Chat is not blocked while that runs. It uses an extra model call on eligible turns, so leave it off unless you want the safety net.
 
 ### What you see (review × write approval)
 

--- a/packages/agent/src/chat-prompt.test.ts
+++ b/packages/agent/src/chat-prompt.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { AGENT_CHANNELS } from "@nakama/core";
 import { buildChatSystemPrompt } from "./chat-prompt";
 
 test("buildChatSystemPrompt includes automation skill pointer when create_automation is available", () => {
@@ -218,4 +219,16 @@ test("buildChatSystemPrompt tells Telegram not to invent attach refusals", () =>
 
   expect(prompt).toContain("do not say you cannot attach");
   expect(prompt).toContain("Telegram document");
+});
+
+// Every channel, so flipping one entry of MESSAGING_CHANNEL_PROMPT between a
+// config and null fails here rather than silently changing the reply style.
+test("buildChatSystemPrompt gives the messaging style to three channels only", () => {
+  const withStyle = AGENT_CHANNELS.filter((channel) =>
+    buildChatSystemPrompt([], { channel, enableToolLoop: true }).includes(
+      "Write like texting a friend"
+    )
+  );
+
+  expect(withStyle).toEqual(["telegram", "whatsapp", "discord"]);
 });

--- a/packages/agent/src/chat-prompt.ts
+++ b/packages/agent/src/chat-prompt.ts
@@ -1,7 +1,5 @@
-import type { ToolDefinition } from "@nakama/core";
+import type { AgentChannel, ToolDefinition } from "@nakama/core";
 import type { AgentRequest } from "./chat";
-
-type MessagingChannel = "telegram" | "whatsapp" | "discord";
 
 type MessagingChannelPromptConfig = {
   label: string;
@@ -10,6 +8,8 @@ type MessagingChannelPromptConfig = {
 };
 
 const MESSAGING_CHANNEL_PROMPT = {
+  automation: null,
+  cli: null,
   discord: {
     format: [
       "Discord supports a Markdown subset: **bold**, *italic*, __underline__, ~~strikethrough~~, inline code, fenced code blocks, and headings.",
@@ -19,6 +19,8 @@ const MESSAGING_CHANNEL_PROMPT = {
     label: "Discord",
     supportsGroupAudience: true,
   },
+  subagent: null,
+  task: null,
   telegram: {
     format: [
       "Write in normal Markdown when formatting helps; Telegram delivery will render a safe rich subset.",
@@ -29,6 +31,7 @@ const MESSAGING_CHANNEL_PROMPT = {
     label: "Telegram",
     supportsGroupAudience: true,
   },
+  web: null,
   whatsapp: {
     format: [
       "WhatsApp only supports simple *bold* and _italic_ formatting.",
@@ -38,7 +41,18 @@ const MESSAGING_CHANNEL_PROMPT = {
     label: "WhatsApp",
     supportsGroupAudience: true,
   },
-} as const satisfies Record<MessagingChannel, MessagingChannelPromptConfig>;
+} as const satisfies Record<AgentChannel, MessagingChannelPromptConfig | null>;
+
+/**
+ * The channels that get a messaging style, read back off the map above instead
+ * of hand-written beside it. The map is total over `AgentChannel`, so a new
+ * channel fails the typecheck there and has to say whether it is one of these.
+ */
+type MessagingChannel = {
+  [K in AgentChannel]: (typeof MESSAGING_CHANNEL_PROMPT)[K] extends null
+    ? never
+    : K;
+}[AgentChannel];
 
 const SHARED_MESSAGING_STYLE = [
   "Write like texting a friend: short paragraphs and a conversational tone.",
@@ -50,7 +64,7 @@ const SHARED_MESSAGING_STYLE = [
 function isMessagingChannel(
   channel: AgentRequest["channel"] | undefined
 ): channel is MessagingChannel {
-  return channel !== undefined && channel in MESSAGING_CHANNEL_PROMPT;
+  return channel !== undefined && MESSAGING_CHANNEL_PROMPT[channel] !== null;
 }
 
 export const UNTRUSTED_DOCUMENT_GUIDANCE =

--- a/packages/core/src/agent-channel.test.ts
+++ b/packages/core/src/agent-channel.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { AGENT_CHANNELS, parseAgentChannel } from "./contract";
+
+describe("parseAgentChannel", () => {
+  test("returns every channel that is in AGENT_CHANNELS", () => {
+    expect(AGENT_CHANNELS.map((channel) => parseAgentChannel(channel))).toEqual(
+      [...AGENT_CHANNELS]
+    );
+  });
+
+  test("returns null for a string that is not a channel", () => {
+    // Session rows keep the column as `string`, so this is the case that
+    // decides what an unknown stored value means everywhere it is read.
+    for (const value of ["sms", "Web", "web ", "", "slack"]) {
+      expect(parseAgentChannel(value)).toBeNull();
+    }
+  });
+});

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -87,6 +87,17 @@ export const AGENT_CHANNELS = [
 
 export type AgentChannel = (typeof AGENT_CHANNELS)[number];
 
+/**
+ * Narrow a stored channel string to `AgentChannel`. Session rows keep the
+ * column as `string`, so this is the one place that decides what an unknown
+ * value means: `null`, never a silent pass.
+ */
+export function parseAgentChannel(value: string): AgentChannel | null {
+  return AGENT_CHANNELS.includes(value as AgentChannel)
+    ? (value as AgentChannel)
+    : null;
+}
+
 export const NAKAMA_API_VERSION = 1;
 
 export interface HealthResponse {


### PR DESCRIPTION
## Summary

Adding a channel to `AGENT_CHANNELS` now fails the typecheck at each site that has to decide about it, instead of compiling clean and going silent at seven of them.

**Before:** seven hand-written subsets decide behaviour, and a ninth channel adds zero typecheck errors, so nothing asks whether it should be interactive, listed, read only, or given a reply style.
**After:** five total maps over `AgentChannel` back those seven sites. A ninth channel adds 14 errors across five files, none of them in `contract.ts`.

Why safe:
1. The map values reproduce the old predicates exactly. `tsc` on the branch has the same error set as main, 8298 either way, 0 new and 0 gone, each side run twice byte-identical.
2. Twelve behaviour changes were written against both main and this branch and scored by each tree's own suite, each proved applied before the suite ran. Main catches 4 of 12, this branch 12 of 12.
3. The `skill_manage` offer and its runtime gate now read one map, so the tool cannot be attached in a channel that then refuses to run it.

Only re-add the hand-written lists if you want the two `agent-service` sites to diverge; today they are the same list, and splitting them later means splitting one map.

Two things worth knowing, both raised in #474 and neither settled by this PR. `StoredSessionRecord.channel` is still `string`; this reuses the `parseAgentChannel` that already existed in `agent-service` rather than narrowing the column, which is a separate change. And `apps/server/src/tools/skill-manage-tool.ts` was missing from the issue's table, so it is included here and the issue comment says so.

## Test plan
- [x] `bun run test` (2768 pass, 0 fail across 11 workspaces; main is 2758)
- [x] `bun run check` and `bun run knip` (both exit 0, no findings)
- [x] `bun x tsc@5.9.3 --noEmit -p tsconfig.json` before and after adding a ninth channel, twice per side (0 new on main, 14 new here)
- [ ] Open a Telegram or Discord session in the web history panel and confirm it still renders read only, and a web session still writable

Refs #474
