### PR TITLE
fix(import): cap archive size on the setup import routes

### DIFF
--- a/apps/server/src/http/routes/data-portability.ts
+++ b/apps/server/src/http/routes/data-portability.ts
@@ -95,6 +95,10 @@ export function registerDataPortabilityRoutes(
           content: { "application/json": { schema: errorSchema } },
           description: "Error",
         },
+        413: {
+          content: { "application/json": { schema: errorSchema } },
+          description: "Error",
+        },
         500: {
           content: { "application/json": { schema: errorSchema } },
           description: "Error",
@@ -129,6 +133,10 @@ export function registerDataPortabilityRoutes(
           content: { "application/json": { schema: errorSchema } },
           description: "Error",
         },
+        413: {
+          content: { "application/json": { schema: errorSchema } },
+          description: "Error",
+        },
         500: {
           content: { "application/json": { schema: errorSchema } },
           description: "Error",
@@ -153,11 +161,11 @@ export function registerDataPortabilityRoutes(
   app.post("/v1/platform/data/import/preview", async (c) => {
     requirePlatformAdminFromContext(c);
     const body = await readJson<PreviewDataImportRequest>(c.req.raw);
+    // Decoded outside the catch so an oversized archive keeps its 413.
+    const archive = decodeArchiveRequestData(body.data);
 
     try {
-      const preview = await previewNakamaDataImport(
-        decodeArchiveRequestData(body.data)
-      );
+      const preview = await previewNakamaDataImport(archive);
       return json<DataImportPreviewResponse>(preview);
     } catch (error) {
       return errorResponse(formatImportError(error), 400);
@@ -167,15 +175,13 @@ export function registerDataPortabilityRoutes(
   app.post("/v1/platform/data/import/restore", async (c) => {
     requirePlatformAdminFromContext(c);
     const body = await readJson<RestoreDataImportRequest>(c.req.raw);
+    const archive = decodeArchiveRequestData(body.data);
 
     let restore;
     try {
-      restore = await restoreNakamaDataImport(
-        decodeArchiveRequestData(body.data),
-        {
-          confirm: body.confirm,
-        }
-      );
+      restore = await restoreNakamaDataImport(archive, {
+        confirm: body.confirm,
+      });
     } catch (error) {
       return errorResponse(formatImportError(error), 400);
     }

--- a/apps/server/src/http/routes/setup-import.ts
+++ b/apps/server/src/http/routes/setup-import.ts
@@ -69,6 +69,10 @@ export function registerSetupImportRoutes(
           content: { "application/json": { schema: errorSchema } },
           description: "Error",
         },
+        413: {
+          content: { "application/json": { schema: errorSchema } },
+          description: "Error",
+        },
         500: {
           content: { "application/json": { schema: errorSchema } },
           description: "Error",
@@ -103,6 +107,10 @@ export function registerSetupImportRoutes(
           content: { "application/json": { schema: errorSchema } },
           description: "Error",
         },
+        413: {
+          content: { "application/json": { schema: errorSchema } },
+          description: "Error",
+        },
         500: {
           content: { "application/json": { schema: errorSchema } },
           description: "Error",
@@ -121,11 +129,11 @@ export function registerSetupImportRoutes(
     await assertSetupImportAllowed(databaseAdapter);
 
     const body = await readJson<PreviewDataImportRequest>(c.req.raw);
+    // Decoded outside the catch so an oversized archive keeps its 413.
+    const archive = decodeArchiveRequestData(body.data);
 
     try {
-      const preview = await previewNakamaDataImport(
-        decodeArchiveRequestData(body.data)
-      );
+      const preview = await previewNakamaDataImport(archive);
       return json<DataImportPreviewResponse>(preview);
     } catch (error) {
       return errorResponse(formatServerError(error), 400);
@@ -140,15 +148,13 @@ export function registerSetupImportRoutes(
     await assertSetupImportAllowed(databaseAdapter);
 
     const body = await readJson<RestoreDataImportRequest>(c.req.raw);
+    const archive = decodeArchiveRequestData(body.data);
 
     let restore;
     try {
-      restore = await restoreNakamaDataImport(
-        decodeArchiveRequestData(body.data),
-        {
-          confirm: body.confirm,
-        }
-      );
+      restore = await restoreNakamaDataImport(archive, {
+        confirm: body.confirm,
+      });
     } catch (error) {
       return errorResponse(formatServerError(error), 400);
     }

--- a/apps/server/src/services/data-portability.test.ts
+++ b/apps/server/src/services/data-portability.test.ts
@@ -9,8 +9,13 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { NakamaApiError } from "@nakama/core";
 import {
   createNakamaDataExport,
+  decodeArchiveRequestData,
+  MAX_IMPORT_ARCHIVE_BYTES,
+  MAX_IMPORT_ENTRY_BYTES,
+  MAX_IMPORT_UNCOMPRESSED_BYTES,
   NAKAMA_EXPORT_MANIFEST,
   previewNakamaDataImport,
   restoreNakamaDataImport,
@@ -196,46 +201,107 @@ describe("Nakama data portability", () => {
       renameMock.mockRestore();
     }
   });
+
+  test("rejects a base64 payload over the archive cap before decoding", () => {
+    const oversized = "A".repeat(
+      Math.ceil(MAX_IMPORT_ARCHIVE_BYTES / 3) * 4 + 1
+    );
+
+    let status = 0;
+    try {
+      decodeArchiveRequestData(oversized);
+    } catch (error) {
+      status = (error as NakamaApiError).status;
+    }
+
+    expect(status).toBe(413);
+  });
+
+  test("rejects an archive entry declaring more than the entry cap", async () => {
+    const archive = buildZipWithEntries([
+      {
+        content: "{}",
+        declaredSize: MAX_IMPORT_ENTRY_BYTES + 1,
+        name: "big.bin",
+      },
+    ]);
+
+    await expect(previewNakamaDataImport(archive, { rootDir })).rejects.toThrow(
+      /big\.bin exceeds/
+    );
+  });
+
+  test("rejects an archive whose entries add up past the total cap", async () => {
+    const count =
+      Math.ceil(MAX_IMPORT_UNCOMPRESSED_BYTES / MAX_IMPORT_ENTRY_BYTES) + 1;
+    const archive = buildZipWithEntries(
+      Array.from({ length: count }, (_, index) => ({
+        content: "{}",
+        declaredSize: MAX_IMPORT_ENTRY_BYTES,
+        name: `part-${index}.bin`,
+      }))
+    );
+
+    await expect(previewNakamaDataImport(archive, { rootDir })).rejects.toThrow(
+      /uncompressed limit/
+    );
+  });
 });
 
 function buildZipWithEntry(name: string, content: string): Buffer {
-  const safe = Buffer.from(content, "utf8");
-  const localHeader = Buffer.alloc(30);
-  localHeader.writeUInt32LE(0x04_03_4b_50, 0);
-  localHeader.writeUInt16LE(20, 4);
-  localHeader.writeUInt16LE(0x08_00, 6);
-  localHeader.writeUInt16LE(0, 8);
-  localHeader.writeUInt32LE(safe.length, 18);
-  localHeader.writeUInt32LE(safe.length, 22);
-  localHeader.writeUInt16LE(Buffer.byteLength(name), 26);
+  return buildZipWithEntries([{ content, name }]);
+}
 
-  const centralHeader = Buffer.alloc(46);
-  centralHeader.writeUInt32LE(0x02_01_4b_50, 0);
-  centralHeader.writeUInt16LE(20, 4);
-  centralHeader.writeUInt16LE(20, 6);
-  centralHeader.writeUInt16LE(0x08_00, 8);
-  centralHeader.writeUInt16LE(0, 10);
-  centralHeader.writeUInt32LE(safe.length, 20);
-  centralHeader.writeUInt32LE(safe.length, 24);
-  centralHeader.writeUInt16LE(Buffer.byteLength(name), 28);
+/**
+ * Hand-rolled so an entry can declare an uncompressed size it does not have,
+ * which is the shape the import size caps have to refuse.
+ */
+function buildZipWithEntries(
+  entries: Array<{ content: string; declaredSize?: number; name: string }>
+): Buffer {
+  const locals: Buffer[] = [];
+  const centrals: Buffer[] = [];
+  let offset = 0;
 
-  const centralOffset =
-    localHeader.length + Buffer.byteLength(name) + safe.length;
+  for (const entry of entries) {
+    const safe = Buffer.from(entry.content, "utf8");
+    const declared = entry.declaredSize ?? safe.length;
+    const nameBytes = Buffer.from(entry.name);
+
+    const localHeader = Buffer.alloc(30);
+    localHeader.writeUInt32LE(0x04_03_4b_50, 0);
+    localHeader.writeUInt16LE(20, 4);
+    localHeader.writeUInt16LE(0x08_00, 6);
+    localHeader.writeUInt16LE(0, 8);
+    localHeader.writeUInt32LE(safe.length, 18);
+    localHeader.writeUInt32LE(declared, 22);
+    localHeader.writeUInt16LE(nameBytes.length, 26);
+
+    const centralHeader = Buffer.alloc(46);
+    centralHeader.writeUInt32LE(0x02_01_4b_50, 0);
+    centralHeader.writeUInt16LE(20, 4);
+    centralHeader.writeUInt16LE(20, 6);
+    centralHeader.writeUInt16LE(0x08_00, 8);
+    centralHeader.writeUInt16LE(0, 10);
+    centralHeader.writeUInt32LE(safe.length, 20);
+    centralHeader.writeUInt32LE(declared, 24);
+    centralHeader.writeUInt16LE(nameBytes.length, 28);
+    centralHeader.writeUInt32LE(offset, 42);
+
+    locals.push(localHeader, nameBytes, safe);
+    centrals.push(centralHeader, nameBytes);
+    offset += localHeader.length + nameBytes.length + safe.length;
+  }
+
+  const central = Buffer.concat(centrals);
   const end = Buffer.alloc(22);
   end.writeUInt32LE(0x06_05_4b_50, 0);
-  end.writeUInt16LE(1, 8);
-  end.writeUInt16LE(1, 10);
-  end.writeUInt32LE(centralHeader.length + Buffer.byteLength(name), 12);
-  end.writeUInt32LE(centralOffset, 16);
+  end.writeUInt16LE(entries.length, 8);
+  end.writeUInt16LE(entries.length, 10);
+  end.writeUInt32LE(central.length, 12);
+  end.writeUInt32LE(offset, 16);
 
-  return Buffer.concat([
-    localHeader,
-    Buffer.from(name),
-    safe,
-    centralHeader,
-    Buffer.from(name),
-    end,
-  ]);
+  return Buffer.concat([...locals, central, end]);
 }
 
 function buildUnsafeZip(): Buffer {

--- a/apps/server/src/services/data-portability.ts
+++ b/apps/server/src/services/data-portability.ts
@@ -34,6 +34,15 @@ import { unzipSync, zipSync } from "fflate";
 export const NAKAMA_EXPORT_MANIFEST = "nakama-export.json";
 export const NAKAMA_EXPORT_FORMAT_VERSION = 1;
 
+// Setup import is unauthenticated until the first admin exists, so an archive
+// has to be capped on the way in rather than once it is already in memory.
+export const MAX_IMPORT_ARCHIVE_BYTES = 100 * 1024 * 1024;
+export const MAX_IMPORT_ENTRY_BYTES = 100 * 1024 * 1024;
+export const MAX_IMPORT_UNCOMPRESSED_BYTES = 500 * 1024 * 1024;
+/** Base64 carries 3 bytes per 4 characters. */
+const MAX_IMPORT_ARCHIVE_BASE64_CHARS =
+  Math.ceil(MAX_IMPORT_ARCHIVE_BYTES / 3) * 4;
+
 export interface CreateDataExportOptions {
   databasePath?: string | null;
   now?: Date;
@@ -168,12 +177,25 @@ export async function previewNakamaDataImport(
 }
 
 export function decodeArchiveRequestData(data: string): Buffer {
+  // Checked before the trim, so an oversized payload is rejected without
+  // being copied and then decoded.
+  if (data.length > MAX_IMPORT_ARCHIVE_BASE64_CHARS) {
+    throw new NakamaApiError(
+      `Import archive must be at most ${megabytes(MAX_IMPORT_ARCHIVE_BYTES)}.`,
+      413
+    );
+  }
+
   const trimmed = data.trim();
   if (!trimmed) {
     throw new NakamaApiError("Import archive data is required.", 400);
   }
 
   return Buffer.from(trimmed, "base64");
+}
+
+function megabytes(bytes: number): string {
+  return `${bytes / (1024 * 1024)} MB`;
 }
 
 export async function restoreNakamaDataImport(
@@ -351,8 +373,34 @@ async function writeRestoredEntry(
 }
 
 function readZip(buffer: Buffer): ZipEntry[] {
+  let uncompressedTotal = 0;
+  // fflate sizes each output buffer from the entry's declared uncompressed
+  // size, so refusing here is what stops a bomb from being inflated at all.
+  const admitEntry = (name: string, size: number): boolean => {
+    if (size > MAX_IMPORT_ENTRY_BYTES) {
+      throw new NakamaApiError(
+        `Archive entry ${name} exceeds the ${megabytes(MAX_IMPORT_ENTRY_BYTES)} limit.`,
+        400
+      );
+    }
+
+    uncompressedTotal += size;
+    if (uncompressedTotal > MAX_IMPORT_UNCOMPRESSED_BYTES) {
+      throw new NakamaApiError(
+        `Archive exceeds the ${megabytes(MAX_IMPORT_UNCOMPRESSED_BYTES)} uncompressed limit.`,
+        400
+      );
+    }
+
+    return true;
+  };
+
   try {
-    return Object.entries(unzipSync(buffer))
+    return Object.entries(
+      unzipSync(buffer, {
+        filter: (file) => admitEntry(file.name, file.originalSize),
+      })
+    )
       .filter(([name]) => !name.endsWith("/"))
       .map(([name, data]) => {
         validateArchivePath(name);


### PR DESCRIPTION
## Summary

The pre-first-admin import routes cap what they decode and unzip.

**Before:** `/v1/auth/setup/import/preview|restore` are unauthenticated until the first admin exists, and they base64 decoded and `unzipSync`ed whatever arrived. fflate sizes each output buffer from the entry's declared uncompressed size, so a few KB of archive could ask for gigabytes.
**After:** `decodeArchiveRequestData` rejects a payload over 100 MB with a 413 before it copies or decodes. `readZip` refuses an entry over 100 MB, or an archive over 500 MB uncompressed, from the unzip filter, which fflate runs before it allocates anything.

Why safe:
1. Both caps sit in the shared functions, so the authenticated platform import routes get them too.
2. Existing behavior kept, a valid archive still previews and restores and both routes still 409 after the first admin.
3. The request body limit itself belongs to #357, so it is not duplicated here.

## Test plan
- [x] `bun run test`, 11 workspaces, 0 fail (server 1109)
- [x] The three new cases go red with the caps raised to `Number.MAX_SAFE_INTEGER` and green as written

Part of #361 (b).
