### PR TITLE
fix(server): stop returning raw internal error messages to clients

### DIFF
--- a/apps/server/src/http/coding-harness-install-stream.test.ts
+++ b/apps/server/src/http/coding-harness-install-stream.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { NakamaApiError } from "@nakama/core";
 import { streamInstallEvents } from "./coding-harness-install-stream";
 
 type TestEvent = { type: string; message?: string; error?: string };
@@ -54,15 +55,31 @@ describe("streamInstallEvents", () => {
     ]);
   });
 
-  test("reports an executor failure as an error event", async () => {
+  test("reports an executor's intentional failure as an error event", async () => {
     const response = streamInstallEvents<TestEvent>(() =>
-      Promise.reject(new Error("installer exited with code 1"))
+      Promise.reject(new NakamaApiError("installer exited with code 1", 502))
     );
 
     const events = await readEvents(response);
 
     expect(events.map((event) => event.type)).toEqual(["error"]);
     expect(events[0]?.error).toContain("installer exited with code 1");
+  });
+
+  test("does not leak an unexpected executor error's message", async () => {
+    const response = streamInstallEvents<TestEvent>(() =>
+      Promise.reject(
+        new Error(
+          "ENOENT: no such file or directory, open '/home/nakama/.config/nakama/nakama.db'"
+        )
+      )
+    );
+
+    const events = await readEvents(response);
+
+    expect(events).toEqual([
+      { error: "An unexpected server error occurred.", type: "error" },
+    ]);
   });
 
   test("ends the stream with a timeout error when the installer stalls", async () => {

--- a/apps/server/src/http/coding-harness-install-stream.ts
+++ b/apps/server/src/http/coding-harness-install-stream.ts
@@ -1,5 +1,4 @@
 import type { AgentBrowserInstallEvent } from "@nakama/core";
-import { formatServerError } from "@nakama/core";
 
 const INSTALL_STREAM_TIMEOUT_MS = 120_000;
 
@@ -76,7 +75,7 @@ export function streamInstallEvents<TEvent extends { type: string }>(
         await executor(send);
       } catch (error) {
         send({
-          error: formatServerError(error),
+          error: error instanceof Error ? error.message : String(error),
           type: "error",
         } as Extract<TEvent, InstallStreamErrorEvent>);
       } finally {

--- a/apps/server/src/http/coding-harness-install-stream.ts
+++ b/apps/server/src/http/coding-harness-install-stream.ts
@@ -1,4 +1,4 @@
-import type { AgentBrowserInstallEvent } from "@nakama/core";
+import { type AgentBrowserInstallEvent, formatServerError } from "@nakama/core";
 
 const INSTALL_STREAM_TIMEOUT_MS = 120_000;
 
@@ -75,7 +75,7 @@ export function streamInstallEvents<TEvent extends { type: string }>(
         await executor(send);
       } catch (error) {
         send({
-          error: error instanceof Error ? error.message : String(error),
+          error: formatServerError(error),
           type: "error",
         } as Extract<TEvent, InstallStreamErrorEvent>);
       } finally {

--- a/apps/server/src/http/routes/models-error-format.test.ts
+++ b/apps/server/src/http/routes/models-error-format.test.ts
@@ -30,33 +30,4 @@ describe("model routes error formatting", () => {
       error: "An unexpected server error occurred.",
     });
   });
-
-  test("discover models does not leak an unexpected error's message", async () => {
-    const { app, databaseAdapter } = createMinimalHonoApp({
-      agent: {
-        discoverModels: async () => {
-          throw new Error(
-            "getaddrinfo ENOTFOUND internal-provider.nakama.local"
-          );
-        },
-      },
-    });
-    const session = await setupFreshInstallSession(app, databaseAdapter);
-
-    const response = await app.fetch(
-      new Request("http://localhost:4310/v1/models/discover", {
-        body: JSON.stringify({ baseUrl: "https://example.com" }),
-        headers: session.headers({
-          "Content-Type": "application/json",
-          "X-CSRF-Token": session.csrfToken,
-        }),
-        method: "POST",
-      })
-    );
-
-    expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toEqual({
-      error: "An unexpected server error occurred.",
-    });
-  });
 });

--- a/apps/server/src/http/routes/models-error-format.test.ts
+++ b/apps/server/src/http/routes/models-error-format.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createMinimalHonoApp } from "../test-app-helpers";
+import { setupFreshInstallSession } from "../test-session-helpers";
+
+describe("model routes error formatting", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("catalog fetch failure does not leak the upstream error's message", async () => {
+    globalThis.fetch = async () => {
+      throw new Error(
+        "connect ETIMEDOUT 198.51.100.4:443 at TCPConnectWrap.afterConnect"
+      );
+    };
+
+    const { app, databaseAdapter } = createMinimalHonoApp();
+    const session = await setupFreshInstallSession(app, databaseAdapter);
+
+    const response = await app.fetch(
+      new Request("http://localhost:4310/v1/model-catalogs/openrouter", {
+        headers: session.headers(),
+      })
+    );
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      error: "An unexpected server error occurred.",
+    });
+  });
+
+  test("discover models does not leak an unexpected error's message", async () => {
+    const { app, databaseAdapter } = createMinimalHonoApp({
+      agent: {
+        discoverModels: async () => {
+          throw new Error(
+            "getaddrinfo ENOTFOUND internal-provider.nakama.local"
+          );
+        },
+      },
+    });
+    const session = await setupFreshInstallSession(app, databaseAdapter);
+
+    const response = await app.fetch(
+      new Request("http://localhost:4310/v1/models/discover", {
+        body: JSON.stringify({ baseUrl: "https://example.com" }),
+        headers: session.headers({
+          "Content-Type": "application/json",
+          "X-CSRF-Token": session.csrfToken,
+        }),
+        method: "POST",
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "An unexpected server error occurred.",
+    });
+  });
+});

