### PR TITLE
fix(db): drop dead orgId field on workspace settings

### DIFF
--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -176,7 +176,6 @@ export interface StoredWorkspaceSettingsRecord {
   codingAgentProviderPassthrough: boolean;
   id: string;
   imageModel: string | null;
-  orgId?: string | null;
   selectedCodingAgentHarness: string | null;
   /** null = inherit the NAKAMA_OMNI env var; true/false = set explicitly here. */
   tokenOptimizerEnabled?: boolean | null;

--- a/packages/db/src/workspace-settings.test.ts
+++ b/packages/db/src/workspace-settings.test.ts
@@ -88,4 +88,13 @@ describe("workspace settings merge", () => {
     expect(merged.transcriptionModel).toBeNull();
     expect(merged.visionModel).toBeNull();
   });
+
+  test("merge output never carries an orgId key", () => {
+    const merged = mergeWorkspaceSettings(null, {
+      id: "default",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    expect(merged).not.toHaveProperty("orgId");
+  });
 });

--- a/packages/db/src/workspace-settings.ts
+++ b/packages/db/src/workspace-settings.ts
@@ -30,7 +30,6 @@ export function mergeWorkspaceSettings(
     ),
     id: pickDefined(patch.id, existing?.id ?? WORKSPACE_SETTINGS_ID),
     imageModel: pickDefined(patch.imageModel, existing?.imageModel ?? null),
-    orgId: "orgId" in patch ? patch.orgId : existing?.orgId,
     selectedCodingAgentHarness: pickDefined(
       patch.selectedCodingAgentHarness,
       existing?.selectedCodingAgentHarness ?? null


### PR DESCRIPTION
## Summary

`StoredWorkspaceSettingsRecord.orgId` is gone. It was declared but never written or read.

**Before:** `orgId?: string | null` sat on the type; `mergeWorkspaceSettings` carried it through patches, but no `upsertWorkspaceSettings` caller ever set it and nothing ever read `.orgId` off a loaded record.
**After:** field removed from the type and from `mergeWorkspaceSettings`. Workspace settings stays a global singleton, matching how every caller already treats it.

Why safe:
1. Checked every `upsertWorkspaceSettings(...)` call site (`agent-service.ts`, `coding-agent-harness-service.ts`, `token-optimization.ts`, all test fixtures), none set `orgId`
2. No caller reads `.orgId` off a `StoredWorkspaceSettingsRecord` anywhere in the tree
3. `WorkspaceSettingsRow`/`upsertWorkspaceSettingsStmt`/`toWorkspaceSettingsRecord` in `sqlite.ts` never referenced it either, so there's no column to migrate

Closes #556

Only re-add if workspace settings actually becomes org-scoped later, that's a new feature, not this fix.

## Test plan
- [x] `bun test` in `packages/db`: 86 pass, 1 fail (`database reopen after restore`, a pre-existing Windows temp-file-lock flake, same fail on unmodified `upstream/main`)
- [x] `bun test` on the server files that touch workspace settings (`agent-service`, `coding-agent-bash-env`, `coding-agent-harness-service`, `image-generation`, `token-optimization`): same 4 pre-existing fails as unmodified `upstream/main` (missing host CLIs on this dev machine), zero new
- [x] `bunx tsc --noEmit` whole repo: identical total error count before/after, both `orgId` errors gone
- [x] `bun run knip` clean
