### PR TITLE
fix(telegram): preserve dollar replacement sequences

### DIFF
--- a/apps/platform/telegram/src/format.test.ts
+++ b/apps/platform/telegram/src/format.test.ts
@@ -46,6 +46,12 @@ describe("stripMarkdownForTelegram", () => {
     );
   });
 
+  test("preserves dollar replacement sequences in bare URLs", () => {
+    const url = "https://example.com/$&/path";
+
+    expect(stripMarkdownForTelegram(url)).toBe(url);
+  });
+
   test("still strips italic markers outside URLs", () => {
     expect(
       stripMarkdownForTelegram("see _share_ then https://example.com/a_b")
@@ -90,6 +96,12 @@ describe("renderTelegramRichText", () => {
     expect(
       renderTelegramRichText("Before <tag>\n```js\n  const x = 1 < 2;\n```")
     ).toBe("Before &lt;tag&gt;\n<pre><code>  const x = 1 &lt; 2;</code></pre>");
+  });
+
+  test("preserves dollar replacement sequences in fenced code blocks", () => {
+    expect(renderTelegramRichText("```text\n$& $` $'\n```")).toBe(
+      "<pre><code>$&amp; $` $'</code></pre>"
+    );
   });
 });
 

--- a/apps/platform/telegram/src/format.ts
+++ b/apps/platform/telegram/src/format.ts
@@ -53,7 +53,7 @@ function restoreBareUrls(text: string, urls: string[]): string {
   let result = text;
 
   for (let index = 0; index < urls.length; index++) {
-    result = result.replace(`@@TCURL${index}@@`, urls[index]!);
+    result = result.replace(`@@TCURL${index}@@`, () => urls[index]!);
   }
 
   return result;
@@ -99,7 +99,7 @@ function restoreProtectedBlocks(text: string, blocks: string[]): string {
   let result = text;
 
   for (let index = 0; index < blocks.length; index++) {
-    result = result.replace(`@@TCTOKEN${index}@@`, blocks[index]!);
+    result = result.replace(`@@TCTOKEN${index}@@`, () => blocks[index]!);
   }
 
   return result;


### PR DESCRIPTION
## Summary

Telegram formatting now preserves JavaScript replacement sequences when restoring bare URLs and fenced code blocks.

**Before:** JavaScript replacement patterns such as `$&`, `$'`, and the dollar-backtick sequence could be interpreted by `String.replace()` during placeholder restoration, corrupting the resulting Telegram message.

**After:** placeholder restoration uses replacement callbacks, so these sequences are preserved literally.

Why safe:
1. The change is limited to restoring protected Telegram formatting content.
2. Normal URL and fenced-code formatting behavior is unchanged.
3. Regression tests cover replacement sequences in both bare URLs and fenced code blocks.

Addresses part (a) of #374.