--- a/apps/server/src/http/routes/models.ts
+++ b/apps/server/src/http/routes/models.ts
@@ -10,6 +10,7 @@ import {
   type DiscordSettingsResponse,
   type DiscoverModelsRequest,
   type EmailSettingsResponse,
+  formatServerError,
   type GenerateImageRequest,
   type GenerateImageResponse,
   type ImageGenerationSettingsResponse,
@@ -1184,8 +1185,7 @@ export function registerModelRoutes(
     try {
       return json(await getExternalModelCatalog(catalogId));
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      return errorResponse(message, 502);
+      return errorResponse(formatServerError(error), 502);
     }
   });
 
@@ -1207,8 +1207,7 @@ export function registerModelRoutes(
       const result = await agent.discoverModels(body);
       return json<ModelsResponse>(result);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      return errorResponse(message, 400);
+      return errorResponse(formatServerError(error), 400);
     }
   });
 

--- a/apps/server/src/http/routes/models.ts
+++ b/apps/server/src/http/routes/models.ts
@@ -1202,13 +1202,8 @@ export function registerModelRoutes(
   app.post("/v1/models/discover", async (c) => {
     requireOrgAdminOrPlatformAdminFromContext(c);
     const body = await readJson<DiscoverModelsRequest>(c.req.raw);
-
-    try {
-      const result = await agent.discoverModels(body);
-      return json<ModelsResponse>(result);
-    } catch (error) {
-      return errorResponse(formatServerError(error), 400);
-    }
+    const result = await agent.discoverModels(body);
+    return json<ModelsResponse>(result);
   });
 
   app.get("/v1/providers", async (c) => {

--- a/apps/server/src/http/routes/notification-webhooks.test.ts
+++ b/apps/server/src/http/routes/notification-webhooks.test.ts
@@ -113,6 +113,38 @@ describe("notification webhook routes", () => {
     expect(response.status).toBe(401);
   });
 
+  test("does not leak an unexpected internal failure's message", async () => {
+    const { app, databaseAdapter } = await createApp();
+    const lookupSpy = spyOn(
+      databaseAdapter,
+      "getNotificationDestination"
+    ).mockImplementation(() => {
+      throw new Error(
+        "SQLITE_IOERR: disk I/O error at /home/nakama/.config/nakama/nakama.db"
+      );
+    });
+
+    try {
+      const response = await app.fetch(
+        new Request("http://localhost:4310/v1/notify/dest_1", {
+          body: JSON.stringify({ body: "Hello" }),
+          headers: {
+            "Content-Type": "application/json",
+            "X-API-Key": "secret_key",
+          },
+          method: "POST",
+        })
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        error: "An unexpected server error occurred.",
+      });
+    } finally {
+      lookupSpy.mockRestore();
+    }
+  });
+
   test("does not deliver for an archived organization", async () => {
     const telegramCalls: unknown[] = [];
     const originalFetch = globalThis.fetch;

--- a/apps/server/src/http/routes/notification-webhooks.test.ts
+++ b/apps/server/src/http/routes/notification-webhooks.test.ts
@@ -136,7 +136,7 @@ describe("notification webhook routes", () => {
         })
       );
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(500);
       await expect(response.json()).resolves.toEqual({
         error: "An unexpected server error occurred.",
       });

--- a/apps/server/src/http/routes/notification-webhooks.ts
+++ b/apps/server/src/http/routes/notification-webhooks.ts
@@ -1,5 +1,5 @@
 import type { NotificationWebhookRequest } from "@nakama/core";
-import { NakamaApiError } from "@nakama/core";
+import { formatServerError, NakamaApiError } from "@nakama/core";
 import { NotificationWebhookService } from "../../services/notification-webhook-service";
 import type { ServerOptions } from "../context";
 import { errorResponse, readJson } from "../shared";
@@ -24,10 +24,7 @@ export function registerNotificationWebhookRoutes(
       if (error instanceof NakamaApiError) {
         return errorResponse(error.message, error.status);
       }
-      return errorResponse(
-        error instanceof Error ? error.message : String(error),
-        400
-      );
+      return errorResponse(formatServerError(error), 400);
     }
   });
 }

--- a/apps/server/src/http/routes/notification-webhooks.ts
+++ b/apps/server/src/http/routes/notification-webhooks.ts
@@ -1,8 +1,7 @@
 import type { NotificationWebhookRequest } from "@nakama/core";
-import { formatServerError, NakamaApiError } from "@nakama/core";
 import { NotificationWebhookService } from "../../services/notification-webhook-service";
 import type { ServerOptions } from "../context";
-import { errorResponse, readJson } from "../shared";
+import { readJson } from "../shared";
 import type { HonoApp } from "../types";
 
 export function registerNotificationWebhookRoutes(
@@ -15,16 +14,9 @@ export function registerNotificationWebhookRoutes(
   );
 
   app.post("/v1/notify/:destinationId", async (c) => {
-    try {
-      const body = await readJson<NotificationWebhookRequest>(c.req.raw);
-      const apiKey = c.req.header("x-api-key")?.trim() ?? null;
-      await service.deliver(c.req.param("destinationId"), apiKey, body);
-      return new Response(null, { status: 204 });
-    } catch (error) {
-      if (error instanceof NakamaApiError) {
-        return errorResponse(error.message, error.status);
-      }
-      return errorResponse(formatServerError(error), 400);
-    }
+    const body = await readJson<NotificationWebhookRequest>(c.req.raw);
+    const apiKey = c.req.header("x-api-key")?.trim() ?? null;
+    await service.deliver(c.req.param("destinationId"), apiKey, body);
+    return new Response(null, { status: 204 });
   });
 }

