### PR TITLE
fix(web-search): drop the custom endpoint provider

### DIFF
--- a/apps/server/src/http/routes/models.ts
+++ b/apps/server/src/http/routes/models.ts
@@ -178,7 +178,7 @@ export function registerModelRoutes(
     .object({
       apiKey: z.string().optional(),
       endpoint: z.string().optional(),
-      provider: z.enum(["exa", "firecrawl", "custom"]).nullable().optional(),
+      provider: z.enum(["exa", "firecrawl"]).nullable().optional(),
     })
     .openapi("UpdateWebSearchSettingsRequest");
   const agentBrowserStatusSchema = z

--- a/apps/web/src/components/settings/WebSearchSettingsCard.tsx
+++ b/apps/web/src/components/settings/WebSearchSettingsCard.tsx
@@ -32,23 +32,8 @@ const PROVIDER_PRESETS: Array<{
   { label: "Firecrawl", value: "firecrawl" },
 ];
 
-export function WebSearchSettingsCard() {
-  const { data: settings } = useWebSearchSettings();
-  const saveMutation = useSaveWebSearchSettings();
-  const [provider, setProvider] = useState<WebSearchProvider | null>(null);
-  const [apiKey, setApiKey] = useState("");
-  const [showApiKey, setShowApiKey] = useState(false);
-  const [formError, setFormError] = useState<string | null>(null);
+function useSavedHint() {
   const [savedHint, setSavedHint] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!settings) {
-      return;
-    }
-
-    setProvider(settings.provider);
-    setApiKey("");
-  }, [settings]);
 
   useEffect(() => {
     if (!savedHint) {
@@ -59,23 +44,45 @@ export function WebSearchSettingsCard() {
     return () => window.clearTimeout(timeout);
   }, [savedHint]);
 
-  const savedProvider = settings?.provider ?? null;
-  const keyAlreadySaved =
-    savedProvider === provider && Boolean(settings?.apiKeyMasked);
+  return [savedHint, setSavedHint] as const;
+}
 
-  function handleProviderChange(value: string | null) {
+function useWebSearchSettingsForm() {
+  const { data: settings } = useWebSearchSettings();
+  const saveMutation = useSaveWebSearchSettings();
+  const [provider, setProvider] = useState<WebSearchProvider | null>(null);
+  const [apiKey, setApiKey] = useState("");
+  const [formError, setFormError] = useState<string | null>(null);
+  const [savedHint, setSavedHint] = useSavedHint();
+
+  useEffect(() => {
+    if (!settings) {
+      return;
+    }
+
+    setProvider(settings.provider);
+    setApiKey("");
+  }, [settings]);
+
+  const keyAlreadySaved =
+    settings?.provider === provider && Boolean(settings?.apiKeyMasked);
+
+  function resetMessages() {
+    setFormError(null);
+    setSavedHint(null);
+    saveMutation.reset();
+  }
+
+  function selectProvider(value: string | null) {
     if (!value) {
       return;
     }
 
-    setFormError(null);
-    setSavedHint(null);
-    saveMutation.reset();
+    resetMessages();
 
     if (value === BUILT_IN_VALUE) {
       setProvider(null);
       setApiKey("");
-
       saveMutation.mutate(
         { provider: null },
         {
@@ -90,15 +97,12 @@ export function WebSearchSettingsCard() {
     setApiKey("");
   }
 
-  function handleSave() {
+  function saveKey() {
     if (!provider) {
       return;
     }
 
-    setFormError(null);
-    setSavedHint(null);
-    saveMutation.reset();
-
+    resetMessages();
     saveMutation.mutate(
       {
         provider,
@@ -114,25 +118,112 @@ export function WebSearchSettingsCard() {
     );
   }
 
+  return {
+    apiKey,
+    formError,
+    keyAlreadySaved,
+    maskedKey: settings?.apiKeyMasked,
+    pending: saveMutation.isPending,
+    provider,
+    savedHint,
+    saveKey,
+    selectProvider,
+    setApiKey,
+    setFormError,
+    setSavedHint,
+  };
+}
+
+function WebSearchApiKeyFields({
+  apiKey,
+  keyAlreadySaved,
+  maskedKey,
+  pending,
+  onApiKeyChange,
+  onSave,
+}: {
+  apiKey: string;
+  keyAlreadySaved: boolean;
+  maskedKey: string | null | undefined;
+  pending: boolean;
+  onApiKeyChange: (value: string) => void;
+  onSave: () => void;
+}) {
+  const [showApiKey, setShowApiKey] = useState(false);
+
+  return (
+    <div className="space-y-2">
+      <label
+        className="block font-medium text-foreground text-xs"
+        htmlFor="web-search-api-key"
+      >
+        API key
+      </label>
+      <div className="flex items-center gap-2">
+        <InputGroup className="h-9 min-w-0 flex-1">
+          <InputGroupInput
+            autoComplete="off"
+            disabled={pending}
+            id="web-search-api-key"
+            onChange={(event) => onApiKeyChange(event.target.value)}
+            placeholder={
+              keyAlreadySaved ? `Saved (${maskedKey})` : "Paste API key"
+            }
+            type={showApiKey ? "text" : "password"}
+            value={apiKey}
+          />
+          <InputGroupAddon align="inline-end">
+            <InputGroupButton
+              aria-label={showApiKey ? "Hide API key" : "Show API key"}
+              onClick={() => setShowApiKey((current) => !current)}
+              size="icon-xs"
+              type="button"
+            >
+              {showApiKey ? (
+                <ViewOffIcon className="size-4" />
+              ) : (
+                <ViewIcon className="size-4" />
+              )}
+            </InputGroupButton>
+          </InputGroupAddon>
+        </InputGroup>
+        <Button
+          className="min-w-[4.5rem] shrink-0"
+          disabled={pending || !(apiKey.trim() || keyAlreadySaved)}
+          id="btn-web-search-save"
+          onClick={onSave}
+          size="sm"
+          type="button"
+        >
+          {pending ? <Spinner className="size-4" /> : "Save"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function WebSearchSettingsCard() {
+  const form = useWebSearchSettingsForm();
+
   return (
     <div className="space-y-3 px-4 py-3" id="web-search-settings">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="min-w-0 space-y-0.5">
           <p className="font-medium text-foreground text-sm">Web search</p>
-          {savedHint ? (
+          {form.savedHint ? (
             <p
               className="text-emerald-700 text-xs dark:text-emerald-300"
               role="status"
             >
-              {savedHint}
+              {form.savedHint}
             </p>
           ) : null}
         </div>
         <div className="w-full min-w-0 sm:w-56">
           <Select
-            disabled={saveMutation.isPending}
-            onValueChange={handleProviderChange}
-            value={provider ?? BUILT_IN_VALUE}
+            disabled={form.pending}
+            onValueChange={form.selectProvider}
+            value={form.provider ?? BUILT_IN_VALUE}
           >
             <SelectTrigger
               aria-label="Web search provider"
@@ -153,67 +244,24 @@ export function WebSearchSettingsCard() {
         </div>
       </div>
 
-      {provider ? (
-        <div className="space-y-2">
-          <label
-            className="block font-medium text-foreground text-xs"
-            htmlFor="web-search-api-key"
-          >
-            API key
-          </label>
-          <div className="flex items-center gap-2">
-            <InputGroup className="h-9 min-w-0 flex-1">
-              <InputGroupInput
-                autoComplete="off"
-                disabled={saveMutation.isPending}
-                id="web-search-api-key"
-                onChange={(event) => {
-                  setApiKey(event.target.value);
-                  setFormError(null);
-                  setSavedHint(null);
-                }}
-                placeholder={
-                  keyAlreadySaved
-                    ? `Saved (${settings?.apiKeyMasked})`
-                    : "Paste API key"
-                }
-                type={showApiKey ? "text" : "password"}
-                value={apiKey}
-              />
-              <InputGroupAddon align="inline-end">
-                <InputGroupButton
-                  aria-label={showApiKey ? "Hide API key" : "Show API key"}
-                  onClick={() => setShowApiKey((current) => !current)}
-                  size="icon-xs"
-                  type="button"
-                >
-                  {showApiKey ? (
-                    <ViewOffIcon className="size-4" />
-                  ) : (
-                    <ViewIcon className="size-4" />
-                  )}
-                </InputGroupButton>
-              </InputGroupAddon>
-            </InputGroup>
-            <Button
-              className="min-w-[4.5rem] shrink-0"
-              disabled={
-                saveMutation.isPending || !(apiKey.trim() || keyAlreadySaved)
-              }
-              id="btn-web-search-save"
-              onClick={handleSave}
-              size="sm"
-              type="button"
-            >
-              {saveMutation.isPending ? <Spinner className="size-4" /> : "Save"}
-            </Button>
-          </div>
-        </div>
+      {form.provider ? (
+        <WebSearchApiKeyFields
+          apiKey={form.apiKey}
+          keyAlreadySaved={form.keyAlreadySaved}
+          maskedKey={form.maskedKey}
+          onApiKeyChange={(value) => {
+            form.setApiKey(value);
+            form.setFormError(null);
+            form.setSavedHint(null);
+          }}
+          onSave={form.saveKey}
+          pending={form.pending}
+        />
       ) : null}
 
-      {formError ? (
+      {form.formError ? (
         <p className="text-destructive text-xs" role="alert">
-          {formError}
+          {form.formError}
         </p>
       ) : null}
     </div>

--- a/apps/web/src/components/settings/WebSearchSettingsCard.tsx
+++ b/apps/web/src/components/settings/WebSearchSettingsCard.tsx
@@ -41,7 +41,6 @@ const PROVIDER_PRESETS: Array<{
     label: "Firecrawl",
     value: "firecrawl",
   },
-  { endpoint: "", label: "Custom endpoint", value: "custom" },
 ];
 
 function presetEndpoint(provider: WebSearchProvider): string {

--- a/apps/web/src/components/settings/WebSearchSettingsCard.tsx
+++ b/apps/web/src/components/settings/WebSearchSettingsCard.tsx
@@ -2,7 +2,6 @@ import type { WebSearchProvider } from "@nakama/core/contract";
 import { ViewIcon, ViewOffIcon } from "hugeicons-react";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import {
   InputGroup,
   InputGroupAddon,
@@ -25,35 +24,18 @@ import { formatError } from "@/lib/client";
 
 const BUILT_IN_VALUE = "__web_search_builtin__";
 
-/**
- * Mirrors WEB_SEARCH_PROVIDER_ENDPOINTS in packages/core/src/web-search-config.ts.
- * Duplicated because that module reads the config file and cannot be bundled
- * for the browser; the server re-derives the endpoint on save anyway.
- */
 const PROVIDER_PRESETS: Array<{
-  endpoint: string;
   label: string;
   value: WebSearchProvider;
 }> = [
-  { endpoint: "https://api.exa.ai/search", label: "Exa", value: "exa" },
-  {
-    endpoint: "https://api.firecrawl.dev/v2/search",
-    label: "Firecrawl",
-    value: "firecrawl",
-  },
+  { label: "Exa", value: "exa" },
+  { label: "Firecrawl", value: "firecrawl" },
 ];
-
-function presetEndpoint(provider: WebSearchProvider): string {
-  return (
-    PROVIDER_PRESETS.find((preset) => preset.value === provider)?.endpoint ?? ""
-  );
-}
 
 export function WebSearchSettingsCard() {
   const { data: settings } = useWebSearchSettings();
   const saveMutation = useSaveWebSearchSettings();
   const [provider, setProvider] = useState<WebSearchProvider | null>(null);
-  const [endpoint, setEndpoint] = useState("");
   const [apiKey, setApiKey] = useState("");
   const [showApiKey, setShowApiKey] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
@@ -65,7 +47,6 @@ export function WebSearchSettingsCard() {
     }
 
     setProvider(settings.provider);
-    setEndpoint(settings.endpoint ?? "");
     setApiKey("");
   }, [settings]);
 
@@ -93,7 +74,6 @@ export function WebSearchSettingsCard() {
 
     if (value === BUILT_IN_VALUE) {
       setProvider(null);
-      setEndpoint("");
       setApiKey("");
 
       saveMutation.mutate(
@@ -106,11 +86,7 @@ export function WebSearchSettingsCard() {
       return;
     }
 
-    const next = value as WebSearchProvider;
-    setProvider(next);
-    setEndpoint(
-      savedProvider === next ? (settings?.endpoint ?? "") : presetEndpoint(next)
-    );
+    setProvider(value as WebSearchProvider);
     setApiKey("");
   }
 
@@ -125,14 +101,12 @@ export function WebSearchSettingsCard() {
 
     saveMutation.mutate(
       {
-        endpoint: endpoint.trim(),
         provider,
         ...(apiKey.trim() ? { apiKey: apiKey.trim() } : {}),
       },
       {
         onError: (error) => setFormError(formatError(error)),
-        onSuccess: (saved) => {
-          setEndpoint(saved.endpoint ?? "");
+        onSuccess: () => {
           setApiKey("");
           setSavedHint("Saved");
         },
@@ -183,26 +157,6 @@ export function WebSearchSettingsCard() {
         <div className="space-y-2">
           <label
             className="block font-medium text-foreground text-xs"
-            htmlFor="web-search-endpoint"
-          >
-            Endpoint
-          </label>
-          <Input
-            autoComplete="off"
-            className="h-9"
-            disabled={saveMutation.isPending}
-            id="web-search-endpoint"
-            onChange={(event) => {
-              setEndpoint(event.target.value);
-              setFormError(null);
-              setSavedHint(null);
-            }}
-            placeholder="https://api.exa.ai/search"
-            value={endpoint}
-          />
-
-          <label
-            className="block font-medium text-foreground text-xs"
             htmlFor="web-search-api-key"
           >
             API key
@@ -243,7 +197,9 @@ export function WebSearchSettingsCard() {
             </InputGroup>
             <Button
               className="min-w-[4.5rem] shrink-0"
-              disabled={saveMutation.isPending || !endpoint.trim()}
+              disabled={
+                saveMutation.isPending || !(apiKey.trim() || keyAlreadySaved)
+              }
               id="btn-web-search-save"
               onClick={handleSave}
               size="sm"

--- a/docs/website/content/docs/builtin-tools.mdx
+++ b/docs/website/content/docs/builtin-tools.mdx
@@ -418,7 +418,7 @@ Org admins configure these from the web **System → Tools** page.
 
 Requires an OpenAI or Anthropic provider with a configured API key, or an Exa or Firecrawl search back-end.
 
-Org admins can point `web_search` at an external search API from the web **Settings → Web search** panel: pick **Exa** or **Firecrawl**, then supply the API key. The endpoint is pre-filled for the vendor. The key is stored in the `[web_search]` section of `~/.nakama/config.ini` and is only ever returned masked.
+Org admins can point `web_search` at an external search API from the web **Settings → Web search** panel: pick **Exa** or **Firecrawl**, then supply the API key. The key is stored in the `[web_search]` section of `~/.nakama/config.ini` and is only ever returned masked.
 
 Leave the provider on **Built-in** to keep using the model provider's own hosted search.
 

--- a/docs/website/content/docs/builtin-tools.mdx
+++ b/docs/website/content/docs/builtin-tools.mdx
@@ -416,9 +416,9 @@ Org admins configure these from the web **System → Tools** page.
 
 ### Web search
 
-Requires an OpenAI or Anthropic provider with a configured API key, or a custom search back-end.
+Requires an OpenAI or Anthropic provider with a configured API key, or an Exa or Firecrawl search back-end.
 
-Org admins can point `web_search` at an external search API from the web **Settings → Web search** panel: pick **Exa**, **Firecrawl**, or **Custom endpoint**, then supply the endpoint and API key. The endpoint is pre-filled for the two named vendors, and a custom endpoint receives `POST { query, limit }` and may return its hits under `results`, `data.web`, `organic`, or `items`. The key is stored in the `[web_search]` section of `~/.nakama/config.ini` and is only ever returned masked.
+Org admins can point `web_search` at an external search API from the web **Settings → Web search** panel: pick **Exa** or **Firecrawl**, then supply the API key. The endpoint is pre-filled for the vendor. The key is stored in the `[web_search]` section of `~/.nakama/config.ini` and is only ever returned masked.
 
 Leave the provider on **Built-in** to keep using the model provider's own hosted search.
 

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -1279,7 +1279,7 @@ export interface UpdateImageGenerationRequest {
 }
 
 /** Search back-end that replaces the provider-hosted `web_search` tool. */
-export type WebSearchProvider = "exa" | "firecrawl" | "custom";
+export type WebSearchProvider = "exa" | "firecrawl";
 
 export interface WebSearchSettingsResponse {
   apiKeyMasked: string | null;

--- a/packages/core/src/tools/custom-web-search.test.ts
+++ b/packages/core/src/tools/custom-web-search.test.ts
@@ -166,10 +166,4 @@ describe("parseCustomWebSearchResults", () => {
       "Five",
     ]);
   });
-
-  test("reads a bare array response", () => {
-    expect(
-      parseCustomWebSearchResults([{ name: "Item", uri: "https://x.example" }])
-    ).toEqual([{ title: "Item", url: "https://x.example" }]);
-  });
 });

--- a/packages/core/src/tools/custom-web-search.test.ts
+++ b/packages/core/src/tools/custom-web-search.test.ts
@@ -132,28 +132,6 @@ describe("createCustomWebSearchTool", () => {
     ]);
   });
 
-  test("omits the auth header for a keyless custom endpoint", async () => {
-    const captured: CapturedRequest[] = [];
-    stubFetch(
-      { body: { organic: [{ link: "https://example.com" }] } },
-      captured
-    );
-
-    const tool = createCustomWebSearchTool(
-      config({
-        apiKey: "",
-        endpoint: "https://search.internal/api",
-        provider: "custom",
-      })
-    );
-    const output = await tool?.run({ query: "internal" }, {});
-
-    expect(captured[0]?.headers.authorization).toBeUndefined();
-    expect(output?.results).toEqual([
-      { title: "https://example.com", url: "https://example.com" },
-    ]);
-  });
-
   test("surfaces the endpoint status on failure", async () => {
     stubFetch({ body: "quota exceeded", status: 402 }, []);
 

--- a/packages/core/src/tools/custom-web-search.ts
+++ b/packages/core/src/tools/custom-web-search.ts
@@ -84,7 +84,7 @@ function buildRequest(
 
 /**
  * Search APIs disagree on where the hit list lives: Exa uses `results`,
- * Firecrawl `data.web`, and self-hosted engines commonly `organic` or `items`.
+ * Firecrawl `data.web`.
  */
 function findResultArray(payload: unknown): unknown[] {
   if (Array.isArray(payload)) {

--- a/packages/core/src/tools/custom-web-search.ts
+++ b/packages/core/src/tools/custom-web-search.ts
@@ -72,9 +72,7 @@ function buildRequest(
     };
   }
 
-  if (config.apiKey) {
-    headers.authorization = `Bearer ${config.apiKey}`;
-  }
+  headers.authorization = `Bearer ${config.apiKey}`;
 
   return {
     body: JSON.stringify({ limit: MAX_RESULTS, query }),
@@ -82,22 +80,15 @@ function buildRequest(
   };
 }
 
-/**
- * Search APIs disagree on where the hit list lives: Exa uses `results`,
- * Firecrawl `data.web`.
- */
+/** Exa puts hits on `results`; Firecrawl on `data.web`. */
 function findResultArray(payload: unknown): unknown[] {
-  if (Array.isArray(payload)) {
-    return payload;
-  }
-
   const record = readRecord(payload);
 
   if (!record) {
     return [];
   }
 
-  for (const key of ["results", "web", "organic", "organic_results", "items"]) {
+  for (const key of ["results", "web"]) {
     const candidate = record[key];
 
     if (Array.isArray(candidate) && candidate.length > 0) {

--- a/packages/core/src/web-search-config.test.ts
+++ b/packages/core/src/web-search-config.test.ts
@@ -95,24 +95,12 @@ describe("web search config", () => {
       "API key"
     );
     await expect(
-      saveWebSearchConfig({ endpoint: "not-a-url", provider: "custom" })
+      saveWebSearchConfig({
+        apiKey: "k",
+        endpoint: "not-a-url",
+        provider: "exa",
+      })
     ).rejects.toThrow("http or https");
-  });
-
-  test("allows a custom endpoint without a key", async () => {
-    await useTempConfigDir();
-
-    const saved = await saveWebSearchConfig({
-      endpoint: "https://search.internal/api",
-      provider: "custom",
-    });
-
-    expect(saved).toEqual({
-      apiKeyMasked: null,
-      configured: true,
-      endpoint: "https://search.internal/api",
-      provider: "custom",
-    });
   });
 
   test("clearing the provider removes the section and other config survives", async () => {

--- a/packages/core/src/web-search-config.ts
+++ b/packages/core/src/web-search-config.ts
@@ -10,26 +10,19 @@ import {
 
 export const WEB_SEARCH_SECTION = "web_search";
 
-/**
- * Search back-ends that can replace the provider-hosted `web_search` tool.
- * `custom` is any endpoint that speaks a JSON search response; the two named
- * entries only pre-fill the endpoint and pick the vendor's request shape.
- */
+/** Search back-ends that can replace the provider-hosted `web_search` tool. */
 export const WEB_SEARCH_PROVIDERS: readonly WebSearchProvider[] = [
   "exa",
   "firecrawl",
-  "custom",
 ];
 
 export const WEB_SEARCH_PROVIDER_ENDPOINTS: Record<WebSearchProvider, string> =
   {
-    custom: "",
     exa: "https://api.exa.ai/search",
     firecrawl: "https://api.firecrawl.dev/v2/search",
   };
 
 export const WEB_SEARCH_PROVIDER_LABELS: Record<WebSearchProvider, string> = {
-  custom: "Custom endpoint",
   exa: "Exa",
   firecrawl: "Firecrawl",
 };
@@ -76,10 +69,6 @@ export function resolveWebSearchEndpoint(
   return endpoint?.trim() || WEB_SEARCH_PROVIDER_ENDPOINTS[provider];
 }
 
-/**
- * `custom` may point at a self-hosted search service with no auth, so only the
- * hosted vendors require a key.
- */
 export function isWebSearchConfigComplete(
   config: WebSearchConfigFile | null
 ): config is WebSearchConfigFile {
@@ -91,7 +80,7 @@ export function isWebSearchConfigComplete(
     return false;
   }
 
-  return config.provider === "custom" || Boolean(config.apiKey.trim());
+  return Boolean(config.apiKey.trim());
 }
 
 function parseWebSearchSection(
@@ -207,7 +196,7 @@ function buildSavedWebSearchConfig(
     existing?.provider === provider ? existing : null
   );
 
-  if (provider !== "custom" && !apiKey) {
+  if (!apiKey) {
     throw new Error(
       `An API key is required for ${WEB_SEARCH_PROVIDER_LABELS[provider]}.`
     );


### PR DESCRIPTION
## Summary

Org admins pick Exa or Firecrawl for `web_search` — no free-form JSON endpoint.

**Before:** Settings → Web search offered Built-in / Exa / Firecrawl / Custom endpoint, and a keyless custom URL was a valid save.
**After:** `WebSearchProvider` is `"exa" | "firecrawl"`; save requires a key; leftover `provider=custom` in `config.ini` is ignored and hosted search stays on.

Why safe:
1. PUT schema and the settings picker share the same two-vendor enum
2. Exa / Firecrawl saves and the built-in hosted path are unchanged
3. An old `custom` section no longer parses as configured, so the model does not call a mystery URL

Only re-add a custom provider if a self-hosted search API needs first-class support again.

## Test plan
- [x] `bun test packages/core/src/web-search-config.test.ts packages/core/src/tools/custom-web-search.test.ts packages/core/src/tools/web-search.test.ts` (18 pass)
- [ ] Settings → Web search → open the picker — Custom endpoint is gone
