### PR TITLE
fix(discord): clear stream cleanup gap before try block

### DIFF
--- a/apps/platform/discord/src/chat-handler.test.ts
+++ b/apps/platform/discord/src/chat-handler.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import path from "node:path";
+import {
+  hasActiveStreams,
+  resetActiveStreamsForTests,
+} from "@nakama/core/channel-active-stream";
 import { ChannelSessionStore as SessionStore } from "@nakama/core/channel-session-store";
 import type { ChatMessage } from "@nakama/core/contract";
 import { loadDiscordConfigFile } from "@nakama/core/discord-config";
@@ -28,6 +32,7 @@ import { ThreadStore } from "./thread-store";
 afterEach(() => {
   resetChatLocksForTests();
   chatLockOptions.waitMs = 15 * 60 * 1000;
+  resetActiveStreamsForTests();
 });
 
 /**
@@ -2013,6 +2018,24 @@ describe("createChatHandler session hot cache", () => {
       // 1 resolve validation + 1 artifact read per turn (hot path skips resolve getMessages)
       expect(calls.getMessages).toBe(3);
       expect(calls.sendStream).toBe(2);
+    });
+  });
+});
+
+describe("stream cleanup", () => {
+  test("clears active stream after sendStream fails", async () => {
+    await withTempHome(async (homeDir) => {
+      const { handleMessage } = await createPairedHandler(homeDir, {
+        onSendStream: async () => {
+          throw new Error("provider down");
+        },
+      });
+
+      const dm = createDmMessage({ content: "hello agent" });
+      await handleMessage(dm.message);
+
+      expect(hasActiveStreams()).toBe(false);
+      expect(dm.sentMessages.some((m) => /provider down/i.test(m))).toBe(true);
     });
   });
 });

--- a/apps/platform/discord/src/chat-handler.ts
+++ b/apps/platform/discord/src/chat-handler.ts
@@ -720,18 +720,19 @@ export function createChatHandler(deps: ChatHandlerDeps) {
       isThread
     );
 
-    const signal = registerActiveStream(conversationKey);
     const typingLoop = createTypingLoop(messenger);
     const todoStatus = new DiscordTodoStatusMessage(messenger);
     const questionnaireStatus = new DiscordQuestionnaireMessage(messenger);
-    typingLoop.start();
 
     let reply = "";
     let earlyAck: Promise<void> | undefined;
     let postedQuestionnaire = false;
     const pendingArtifactUploads: Promise<unknown>[] = [];
+    const signal = registerActiveStream(conversationKey);
 
     try {
+      typingLoop.start();
+
       reply = await session.sendStream(
         streamInput,
         {


### PR DESCRIPTION
Closes #562

## Summary

A throw before Discord's chat handler enters `try` now leaks nothing → `registerActiveStream` is called last, `typingLoop.start()` moved inside `try`.

**Before:** `registerActiveStream`, `createTypingLoop`, two status constructors, and `typingLoop.start()` all ran before `try`; a throw in any of them left the AbortController registered in `activeByChat` with no `finally` to clear it.
**After:** constructors and `let`s run first, `registerActiveStream(conversationKey)` is the last statement before `try`, `typingLoop.start()` moved to the first line inside `try`.

Why safe:
1. Same shape already shipped for telegram/whatsapp in #762 — this closes the gap that PR left open for discord
2. Nothing in the try/catch/finally body changed, only what runs before it
3. New test proves `hasActiveStreams()` goes false after a stream failure, matching telegram/whatsapp's existing coverage (discord had none)

Only re-open if a future constructor added to that prologue needs to run after `registerActiveStream` for some reason — keep it last.

## Test plan
- [x] `bun test apps/platform/discord/src/chat-handler.test.ts` (52 pass)
- [x] `bun test` in `apps/platform/discord` (105 pass)
- [x] `bunx tsc --noEmit` — no new errors vs baseline
- [ ] Kill the process mid-stream on a real Discord DM, confirm no stale entry survives (`hasActiveStreams()` false)