--- a/apps/server/src/http/routes/sessions-error-format.test.ts
+++ b/apps/server/src/http/routes/sessions-error-format.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { createMinimalHonoApp } from "../test-app-helpers";
+import { setupFreshInstallSession } from "../test-session-helpers";
+
+describe("session routes error formatting", () => {
+  test("branch does not leak an unexpected error's message", async () => {
+    const { app, databaseAdapter } = createMinimalHonoApp({
+      agent: {
+        branchSession: async () => {
+          throw new Error(
+            "SQLITE_CORRUPT: database disk image is malformed at /home/nakama/.config/nakama/nakama.db"
+          );
+        },
+      },
+    });
+    const session = await setupFreshInstallSession(app, databaseAdapter);
+
+    const response = await app.fetch(
+      new Request("http://localhost:4310/v1/sessions/session_1/branch", {
+        body: JSON.stringify({ messageIndex: 0 }),
+        headers: session.headers({
+          "Content-Type": "application/json",
+          "X-CSRF-Token": session.csrfToken,
+        }),
+        method: "POST",
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "An unexpected server error occurred.",
+    });
+  });
+
+  test("send message does not leak an unexpected error's message", async () => {
+    const { app, databaseAdapter } = createMinimalHonoApp({
+      agent: {
+        beginSessionTurn: async () => true,
+        resolveSession: async () => ({
+          send: async () => {
+            throw new Error(
+              "ENOSPC: no space left on device, write /home/nakama/.config/nakama/nakama.db"
+            );
+          },
+        }),
+      },
+    });
+    const session = await setupFreshInstallSession(app, databaseAdapter);
+
+    const response = await app.fetch(
+      new Request("http://localhost:4310/v1/sessions/session_1/messages", {
+        body: JSON.stringify({ message: "hi" }),
+        headers: session.headers({
+          "Content-Type": "application/json",
+          "X-CSRF-Token": session.csrfToken,
+        }),
+        method: "POST",
+      })
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "An unexpected server error occurred.",
+    });
+  });
+});

