### PR TITLE
fix(orgs): revoke a removed member's sessions at removal time

### DIFF
--- a/apps/server/src/http/org-member-removal-sessions.test.ts
+++ b/apps/server/src/http/org-member-removal-sessions.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import { setupTestConfigDir } from "../test-config-dir";
+import { createMinimalHonoApp } from "./test-app-helpers";
+import {
+  loginPlatformAdminSession,
+  loginUserSession,
+} from "./test-session-helpers";
+
+setupTestConfigDir("nakama-member-removal-sessions-test-");
+
+describe("removing an org member", () => {
+  test("revokes the removed member's browser sessions", async () => {
+    const { app, authService, databaseAdapter } = createMinimalHonoApp();
+    const platformSession = await loginPlatformAdminSession(
+      app,
+      authService,
+      databaseAdapter
+    );
+
+    const createResponse = await app.fetch(
+      new Request("http://localhost:4310/v1/platform/orgs", {
+        body: JSON.stringify({
+          admin: {
+            email: "admin-offboard@acme.com",
+            name: "Acme Admin",
+            phone: "+628123456789",
+          },
+          name: "Acme",
+          slug: "acme-offboard",
+        }),
+        headers: platformSession.headers({
+          "X-CSRF-Token": platformSession.csrfToken,
+        }),
+        method: "POST",
+      })
+    );
+    const created = (await createResponse.json()) as {
+      organization: { id: string };
+      adminMember: { temporaryPassword: string };
+    };
+    const orgId = created.organization.id;
+    const adminSession = await loginUserSession(
+      app,
+      "admin-offboard@acme.com",
+      created.adminMember.temporaryPassword
+    );
+
+    const addResponse = await app.fetch(
+      new Request(`http://localhost:4310/v1/orgs/${orgId}/members`, {
+        body: JSON.stringify({
+          email: "leaver@acme.com",
+          name: "Leaver",
+          phone: "+628987654321",
+          role: "member",
+        }),
+        headers: adminSession.headers(
+          { "X-CSRF-Token": adminSession.csrfToken },
+          orgId
+        ),
+        method: "POST",
+      })
+    );
+    const added = (await addResponse.json()) as {
+      member: { userId: string };
+      temporaryPassword: string;
+    };
+    const leaverSession = await loginUserSession(
+      app,
+      "leaver@acme.com",
+      added.temporaryPassword
+    );
+
+    // /v1/auth/me is the check that matters: the org middleware already 404s a
+    // removed member on org-scoped routes, so only an auth route can tell a
+    // revoked cookie from a merely org-less one.
+    const beforeRemoval = await app.fetch(
+      new Request("http://localhost:4310/v1/auth/me", {
+        headers: leaverSession.headers(),
+      })
+    );
+    expect(beforeRemoval.status).toBe(200);
+
+    const removeResponse = await app.fetch(
+      new Request(
+        `http://localhost:4310/v1/orgs/${orgId}/members/${added.member.userId}`,
+        {
+          headers: adminSession.headers(
+            { "X-CSRF-Token": adminSession.csrfToken },
+            orgId
+          ),
+          method: "DELETE",
+        }
+      )
+    );
+    expect(removeResponse.status).toBe(204);
+
+    const afterRemoval = await app.fetch(
+      new Request("http://localhost:4310/v1/auth/me", {
+        headers: leaverSession.headers(),
+      })
+    );
+    expect(afterRemoval.status).toBe(401);
+  });
+});

--- a/apps/server/src/services/org-service.ts
+++ b/apps/server/src/services/org-service.ts
@@ -550,6 +550,15 @@ export class OrgService {
       await this.assertCanChangeAdminMembership(orgId, userId);
       throw new NakamaApiError("Not found", 404);
     }
+
+    // The org middleware stops org routes for a non-member, but the cookie stays
+    // valid on /v1/auth/* until it expires. Revoke like changePassword does: all
+    // of the user's sessions, so a multi-org user re-authenticates rather than
+    // keeping a session whose active org they were just removed from.
+    await this.databaseAdapter.revokeBrowserSessionsForUser(
+      userId,
+      new Date().toISOString()
+    );
   }
 
   async updateMember(


### PR DESCRIPTION
## Summary

Removing someone from an organization now ends their login sessions at removal instead of at cookie expiry.

**Before:** `removeMember` deleted the membership row and nothing else, so the removed user's session cookie stayed valid on `/v1/auth/*` for up to 7 days.
**After:** it also calls `revokeBrowserSessionsForUser`, the same revocation `changePassword` already uses 250 lines down the same file.

Why safe:
1. Reuses the existing adapter method and the existing call shape, so there is no second revocation path to keep in sync.
2. Org-scoped routes already 404 a non-member in `org-middleware.ts`, so this only closes the `/v1/auth/*` remainder rather than changing how org access works.
3. Full suite green across all 11 workspaces.

Only follow up if revoking every session proves too blunt for multi-org users. The narrower version revokes only sessions whose active org is the one they left, and that needs a new adapter method for one caller.

## Test plan
- [x] `bun test apps/server/src/http/org-member-removal-sessions.test.ts` (1 pass). On `main` the same test fails at the assertion that matters: `Expected: 401, Received: 200`.
- [x] `bun run test` (all 11 workspaces exited 0; 1086 server, 733 core, 313 web, 92 db)
- [ ] Remove a member from the dashboard while they have a tab open, then confirm their next request bounces to the login page.

The test asserts through `/v1/auth/me` on purpose. An org-scoped route would have passed before this change too, since the middleware already blocks a non-member there.

`Refs #367`, not `Closes`. This is the first of its three acceptance criteria; `listBrowserSessionsByUser` and a platform-admin force-revoke have no adapter method or route yet, and are left out rather than bundled.
