### PR TITLE
fix(web): keep the last picked chat model on a new chat

### DIFF
--- a/apps/web/src/lib/chat-history-route.test.ts
+++ b/apps/web/src/lib/chat-history-route.test.ts
@@ -4,12 +4,15 @@ import {
   buildNewChatPath,
   CHAT_DRAFT_STORAGE_PREFIX,
   chatProfileIdFromPath,
+  clearLastChatModel,
   consumeStoredChatDraft,
   isChatSessionPath,
   isProfilesPath,
+  lastChatModelStorageKey,
   parseChatRouteParams,
   pickKnownProfileId,
   readInitialDraftChatProfileId,
+  readLastChatModel,
   readRequestedDraftFromNewChatSearch,
   readRequestedDraftKeyFromNewChatSearch,
   readRequestedProfileFromNewChatSearch,
@@ -18,6 +21,7 @@ import {
   resolveHistoryProfileId,
   resolveProfilesPageProfileId,
   storeChatDraft,
+  writeLastChatModel,
   writeStoredActiveChatProfileId,
 } from "./chat-history";
 
@@ -301,5 +305,49 @@ describe("chat history route helpers", () => {
     const profiles = [{ id: "default" }, { id: "super" }];
     expect(pickKnownProfileId(profiles, "missing", "super")).toBe("super");
     expect(pickKnownProfileId(profiles, "missing")).toBeNull();
+  });
+
+  test("remembers the last hand-picked model per profile", () => {
+    const store = new Map<string, string>();
+    const previousLocalStorage = globalThis.localStorage;
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: (key: string) => store.get(key) ?? null,
+        removeItem: (key: string) => {
+          store.delete(key);
+        },
+        setItem: (key: string, value: string) => {
+          store.set(key, value);
+        },
+      },
+    });
+
+    try {
+      expect(readLastChatModel("default")).toBeNull();
+
+      writeLastChatModel("default", "openai-1::gpt-5.6");
+      writeLastChatModel("super", "anthropic-1::claude-opus-5");
+
+      expect(store.get(lastChatModelStorageKey("default"))).toBe(
+        "openai-1::gpt-5.6"
+      );
+      expect(readLastChatModel("default")).toBe("openai-1::gpt-5.6");
+      // Each profile keeps its own pick.
+      expect(readLastChatModel("super")).toBe("anthropic-1::claude-opus-5");
+
+      // Empty writes never clobber a stored pick.
+      writeLastChatModel("default", "");
+      expect(readLastChatModel("default")).toBe("openai-1::gpt-5.6");
+
+      clearLastChatModel("default");
+      expect(readLastChatModel("default")).toBeNull();
+      expect(readLastChatModel("super")).toBe("anthropic-1::claude-opus-5");
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", {
+        configurable: true,
+        value: previousLocalStorage,
+      });
+    }
   });
 });