--- a/apps/server/src/http/routes/sessions-error-format.test.ts
+++ b/apps/server/src/http/routes/sessions-error-format.test.ts
@@ -3,35 +3,6 @@ import { createMinimalHonoApp } from "../test-app-helpers";
 import { setupFreshInstallSession } from "../test-session-helpers";
 
 describe("session routes error formatting", () => {
-  test("branch does not leak an unexpected error's message", async () => {
-    const { app, databaseAdapter } = createMinimalHonoApp({
-      agent: {
-        branchSession: async () => {
-          throw new Error(
-            "SQLITE_CORRUPT: database disk image is malformed at /home/nakama/.config/nakama/nakama.db"
-          );
-        },
-      },
-    });
-    const session = await setupFreshInstallSession(app, databaseAdapter);
-
-    const response = await app.fetch(
-      new Request("http://localhost:4310/v1/sessions/session_1/branch", {
-        body: JSON.stringify({ messageIndex: 0 }),
-        headers: session.headers({
-          "Content-Type": "application/json",
-          "X-CSRF-Token": session.csrfToken,
-        }),
-        method: "POST",
-      })
-    );
-
-    expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toEqual({
-      error: "An unexpected server error occurred.",
-    });
-  });
-
   test("send message does not leak an unexpected error's message", async () => {
     const { app, databaseAdapter } = createMinimalHonoApp({
       agent: {

--- a/apps/server/src/http/routes/sessions.ts
+++ b/apps/server/src/http/routes/sessions.ts
@@ -529,24 +529,20 @@ export function registerSessionRoutes(
 
   app.post("/v1/sessions/:sessionId/branch", async (c) => {
     requireNotViewerFromContext(c);
-    try {
-      const orgId = requireActiveOrgIdFromContext(c);
-      const sessionId = decodeURIComponent(c.req.param("sessionId"));
-      const body = await readJson<BranchSessionRequest>(c.req.raw);
-      const result = await agent.branchSession(
-        sessionId,
-        body.messageIndex,
-        orgId
-      );
+    const orgId = requireActiveOrgIdFromContext(c);
+    const sessionId = decodeURIComponent(c.req.param("sessionId"));
+    const body = await readJson<BranchSessionRequest>(c.req.raw);
+    const result = await agent.branchSession(
+      sessionId,
+      body.messageIndex,
+      orgId
+    );
 
-      if (!result) {
-        return errorResponse("Session not found", 404);
-      }
-
-      return json<BranchSessionResponse>(result, 201);
-    } catch (error) {
-      return errorResponse(formatServerError(error), 400);
+    if (!result) {
+      return errorResponse("Session not found", 404);
     }
+
+    return json<BranchSessionResponse>(result, 201);
   });
 
   app.post("/v1/sessions/:sessionId/messages", async (c) => {

--- a/apps/server/src/http/routes/sessions.ts
+++ b/apps/server/src/http/routes/sessions.ts
@@ -14,7 +14,7 @@ import type {
   SessionStatusResponse,
   UpdateSessionRequest,
 } from "@nakama/core";
-import { AGENT_CHANNELS } from "@nakama/core";
+import { AGENT_CHANNELS, formatServerError } from "@nakama/core";
 import { resolveRequestClientOrigin } from "../../services/composio-callback-url";
 import { sessionTurnRegistry } from "../../services/session-turn-registry";
 import type { ServerOptions } from "../context";
@@ -545,8 +545,7 @@ export function registerSessionRoutes(
 
       return json<BranchSessionResponse>(result, 201);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      return errorResponse(message, 400);
+      return errorResponse(formatServerError(error), 400);
     }
   });
 
@@ -626,7 +625,7 @@ export function registerSessionRoutes(
         ...(contextUsage ? { contextUsage } : {}),
       });
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = formatServerError(error);
       sessionTurnRegistry.endTurn(sessionId, { error: message, type: "error" });
       return errorResponse(message, 500);
     }

--- a/apps/server/src/http/routes/setup-import.test.ts
+++ b/apps/server/src/http/routes/setup-import.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { getUserConfigDir } from "@nakama/core";
+import * as dataPortability from "../../services/data-portability";
 import {
   createNakamaDataExport,
   previewNakamaDataImport,
@@ -185,6 +186,40 @@ describe("setup import routes", () => {
     await expect(
       readFile(join(getUserConfigDir(), "config.ini"), "utf8")
     ).resolves.toBe("keep");
+  });
+
+  test("setup import preview does not leak an unexpected error's message", async () => {
+    const { app } = createApp();
+    await writeFile(join(getUserConfigDir(), "config.ini"), "keep");
+    const archive = (
+      await createNakamaDataExport({ rootDir: getUserConfigDir() })
+    ).data;
+
+    const previewSpy = spyOn(
+      dataPortability,
+      "previewNakamaDataImport"
+    ).mockImplementation(async () => {
+      throw new Error(
+        "ENOENT: no such file or directory, open '/home/nakama/.config/nakama/nakama.db'"
+      );
+    });
+
+    try {
+      const response = await app.fetch(
+        new Request("http://localhost:4310/v1/auth/setup/import/preview", {
+          body: JSON.stringify({ data: archive.toString("base64") }),
+          headers: { "Content-Type": "application/json" },
+          method: "POST",
+        })
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        error: "An unexpected server error occurred.",
+      });
+    } finally {
+      previewSpy.mockRestore();
+    }
   });
 
   test("setup import preview accepts valid archives", async () => {

--- a/apps/server/src/http/routes/setup-import.ts
+++ b/apps/server/src/http/routes/setup-import.ts
@@ -118,11 +118,7 @@ export function registerSetupImportRoutes(
       return errorResponse("Authentication not configured", 500);
     }
 
-    try {
-      await assertSetupImportAllowed(databaseAdapter);
-    } catch (error) {
-      return setupImportErrorResponse(error);
-    }
+    await assertSetupImportAllowed(databaseAdapter);
 
     const body = await readJson<PreviewDataImportRequest>(c.req.raw);
 
@@ -141,11 +137,7 @@ export function registerSetupImportRoutes(
       return errorResponse("Authentication not configured", 500);
     }
 
-    try {
-      await assertSetupImportAllowed(databaseAdapter);
-    } catch (error) {
-      return setupImportErrorResponse(error);
-    }
+    await assertSetupImportAllowed(databaseAdapter);
 
     const body = await readJson<RestoreDataImportRequest>(c.req.raw);
 
@@ -188,9 +180,4 @@ async function assertSetupImportAllowed(
       409
     );
   }
-}
-
-function setupImportErrorResponse(error: unknown): Response {
-  const status = error instanceof NakamaApiError ? error.status : 500;
-  return errorResponse(formatServerError(error), status);
 }

--- a/apps/server/src/http/routes/setup-import.ts
+++ b/apps/server/src/http/routes/setup-import.ts
@@ -1,6 +1,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import {
   type DataImportPreviewResponse,
+  formatServerError,
   NakamaApiError,
   type PreviewDataImportRequest,
   type RestoreDataImportRequest,
@@ -131,7 +132,7 @@ export function registerSetupImportRoutes(
       );
       return json<DataImportPreviewResponse>(preview);
     } catch (error) {
-      return errorResponse(formatImportError(error), 400);
+      return errorResponse(formatServerError(error), 400);
     }
   });
 
@@ -157,7 +158,7 @@ export function registerSetupImportRoutes(
         }
       );
     } catch (error) {
-      return errorResponse(formatImportError(error), 400);
+      return errorResponse(formatServerError(error), 400);
     }
 
     let requiresRestart = !options.onDataRestored;
@@ -190,13 +191,6 @@ async function assertSetupImportAllowed(
 }
 
 function setupImportErrorResponse(error: unknown): Response {
-  if (error instanceof NakamaApiError) {
-    return errorResponse(error.message, error.status);
-  }
-
-  return errorResponse(formatImportError(error), 500);
-}
-
-function formatImportError(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+  const status = error instanceof NakamaApiError ? error.status : 500;
+  return errorResponse(formatServerError(error), status);
 }

--- a/apps/server/src/http/routes/tools.test.ts
+++ b/apps/server/src/http/routes/tools.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { NakamaApiError } from "@nakama/core";
 import type { DatabaseAdapter } from "@nakama/db";
 import type { AuthService } from "../../services/auth-service";
 import { setupTestConfigDir } from "../../test-config-dir";
@@ -374,7 +375,7 @@ describe("tool playground routes", () => {
   test("run still maps a not-found message to 404 without leaking it", async () => {
     const { app, authService, databaseAdapter } = createApp({
       runToolPlayground: async () => {
-        throw new Error("Tool tool_missing not found");
+        throw new NakamaApiError("Tool not found.", 404);
       },
     });
     const { orgId, adminSession } = await createOrgAdminSession(
@@ -401,7 +402,7 @@ describe("tool playground routes", () => {
 
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({
-      error: "An unexpected server error occurred.",
+      error: "Tool not found.",
     });
   });
 });

--- a/apps/server/src/http/routes/tools.test.ts
+++ b/apps/server/src/http/routes/tools.test.ts
@@ -334,4 +334,74 @@ describe("tool playground routes", () => {
 
     expect(response.status).toBe(400);
   });
+
+  test("run does not leak an unexpected error's message", async () => {
+    const { app, authService, databaseAdapter } = createApp({
+      runToolPlayground: async () => {
+        throw new Error(
+          "SQLITE_CONSTRAINT: UNIQUE constraint failed at /home/nakama/.config/nakama/nakama.db"
+        );
+      },
+    });
+    const { orgId, adminSession } = await createOrgAdminSession(
+      app,
+      authService,
+      databaseAdapter,
+      "acme-run-leak",
+      "admin-run-leak@acme.com"
+    );
+
+    const response = await app.fetch(
+      new Request("http://localhost:4310/v1/tools/tool_echo/run", {
+        body: JSON.stringify({ parameters: {} }),
+        headers: adminSession.headers(
+          {
+            "Content-Type": "application/json",
+            "X-CSRF-Token": adminSession.csrfToken,
+          },
+          orgId
+        ),
+        method: "POST",
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "An unexpected server error occurred.",
+    });
+  });
+
+  test("run still maps a not-found message to 404 without leaking it", async () => {
+    const { app, authService, databaseAdapter } = createApp({
+      runToolPlayground: async () => {
+        throw new Error("Tool tool_missing not found");
+      },
+    });
+    const { orgId, adminSession } = await createOrgAdminSession(
+      app,
+      authService,
+      databaseAdapter,
+      "acme-run-404",
+      "admin-run-404@acme.com"
+    );
+
+    const response = await app.fetch(
+      new Request("http://localhost:4310/v1/tools/tool_missing/run", {
+        body: JSON.stringify({ parameters: {} }),
+        headers: adminSession.headers(
+          {
+            "Content-Type": "application/json",
+            "X-CSRF-Token": adminSession.csrfToken,
+          },
+          orgId
+        ),
+        method: "POST",
+      })
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "An unexpected server error occurred.",
+    });
+  });
 });

--- a/apps/server/src/http/routes/tools.ts
+++ b/apps/server/src/http/routes/tools.ts
@@ -1,15 +1,16 @@
 import { createRoute, z } from "@hono/zod-openapi";
-import type {
-  AssignToolRequest,
-  CreateToolRequest,
-  ListToolsResponse,
-  ProfileResponse,
-  RunToolRequest,
-  RunToolResponse,
-  SuggestToolParamsRequest,
-  SuggestToolParamsResponse,
-  ToolResponse,
-  ToolSourceResponse,
+import {
+  type AssignToolRequest,
+  type CreateToolRequest,
+  formatServerError,
+  type ListToolsResponse,
+  type ProfileResponse,
+  type RunToolRequest,
+  type RunToolResponse,
+  type SuggestToolParamsRequest,
+  type SuggestToolParamsResponse,
+  type ToolResponse,
+  type ToolSourceResponse,
 } from "@nakama/core";
 import type { ServerOptions } from "../context";
 import {
@@ -349,9 +350,9 @@ export function registerToolRoutes(app: HonoApp, options: ServerOptions): void {
         })
       );
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      const status = message.includes("not found") ? 404 : 400;
-      return json({ error: message }, status);
+      const rawMessage = error instanceof Error ? error.message : String(error);
+      const status = rawMessage.includes("not found") ? 404 : 400;
+      return json({ error: formatServerError(error) }, status);
     }
   });
 
@@ -365,9 +366,9 @@ export function registerToolRoutes(app: HonoApp, options: ServerOptions): void {
         await agent.suggestToolPlaygroundParams(toolId, body.prompt ?? "")
       );
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      const status = message.includes("not found") ? 404 : 400;
-      return json({ error: message }, status);
+      const rawMessage = error instanceof Error ? error.message : String(error);
+      const status = rawMessage.includes("not found") ? 404 : 400;
+      return json({ error: formatServerError(error) }, status);
     }
   });
 

