### PR TITLE
fix(cli): guard against raw-mode leak in readPassword setup

### DIFF
--- a/apps/cli/src/setup.test.ts
+++ b/apps/cli/src/setup.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { readPassword } from "./setup";
+
+class MockStdin extends EventEmitter {
+  isTTY = true;
+  rawModeEnabled = false;
+  paused = true;
+  failOnResume = false;
+
+  setRawMode(enabled: boolean) {
+    this.rawModeEnabled = enabled;
+    return this;
+  }
+
+  isPaused() {
+    return this.paused;
+  }
+
+  resume() {
+    this.paused = false;
+    if (this.failOnResume) {
+      throw new Error("simulated stdin failure");
+    }
+    return this;
+  }
+
+  pause() {
+    this.paused = true;
+    return this;
+  }
+
+  setEncoding() {
+    return this;
+  }
+}
+
+describe("readPassword", () => {
+  test("restores raw mode after Enter", async () => {
+    const stdin = new MockStdin();
+    const originalStdin = process.stdin;
+    const originalWrite = process.stdout.write;
+    process.stdout.write = () => true;
+    Object.defineProperty(process, "stdin", {
+      configurable: true,
+      value: stdin,
+    });
+
+    try {
+      const promise = readPassword("Password: ");
+      stdin.emit("data", "hunter2\n");
+      await expect(promise).resolves.toBe("hunter2");
+      expect(stdin.rawModeEnabled).toBe(false);
+    } finally {
+      Object.defineProperty(process, "stdin", {
+        configurable: true,
+        value: originalStdin,
+      });
+      process.stdout.write = originalWrite;
+    }
+  });
+
+  test("restores raw mode when stdin setup throws synchronously", async () => {
+    const stdin = new MockStdin();
+    stdin.failOnResume = true;
+    const originalStdin = process.stdin;
+    const originalWrite = process.stdout.write;
+    process.stdout.write = () => true;
+    Object.defineProperty(process, "stdin", {
+      configurable: true,
+      value: stdin,
+    });
+
+    try {
+      await expect(readPassword("Password: ")).rejects.toThrow(
+        "simulated stdin failure"
+      );
+      expect(stdin.rawModeEnabled).toBe(false);
+      expect(stdin.listenerCount("data")).toBe(0);
+    } finally {
+      Object.defineProperty(process, "stdin", {
+        configurable: true,
+        value: originalStdin,
+      });
+      process.stdout.write = originalWrite;
+    }
+  });
+});

--- a/apps/cli/src/setup.ts
+++ b/apps/cli/src/setup.ts
@@ -9,7 +9,7 @@ import {
 import { formatCliDisplayPath, isCliVerbose } from "./display-path";
 import { printLine } from "./terminal-safe";
 
-function readPassword(prompt: string): Promise<string> {
+export function readPassword(prompt: string): Promise<string> {
   return new Promise((resolve, reject) => {
     const stdin = process.stdin;
     const stdout = process.stdout;
@@ -22,26 +22,27 @@ function readPassword(prompt: string): Promise<string> {
     stdout.write(prompt);
 
     const wasPaused = stdin.isPaused();
-    stdin.setRawMode(true);
-    stdin.resume();
-    stdin.setEncoding("utf8");
-
-    let password = "";
+    let rawModeEnabled = false;
 
     const restoreStdin = () => {
-      stdin.setRawMode(false);
+      if (rawModeEnabled) {
+        stdin.setRawMode(false);
+        rawModeEnabled = false;
+      }
       if (wasPaused) {
         stdin.pause();
       }
       stdin.removeListener("data", onData);
-      stdout.write("\n");
     };
+
+    let password = "";
 
     const onData = (chunk: string) => {
       for (const char of chunk) {
         if (char === "\n" || char === "\r" || char === "\u0004") {
           // Enter or EOF
           restoreStdin();
+          stdout.write("\n");
           resolve(password);
           return;
         }
@@ -49,6 +50,7 @@ function readPassword(prompt: string): Promise<string> {
         if (char === "\u0003") {
           // Ctrl+C
           restoreStdin();
+          stdout.write("\n");
           process.exit(130);
         }
 
@@ -66,7 +68,16 @@ function readPassword(prompt: string): Promise<string> {
       }
     };
 
-    stdin.on("data", onData);
+    try {
+      stdin.setRawMode(true);
+      rawModeEnabled = true;
+      stdin.resume();
+      stdin.setEncoding("utf8");
+      stdin.on("data", onData);
+    } catch (error) {
+      restoreStdin();
+      reject(error instanceof Error ? error : new Error(String(error)));
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- Fixes #615 — `readPassword()` in `apps/cli/src/setup.ts` could leave the terminal stuck in raw mode if enabling raw mode or attaching the `data` listener threw synchronously (e.g. the tty handle erroring on `resume()`). The `Promise` executor would reject with no cleanup path since the listener that calls `restoreStdin()` was never attached.
- Wrapped the raw-mode setup (`setRawMode(true)` → `resume()` → `setEncoding()` → `on("data", ...)`) in try/catch, tracking whether raw mode was actually enabled, and restore it on failure before rejecting.
- Exported `readPassword` and added `apps/cli/src/setup.test.ts` covering the happy path and the synchronous-setup-failure path (repros the leak against `main` before the fix).

## Test plan
- [x] `bun test` in `apps/cli` — 108 pass
- [x] `ultracite check` on changed files — clean

