### PR TITLE
refactor(client): fold auth-expired 401 paths after #805 review

### DIFF
--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -385,39 +385,6 @@ test("non-browser clients throw NakamaAuthExpiredError when 401 token is unchang
         }),
     });
 
-    try {
-      await client.health();
-      throw new Error("expected NakamaAuthExpiredError");
-    } catch (error) {
-      expect(error).toBeInstanceOf(NakamaAuthExpiredError);
-      expect((error as NakamaAuthExpiredError).name).toBe(
-        "NakamaAuthExpiredError"
-      );
-      expect((error as NakamaAuthExpiredError).status).toBe(401);
-    }
-  } finally {
-    delete process.env.NAKAMA_CONFIG_DIR;
-    await rm(configDir, { force: true, recursive: true });
-  }
-});
-
-test("non-browser clients throw NakamaAuthExpiredError when token reload still 401s", async () => {
-  const configDir = await mkdtemp(
-    join(tmpdir(), "nakama-client-auth-missing-")
-  );
-  process.env.NAKAMA_CONFIG_DIR = configDir;
-
-  try {
-    const client = new NakamaClient({
-      authToken: "tc_local_gone",
-      baseUrl: "http://localhost:4310",
-      fetch: async () =>
-        new Response(JSON.stringify({ error: "Authentication required" }), {
-          headers: { "Content-Type": "application/json" },
-          status: 401,
-        }),
-    });
-
     await expect(client.health()).rejects.toBeInstanceOf(
       NakamaAuthExpiredError
     );

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -2459,22 +2459,15 @@ export class NakamaClient {
       if (
         response.status === 401 &&
         this.authToken &&
-        !retried &&
-        path !== "/v1/auth/local-token/rotate"
+        (retried || path !== "/v1/auth/local-token/rotate")
       ) {
-        const freshToken = await loadLocalAuthToken();
-        if (freshToken && freshToken !== this.authToken) {
-          this.authToken = freshToken;
-          return this.request(path, init, true);
+        if (!retried) {
+          const freshToken = await loadLocalAuthToken();
+          if (freshToken && freshToken !== this.authToken) {
+            this.authToken = freshToken;
+            return this.request(path, init, true);
+          }
         }
-
-        throw new NakamaAuthExpiredError(
-          await readApiErrorMessage(response),
-          path
-        );
-      }
-
-      if (response.status === 401 && retried) {
         throw new NakamaAuthExpiredError(
           await readApiErrorMessage(response),
           path
@@ -2511,22 +2504,15 @@ export class NakamaClient {
       if (
         response.status === 401 &&
         this.authToken &&
-        !retried &&
-        path !== "/v1/auth/local-token/rotate"
+        (retried || path !== "/v1/auth/local-token/rotate")
       ) {
-        const freshToken = await loadLocalAuthToken();
-        if (freshToken && freshToken !== this.authToken) {
-          this.authToken = freshToken;
-          return this.fetchRaw(path, init, true);
+        if (!retried) {
+          const freshToken = await loadLocalAuthToken();
+          if (freshToken && freshToken !== this.authToken) {
+            this.authToken = freshToken;
+            return this.fetchRaw(path, init, true);
+          }
         }
-
-        throw new NakamaAuthExpiredError(
-          await readApiErrorMessage(response),
-          path
-        );
-      }
-
-      if (response.status === 401 && retried) {
         throw new NakamaAuthExpiredError(
           await readApiErrorMessage(response),
           path


### PR DESCRIPTION
## Summary

Apply #805 review: one auth-expired throw path in `request`/`fetchRaw`, one focused test.

**Before:** two near-identical `NakamaAuthExpiredError` branches + a redundant missing-token test.
**After:** folded reload → expired throw; keep unchanged-token coverage via `rejects.toBeInstanceOf`.

Why safe:
1. Same outcomes — rotate still falls through to generic API error; unchanged/missing token still expired
2. Successful reload+retry path untouched
3. Dropped test covered the same branch as unchanged-token

Only re-add a dedicated `retried` test if a real reload-then-401 path needs its own fixture.

## Test plan
- [x] `bun test packages/client/src/client.test.ts` (14 pass)
- [ ] Spot-check CLI/local-token 401 still surfaces as auth expired

Follows #805 review feedback.