--- a/apps/web/src/lib/chat-history-route.test.ts
+++ b/apps/web/src/lib/chat-history-route.test.ts
@@ -4,7 +4,6 @@ import {
   buildNewChatPath,
   CHAT_DRAFT_STORAGE_PREFIX,
   chatProfileIdFromPath,
-  clearLastChatModel,
   consumeStoredChatDraft,
   isChatSessionPath,
   isProfilesPath,
@@ -336,11 +335,8 @@ describe("chat history route helpers", () => {
       // Each profile keeps its own pick.
       expect(readLastChatModel("super")).toBe("anthropic-1::claude-opus-5");
 
-      // Empty writes never clobber a stored pick.
-      writeLastChatModel("default", "");
-      expect(readLastChatModel("default")).toBe("openai-1::gpt-5.6");
-
-      clearLastChatModel("default");
+      // A falsy selection forgets that profile's pick, and only that one.
+      writeLastChatModel("default", null);
       expect(readLastChatModel("default")).toBeNull();
       expect(readLastChatModel("super")).toBe("anthropic-1::claude-opus-5");
     } finally {

--- a/apps/web/src/lib/chat-history.ts
+++ b/apps/web/src/lib/chat-history.ts
@@ -394,6 +394,42 @@ export function sessionStorageKey(profileId: string): string {
   return `nakama:session:${profileId}`;
 }
 
+export const LAST_CHAT_MODEL_STORAGE_PREFIX = "nakama:last-model:";
+
+export function lastChatModelStorageKey(profileId: string): string {
+  return `${LAST_CHAT_MODEL_STORAGE_PREFIX}${profileId}`;
+}
+
+/**
+ * The model the user last picked by hand, per profile — a new chat resumes it
+ * instead of snapping back to the profile default.
+ */
+export function readLastChatModel(profileId: string): string | null {
+  if (typeof localStorage === "undefined" || !profileId) {
+    return null;
+  }
+
+  return (
+    localStorage.getItem(lastChatModelStorageKey(profileId))?.trim() || null
+  );
+}
+
+export function writeLastChatModel(profileId: string, selection: string): void {
+  if (typeof localStorage === "undefined" || !(profileId && selection)) {
+    return;
+  }
+
+  localStorage.setItem(lastChatModelStorageKey(profileId), selection);
+}
+
+export function clearLastChatModel(profileId: string): void {
+  if (typeof localStorage === "undefined" || !profileId) {
+    return;
+  }
+
+  localStorage.removeItem(lastChatModelStorageKey(profileId));
+}
+
 /**
  * Which channels the history panel lists. Total over `AgentChannel`, so a new
  * channel fails the typecheck here rather than dropping out of the list in

--- a/apps/web/src/lib/chat-history.ts
+++ b/apps/web/src/lib/chat-history.ts
@@ -394,14 +394,12 @@ export function sessionStorageKey(profileId: string): string {
   return `nakama:session:${profileId}`;
 }
 
-export const LAST_CHAT_MODEL_STORAGE_PREFIX = "nakama:last-model:";
-
 export function lastChatModelStorageKey(profileId: string): string {
-  return `${LAST_CHAT_MODEL_STORAGE_PREFIX}${profileId}`;
+  return `nakama:last-model:${profileId}`;
 }
 
 /**
- * The model the user last picked by hand, per profile — a new chat resumes it
+ * The model the user last picked by hand, per profile. A new chat resumes it
  * instead of snapping back to the profile default.
  */
 export function readLastChatModel(profileId: string): string | null {
@@ -414,20 +412,22 @@ export function readLastChatModel(profileId: string): string | null {
   );
 }
 
-export function writeLastChatModel(profileId: string, selection: string): void {
-  if (typeof localStorage === "undefined" || !(profileId && selection)) {
-    return;
-  }
-
-  localStorage.setItem(lastChatModelStorageKey(profileId), selection);
-}
-
-export function clearLastChatModel(profileId: string): void {
+/** A falsy selection forgets the pick. */
+export function writeLastChatModel(
+  profileId: string,
+  selection: string | null
+): void {
   if (typeof localStorage === "undefined" || !profileId) {
     return;
   }
 
-  localStorage.removeItem(lastChatModelStorageKey(profileId));
+  const key = lastChatModelStorageKey(profileId);
+
+  if (selection) {
+    localStorage.setItem(key, selection);
+  } else {
+    localStorage.removeItem(key);
+  }
 }
 
 /**

--- a/apps/web/src/lib/models.test.ts
+++ b/apps/web/src/lib/models.test.ts
@@ -7,6 +7,7 @@ import {
   hasOpenCodeZenProvider,
   isOpenCodeZenBaseUrl,
   isProviderTypeAlreadyConfigured,
+  knownModelSelection,
   PROVIDER_OPTIONS,
   profileModelSelectionValue,
   resolveModelThinkingSupport,
@@ -349,6 +350,36 @@ describe("profileModelSelectionValue", () => {
     expect(profileModelSelectionValue("openai-1::gpt-5.6-luna", groups)).toBe(
       "openai-1::gpt-5.6-luna"
     );
+  });
+});
+
+describe("knownModelSelection", () => {
+  const groups = group("openai-1", "openai");
+
+  test("keeps a remembered pick that still exists", () => {
+    expect(knownModelSelection("openai-1::model-1", groups)).toBe(
+      "openai-1::model-1"
+    );
+  });
+
+  test("re-encodes a bare model id onto its provider", () => {
+    expect(knownModelSelection("model-1", groups)).toBe("openai-1::model-1");
+  });
+
+  test("drops a pick whose provider or model is gone", () => {
+    expect(knownModelSelection("openai-1::retired-model", groups)).toBeNull();
+    expect(knownModelSelection("deleted-provider::model-9", groups)).toBeNull();
+  });
+
+  test("keeps the pick while the catalog has not loaded", () => {
+    expect(knownModelSelection("openai-1::model-1", [])).toBe(
+      "openai-1::model-1"
+    );
+  });
+
+  test("returns null for an empty selection", () => {
+    expect(knownModelSelection(null, groups)).toBeNull();
+    expect(knownModelSelection("", groups)).toBeNull();
   });
 });
 

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -763,6 +763,44 @@ export function profileModelSelectionValue(
   return encodeModelSelection("__unknown__", resolvedModelId);
 }
 
+/**
+ * Drop a remembered selection whose provider or model is gone, so a stale pick
+ * falls back to the profile default instead of a model nobody can pick. An
+ * explicit provider is never remapped onto another one offering the same model
+ * id; empty groups mean the catalog has not loaded yet, so keep the selection.
+ */
+export function knownModelSelection(
+  selection: string | null | undefined,
+  groups: ReturnType<typeof groupModelsByProvider>
+): string | null {
+  if (!selection) {
+    return null;
+  }
+
+  if (groups.length === 0) {
+    return selection;
+  }
+
+  const decoded = decodeModelSelection(selection);
+  const modelId = decoded?.modelId ?? selection;
+
+  if (decoded && decoded.providerId !== "__unknown__") {
+    const group = groups.find(
+      (entry) => entry.providerId === decoded.providerId
+    );
+
+    return group?.models.some((model) => model.id === modelId)
+      ? encodeModelSelection(group.providerId, modelId)
+      : null;
+  }
+
+  const match = groups.find((group) =>
+    group.models.some((model) => model.id === modelId)
+  );
+
+  return match ? encodeModelSelection(match.providerId, modelId) : null;
+}
+
 export function profileModelLabel(
   modelId: string | null,
   groups: ReturnType<typeof groupModelsByProvider>

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -783,19 +783,13 @@ export function knownModelSelection(
 
   const decoded = decodeModelSelection(selection);
   const modelId = decoded?.modelId ?? selection;
+  const pinnedProvider =
+    decoded && decoded.providerId !== "__unknown__" ? decoded.providerId : null;
 
-  if (decoded && decoded.providerId !== "__unknown__") {
-    const group = groups.find(
-      (entry) => entry.providerId === decoded.providerId
-    );
-
-    return group?.models.some((model) => model.id === modelId)
-      ? encodeModelSelection(group.providerId, modelId)
-      : null;
-  }
-
-  const match = groups.find((group) =>
-    group.models.some((model) => model.id === modelId)
+  const match = groups.find(
+    (group) =>
+      (!pinnedProvider || group.providerId === pinnedProvider) &&
+      group.models.some((model) => model.id === modelId)
   );
 
   return match ? encodeModelSelection(match.providerId, modelId) : null;

--- a/apps/web/src/pages/chat/use-chat-page.ts
+++ b/apps/web/src/pages/chat/use-chat-page.ts
@@ -43,18 +43,21 @@ import {
   type ChatListItem,
   chatMessagesToListItems,
   clearFailedChatTurn,
+  clearLastChatModel,
   consumeStoredChatDraft,
   isReadOnlySessionChannel,
   parseChatRouteParams,
   pickKnownProfileId,
   readFailedChatTurn,
   readInitialDraftChatProfileId,
+  readLastChatModel,
   readRequestedDraftFromNewChatSearch,
   readRequestedDraftKeyFromNewChatSearch,
   readStoredActiveChatProfileId,
   resolveDefaultProfileId,
   sessionStorageKey,
   storeFailedChatTurn,
+  writeLastChatModel,
 } from "@/lib/chat-history";
 import {
   filePartsToDisplayDocuments,
@@ -79,6 +82,7 @@ import {
   decodeModelSelection,
   effectiveProfileModelSelection,
   groupModelsByProvider,
+  knownModelSelection,
   resolveModelThinkingSupport,
   resolveModelVisionSupport,
 } from "@/lib/models";
@@ -217,6 +221,22 @@ export function useChatPage() {
     () => groupModelsByProvider(models?.models ?? []),
     [models?.models]
   );
+  const providerModelGroupsRef = useRef(providerModelGroups);
+
+  useEffect(() => {
+    providerModelGroupsRef.current = providerModelGroups;
+  }, [providerModelGroups]);
+
+  // A draft chat opens on the model the user picked last, not the profile
+  // default. Read through a ref so the draft-entry callbacks stay stable.
+  const restoreLastChatModel = useCallback(
+    (nextProfileId: string) =>
+      knownModelSelection(
+        readLastChatModel(nextProfileId),
+        providerModelGroupsRef.current
+      ),
+    []
+  );
 
   const currentModelSelection = useMemo(
     () =>
@@ -289,7 +309,9 @@ export function useChatPage() {
       }
 
       const previousModel = sessionModel;
+      const previousStoredModel = readLastChatModel(profileId);
       setSessionModel(selection);
+      writeLastChatModel(profileId, selection);
 
       if (!session) {
         return;
@@ -308,6 +330,11 @@ export function useChatPage() {
             return;
           }
           setSessionModel(previousModel);
+          if (previousStoredModel) {
+            writeLastChatModel(profileId, previousStoredModel);
+          } else {
+            clearLastChatModel(profileId);
+          }
           setError(formatError(err));
         });
     },
@@ -356,7 +383,7 @@ export function useChatPage() {
       activeSessionIdRef.current = null;
       setQueuedMessages([]);
       setSession(null);
-      setSessionModel(null);
+      setSessionModel(restoreLastChatModel(nextProfileId));
       setSessionChannel("web");
       setMessages([]);
       setError(null);
@@ -369,7 +396,7 @@ export function useChatPage() {
         navigate(buildNewChatPath(nextProfileId), { replace: true });
       }
     },
-    [location.pathname, navigate]
+    [location.pathname, navigate, restoreLastChatModel]
   );
 
   const handleThinkingEffortChange = useCallback(
@@ -640,7 +667,9 @@ export function useChatPage() {
     activeSessionIdRef.current = null;
     setQueuedMessages([]);
     setSession(null);
-    setSessionModel(null);
+    setSessionModel(
+      targetProfileId ? restoreLastChatModel(targetProfileId) : null
+    );
     setSessionChannel("web");
     setMessages([]);
     setError(null);
@@ -657,7 +686,7 @@ export function useChatPage() {
     }
 
     navigate(buildChatBasePath(), { replace: true });
-  }, [searchParams, navigate, location.search]);
+  }, [searchParams, navigate, location.search, restoreLastChatModel]);
 
   useEffect(() => {
     if (!profileId || routeSession) {

--- a/apps/web/src/pages/chat/use-chat-page.ts
+++ b/apps/web/src/pages/chat/use-chat-page.ts
@@ -43,7 +43,6 @@ import {
   type ChatListItem,
   chatMessagesToListItems,
   clearFailedChatTurn,
-  clearLastChatModel,
   consumeStoredChatDraft,
   isReadOnlySessionChannel,
   parseChatRouteParams,
@@ -330,11 +329,7 @@ export function useChatPage() {
             return;
           }
           setSessionModel(previousModel);
-          if (previousStoredModel) {
-            writeLastChatModel(profileId, previousStoredModel);
-          } else {
-            clearLastChatModel(profileId);
-          }
+          writeLastChatModel(profileId, previousStoredModel);
           setError(formatError(err));
         });
     },


### PR DESCRIPTION
## Summary

Pick a model, start a new chat → the picker stays on that model, per profile. Fixes #840.

**Before:** every new chat cleared `sessionModel`, so the selection fell back to `activeProfile.model` and the user's pick was gone.
**After:** an explicit pick is stored per profile (`nakama:last-model:<profileId>`) and seeded back into `sessionModel` at both draft-entry points.

Why safe:
1. Seeding `sessionModel` reuses the existing path, so `createSession`, the picker label and the thinking/vision checks follow unchanged
2. Only a `handleModelChange` pick is stored, and it rolls back with the visible state when the session update fails
3. `knownModelSelection` drops a pick whose provider or model is gone, so a stale value falls back to the profile default instead of `__unknown__`

Only revisit if the model catalog can be empty at draft entry for a reason other than "not loaded yet". The stored pick is deliberately kept in that window.

## Test plan
- [x] `bun test` in `apps/web` (330 pass)
- [x] `bun x tsc --noEmit` in `apps/web` (clean)
- [ ] Pick a non-default model → New chat → picker still shows it; then delete that provider → picker falls back to the profile default

Related, not fixed: #522, the hard-coded `"web"` channel in the same `createSession` call.
