### PR TITLE
fix(setup): claim the first admin in one transaction

### DIFF
--- a/apps/server/src/http/app.test.ts
+++ b/apps/server/src/http/app.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { loadLocalAuthToken, verifyLocalAuthToken } from "@nakama/core";
+import { LOCAL_CLIENT_USER_ID } from "@nakama/core/local-auth";
 import { createInMemoryDatabaseAdapter } from "@nakama/db";
 import { AuthService } from "../services/auth-service";
 import { OrgService } from "../services/org-service";
@@ -825,6 +826,40 @@ describe("createHonoApp", () => {
     // The org used to be committed before the admin was validated, so the
     // retry lost the slug it had just taken.
     expect((await setup("admin@example.com")).status).toBe(201);
+  });
+
+  test("concurrent setup creates exactly one org and one admin", async () => {
+    const options = createServerOptions();
+    const app = createHonoApp(options);
+    const setup = (slug: string) =>
+      app.fetch(
+        new Request("http://localhost:4310/v1/auth/setup", {
+          body: JSON.stringify(
+            buildSetupAuthBody(`${slug}@example.com`, {
+              organization: { name: slug, slug },
+            })
+          ),
+          headers: { "Content-Type": "application/json" },
+          method: "POST",
+        })
+      );
+
+    // Distinct slugs, so nothing but the human-user check can stop the loser.
+    const statuses = (await Promise.all([setup("alpha"), setup("beta")])).map(
+      (response) => response.status
+    );
+
+    expect(statuses.toSorted()).toEqual([201, 409]);
+    expect(await options.databaseAdapter.countHumanUsers()).toBe(1);
+
+    const organizations = await options.databaseAdapter.listOrganizations();
+    expect(organizations).toHaveLength(1);
+    const members = await options.databaseAdapter.listOrgMembers(
+      organizations[0]?.id ?? ""
+    );
+    expect(
+      members.filter((member) => member.userId !== LOCAL_CLIENT_USER_ID)
+    ).toHaveLength(1);
   });
 
   test("sends HSTS behind a TLS terminator", async () => {

--- a/apps/server/src/services/org-service.ts
+++ b/apps/server/src/services/org-service.ts
@@ -499,11 +499,7 @@ export class OrgService {
       throw new NakamaApiError("A valid email address is required.", 400);
     }
 
-    const organization = await this.insertOrganization({
-      name: input.organization.name,
-      slug: input.organization.slug,
-    });
-
+    const organization = await this.buildOrganizationRecord(input.organization);
     const now = new Date().toISOString();
     const user: StoredUserRecord = {
       createdAt: now,
@@ -516,15 +512,27 @@ export class OrgService {
       updatedAt: now,
     };
 
-    await this.databaseAdapter.createUser(user);
-    await this.databaseAdapter.upsertOrgMember({
-      createdAt: now,
-      orgId: organization.id,
-      role: "admin",
-      userId: user.id,
+    // One transaction, so a second concurrent setup that also passed the
+    // route's human-user check loses here instead of committing an org it
+    // can never become a member of.
+    const claimed = await this.databaseAdapter.bootstrapInitialSetup({
+      member: {
+        createdAt: now,
+        orgId: organization.id,
+        role: "admin",
+        userId: user.id,
+      },
+      organization,
+      user,
     });
+    if (!claimed) {
+      throw new NakamaApiError("Admin user already exists", 409);
+    }
 
-    return { organization, user };
+    await this.seedOrgProfiles(organization.id);
+    await ensureLocalClientAccess(this.databaseAdapter);
+
+    return { organization: toOrganizationSummary(organization), user };
   }
 
   async listMembers(orgId: string): Promise<ListOrgMembersResponse> {
@@ -853,9 +861,10 @@ export class OrgService {
     return member;
   }
 
-  private async insertOrganization(
-    request: CreateOrganizationRequest
-  ): Promise<OrganizationSummary> {
+  private async buildOrganizationRecord(request: {
+    name: string;
+    slug: string;
+  }): Promise<StoredOrganizationRecord> {
     const name = request.name.trim();
     const slug = request.slug.trim().toLowerCase();
 
@@ -870,20 +879,13 @@ export class OrgService {
       );
     }
 
-    if (
-      request.admin &&
-      !(request.admin.name.trim() && request.admin.email.trim())
-    ) {
-      throw new NakamaApiError("Admin name and email are required.", 400);
-    }
-
     const existing = await this.databaseAdapter.getOrganizationBySlug(slug);
     if (existing) {
       throw new NakamaApiError("Organization slug already exists.", 409);
     }
 
     const now = new Date().toISOString();
-    const record: StoredOrganizationRecord = {
+    return {
       createdAt: now,
       id: `org_${crypto.randomUUID().replace(/-/g, "")}`,
       name,
@@ -892,7 +894,19 @@ export class OrgService {
       slug,
       updatedAt: now,
     };
+  }
 
+  private async insertOrganization(
+    request: CreateOrganizationRequest
+  ): Promise<OrganizationSummary> {
+    if (
+      request.admin &&
+      !(request.admin.name.trim() && request.admin.email.trim())
+    ) {
+      throw new NakamaApiError("Admin name and email are required.", 400);
+    }
+
+    const record = await this.buildOrganizationRecord(request);
     await this.databaseAdapter.upsertOrganization(record);
     await this.seedOrgProfiles(record.id);
     await ensureLocalClientAccess(this.databaseAdapter);

--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -1691,6 +1691,63 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
     ON CONFLICT(org_id, user_id) DO UPDATE SET
       role = excluded.role
   `);
+  const runCreateUserStmt = (record: StoredUserRecord) => {
+    createUserStmt.run(
+      record.id,
+      record.email,
+      record.passwordHash,
+      record.name ?? null,
+      record.phone ?? null,
+      record.isPlatformAdmin ? 1 : 0,
+      record.createdAt,
+      record.updatedAt
+    );
+  };
+  const runUpsertOrganizationStmt = (record: StoredOrganizationRecord) => {
+    upsertOrganizationStmt.run(
+      record.id,
+      record.name,
+      record.slug,
+      record.skillsWriteApproval ? 1 : 0,
+      record.skillsPostTurnReview ? 1 : 0,
+      record.skillsCuratorEnabled ? 1 : 0,
+      record.skillsCuratorStaleAfterDays ?? 30,
+      record.skillsCuratorArchiveAfterDays ?? 90,
+      record.skillsCuratorConsolidateEnabled ? 1 : 0,
+      record.skillsCuratorLastRunAt ?? null,
+      record.archivedAt ?? null,
+      record.createdAt,
+      record.updatedAt
+    );
+  };
+  const runUpsertOrgMemberStmt = (record: StoredOrgMemberRecord) => {
+    upsertOrgMemberStmt.run(
+      record.orgId,
+      record.userId,
+      record.role,
+      record.userContext ?? null,
+      record.createdAt
+    );
+  };
+  const bootstrapInitialSetupTransaction = db.transaction(
+    (input: {
+      member: StoredOrgMemberRecord;
+      organization: StoredOrganizationRecord;
+      user: StoredUserRecord;
+    }) => {
+      const row = countHumanUsersStmt.get(LOCAL_CLIENT_USER_ID) as {
+        count: number;
+      };
+      if (row.count > 0) {
+        return false;
+      }
+
+      runUpsertOrganizationStmt(input.organization);
+      runCreateUserStmt(input.user);
+      runUpsertOrgMemberStmt(input.member);
+      return true;
+    }
+  );
   const listOrgMembersStmt = db.prepare(`
     SELECT org_id, user_id, role, user_context, created_at
     FROM org_members
@@ -1750,6 +1807,10 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
 
     async assignToolToProfile(profileId, toolId) {
       assignToolStmt.run(profileId, toolId);
+    },
+
+    async bootstrapInitialSetup(input) {
+      return bootstrapInitialSetupTransaction.immediate(input);
     },
 
     async countHumanUsers() {
@@ -1914,16 +1975,7 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
     },
 
     async createUser(record) {
-      createUserStmt.run(
-        record.id,
-        record.email,
-        record.passwordHash,
-        record.name ?? null,
-        record.phone ?? null,
-        record.isPlatformAdmin ? 1 : 0,
-        record.createdAt,
-        record.updatedAt
-      );
+      runCreateUserStmt(record);
     },
 
     async deleteAttachment(id) {
@@ -3014,31 +3066,11 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
     },
 
     async upsertOrganization(record) {
-      upsertOrganizationStmt.run(
-        record.id,
-        record.name,
-        record.slug,
-        record.skillsWriteApproval ? 1 : 0,
-        record.skillsPostTurnReview ? 1 : 0,
-        record.skillsCuratorEnabled ? 1 : 0,
-        record.skillsCuratorStaleAfterDays ?? 30,
-        record.skillsCuratorArchiveAfterDays ?? 90,
-        record.skillsCuratorConsolidateEnabled ? 1 : 0,
-        record.skillsCuratorLastRunAt ?? null,
-        record.archivedAt ?? null,
-        record.createdAt,
-        record.updatedAt
-      );
+      runUpsertOrganizationStmt(record);
     },
 
     async upsertOrgMember(record) {
-      upsertOrgMemberStmt.run(
-        record.orgId,
-        record.userId,
-        record.role,
-        record.userContext ?? null,
-        record.createdAt
-      );
+      runUpsertOrgMemberStmt(record);
     },
 
     async upsertProfile(record) {

--- a/packages/db/src/bootstrap-initial-setup.test.ts
+++ b/packages/db/src/bootstrap-initial-setup.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { createSqliteDatabase } from "./adapters/sqlite";
+
+const NOW = "2020-01-01T00:00:00.000Z";
+
+function setupInput(email: string) {
+  return {
+    member: {
+      createdAt: NOW,
+      orgId: "org_boot",
+      role: "admin" as const,
+      userId: "user_admin",
+    },
+    organization: {
+      createdAt: NOW,
+      id: "org_boot",
+      name: "Acme",
+      slug: "acme",
+      updatedAt: NOW,
+    },
+    user: {
+      createdAt: NOW,
+      email,
+      id: "user_admin",
+      isPlatformAdmin: true,
+      name: "Admin",
+      passwordHash: "hash",
+      updatedAt: NOW,
+    },
+  };
+}
+
+describe("bootstrapInitialSetup", () => {
+  test("rolls the organization back when the admin insert fails", async () => {
+    const database = await createSqliteDatabase(":memory:");
+    try {
+      // The CLI bearer identity is not a human user, so the claim check passes
+      // and the admin insert is what trips the unique email index.
+      await database.adapter.createUser({
+        createdAt: NOW,
+        email: "taken@example.com",
+        id: "user_local_client",
+        passwordHash: "hash",
+        updatedAt: NOW,
+      });
+
+      await expect(
+        database.adapter.bootstrapInitialSetup(setupInput("taken@example.com"))
+      ).rejects.toThrow();
+
+      expect(await database.adapter.listOrganizations()).toHaveLength(0);
+    } finally {
+      database.close();
+    }
+  });
+
+  test("refuses to claim once a human user exists", async () => {
+    const database = await createSqliteDatabase(":memory:");
+    try {
+      expect(
+        await database.adapter.bootstrapInitialSetup(
+          setupInput("first@example.com")
+        )
+      ).toBe(true);
+
+      const second = setupInput("second@example.com");
+      second.organization.id = "org_second";
+      second.organization.slug = "second";
+      second.member.orgId = "org_second";
+      second.user.id = "user_second";
+
+      expect(await database.adapter.bootstrapInitialSetup(second)).toBe(false);
+      expect(await database.adapter.listOrganizations()).toHaveLength(1);
+    } finally {
+      database.close();
+    }
+  });
+});

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -561,6 +561,16 @@ export interface DatabaseAdapter {
   assignMcpServerToProfile(profileId: string, serverId: string): Promise<void>;
   assignSkillToProfile(profileId: string, skillId: string): Promise<void>;
   assignToolToProfile(profileId: string, toolId: string): Promise<void>;
+  /**
+   * First-admin claim. Writes the org, the admin and the membership in one
+   * transaction, and returns false without writing anything when a human user
+   * already exists, so two concurrent setups cannot leave a memberless org.
+   */
+  bootstrapInitialSetup(input: {
+    member: StoredOrgMemberRecord;
+    organization: StoredOrganizationRecord;
+    user: StoredUserRecord;
+  }): Promise<boolean>;
   /** Users excluding the auto-created CLI bearer-auth identity. */
   countHumanUsers(): Promise<number>;
   countOrgMemoryProposals(


### PR DESCRIPTION
## Summary

Setup claims the first admin inside one transaction, so two concurrent requests cannot leave an orphan organization.

**Before:** two `POST /v1/auth/setup` requests both pass `countHumanUsers() === 0`, both insert an organization, one creates `user_admin` and the other gets a 500 on the fixed id. Its organization stays committed with no members.
**After:** `bootstrapInitialSetup` re-checks for a human user and writes the org, the admin and the membership in one sqlite transaction. The loser writes nothing and gets a 409.

Why safe:
1. The claim check moves into the transaction, so the check and the writes cannot interleave.
2. A failure partway through rolls the org back. The new db test proves it: without the transaction the org survives the failed admin insert.
3. Existing behavior kept, setup still 409s once a human user exists and invalid setup still creates nothing.

## Test plan
- [x] `bun run test`, 11 workspaces, 0 fail (server 1107, db 98)
- [x] New concurrency test goes red on main (`[201, 500]`) and green here (`[201, 409]`)

Part of #361 (a).
