### PR TITLE
fix(web): await prior attachment panel onClose before swap

### DIFF
--- a/apps/web/src/context/chat-attachment-panel-context-shared.ts
+++ b/apps/web/src/context/chat-attachment-panel-context-shared.ts
@@ -15,6 +15,54 @@ export interface ChatAttachmentPanelConfig {
   typeLabel?: string | null;
 }
 
+/** In-flight prior-panel close so rapid show() swaps do not re-fire onClose. */
+export type AttachmentPanelCloseInFlight = {
+  id: string;
+  promise: Promise<void>;
+} | null;
+
+/**
+ * Starts (or reuses) `current.onClose`. Returns null when there is nothing to
+ * await.
+ */
+export function beginAttachmentPanelClose(
+  current: Pick<ChatAttachmentPanelConfig, "id" | "onClose"> | null,
+  inFlight: { current: AttachmentPanelCloseInFlight }
+): Promise<void> | null {
+  if (!current) {
+    return null;
+  }
+
+  if (inFlight.current?.id === current.id) {
+    return inFlight.current.promise;
+  }
+
+  if (!current.onClose) {
+    return null;
+  }
+
+  const id = current.id;
+  const promise = Promise.resolve(current.onClose()).finally(() => {
+    if (inFlight.current?.id === id) {
+      inFlight.current = null;
+    }
+  });
+  inFlight.current = { id, promise };
+  return promise;
+}
+
+/** Await prior panel close before mounting a different `nextId`, or null. */
+export function beginPriorAttachmentPanelClose(
+  current: Pick<ChatAttachmentPanelConfig, "id" | "onClose"> | null,
+  nextId: string,
+  inFlight: { current: AttachmentPanelCloseInFlight }
+): Promise<void> | null {
+  if (!current || current.id === nextId) {
+    return null;
+  }
+  return beginAttachmentPanelClose(current, inFlight);
+}
+
 export interface ChatAttachmentPanelContextValue {
   activeId: string | null;
   hide: (id?: string) => void;

--- a/apps/web/src/context/chat-attachment-panel-context-shared.ts
+++ b/apps/web/src/context/chat-attachment-panel-context-shared.ts
@@ -8,7 +8,7 @@ export interface ChatAttachmentPanelConfig {
   headerActions?: ReactNode;
   id: string;
   leading?: ReactNode;
-  onClose?: () => void;
+  onClose?: () => void | Promise<void>;
   resizable?: boolean;
   subtitle?: string | null;
   title: string;

--- a/apps/web/src/context/chat-attachment-panel-context-shared.ts
+++ b/apps/web/src/context/chat-attachment-panel-context-shared.ts
@@ -51,18 +51,6 @@ export function beginAttachmentPanelClose(
   return promise;
 }
 
-/** Await prior panel close before mounting a different `nextId`, or null. */
-export function beginPriorAttachmentPanelClose(
-  current: Pick<ChatAttachmentPanelConfig, "id" | "onClose"> | null,
-  nextId: string,
-  inFlight: { current: AttachmentPanelCloseInFlight }
-): Promise<void> | null {
-  if (!current || current.id === nextId) {
-    return null;
-  }
-  return beginAttachmentPanelClose(current, inFlight);
-}
-
 export interface ChatAttachmentPanelContextValue {
   activeId: string | null;
   hide: (id?: string) => void;

--- a/apps/web/src/context/chat-attachment-panel-context.tsx
+++ b/apps/web/src/context/chat-attachment-panel-context.tsx
@@ -62,15 +62,28 @@ export function ChatAttachmentPanelProvider({
     });
   }, []);
 
+  const showGenerationRef = useRef(0);
+
   const show = useCallback((nextConfig: ChatAttachmentPanelConfig) => {
+    const generation = ++showGenerationRef.current;
+
+    const apply = () => {
+      if (generation !== showGenerationRef.current) {
+        return;
+      }
+      setConfig(nextConfig);
+      if (nextConfig.defaultWidth != null) {
+        setWidth(clampAttachmentPanelWidth(nextConfig.defaultWidth));
+      }
+    };
+
     const current = configRef.current;
-    if (current && current.id !== nextConfig.id) {
-      current.onClose?.();
+    if (current && current.id !== nextConfig.id && current.onClose) {
+      void Promise.resolve(current.onClose()).finally(apply);
+      return;
     }
-    setConfig(nextConfig);
-    if (nextConfig.defaultWidth != null) {
-      setWidth(clampAttachmentPanelWidth(nextConfig.defaultWidth));
-    }
+
+    apply();
   }, []);
 
   const update = useCallback(

--- a/apps/web/src/context/chat-attachment-panel-context.tsx
+++ b/apps/web/src/context/chat-attachment-panel-context.tsx
@@ -11,7 +11,6 @@ import { clampAttachmentPanelWidth } from "@/components/chat/attachment-panel-wi
 import {
   type AttachmentPanelCloseInFlight,
   beginAttachmentPanelClose,
-  beginPriorAttachmentPanelClose,
   type ChatAttachmentPanelConfig,
   ChatAttachmentPanelContext,
 } from "@/context/chat-attachment-panel-context-shared";
@@ -81,11 +80,11 @@ export function ChatAttachmentPanelProvider({
       }
     };
 
-    const priorClose = beginPriorAttachmentPanelClose(
-      configRef.current,
-      nextConfig.id,
-      closeInFlightRef
-    );
+    const current = configRef.current;
+    const priorClose =
+      current && current.id !== nextConfig.id
+        ? beginAttachmentPanelClose(current, closeInFlightRef)
+        : null;
     if (priorClose) {
       void priorClose.finally(apply);
       return;

--- a/apps/web/src/context/chat-attachment-panel-context.tsx
+++ b/apps/web/src/context/chat-attachment-panel-context.tsx
@@ -9,6 +9,9 @@ import {
 import { AttachmentDetailPanel } from "@/components/chat/attachment-detail-panel";
 import { clampAttachmentPanelWidth } from "@/components/chat/attachment-panel-width";
 import {
+  type AttachmentPanelCloseInFlight,
+  beginAttachmentPanelClose,
+  beginPriorAttachmentPanelClose,
   type ChatAttachmentPanelConfig,
   ChatAttachmentPanelContext,
 } from "@/context/chat-attachment-panel-context-shared";
@@ -63,6 +66,7 @@ export function ChatAttachmentPanelProvider({
   }, []);
 
   const showGenerationRef = useRef(0);
+  const closeInFlightRef = useRef<AttachmentPanelCloseInFlight>(null);
 
   const show = useCallback((nextConfig: ChatAttachmentPanelConfig) => {
     const generation = ++showGenerationRef.current;
@@ -77,9 +81,13 @@ export function ChatAttachmentPanelProvider({
       }
     };
 
-    const current = configRef.current;
-    if (current && current.id !== nextConfig.id && current.onClose) {
-      void Promise.resolve(current.onClose()).finally(apply);
+    const priorClose = beginPriorAttachmentPanelClose(
+      configRef.current,
+      nextConfig.id,
+      closeInFlightRef
+    );
+    if (priorClose) {
+      void priorClose.finally(apply);
       return;
     }
 
@@ -103,7 +111,18 @@ export function ChatAttachmentPanelProvider({
   );
 
   const handlePanelClose = useCallback(() => {
-    configRef.current?.onClose?.();
+    // Drop any pending show() apply so a late prior-close cannot remount.
+    showGenerationRef.current += 1;
+    const priorClose = beginAttachmentPanelClose(
+      configRef.current,
+      closeInFlightRef
+    );
+    if (priorClose) {
+      void priorClose.finally(() => {
+        setConfig(null);
+      });
+      return;
+    }
     setConfig(null);
   }, []);
 

--- a/apps/web/src/context/chat-attachment-panel-swap.test.ts
+++ b/apps/web/src/context/chat-attachment-panel-swap.test.ts
@@ -2,57 +2,16 @@ import { describe, expect, test } from "bun:test";
 import {
   type AttachmentPanelCloseInFlight,
   beginAttachmentPanelClose,
-  beginPriorAttachmentPanelClose,
 } from "./chat-attachment-panel-context-shared";
 
-describe("beginPriorAttachmentPanelClose", () => {
-  test("returns null when same id or missing prior panel", () => {
-    const inFlight = { current: null as AttachmentPanelCloseInFlight };
-    expect(
-      beginPriorAttachmentPanelClose(
-        { id: "a", onClose: () => {} },
-        "a",
-        inFlight
-      )
-    ).toBeNull();
-    expect(beginPriorAttachmentPanelClose(null, "b", inFlight)).toBeNull();
-    expect(
-      beginPriorAttachmentPanelClose({ id: "a" }, "b", inFlight)
-    ).toBeNull();
-  });
-
-  test("awaits onClose once across rapid swaps to different ids", async () => {
-    const inFlight = { current: null as AttachmentPanelCloseInFlight };
-    let closeCount = 0;
-    let releaseClose!: () => void;
-    const onClose = () =>
-      new Promise<void>((resolve) => {
-        closeCount += 1;
-        releaseClose = resolve;
-      });
-
-    const first = beginPriorAttachmentPanelClose(
-      { id: "a", onClose },
-      "b",
-      inFlight
-    );
-    const second = beginPriorAttachmentPanelClose(
-      { id: "a", onClose },
-      "c",
-      inFlight
-    );
-
-    expect(first).toBe(second);
-    expect(closeCount).toBe(1);
-
-    releaseClose();
-    await first;
-    expect(inFlight.current).toBeNull();
-  });
-});
-
 describe("beginAttachmentPanelClose", () => {
-  test("reuses in-flight close for the same panel", async () => {
+  test("returns null when missing panel or onClose", () => {
+    const inFlight = { current: null as AttachmentPanelCloseInFlight };
+    expect(beginAttachmentPanelClose(null, inFlight)).toBeNull();
+    expect(beginAttachmentPanelClose({ id: "a" }, inFlight)).toBeNull();
+  });
+
+  test("awaits onClose once across rapid reuse", async () => {
     const inFlight = { current: null as AttachmentPanelCloseInFlight };
     let closeCount = 0;
     let releaseClose!: () => void;
@@ -70,5 +29,6 @@ describe("beginAttachmentPanelClose", () => {
 
     releaseClose();
     await first;
+    expect(inFlight.current).toBeNull();
   });
 });

--- a/apps/web/src/context/chat-attachment-panel-swap.test.ts
+++ b/apps/web/src/context/chat-attachment-panel-swap.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type AttachmentPanelCloseInFlight,
+  beginAttachmentPanelClose,
+  beginPriorAttachmentPanelClose,
+} from "./chat-attachment-panel-context-shared";
+
+describe("beginPriorAttachmentPanelClose", () => {
+  test("returns null when same id or missing prior panel", () => {
+    const inFlight = { current: null as AttachmentPanelCloseInFlight };
+    expect(
+      beginPriorAttachmentPanelClose(
+        { id: "a", onClose: () => {} },
+        "a",
+        inFlight
+      )
+    ).toBeNull();
+    expect(beginPriorAttachmentPanelClose(null, "b", inFlight)).toBeNull();
+    expect(
+      beginPriorAttachmentPanelClose({ id: "a" }, "b", inFlight)
+    ).toBeNull();
+  });
+
+  test("awaits onClose once across rapid swaps to different ids", async () => {
+    const inFlight = { current: null as AttachmentPanelCloseInFlight };
+    let closeCount = 0;
+    let releaseClose!: () => void;
+    const onClose = () =>
+      new Promise<void>((resolve) => {
+        closeCount += 1;
+        releaseClose = resolve;
+      });
+
+    const first = beginPriorAttachmentPanelClose(
+      { id: "a", onClose },
+      "b",
+      inFlight
+    );
+    const second = beginPriorAttachmentPanelClose(
+      { id: "a", onClose },
+      "c",
+      inFlight
+    );
+
+    expect(first).toBe(second);
+    expect(closeCount).toBe(1);
+
+    releaseClose();
+    await first;
+    expect(inFlight.current).toBeNull();
+  });
+});
+
+describe("beginAttachmentPanelClose", () => {
+  test("reuses in-flight close for the same panel", async () => {
+    const inFlight = { current: null as AttachmentPanelCloseInFlight };
+    let closeCount = 0;
+    let releaseClose!: () => void;
+    const onClose = () =>
+      new Promise<void>((resolve) => {
+        closeCount += 1;
+        releaseClose = resolve;
+      });
+
+    const first = beginAttachmentPanelClose({ id: "a", onClose }, inFlight);
+    const second = beginAttachmentPanelClose({ id: "a", onClose }, inFlight);
+
+    expect(first).toBe(second);
+    expect(closeCount).toBe(1);
+
+    releaseClose();
+    await first;
+  });
+});


### PR DESCRIPTION
## Summary

Swapping the chat attachment panel waits for the previous owner’s `onClose` before mounting the next panel, and rapid swaps reuse one in-flight close. Fixes #574.

**Before:** `onClose?.()` then immediate `setConfig(next)` — abort/fetch cleanup could race; rapid A→B→C could fire A’s `onClose` twice.
**After:** `beginAttachmentPanelClose` + generation guard at `show()`; close button also awaits and cancels pending show applies.

Why safe:
1. Sync `onClose` still applies via microtask/`finally`
2. Same panel id reuses one close promise (no double fire)
3. Closing the panel bumps generation so a late swap cannot remount

Only revisit if a panel’s `onClose` hangs without resolving (would delay the next open).

## Test plan
- [x] `bun test apps/web/src/context/chat-attachment-panel-swap.test.ts` (2 pass)
- [ ] Chat: open artifact A, then quickly artifact B — no flash of A’s body in B
