### PR TITLE
fix(web): tie backup-import preview cleanup to generation

### DIFF
--- a/apps/web/src/components/setup-wizard/SetupStepBackupImport.tsx
+++ b/apps/web/src/components/setup-wizard/SetupStepBackupImport.tsx
@@ -14,6 +14,7 @@ import { Card } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
 import {
   canRestoreDataImport,
+  shouldClearInitialPreviewDedupe,
   shouldStartInitialFilePreview,
   usePreviewSetupDataImport,
   useRestoreSetupDataImport,
@@ -120,8 +121,16 @@ export function SetupStepBackupImport({
 
     return () => {
       cancelled = true;
-      // Allow Strict Mode remount to retry the same File after cleanup.
-      initialPreviewStartedForRef.current = null;
+      // Strict Mode remount may retry the same File only when this generation
+      // is still current — do not clear a newer in-flight preview's dedupe key.
+      if (
+        shouldClearInitialPreviewDedupe(
+          generation,
+          previewGenerationRef.current
+        )
+      ) {
+        initialPreviewStartedForRef.current = null;
+      }
     };
   }, [initialFile, previewImport]);
 

--- a/apps/web/src/hooks/use-data-portability.test.ts
+++ b/apps/web/src/hooks/use-data-portability.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   formatDataPortabilityBytes,
+  shouldClearInitialPreviewDedupe,
   shouldStartInitialFilePreview,
 } from "./use-data-portability";
 
@@ -22,5 +23,13 @@ describe("shouldStartInitialFilePreview", () => {
     expect(shouldStartInitialFilePreview(file, file)).toBe(false);
     expect(shouldStartInitialFilePreview(other, file)).toBe(true);
     expect(shouldStartInitialFilePreview(null, file)).toBe(false);
+  });
+});
+
+describe("shouldClearInitialPreviewDedupe", () => {
+  test("only the current generation clears the dedupe key", () => {
+    expect(shouldClearInitialPreviewDedupe(1, 1)).toBe(true);
+    expect(shouldClearInitialPreviewDedupe(1, 2)).toBe(false);
+    expect(shouldClearInitialPreviewDedupe(2, 2)).toBe(true);
   });
 });

--- a/apps/web/src/hooks/use-data-portability.ts
+++ b/apps/web/src/hooks/use-data-portability.ts
@@ -80,3 +80,14 @@ export function shouldStartInitialFilePreview(
 ): boolean {
   return initialFile != null && initialFile !== alreadyStartedFor;
 }
+
+/**
+ * Only the latest preview generation may clear the dedupe key on cleanup.
+ * Older cleanups must leave a newer in-flight File marked as started.
+ */
+export function shouldClearInitialPreviewDedupe(
+  effectGeneration: number,
+  currentGeneration: number
+): boolean {
+  return effectGeneration === currentGeneration;
+}


### PR DESCRIPTION
## Summary

Setup Wizard backup-import cleanup only clears the initial-preview dedupe key when that effect’s generation is still current.

**Before:** every cleanup set `initialPreviewStartedForRef = null`, so a newer in-flight preview could be re-started for the same File after an older cleanup ran.
**After:** clear only if `effectGeneration === previewGenerationRef.current` (`shouldClearInitialPreviewDedupe`).

Why safe:
1. Strict Mode remount still clears when generation is current → retry works
2. Rapid file swap: older cleanup cannot wipe the newer File’s dedupe mark
3. Helper covered by unit test; preview success/error already generation-gated

Only re-add / follow up if preview should intentionally restart the same File without a Strict Mode remount.

## Test plan
- [x] `bun test apps/web/src/hooks/use-data-portability.test.ts` (3 pass)
- [x] `shouldClearInitialPreviewDedupe` — stale generation never clears newer dedupe key
- [x] Effect cleanup uses generation gate; success/error handlers already generation-gated

Closes #583