### PR TITLE
fix(client): throw NakamaAuthExpiredError on unchanged 401 token

### DIFF
--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -367,6 +367,13 @@ test("non-browser clients throw NakamaAuthExpiredError when 401 token is unchang
       "tc_local_same\n",
       "utf8"
     );
+    await saveUserConfig({
+      defaultProviderId: null,
+      localAuthTokenHash: createHash("sha256")
+        .update("tc_local_same")
+        .digest("hex"),
+      providers: [],
+    });
 
     const client = new NakamaClient({
       authToken: "tc_local_same",
@@ -394,7 +401,7 @@ test("non-browser clients throw NakamaAuthExpiredError when 401 token is unchang
   }
 });
 
-test("non-browser clients throw NakamaAuthExpiredError when token file is missing", async () => {
+test("non-browser clients throw NakamaAuthExpiredError when token reload still 401s", async () => {
   const configDir = await mkdtemp(
     join(tmpdir(), "nakama-client-auth-missing-")
   );

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getUserConfigDir, saveUserConfig } from "@nakama/core";
-import { NakamaClient } from "./index";
+import { NakamaAuthExpiredError, NakamaClient } from "./index";
 
 test("chat stream request includes cookie CSRF protection", async () => {
   const originalDocument = (
@@ -349,6 +349,71 @@ test("non-browser clients reload the local auth token once after a 401", async (
 
     await expect(client.health()).resolves.toEqual({ ok: true });
     expect(attempts).toBe(2);
+  } finally {
+    delete process.env.NAKAMA_CONFIG_DIR;
+    await rm(configDir, { force: true, recursive: true });
+  }
+});
+
+test("non-browser clients throw NakamaAuthExpiredError when 401 token is unchanged", async () => {
+  const configDir = await mkdtemp(
+    join(tmpdir(), "nakama-client-auth-expired-")
+  );
+  process.env.NAKAMA_CONFIG_DIR = configDir;
+
+  try {
+    await writeFile(
+      join(getUserConfigDir(), "local-auth-token"),
+      "tc_local_same\n",
+      "utf8"
+    );
+
+    const client = new NakamaClient({
+      authToken: "tc_local_same",
+      baseUrl: "http://localhost:4310",
+      fetch: async () =>
+        new Response(JSON.stringify({ error: "Authentication required" }), {
+          headers: { "Content-Type": "application/json" },
+          status: 401,
+        }),
+    });
+
+    try {
+      await client.health();
+      throw new Error("expected NakamaAuthExpiredError");
+    } catch (error) {
+      expect(error).toBeInstanceOf(NakamaAuthExpiredError);
+      expect((error as NakamaAuthExpiredError).name).toBe(
+        "NakamaAuthExpiredError"
+      );
+      expect((error as NakamaAuthExpiredError).status).toBe(401);
+    }
+  } finally {
+    delete process.env.NAKAMA_CONFIG_DIR;
+    await rm(configDir, { force: true, recursive: true });
+  }
+});
+
+test("non-browser clients throw NakamaAuthExpiredError when token file is missing", async () => {
+  const configDir = await mkdtemp(
+    join(tmpdir(), "nakama-client-auth-missing-")
+  );
+  process.env.NAKAMA_CONFIG_DIR = configDir;
+
+  try {
+    const client = new NakamaClient({
+      authToken: "tc_local_gone",
+      baseUrl: "http://localhost:4310",
+      fetch: async () =>
+        new Response(JSON.stringify({ error: "Authentication required" }), {
+          headers: { "Content-Type": "application/json" },
+          status: 401,
+        }),
+    });
+
+    await expect(client.health()).rejects.toBeInstanceOf(
+      NakamaAuthExpiredError
+    );
   } finally {
     delete process.env.NAKAMA_CONFIG_DIR;
     await rm(configDir, { force: true, recursive: true });

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,4 +1,8 @@
-import { NakamaApiError, readApiErrorMessage } from "@nakama/core/api-error";
+import {
+  NakamaApiError,
+  NakamaAuthExpiredError,
+  readApiErrorMessage,
+} from "@nakama/core/api-error";
 import type {
   AddOrgMemberRequest,
   AddOrgMemberResponse,
@@ -2441,6 +2445,11 @@ export class NakamaClient {
           this.authToken = freshToken;
           return this.request(path, init, true);
         }
+
+        throw new NakamaAuthExpiredError(
+          await readApiErrorMessage(response),
+          path
+        );
       }
 
       throw await createApiError(response, path);
@@ -2476,6 +2485,11 @@ export class NakamaClient {
           this.authToken = freshToken;
           return this.fetchRaw(path, init, true);
         }
+
+        throw new NakamaAuthExpiredError(
+          await readApiErrorMessage(response),
+          path
+        );
       }
 
       throw await createApiError(response, path);

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -2452,6 +2452,13 @@ export class NakamaClient {
         );
       }
 
+      if (response.status === 401 && retried) {
+        throw new NakamaAuthExpiredError(
+          await readApiErrorMessage(response),
+          path
+        );
+      }
+
       throw await createApiError(response, path);
     }
 
@@ -2486,6 +2493,13 @@ export class NakamaClient {
           return this.fetchRaw(path, init, true);
         }
 
+        throw new NakamaAuthExpiredError(
+          await readApiErrorMessage(response),
+          path
+        );
+      }
+
+      if (response.status === 401 && retried) {
         throw new NakamaAuthExpiredError(
           await readApiErrorMessage(response),
           path

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -2486,7 +2486,12 @@ export class NakamaClient {
     });
 
     if (!response.ok) {
-      if (response.status === 401 && this.authToken && !retried) {
+      if (
+        response.status === 401 &&
+        this.authToken &&
+        !retried &&
+        path !== "/v1/auth/local-token/rotate"
+      ) {
         const freshToken = await loadLocalAuthToken();
         if (freshToken && freshToken !== this.authToken) {
           this.authToken = freshToken;

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,6 +1,7 @@
 export {
   formatClientError as formatError,
   NakamaApiError,
+  NakamaAuthExpiredError,
 } from "@nakama/core/api-error";
 export { NakamaClient } from "./client";
 export type {

--- a/packages/core/src/api-error.ts
+++ b/packages/core/src/api-error.ts
@@ -20,6 +20,14 @@ export class NakamaApiError extends Error {
   }
 }
 
+/** 401 after local-token reload did not yield a different token (or file missing). */
+export class NakamaAuthExpiredError extends NakamaApiError {
+  constructor(message: string, path?: string) {
+    super(message, 401, path);
+    this.name = "NakamaAuthExpiredError";
+  }
+}
+
 export async function readApiErrorMessage(response: Response): Promise<string> {
   const status = response.status;
   let bodyText = "";


### PR DESCRIPTION
## Summary

Local-token 401 reload failures now throw `NakamaAuthExpiredError` instead of a generic `NakamaApiError`, so CLI/clients can tell “session expired” from other auth failures.

**Before:** unchanged/missing-token 401s fell through to `createApiError` (same shape as any other 401).
**After:** no usable token change → `NakamaAuthExpiredError`; reload that still 401s after retry → same subclass.

Why safe:
1. Extends `NakamaApiError` — existing `instanceof NakamaApiError` / `formatClientError` keep working
2. Successful reload+retry path unchanged (existing test still green)
3. Exported from `@nakama/client` for callers that want the narrow type

Only re-add / follow up if browser cookie sessions need a parallel distinct code (this path is local-token reload).

## Test plan
- [x] `bun test packages/client/src/client.test.ts` (15 pass)
- [x] Unchanged local token on 401 → `NakamaAuthExpiredError` (name + status 401)
- [x] Missing token file on 401 → `NakamaAuthExpiredError`
- [x] `fetchRaw` skips reload on `/v1/auth/local-token/rotate` (parity with `request()`)

Closes #604