### PR TITLE
fix(web): allowlist Composio OAuth redirect hosts

### DIFF
--- a/apps/web/src/hooks/use-composio.test.ts
+++ b/apps/web/src/hooks/use-composio.test.ts
@@ -24,6 +24,16 @@ describe("isAllowedComposioRedirectUrl", () => {
     expect(
       isAllowedComposioRedirectUrl("https://composio.dev.evil.com/phish")
     ).toBe(false);
+    expect(
+      isAllowedComposioRedirectUrl("https://notcomposio.dev/connect")
+    ).toBe(false);
+    expect(isAllowedComposioRedirectUrl("")).toBe(false);
     expect(isAllowedComposioRedirectUrl("not a url")).toBe(false);
+  });
+
+  test("allows documented dashboard host", () => {
+    expect(
+      isAllowedComposioRedirectUrl("https://dashboard.composio.dev/oauth")
+    ).toBe(true);
   });
 });

--- a/apps/web/src/hooks/use-composio.test.ts
+++ b/apps/web/src/hooks/use-composio.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { isAllowedComposioRedirectUrl } from "./use-composio";
+
+describe("isAllowedComposioRedirectUrl", () => {
+  test("allows https composio.dev and subdomains", () => {
+    expect(
+      isAllowedComposioRedirectUrl("https://backend.composio.dev/api/v3/s/abc")
+    ).toBe(true);
+    expect(
+      isAllowedComposioRedirectUrl("https://composio.dev/connect?toolkit=gmail")
+    ).toBe(true);
+    expect(
+      isAllowedComposioRedirectUrl("https://PLATFORM.COMPOSIO.DEV/oauth/start")
+    ).toBe(true);
+  });
+
+  test("rejects non-https, foreign hosts, and garbage", () => {
+    expect(
+      isAllowedComposioRedirectUrl("http://backend.composio.dev/api/v3/s/abc")
+    ).toBe(false);
+    expect(
+      isAllowedComposioRedirectUrl("https://evil.com/?next=composio.dev")
+    ).toBe(false);
+    expect(
+      isAllowedComposioRedirectUrl("https://composio.dev.evil.com/phish")
+    ).toBe(false);
+    expect(isAllowedComposioRedirectUrl("not a url")).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/use-composio.test.ts
+++ b/apps/web/src/hooks/use-composio.test.ts
@@ -12,6 +12,9 @@ describe("isAllowedComposioRedirectUrl", () => {
     expect(
       isAllowedComposioRedirectUrl("https://PLATFORM.COMPOSIO.DEV/oauth/start")
     ).toBe(true);
+    expect(
+      isAllowedComposioRedirectUrl("https://dashboard.composio.dev/oauth")
+    ).toBe(true);
   });
 
   test("rejects non-https, foreign hosts, and garbage", () => {
@@ -29,11 +32,5 @@ describe("isAllowedComposioRedirectUrl", () => {
     ).toBe(false);
     expect(isAllowedComposioRedirectUrl("")).toBe(false);
     expect(isAllowedComposioRedirectUrl("not a url")).toBe(false);
-  });
-
-  test("allows documented dashboard host", () => {
-    expect(
-      isAllowedComposioRedirectUrl("https://dashboard.composio.dev/oauth")
-    ).toBe(true);
   });
 });

--- a/apps/web/src/hooks/use-composio.ts
+++ b/apps/web/src/hooks/use-composio.ts
@@ -10,6 +10,24 @@ import {
 } from "@tanstack/react-query";
 import { client } from "@/lib/client";
 import { queryKeys } from "@/lib/query-keys";
+import { toast } from "@/lib/toast";
+
+/**
+ * Composio OAuth connect links are hosted on composio.dev (and subdomains such
+ * as backend.composio.dev). Reject anything else before assigning location.href.
+ */
+export function isAllowedComposioRedirectUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:") {
+      return false;
+    }
+    const host = parsed.hostname.toLowerCase();
+    return host === "composio.dev" || host.endsWith(".composio.dev");
+  } catch {
+    return false;
+  }
+}
 
 export const composioSettingsQueryOptions = queryOptions({
   queryFn: () => client.getComposioSettings(),
@@ -78,6 +96,10 @@ export function useConnectComposioToolkit() {
     onSuccess: (response) => {
       // Composio hosts the account picker and consent, then redirects back to
       // /integrations through our OAuth callback.
+      if (!isAllowedComposioRedirectUrl(response.redirectUrl)) {
+        toast("Blocked an unexpected Composio redirect URL.");
+        return;
+      }
       window.location.href = response.redirectUrl;
     },
   });


### PR DESCRIPTION
## Summary

Connect Composio toolkit → browser only navigates to `https://*.composio.dev` OAuth URLs. Fixes #580.

**Before:** `window.location.href = response.redirectUrl` with no host check.
**After:** `isAllowedComposioRedirectUrl` gates https + `composio.dev` / `*.composio.dev`; else toast and stay.

Why safe:
1. Matches Composio connect hosts (`backend.composio.dev`, `dashboard.composio.dev`)
2. Rejects http, lookalike hosts (`composio.dev.evil.com`, `notcomposio.dev`), empty/garbage URLs
3. Failure mode is stay-on-page + toast, not a broken allow path for real links

Only reopen if Composio starts issuing connect links on a non-`composio.dev` host.

## Test plan
- [x] `bun test apps/web/src/hooks/use-composio.test.ts` (2 pass)
- [ ] Integrations → Connect on a toolkit — still lands on Composio OAuth