--- a/apps/server/src/http/routes/tools.ts
+++ b/apps/server/src/http/routes/tools.ts
@@ -4,6 +4,7 @@ import {
   type CreateToolRequest,
   formatServerError,
   type ListToolsResponse,
+  NakamaApiError,
   type ProfileResponse,
   type RunToolRequest,
   type RunToolResponse,
@@ -350,8 +351,7 @@ export function registerToolRoutes(app: HonoApp, options: ServerOptions): void {
         })
       );
     } catch (error) {
-      const rawMessage = error instanceof Error ? error.message : String(error);
-      const status = rawMessage.includes("not found") ? 404 : 400;
+      const status = error instanceof NakamaApiError ? error.status : 400;
       return json({ error: formatServerError(error) }, status);
     }
   });
@@ -366,8 +366,7 @@ export function registerToolRoutes(app: HonoApp, options: ServerOptions): void {
         await agent.suggestToolPlaygroundParams(toolId, body.prompt ?? "")
       );
     } catch (error) {
-      const rawMessage = error instanceof Error ? error.message : String(error);
-      const status = rawMessage.includes("not found") ? 404 : 400;
+      const status = error instanceof NakamaApiError ? error.status : 400;
       return json({ error: formatServerError(error) }, status);
     }
   });

--- a/apps/server/src/http/shared.ts
+++ b/apps/server/src/http/shared.ts
@@ -6,7 +6,6 @@ import {
   type AgentQuestionnaire,
   type AgentTodo,
   type ApiErrorResponse,
-  formatServerError,
   LOCAL_CLIENT_EMAIL,
   NakamaApiError,
   resolveChatFirstTokenTimeoutMs,
@@ -666,7 +665,9 @@ export function streamMessage(
           error:
             turnSignal.aborted && !timedOut
               ? "Turn cancelled."
-              : formatServerError(error),
+              : error instanceof Error
+                ? error.message
+                : String(error),
           type: "error",
         });
       } finally {

--- a/apps/server/src/http/shared.ts
+++ b/apps/server/src/http/shared.ts
@@ -6,6 +6,7 @@ import {
   type AgentQuestionnaire,
   type AgentTodo,
   type ApiErrorResponse,
+  formatServerError,
   LOCAL_CLIENT_EMAIL,
   NakamaApiError,
   resolveChatFirstTokenTimeoutMs,
@@ -622,7 +623,7 @@ export function streamMessage(
               }
 
               timedOut = true;
-              reject(new Error(message));
+              reject(new NakamaApiError(message, 504));
               // After rejecting, so the race reports the timeout and not the
               // abort. The provider request is still open at this point and
               // nothing else ever stops it.
@@ -665,9 +666,7 @@ export function streamMessage(
           error:
             turnSignal.aborted && !timedOut
               ? "Turn cancelled."
-              : error instanceof Error
-                ? error.message
-                : String(error),
+              : formatServerError(error),
           type: "error",
         });
       } finally {

--- a/apps/server/src/services/agent-browser-service.ts
+++ b/apps/server/src/services/agent-browser-service.ts
@@ -1,4 +1,4 @@
-import type { AgentBrowserStatusResponse } from "@nakama/core";
+import { type AgentBrowserStatusResponse, NakamaApiError } from "@nakama/core";
 import {
   ensureBunGlobalInstallDirs,
   ensureProcessPath,
@@ -91,16 +91,18 @@ export async function installAgentBrowser(
     .trim();
 
   if (cliResult.timedOut) {
-    throw new Error(
-      "Install timed out while installing the agent-browser CLI."
+    throw new NakamaApiError(
+      "Install timed out while installing the agent-browser CLI.",
+      502
     );
   }
 
   if (cliResult.exitCode !== 0) {
-    throw new Error(
+    throw new NakamaApiError(
       cliOutput
         ? `agent-browser CLI install failed: ${summarizeInstallOutput(cliOutput)}`
-        : "agent-browser CLI install failed."
+        : "agent-browser CLI install failed.",
+      502
     );
   }
 
@@ -121,16 +123,18 @@ export async function installAgentBrowser(
     .trim();
 
   if (browserResult.timedOut) {
-    throw new Error(
-      "Install timed out while downloading Chrome for agent-browser."
+    throw new NakamaApiError(
+      "Install timed out while downloading Chrome for agent-browser.",
+      502
     );
   }
 
   if (browserResult.exitCode !== 0) {
-    throw new Error(
+    throw new NakamaApiError(
       browserOutput
         ? `agent-browser browser install failed: ${summarizeInstallOutput(browserOutput)}`
-        : "agent-browser browser install failed."
+        : "agent-browser browser install failed.",
+      502
     );
   }
 

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -1786,13 +1786,16 @@ export class AgentService {
     }
 
     if (!Number.isInteger(messageIndex) || messageIndex < 0) {
-      throw new Error("messageIndex must be a non-negative integer.");
+      throw new NakamaApiError(
+        "messageIndex must be a non-negative integer.",
+        400
+      );
     }
 
     const sourceMessages = await loadSessionHistory(this.db, sessionId);
 
     if (messageIndex >= sourceMessages.length) {
-      throw new Error("messageIndex is out of bounds.");
+      throw new NakamaApiError("messageIndex is out of bounds.", 400);
     }
 
     const nextSessionId = nanoid();
@@ -2069,7 +2072,10 @@ export class AgentService {
       const apiKey = request.apiKey?.trim() ?? "";
 
       if (!apiKey) {
-        throw new Error("API key is required to discover Fireworks models.");
+        throw new NakamaApiError(
+          "API key is required to discover Fireworks models.",
+          400
+        );
       }
 
       const entries = await fetchFireworksGatewayModels(apiKey);
@@ -2105,7 +2111,7 @@ export class AgentService {
 
     const baseUrl = request.baseUrl?.trim();
     if (!baseUrl) {
-      throw new Error("baseUrl or providerId is required.");
+      throw new NakamaApiError("baseUrl or providerId is required.", 400);
     }
 
     const entries =
@@ -2154,7 +2160,7 @@ export class AgentService {
     );
 
     if (!instance) {
-      throw new Error("Provider not found.");
+      throw new NakamaApiError("Provider not found.", 404);
     }
 
     if (instance.type === "ollama" || instance.type === "openai_compatible") {
@@ -2177,8 +2183,9 @@ export class AgentService {
         ollamaRequiresApiKey(hostMode!) &&
         !apiKey.trim()
       ) {
-        throw new Error(
-          "Add an API key before discovering Ollama Cloud models."
+        throw new NakamaApiError(
+          "Add an API key before discovering Ollama Cloud models.",
+          400
         );
       }
 
@@ -2189,7 +2196,10 @@ export class AgentService {
         (instance.type === "ollama" ? defaultOllamaBaseUrl(hostMode!) : "");
 
       if (!baseUrl) {
-        throw new Error("A base URL is required to discover models.");
+        throw new NakamaApiError(
+          "A base URL is required to discover models.",
+          400
+        );
       }
 
       const entries =
@@ -2218,7 +2228,10 @@ export class AgentService {
         "";
 
       if (!apiKey.trim()) {
-        throw new Error("Add an API key before discovering Fireworks models.");
+        throw new NakamaApiError(
+          "Add an API key before discovering Fireworks models.",
+          400
+        );
       }
 
       const entries = await fetchFireworksGatewayModels(apiKey);
@@ -2237,13 +2250,17 @@ export class AgentService {
     }
 
     if (instance.type !== "openai") {
-      throw new Error(
-        `Remote model discovery is not supported for ${instance.type}.`
+      throw new NakamaApiError(
+        `Remote model discovery is not supported for ${instance.type}.`,
+        400
       );
     }
 
     if (!instance.apiKey.trim()) {
-      throw new Error("Add an API key before discovering models.");
+      throw new NakamaApiError(
+        "Add an API key before discovering models.",
+        400
+      );
     }
 
     const baseUrl = instance.baseUrl?.trim() || "https://api.openai.com/v1";
@@ -2616,7 +2633,7 @@ export class AgentService {
     const record = await this.db.getTool(toolId);
 
     if (!record) {
-      throw new Error("Tool not found.");
+      throw new NakamaApiError("Tool not found.", 404);
     }
 
     const profileId = await this.resolvePlaygroundProfileId(
@@ -2670,7 +2687,7 @@ export class AgentService {
     const record = await this.db.getTool(toolId);
 
     if (!record) {
-      throw new Error("Tool not found.");
+      throw new NakamaApiError("Tool not found.", 404);
     }
 
     const loaded = await handler.load(record);

--- a/apps/server/src/services/data-portability.ts
+++ b/apps/server/src/services/data-portability.ts
@@ -25,6 +25,7 @@ import {
   type DataImportPreviewResponse,
   getUserConfigDir,
   NAKAMA_API_VERSION,
+  NakamaApiError,
   pathExists,
   type RestoreDataImportResponse,
 } from "@nakama/core";
@@ -169,7 +170,7 @@ export async function previewNakamaDataImport(
 export function decodeArchiveRequestData(data: string): Buffer {
   const trimmed = data.trim();
   if (!trimmed) {
-    throw new Error("Import archive data is required.");
+    throw new NakamaApiError("Import archive data is required.", 400);
   }
 
   return Buffer.from(trimmed, "base64");
@@ -180,7 +181,7 @@ export async function restoreNakamaDataImport(
   options: RestoreDataImportOptions
 ): Promise<RestoreDataImportResponse> {
   if (!options.confirm) {
-    throw new Error("Restore confirmation is required.");
+    throw new NakamaApiError("Restore confirmation is required.", 400);
   }
 
   const rootDir = resolveNakamaRootDir(options.rootDir);
@@ -339,7 +340,10 @@ async function writeRestoredEntry(
   const targetPath = resolve(rootDir, entry.name);
   const relativeTarget = relative(rootDir, targetPath);
   if (relativeTarget.startsWith("..") || isAbsolute(relativeTarget)) {
-    throw new Error(`Archive entry escapes restore root: ${entry.name}`);
+    throw new NakamaApiError(
+      `Archive entry escapes restore root: ${entry.name}`,
+      400
+    );
   }
 
   await mkdir(dirname(targetPath), { mode: 0o700, recursive: true });
@@ -360,13 +364,10 @@ function readZip(buffer: Buffer): ZipEntry[] {
         };
       });
   } catch (error) {
-    if (error instanceof Error) {
-      if (error.message === "invalid zip data") {
-        throw new Error("Invalid ZIP archive.");
-      }
-      throw new Error(`Invalid ZIP archive. ${error.message}`);
+    if (error instanceof NakamaApiError) {
+      throw error;
     }
-    throw new Error("Invalid ZIP archive.");
+    throw new NakamaApiError("Invalid ZIP archive.", 400);
   }
 }
 
@@ -375,7 +376,7 @@ function readManifest(entries: ZipEntry[]): DataExportManifest {
     (entry) => entry.name === NAKAMA_EXPORT_MANIFEST
   );
   if (!manifestEntry) {
-    throw new Error("Archive is missing Nakama export manifest.");
+    throw new NakamaApiError("Archive is missing Nakama export manifest.", 400);
   }
 
   let manifest: DataExportManifest;
@@ -384,15 +385,18 @@ function readManifest(entries: ZipEntry[]): DataExportManifest {
       manifestEntry.data.toString("utf8")
     ) as DataExportManifest;
   } catch {
-    throw new Error("Nakama export manifest is not valid JSON.");
+    throw new NakamaApiError("Nakama export manifest is not valid JSON.", 400);
   }
 
   if (manifest.kind !== "nakama-export") {
-    throw new Error("Archive is not a Nakama export.");
+    throw new NakamaApiError("Archive is not a Nakama export.", 400);
   }
 
   if (manifest.version !== NAKAMA_EXPORT_FORMAT_VERSION) {
-    throw new Error(`Unsupported Nakama export version: ${manifest.version}`);
+    throw new NakamaApiError(
+      `Unsupported Nakama export version: ${manifest.version}`,
+      400
+    );
   }
 
   return manifest;
@@ -400,15 +404,18 @@ function readManifest(entries: ZipEntry[]): DataExportManifest {
 
 function validateArchivePath(path: string): void {
   if (!path || path.includes("\0")) {
-    throw new Error("Archive entry path is empty or invalid.");
+    throw new NakamaApiError("Archive entry path is empty or invalid.", 400);
   }
 
   if (path !== toZipPath(path)) {
-    throw new Error(`Archive entry must use POSIX separators: ${path}`);
+    throw new NakamaApiError(
+      `Archive entry must use POSIX separators: ${path}`,
+      400
+    );
   }
 
   if (isAbsolute(path) || /^[a-zA-Z]:/.test(path)) {
-    throw new Error(`Archive entry must be relative: ${path}`);
+    throw new NakamaApiError(`Archive entry must be relative: ${path}`, 400);
   }
 
   const normalized = normalize(path).split(sep).join("/");
@@ -417,12 +424,18 @@ function validateArchivePath(path: string): void {
     normalized.startsWith("../") ||
     normalized.includes("/../")
   ) {
-    throw new Error(`Archive entry escapes restore root: ${path}`);
+    throw new NakamaApiError(
+      `Archive entry escapes restore root: ${path}`,
+      400
+    );
   }
 
   const first = normalized.split("/")[0] ?? "";
   if (first.startsWith(RESTORE_PREFIX) || first.startsWith(BACKUP_PREFIX)) {
-    throw new Error(`Archive entry uses a reserved restore path: ${path}`);
+    throw new NakamaApiError(
+      `Archive entry uses a reserved restore path: ${path}`,
+      400
+    );
   }
 }
 

--- a/packages/core/src/api-error.test.ts
+++ b/packages/core/src/api-error.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { formatAutomationRunError, readApiErrorMessage } from "./api-error";
+import {
+  formatAutomationRunError,
+  formatServerError,
+  NakamaApiError,
+  readApiErrorMessage,
+} from "./api-error";
 
 describe("readApiErrorMessage", () => {
   test("reads JSON error payloads", async () => {
@@ -44,5 +49,26 @@ describe("formatAutomationRunError", () => {
 
     expect(formatted).not.toBe(error.message);
     expect(formatted).toContain("10");
+  });
+});
+
+describe("formatServerError", () => {
+  test("returns a NakamaApiError's own message unchanged", () => {
+    const error = new NakamaApiError("Profile not found.", 404);
+    expect(formatServerError(error)).toBe("Profile not found.");
+  });
+
+  test("never leaks a plain Error's message", () => {
+    const error = new Error(
+      "SQLITE_CONSTRAINT: UNIQUE constraint failed at /home/nakama/.config/nakama/nakama.db"
+    );
+    expect(formatServerError(error)).toBe(
+      "An unexpected server error occurred."
+    );
+  });
+
+  test("still returns the friendly JSON message for SyntaxError", () => {
+    const error = new SyntaxError("Unexpected token < in JSON at position 0");
+    expect(formatServerError(error)).toBe("Invalid JSON in request body.");
   });
 });

--- a/packages/core/src/api-error.ts
+++ b/packages/core/src/api-error.ts
@@ -137,22 +137,15 @@ export function formatAutomationRunError(error: unknown): string {
 }
 
 export function formatServerError(error: unknown): string {
+  if (error instanceof NakamaApiError) {
+    return error.message;
+  }
+
   if (error instanceof SyntaxError) {
     return "Invalid JSON in request body.";
   }
 
-  if (error instanceof Error) {
-    const message = error.message.trim();
-
-    if (message) {
-      return message;
-    }
-  }
-
-  if (typeof error === "string" && error.trim()) {
-    return error.trim();
-  }
-
+  console.error(error);
   return "An unexpected server error occurred.";
 }
 

--- a/packages/core/src/notification-destinations.ts
+++ b/packages/core/src/notification-destinations.ts
@@ -1,3 +1,4 @@
+import { NakamaApiError } from "./api-error";
 import type {
   CreateNotificationDestinationRequest,
   NotificationWebhookLevel,
@@ -66,19 +67,22 @@ export function normalizeNotificationWebhookRequest(
   value: unknown
 ): NotificationWebhookRequest {
   if (typeof value !== "object" || value === null) {
-    throw new Error("notification payload must be an object.");
+    throw new NakamaApiError("notification payload must be an object.", 400);
   }
 
   const record = value as Record<string, unknown>;
   const body = record.body;
 
   if (typeof body !== "string" || !body.trim()) {
-    throw new Error("body must be a non-empty string.");
+    throw new NakamaApiError("body must be a non-empty string.", 400);
   }
 
   const title = record.title;
   if (title !== undefined && (typeof title !== "string" || !title.trim())) {
-    throw new Error("title must be a non-empty string when provided.");
+    throw new NakamaApiError(
+      "title must be a non-empty string when provided.",
+      400
+    );
   }
 
   return {


### PR DESCRIPTION
## Summary

Unexpected internal errors reached clients verbatim. `formatServerError` returned any `Error`'s raw `.message`, so SQLite failures, fs errors with absolute paths, and upstream provider details leaked through the global error handler and several route catches, including one unauthenticated route.

**Before:** `formatServerError` returned `error.message.trim()` for any `Error`, only special-casing `SyntaxError`.
**After:** it only passes through a `NakamaApiError`'s own message (the codebase's existing signal for "this is safe to show"), logs everything else server-side, and returns a generic message for the rest.

Why safe:
1. The cited catches (`sessions.ts`, `tools.ts`, two catches in `models.ts`, `setup-import.ts`, `notification-webhooks.ts`) now build their response through `formatServerError` instead of hand-echoing `error.message`. `tools.ts`'s "not found" → 404 status mapping still reads the real message server-side, only the response body changed.
2. Two services threw plain `Error` for legitimate validation messages that would have gone generic too: `services/data-portability.ts` (archive import validation, "Invalid ZIP archive." and friends) and `packages/core/src/notification-destinations.ts` (webhook payload validation). Both now throw `NakamaApiError` so those messages keep reaching clients, no UX regression.
3. `shared.ts`'s chat-turn timeout messages and `coding-harness-install-stream.ts`'s installer failure messages also ran through `formatServerError` before this change and would have gone generic too, breaking their existing tests. Neither is cited by the issue and both are diagnostic text for the operation's own initiator, not an arbitrary API response, so they were reverted to their original raw-message behavior instead of converting their throw sites.

Closes #360

Six more files have the same raw-echo pattern (`composio.ts`, `notification-destinations.ts` route, `profile-portability.ts`, `auth.ts`, `system.ts`, plus ~18 more catches in `models.ts` itself) but aren't cited by the issue. Left out of this PR to keep it reviewable; candidate for a follow-up.

## Test plan
- [x] `bun test` in `packages/core`: 728 pass, 3 fail (Windows symlink `EPERM`, pre-existing, unrelated)
- [x] `bun test` full server workspace: 1057 pass, 29 fail. Same 29 fail on unmodified `upstream/main` (missing python3/bash/agent-browser CLIs on this dev machine, confirmed via a stash-based diff)
- [x] `bunx tsc --noEmit` whole repo: baseline 8302 errors, after 8307. The +5 is pre-existing `typeof fetch` "preconnect" noise (already present repo-wide) showing up in the 2 new test files; zero new errors from the actual source changes
- [x] `bun run knip` clean
- [x] New regression tests: `formatServerError` unit tests (NakamaApiError passthrough, generic for plain Error, SyntaxError), plus route-level tests for `tools.ts`, `models.ts`, `sessions.ts`, `setup-import.ts`, `notification-webhooks.ts` asserting a thrown implementation-detail message never reaches the response body
