### PR TITLE
fix(web): keep chat message actions visible on touch

### DIFF
--- a/apps/web/src/components/chat/chat-message-list.tsx
+++ b/apps/web/src/components/chat/chat-message-list.tsx
@@ -543,7 +543,7 @@ function AssistantMessageActions({
     : null;
 
   return (
-    <div className="flex items-center gap-1 pt-1 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
+    <div className="flex items-center gap-1 pt-1 opacity-60 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 group-active:opacity-100">
       <button
         aria-label={copied ? "Copied" : "Copy response"}
         className={cn(


### PR DESCRIPTION
## Summary

Chat message copy / retry / branch actions stay at least faintly visible on touch (no hover). Fixes #581.

**Before:** `opacity-0` until `group-hover` / `group-focus-within`.
**After:** `opacity-60` baseline + `group-active` / hover / focus-within → full opacity.

Why safe:
1. Same buttons and handlers; CSS-only
2. Desktop hover/focus still brighten to 100%
3. No layout shift (controls were already in the DOM)

Only tweak if designers want actions fully hidden on desktop again.

## Test plan
- [x] Diff review: single className change on `AssistantMessageActions` row
- [x] Parent turn wrapper already has `group` (hover/active/focus-within apply)
- [ ] Phone / touch: open a chat reply — copy/retry visible without long-press hover
