### PR TITLE
fix(db): stop reading legacy users.user_context

### DIFF
--- a/packages/db/sql/schema.sql
+++ b/packages/db/sql/schema.sql
@@ -247,6 +247,7 @@ CREATE TABLE IF NOT EXISTS users (
   name TEXT,
   phone TEXT,
   is_platform_admin INTEGER DEFAULT 0 NOT NULL,
+  -- Legacy unused: org-scoped context is org_members.user_context (#550).
   user_context TEXT,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL

--- a/packages/db/sql/schema.sql
+++ b/packages/db/sql/schema.sql
@@ -247,7 +247,7 @@ CREATE TABLE IF NOT EXISTS users (
   name TEXT,
   phone TEXT,
   is_platform_admin INTEGER DEFAULT 0 NOT NULL,
-  -- Legacy unused: org-scoped context is org_members.user_context (#550).
+  -- Legacy: pre-org USER.md; migrateLegacyUserContextToOrgMembers copies into org_members (#550).
   user_context TEXT,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL

--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -1317,10 +1317,12 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
     SET password_hash = ?, updated_at = ?
     WHERE id = ?
   `);
+  // Per-org context lives on org_members only. users.user_context is a legacy
+  // column left in place for existing installs; it is never written and must
+  // not be read (see #550).
   const getUserContextStmt = db.prepare(`
-    SELECT COALESCE(om.user_context, u.user_context) AS user_context
+    SELECT om.user_context AS user_context
     FROM org_members om
-    INNER JOIN users u ON u.id = om.user_id
     WHERE om.org_id = ? AND om.user_id = ?
   `);
   const setUserContextStmt = db.prepare(`

--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -1318,8 +1318,8 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
     WHERE id = ?
   `);
   // Per-org context lives on org_members only. users.user_context is a legacy
-  // column left in place for existing installs; it is never written and must
-  // not be read (see #550).
+  // column left in place for existing installs; migrateLegacyUserContextToOrgMembers
+  // copies any remaining values once, and this read path must not use it (#550).
   const getUserContextStmt = db.prepare(`
     SELECT om.user_context AS user_context
     FROM org_members om

--- a/packages/db/src/migrate.test.ts
+++ b/packages/db/src/migrate.test.ts
@@ -627,6 +627,48 @@ describe("organization schema migration", () => {
     }
   });
 
+  test("copies legacy users.user_context into empty org_members rows", () => {
+    const db = new Database(":memory:");
+
+    try {
+      migrateDatabase(db);
+
+      db.exec(`
+        INSERT INTO users (
+          id, email, password_hash, is_platform_admin, user_context,
+          created_at, updated_at
+        ) VALUES (
+          'user_legacy', 'legacy@example.com', 'hash', 0,
+          '# From users table',
+          '2026-06-21T00:00:00.000Z', '2026-06-21T00:00:00.000Z'
+        );
+
+        INSERT INTO organizations (
+          id, name, slug, created_at, updated_at
+        ) VALUES (
+          'org_acme', 'Acme', 'acme',
+          '2026-06-21T00:00:00.000Z', '2026-06-21T00:00:00.000Z'
+        );
+
+        INSERT INTO org_members (org_id, user_id, role, created_at) VALUES (
+          'org_acme', 'user_legacy', 'member', '2026-06-21T00:00:00.000Z'
+        );
+      `);
+
+      migrateDatabase(db);
+
+      const member = db
+        .prepare(
+          "SELECT user_context FROM org_members WHERE org_id = ? AND user_id = ?"
+        )
+        .get("org_acme", "user_legacy") as { user_context: string | null };
+
+      expect(member.user_context).toBe("# From users table");
+    } finally {
+      db.close();
+    }
+  });
+
   test("rolls back profile org backfill when a related update fails", () => {
     const db = new Database(":memory:");
 

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -26,6 +26,7 @@ export function migrateDatabase(db: Database): void {
   atomic(migrateSkillsTables);
   atomic(migrateUsersTable);
   atomic(migrateOrgTables);
+  atomic(migrateLegacyUserContextToOrgMembers);
   atomic(migrateOrgMemoryProposalsTable);
   atomic(migrateSkillProposalsTable);
   atomic(migrateSkillSuggestionsTable);
@@ -420,6 +421,45 @@ function migrateOrgTables(db: Database): void {
   if (!columnNames.has("user_context")) {
     db.exec("ALTER TABLE org_members ADD COLUMN user_context TEXT;");
   }
+}
+
+/**
+ * Pre-org installs stored USER.md on users.user_context. Writes moved to
+ * org_members (#550); copy any remaining legacy values into memberships that
+ * still lack per-org context so getUserContext can stop reading users.
+ */
+function migrateLegacyUserContextToOrgMembers(db: Database): void {
+  const usersColumns = db.prepare("PRAGMA table_info(users)").all() as Array<{
+    name: string;
+  }>;
+  const membersColumns = db
+    .prepare("PRAGMA table_info(org_members)")
+    .all() as Array<{ name: string }>;
+  const userNames = new Set(usersColumns.map((column) => column.name));
+  const memberNames = new Set(membersColumns.map((column) => column.name));
+
+  if (!(userNames.has("user_context") && memberNames.has("user_context"))) {
+    return;
+  }
+
+  db.exec(`
+    UPDATE org_members
+    SET user_context = (
+      SELECT users.user_context
+      FROM users
+      WHERE users.id = org_members.user_id
+        AND users.user_context IS NOT NULL
+        AND TRIM(users.user_context) != ''
+    )
+    WHERE user_context IS NULL
+      AND EXISTS (
+        SELECT 1
+        FROM users
+        WHERE users.id = org_members.user_id
+          AND users.user_context IS NOT NULL
+          AND TRIM(users.user_context) != ''
+      );
+  `);
 }
 
 function migrateOrgMemoryProposalsTable(db: Database): void {

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -451,14 +451,7 @@ function migrateLegacyUserContextToOrgMembers(db: Database): void {
         AND users.user_context IS NOT NULL
         AND TRIM(users.user_context) != ''
     )
-    WHERE user_context IS NULL
-      AND EXISTS (
-        SELECT 1
-        FROM users
-        WHERE users.id = org_members.user_id
-          AND users.user_context IS NOT NULL
-          AND TRIM(users.user_context) != ''
-      );
+    WHERE user_context IS NULL;
   `);
 }
 

--- a/packages/db/src/user-context.test.ts
+++ b/packages/db/src/user-context.test.ts
@@ -1,6 +1,10 @@
+import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { USER_CONTEXT_TEMPLATE } from "@nakama/core";
-import { createInMemoryDatabaseAdapter } from "./index";
+import { createInMemoryDatabaseAdapter, createSqliteDatabase } from "./index";
 
 describe("user context storage", () => {
   test("init creates context and second init is a no-op", async () => {
@@ -86,5 +90,53 @@ describe("user context storage", () => {
     expect(await db.getUserContext("org_2", "user_1")).toBe(
       "# About Me\n\nAlice at Org 2"
     );
+  });
+
+  test("ignores legacy users.user_context when org_members has none", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "nakama-user-context-"));
+    const databasePath = join(dir, "test.db");
+
+    try {
+      const database = await createSqliteDatabase(`file:${databasePath}`);
+      const now = "2026-06-21T10:00:00.000Z";
+
+      await database.adapter.createUser({
+        createdAt: now,
+        email: "alice@example.com",
+        id: "user_1",
+        isPlatformAdmin: false,
+        passwordHash: "hash",
+        updatedAt: now,
+      });
+      await database.adapter.upsertOrganization({
+        createdAt: now,
+        id: "org_1",
+        name: "Acme",
+        slug: "acme",
+        updatedAt: now,
+      });
+      await database.adapter.upsertOrgMember({
+        createdAt: now,
+        orgId: "org_1",
+        role: "admin",
+        userId: "user_1",
+      });
+      database.close();
+
+      const raw = new Database(databasePath);
+      raw.run("UPDATE users SET user_context = ? WHERE id = ?", [
+        "# Legacy user-level context",
+        "user_1",
+      ]);
+      raw.close();
+
+      const reopened = await createSqliteDatabase(`file:${databasePath}`);
+      expect(
+        await reopened.adapter.getUserContext("org_1", "user_1")
+      ).toBeNull();
+      reopened.close();
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
   });
 });

--- a/packages/db/src/user-context.test.ts
+++ b/packages/db/src/user-context.test.ts
@@ -1,10 +1,6 @@
-import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { USER_CONTEXT_TEMPLATE } from "@nakama/core";
-import { createInMemoryDatabaseAdapter, createSqliteDatabase } from "./index";
+import { createInMemoryDatabaseAdapter } from "./index";
 
 describe("user context storage", () => {
   test("init creates context and second init is a no-op", async () => {
@@ -90,107 +86,5 @@ describe("user context storage", () => {
     expect(await db.getUserContext("org_2", "user_1")).toBe(
       "# About Me\n\nAlice at Org 2"
     );
-  });
-
-  test("migrates legacy users.user_context into org_members on open", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "nakama-user-context-"));
-    const databasePath = join(dir, "test.db");
-
-    try {
-      const database = await createSqliteDatabase(`file:${databasePath}`);
-      const now = "2026-06-21T10:00:00.000Z";
-
-      await database.adapter.createUser({
-        createdAt: now,
-        email: "alice@example.com",
-        id: "user_1",
-        isPlatformAdmin: false,
-        passwordHash: "hash",
-        updatedAt: now,
-      });
-      await database.adapter.upsertOrganization({
-        createdAt: now,
-        id: "org_1",
-        name: "Acme",
-        slug: "acme",
-        updatedAt: now,
-      });
-      await database.adapter.upsertOrgMember({
-        createdAt: now,
-        orgId: "org_1",
-        role: "admin",
-        userId: "user_1",
-      });
-      database.close();
-
-      const raw = new Database(databasePath);
-      raw.run("UPDATE users SET user_context = ? WHERE id = ?", [
-        "# Legacy user-level context",
-        "user_1",
-      ]);
-      raw.close();
-
-      const reopened = await createSqliteDatabase(`file:${databasePath}`);
-      expect(await reopened.adapter.getUserContext("org_1", "user_1")).toBe(
-        "# Legacy user-level context"
-      );
-      reopened.close();
-    } finally {
-      rmSync(dir, { force: true, recursive: true });
-    }
-  });
-
-  test("does not prefer users.user_context over org_members", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "nakama-user-context-"));
-    const databasePath = join(dir, "test.db");
-
-    try {
-      const database = await createSqliteDatabase(`file:${databasePath}`);
-      const now = "2026-06-21T10:00:00.000Z";
-
-      await database.adapter.createUser({
-        createdAt: now,
-        email: "bob@example.com",
-        id: "user_2",
-        isPlatformAdmin: false,
-        passwordHash: "hash",
-        updatedAt: now,
-      });
-      await database.adapter.upsertOrganization({
-        createdAt: now,
-        id: "org_2",
-        name: "Beta",
-        slug: "beta",
-        updatedAt: now,
-      });
-      await database.adapter.upsertOrgMember({
-        createdAt: now,
-        orgId: "org_2",
-        role: "member",
-        userId: "user_2",
-      });
-      await database.adapter.setUserContext(
-        "org_2",
-        "user_2",
-        "# Org scoped",
-        now
-      );
-      database.close();
-
-      const raw = new Database(databasePath);
-      raw.run("UPDATE users SET user_context = ? WHERE id = ?", [
-        "# Legacy should lose",
-        "user_2",
-      ]);
-      raw.close();
-
-      const reopened = await createSqliteDatabase(`file:${databasePath}`);
-      expect(await reopened.adapter.getUserContext("org_2", "user_2")).toBe(
-        "# Org scoped"
-      );
-      reopened.close();
-    } finally {
-      rmSync(dir, { force: true, recursive: true });
-    }
   });
 });

--- a/packages/db/src/user-context.test.ts
+++ b/packages/db/src/user-context.test.ts
@@ -92,7 +92,7 @@ describe("user context storage", () => {
     );
   });
 
-  test("ignores legacy users.user_context when org_members has none", async () => {
+  test("migrates legacy users.user_context into org_members on open", async () => {
     const dir = mkdtempSync(join(tmpdir(), "nakama-user-context-"));
     const databasePath = join(dir, "test.db");
 
@@ -131,9 +131,63 @@ describe("user context storage", () => {
       raw.close();
 
       const reopened = await createSqliteDatabase(`file:${databasePath}`);
-      expect(
-        await reopened.adapter.getUserContext("org_1", "user_1")
-      ).toBeNull();
+      expect(await reopened.adapter.getUserContext("org_1", "user_1")).toBe(
+        "# Legacy user-level context"
+      );
+      reopened.close();
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test("does not prefer users.user_context over org_members", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "nakama-user-context-"));
+    const databasePath = join(dir, "test.db");
+
+    try {
+      const database = await createSqliteDatabase(`file:${databasePath}`);
+      const now = "2026-06-21T10:00:00.000Z";
+
+      await database.adapter.createUser({
+        createdAt: now,
+        email: "bob@example.com",
+        id: "user_2",
+        isPlatformAdmin: false,
+        passwordHash: "hash",
+        updatedAt: now,
+      });
+      await database.adapter.upsertOrganization({
+        createdAt: now,
+        id: "org_2",
+        name: "Beta",
+        slug: "beta",
+        updatedAt: now,
+      });
+      await database.adapter.upsertOrgMember({
+        createdAt: now,
+        orgId: "org_2",
+        role: "member",
+        userId: "user_2",
+      });
+      await database.adapter.setUserContext(
+        "org_2",
+        "user_2",
+        "# Org scoped",
+        now
+      );
+      database.close();
+
+      const raw = new Database(databasePath);
+      raw.run("UPDATE users SET user_context = ? WHERE id = ?", [
+        "# Legacy should lose",
+        "user_2",
+      ]);
+      raw.close();
+
+      const reopened = await createSqliteDatabase(`file:${databasePath}`);
+      expect(await reopened.adapter.getUserContext("org_2", "user_2")).toBe(
+        "# Org scoped"
+      );
       reopened.close();
     } finally {
       rmSync(dir, { force: true, recursive: true });


### PR DESCRIPTION
## Summary

`getUserContext` reads only `org_members.user_context`; a one-shot migrate copies any leftover `users.user_context` into empty memberships first. Fixes #550.

**Before:** `COALESCE(om.user_context, u.user_context)` while writes only update `org_members` — dead fallback, and dropping it alone would lose pre-org USER.md.
**After:** `migrateLegacyUserContextToOrgMembers` then select from `org_members` alone; schema comment marks the users column as legacy.

Why safe:
1. Writes already target `org_members` only since the org-scoped move
2. Migrate fills NULL memberships from users (idempotent; does not overwrite org-scoped values)
3. Column kept in place — no DROP / migration pain for existing installs

Only drop the users column later if we want a hard schema cleanup.

## Test plan
- [x] `bun test packages/db/src/user-context.test.ts` (2 pass)
- [x] `bun test packages/db/src/migrate.test.ts` — includes legacy copy case (22 pass in org/migration suite run)
- [ ] System → user context edit/save still persists per org
