### PR TITLE
fix(origin): allowlist the client-supplied origin

### DIFF
--- a/apps/server/src/http/routes/artifact-shares.test.ts
+++ b/apps/server/src/http/routes/artifact-shares.test.ts
@@ -273,7 +273,7 @@ describe("artifact share routes", () => {
     );
   });
 
-  test("publish prefers clientOrigin over loopback request URL", async () => {
+  test("publish refuses a clientOrigin off the request host", async () => {
     const { app, databaseAdapter } = createApp();
     const session = await setupFreshInstallSession(app, databaseAdapter);
     const orgId = session.orgId!;
@@ -301,13 +301,12 @@ describe("artifact share routes", () => {
       })
     );
 
-    expect(publishResponse.status).toBe(201);
-    const published = (await publishResponse.json()) as {
-      shareUrl: string | null;
-      webPublicUrlConfigured: boolean;
-    };
-    expect(published.shareUrl).toMatch(/^https:\/\/nakama\.example\.com\/s\//);
-    expect(published.webPublicUrlConfigured).toBe(true);
+    // The origin ends up in the share link, so an unconfigured install takes
+    // it only from loopback or the host the request arrived on.
+    expect(publishResponse.status).toBe(400);
+    await expect(publishResponse.json()).resolves.toEqual({
+      error: "Origin is not allowed.",
+    });
   });
 
   test("publish prefers configured web public URL over loopback request URL", async () => {

--- a/apps/server/src/services/artifact-share-service.test.ts
+++ b/apps/server/src/services/artifact-share-service.test.ts
@@ -56,13 +56,15 @@ async function withFreshConfigDir<T>(run: () => T | Promise<T>): Promise<T> {
 }
 
 describe("resolveArtifactShareBaseUrl", () => {
-  test("prefers explicit clientOrigin over loopback request URL", () => {
-    expect(
+  test("refuses a clientOrigin off the request host", () => {
+    // The origin ends up in the share link, so an unconfigured install takes
+    // it only from loopback or the host the request arrived on.
+    expect(() =>
       resolveArtifactShareBaseUrl({
         clientOrigin: "https://nakama.example.com/",
         request: sharePublishRequest(),
       })
-    ).toBe("https://nakama.example.com");
+    ).toThrow("Origin is not allowed.");
   });
 
   test("prefers configured web public URL when request host is loopback", async () => {
@@ -88,9 +90,9 @@ describe("resolveArtifactShareBaseUrl", () => {
     expect(
       resolveArtifactShareBaseUrl({
         request: sharePublishRequest({
-          headers: { Origin: "https://app.example.com" },
+          headers: { Origin: "http://localhost:3003" },
         }),
       })
-    ).toBe("https://app.example.com");
+    ).toBe("http://localhost:3003");
   });
 });

--- a/apps/server/src/services/composio-callback-url.test.ts
+++ b/apps/server/src/services/composio-callback-url.test.ts
@@ -12,7 +12,7 @@ import {
 describe("composio-callback-url", () => {
   test("resolveRequestClientOrigin prefers explicit origin", () => {
     const request = new Request(
-      "http://api.example.com/v1/composio/toolkits/gmail/connect",
+      "http://app.example.com/v1/composio/toolkits/gmail/connect",
       {
         headers: { Origin: "http://ignored.example.com" },
       }
@@ -21,6 +21,26 @@ describe("composio-callback-url", () => {
     expect(
       resolveRequestClientOrigin(request, "https://app.example.com/")
     ).toBe("https://app.example.com");
+  });
+
+  test("resolveRequestClientOrigin rejects an origin off the request host", () => {
+    const request = new Request(
+      "http://api.example.com/v1/composio/toolkits/gmail/connect"
+    );
+
+    expect(() =>
+      resolveRequestClientOrigin(request, "https://evil.example.com")
+    ).toThrow("Origin is not allowed.");
+  });
+
+  test("resolveRequestClientOrigin rejects a non-http scheme", () => {
+    const request = new Request(
+      "http://api.example.com/v1/composio/toolkits/gmail/connect"
+    );
+
+    expect(() =>
+      resolveRequestClientOrigin(request, "javascript:alert(1)")
+    ).toThrow("Origin must be an http or https URL.");
   });
 
   test("resolveRequestClientOrigin reads Origin header", () => {
@@ -63,7 +83,7 @@ describe("composio-callback-url", () => {
     }
   });
 
-  test("caller headers cannot move the callback off the configured URL", () => {
+  test("caller headers off the configured URL are refused", () => {
     const previous = process.env.NAKAMA_WEB_PUBLIC_URL;
     process.env.NAKAMA_WEB_PUBLIC_URL = "https://deployed.example.com";
     const request = new Request(
@@ -79,12 +99,12 @@ describe("composio-callback-url", () => {
     );
 
     try {
-      expect(
+      expect(() =>
         resolveComposioCallbackBaseUrl({
           clientOrigin: "https://evil.example.com",
           request,
         })
-      ).toBe("https://deployed.example.com");
+      ).toThrow("Origin is not allowed.");
     } finally {
       if (previous === undefined) {
         delete process.env.NAKAMA_WEB_PUBLIC_URL;
@@ -94,7 +114,7 @@ describe("composio-callback-url", () => {
     }
   });
 
-  test("an unparseable clientOrigin does not become the callback base", () => {
+  test("an unparseable clientOrigin is refused, not silently dropped", () => {
     const configDir = join(tmpdir(), `nakama-callback-url-unset-${Date.now()}`);
     mkdirSync(configDir, { recursive: true });
     const previousConfigDir = process.env.NAKAMA_CONFIG_DIR;
@@ -107,12 +127,12 @@ describe("composio-callback-url", () => {
     );
 
     try {
-      expect(
+      expect(() =>
         resolveComposioCallbackBaseUrl({
           clientOrigin: "javascript:alert(1)",
           request,
         })
-      ).toBe("http://127.0.0.1:4310");
+      ).toThrow("Origin must be an http or https URL.");
     } finally {
       if (previousConfigDir === undefined) {
         delete process.env.NAKAMA_CONFIG_DIR;

--- a/apps/server/src/services/composio-callback-url.ts
+++ b/apps/server/src/services/composio-callback-url.ts
@@ -1,13 +1,40 @@
 import {
   isValidBaseUrl,
   loadUserWebPublicUrl,
+  NakamaApiError,
   normalizeBaseUrl,
   resolveWebPublicUrl,
   saveUserWebPublicUrl,
   type WebPublicUrlSettingsResponse,
 } from "@nakama/core";
 
+/**
+ * The origin the caller claims. `clientOrigin` in the body, `Origin` and
+ * `Referer` are all attacker-settable, and it ends up in an OAuth redirect_uri
+ * and in share links, so an origin we cannot vouch for is refused rather than
+ * echoed back into a generated URL.
+ */
 export function resolveRequestClientOrigin(
+  request?: Request,
+  explicitOrigin?: string
+): string | undefined {
+  const candidate = readClaimedOrigin(request, explicitOrigin);
+  if (!candidate) {
+    return;
+  }
+
+  if (!isValidBaseUrl(candidate)) {
+    throw new NakamaApiError("Origin must be an http or https URL.", 400);
+  }
+
+  if (!isAllowedClientOrigin(candidate, request)) {
+    throw new NakamaApiError("Origin is not allowed.", 400);
+  }
+
+  return candidate;
+}
+
+function readClaimedOrigin(
   request?: Request,
   explicitOrigin?: string
 ): string | undefined {
@@ -35,6 +62,68 @@ export function resolveRequestClientOrigin(
   }
 }
 
+/**
+ * A configured public URL is the operator's answer and is the whole allowlist.
+ * Without one the caller may still name the origin the request arrived on, or a
+ * loopback origin, which is how the split-port dev setup (web on 3003, API on
+ * 4310) and first-time setup work.
+ */
+function isAllowedClientOrigin(candidate: string, request?: Request): boolean {
+  const configured = resolveWebPublicUrl();
+  if (configured) {
+    return sameHost(candidate, configured);
+  }
+
+  if (!request) {
+    // Internal hop: an agent tool carries the origin its own HTTP route
+    // already checked, and there is no request here to check it against.
+    return true;
+  }
+
+  return (
+    isLoopbackComposioCallbackBaseUrl(candidate) ||
+    sameHost(candidate, resolveRequestSelfOrigin(request))
+  );
+}
+
+/**
+ * Host and port, not the whole origin: a TLS terminator that forwards without
+ * X-Forwarded-Proto leaves the request looking like http while the browser
+ * reports https, and the attack this refuses is a different host.
+ */
+function sameHost(a: string, b?: string): boolean {
+  if (!b) {
+    return false;
+  }
+
+  try {
+    return new URL(a).host === new URL(b).host;
+  } catch {
+    return false;
+  }
+}
+
+/** Where the request actually landed: the proxy's host if there is one. */
+function resolveRequestSelfOrigin(request?: Request): string | undefined {
+  if (!request) {
+    return;
+  }
+
+  const forwardedHost = request.headers.get("x-forwarded-host")?.trim();
+  if (forwardedHost) {
+    const proto = request.headers.get("x-forwarded-proto")?.trim() || "http";
+    const forwarded = `${proto}://${forwardedHost}`;
+    if (isValidBaseUrl(forwarded)) {
+      return forwarded;
+    }
+  }
+
+  try {
+    const url = new URL(request.url);
+    return `${url.protocol}//${url.host}`;
+  } catch {}
+}
+
 export async function persistWebPublicUrl(input: string): Promise<string> {
   const trimmed = input.trim();
   if (!(trimmed && isValidBaseUrl(trimmed))) {
@@ -60,38 +149,30 @@ export async function getWebPublicUrlSettings(): Promise<WebPublicUrlSettingsRes
  * wins: clientOrigin, Origin, Referer and X-Forwarded-Host all come from the
  * caller, and this base ends up in the redirect_uri an OAuth code is delivered
  * to. They still decide when nothing is configured, which is how a dev install
- * on localhost works, and they have to parse as an http(s) URL to be used.
+ * on localhost works.
  */
 export function resolveComposioCallbackBaseUrl(
   options: { clientOrigin?: string; request?: Request } = {}
 ): string {
+  // Resolved before the configured URL is returned, so a caller origin we do
+  // not recognise is refused rather than quietly swapped for the right one.
+  const fromBrowser = resolveRequestClientOrigin(
+    options.request,
+    options.clientOrigin
+  );
+
   const configured = resolveWebPublicUrl();
   if (configured) {
     return configured;
   }
 
-  const fromBrowser = resolveRequestClientOrigin(
-    options.request,
-    options.clientOrigin
-  );
-  if (fromBrowser && isValidBaseUrl(fromBrowser)) {
+  if (fromBrowser) {
     return fromBrowser;
   }
 
-  if (options.request) {
-    const forwardedHost = options.request.headers.get("x-forwarded-host");
-    const forwardedProto =
-      options.request.headers.get("x-forwarded-proto") ?? "http";
-    const forwarded = forwardedHost
-      ? `${forwardedProto}://${forwardedHost}`
-      : null;
-
-    if (forwarded && isValidBaseUrl(forwarded)) {
-      return forwarded;
-    }
-
-    const url = new URL(options.request.url);
-    return `${url.protocol}//${url.host}`;
+  const self = resolveRequestSelfOrigin(options.request);
+  if (self) {
+    return self;
   }
 
   const webPort = process.env.NAKAMA_WEB_PORT?.trim() || "3003";


### PR DESCRIPTION
## Summary

A client-supplied origin has to be one we recognise before it goes into a generated URL.

**Before:** `resolveRequestClientOrigin` took `clientOrigin` from the body, or the `Origin` or `Referer` header, stripped a trailing slash and returned it. That value becomes the Composio OAuth `redirect_uri` and the artifact share link. A configured `webPublicUrl` won for the callback, but a mismatching origin was ignored silently rather than refused, and an install with none accepted any host.
**After:** the origin must be http or https, and must either match the configured `webPublicUrl` or, on an install with none, be loopback or the host the request arrived on. Anything else is a 400 on Composio connect, artifact share publish and status, session send and setup.

Why safe:
1. Hosts are compared without the scheme, so a TLS terminator that drops `X-Forwarded-Proto` does not reject its own users.
2. Loopback stays allowed when nothing is configured, which is what the split-port dev setup and first-time setup need.
3. The agent-tool hop carries an origin its own route already checked and has no request to compare against, so it passes through.

This takes the stricter of the two options #361(d) names. An install that serves the UI from a host other than its configured `webPublicUrl` now gets a 400 instead of a silently rewritten link.

## Test plan
- [x] `bun run test`, 11 workspaces, 0 fail (server 1108)
- [x] The four allowlist cases go red with the check stubbed out and green as written

Part of #361 (d).
