### PR TITLE
fix(db): unassign profiles inside deleteTool transaction

### DIFF
--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -670,6 +670,14 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
     DELETE FROM profile_tools
     WHERE profile_id = ? AND tool_id = ?
   `);
+  const unassignToolFromAllProfilesStmt = db.prepare(`
+    DELETE FROM profile_tools
+    WHERE tool_id = ?
+  `);
+  const deleteToolEverywhereTransaction = db.transaction((toolId: string) => {
+    unassignToolFromAllProfilesStmt.run(toolId);
+    return deleteToolStmt.run(toolId);
+  });
 
   const listSessionsStmt = db.prepare("SELECT * FROM sessions");
   const getSessionStmt = db.prepare("SELECT * FROM sessions WHERE id = ?");
@@ -1964,7 +1972,9 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
     },
 
     async deleteTool(id) {
-      const result = deleteToolStmt.run(id);
+      // FK cascade is off (PRAGMA foreign_keys = OFF), so unassign + delete
+      // must be one transaction or seed/admin delete can leave partial state.
+      const result = deleteToolEverywhereTransaction(id);
       return result.changes > 0;
     },
 

--- a/packages/db/src/seed.test.ts
+++ b/packages/db/src/seed.test.ts
@@ -15,6 +15,46 @@ import {
 } from "./seed";
 
 describe("seed cleanup", () => {
+  test("deleteTool unassigns every profile before deleting", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const now = new Date().toISOString();
+
+    await db.upsertProfile({
+      createdAt: now,
+      id: "profile_a",
+      isSuper: false,
+      model: null,
+      name: "A",
+      systemPrompt: "a",
+      updatedAt: now,
+    });
+    await db.upsertProfile({
+      createdAt: now,
+      id: "profile_b",
+      isSuper: false,
+      model: null,
+      name: "B",
+      systemPrompt: "b",
+      updatedAt: now,
+    });
+    await db.upsertTool({
+      createdAt: now,
+      description: "doomed",
+      handlerConfig: {},
+      handlerType: "custom",
+      id: "tool_doomed",
+      name: "doomed-custom",
+      updatedAt: now,
+    });
+    await db.assignToolToProfile("profile_a", "tool_doomed");
+    await db.assignToolToProfile("profile_b", "tool_doomed");
+
+    expect(await db.deleteTool("tool_doomed")).toBe(true);
+    expect(await db.getTool("tool_doomed")).toBeNull();
+    expect(await db.listToolsForProfile("profile_a")).toHaveLength(0);
+    expect(await db.listToolsForProfile("profile_b")).toHaveLength(0);
+  });
+
   test("removes unsupported tool handler types", async () => {
     const db = createInMemoryDatabaseAdapter();
     const now = new Date().toISOString();

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -58,7 +58,6 @@ export async function seedDatabase(db: DatabaseAdapter): Promise<void> {
 export async function removeLegacyBuiltinTools(
   db: DatabaseAdapter
 ): Promise<void> {
-  const profiles = await db.listProfiles();
   const tools = await db.listTools();
 
   for (const tool of tools) {
@@ -69,10 +68,7 @@ export async function removeLegacyBuiltinTools(
       continue;
     }
 
-    for (const profile of profiles) {
-      await db.unassignToolFromProfile(profile.id, tool.id);
-    }
-
+    // deleteTool unassigns every profile + deletes in one SQLite transaction.
     await db.deleteTool(tool.id);
   }
 }
@@ -80,7 +76,6 @@ export async function removeLegacyBuiltinTools(
 export async function removeDeprecatedBuiltinTools(
   db: DatabaseAdapter
 ): Promise<void> {
-  const profiles = await db.listProfiles();
   const tools = await db.listTools();
 
   for (const tool of tools) {
@@ -91,10 +86,6 @@ export async function removeDeprecatedBuiltinTools(
       continue;
     }
 
-    for (const profile of profiles) {
-      await db.unassignToolFromProfile(profile.id, tool.id);
-    }
-
     await db.deleteTool(tool.id);
   }
 }
@@ -102,16 +93,11 @@ export async function removeDeprecatedBuiltinTools(
 export async function removeDeprecatedServerTools(
   db: DatabaseAdapter
 ): Promise<void> {
-  const profiles = await db.listProfiles();
   const tools = await db.listTools();
 
   for (const tool of tools) {
     if (!DEPRECATED_SERVER_TOOL_NAMES.has(tool.name)) {
       continue;
-    }
-
-    for (const profile of profiles) {
-      await db.unassignToolFromProfile(profile.id, tool.id);
     }
 
     await db.deleteTool(tool.id);
@@ -121,16 +107,11 @@ export async function removeDeprecatedServerTools(
 export async function removeUnsupportedTools(
   db: DatabaseAdapter
 ): Promise<void> {
-  const profiles = await db.listProfiles();
   const tools = await db.listTools();
 
   for (const tool of tools) {
     if (SUPPORTED_TOOL_HANDLER_TYPES.has(tool.handlerType)) {
       continue;
-    }
-
-    for (const profile of profiles) {
-      await db.unassignToolFromProfile(profile.id, tool.id);
     }
 
     await db.deleteTool(tool.id);


### PR DESCRIPTION
## Summary

Seed/admin tool delete now unassigns every profile and deletes the tool in one SQLite transaction — no partial profile_tools leftovers.

**Before:** seed loops unassigned per profile then `deleteTool`, with FK cascade off, so a mid-loop failure could leave assignments without a tool (or the reverse race).
**After:** `deleteTool` runs `DELETE FROM profile_tools WHERE tool_id=?` + `DELETE FROM tools` inside `db.transaction`; seed just calls `deleteTool`.

Why safe:
1. Same end state as the old unassign-then-delete loops
2. Existing seed cleanup tests still pass; added multi-profile delete assertion
3. `profile-service.deleteTool` benefits from the same atomic path

Only re-add / follow up if another adapter without this transactional delete is introduced.

## Test plan
- [x] `bun test packages/db/src/seed.test.ts` (15 pass)
- [x] `deleteTool unassigns every profile before deleting` — multi-profile assignment cleared atomically
- [x] Existing seed cleanup paths (unsupported/deprecated/legacy) still pass without per-profile unassign loops

Closes #605