### PR TITLE
chore(packages): shrink agent client and db wrappers

### DIFF
--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -1,9 +1,10 @@
 import { join } from "node:path";
 import {
   type AgentChatSession,
-  type AgentHarness,
+  type AgentDependencies,
   type CompactionConfig,
-  createAgentHarness,
+  createAgentChatSession,
+  createAutomationFromPrompt,
   executeToolCall,
   expandLearnInLastUserMessage,
   suggestToolParamsFromPrompt,
@@ -319,7 +320,7 @@ export interface CreateSessionOptions {
 }
 
 export class AgentService {
-  private harness: AgentHarness;
+  private harness: AgentDependencies;
   private userConfig: UserConfig | null;
   private readonly db: DatabaseAdapter;
   private readonly profileService: ProfileService;
@@ -1323,7 +1324,7 @@ export class AgentService {
     const userContext = await this.loadUserContextForUser(orgId, undefined);
     const harness = this.createHarnessForProfile(profile);
 
-    const session = harness.createChatSession({
+    const session = createAgentChatSession(harness, {
       channel: "automation",
       enableToolLoop: true,
       soul: soulActive,
@@ -1388,7 +1389,7 @@ export class AgentService {
     const harness = this.createHarnessForProfile(profile);
     const prompt = buildSubAgentPrompt(task, input.context);
 
-    const session = harness.createChatSession({
+    const session = createAgentChatSession(harness, {
       channel: "subagent",
       enableToolLoop: true,
       soul: soulActive,
@@ -1914,7 +1915,7 @@ export class AgentService {
       throw new Error("Provider is not configured.");
     }
 
-    return this.harness.createAutomationFromPrompt({ channel, prompt });
+    return createAutomationFromPrompt(this.harness, { channel, prompt });
   }
 
   async discoverModels(
@@ -2951,7 +2952,7 @@ export class AgentService {
     providerInstance?: ReturnType<typeof getActiveProviderInstance>;
     modelId?: string | null;
     thinking: ThinkingSettings;
-  }): AgentHarness {
+  }): AgentDependencies {
     const providerInstance = options.providerInstance ?? null;
 
     this.syncUsagePricingContext(providerInstance);
@@ -2965,13 +2966,13 @@ export class AgentService {
           )
         : options.provider;
 
-    return createAgentHarness({
+    return {
       chatOptions: this.resolveChatProviderOptions(
         providerInstance,
         options.thinking
       ),
       provider: trackedProvider ?? undefined,
-    });
+    };
   }
 
   private syncUsagePricingContext(
@@ -3259,7 +3260,7 @@ export class AgentService {
     });
     const hasSkillManage = tools.some((tool) => tool.name === "skill_manage");
 
-    const session = harness.createChatSession({
+    const session = createAgentChatSession(harness, {
       channel,
       compaction,
       enableToolLoop: true,
@@ -3588,7 +3589,7 @@ export class AgentService {
   private createHarnessForProfile(
     profile: StoredProfileRecord,
     selectedModel: string | null = profile.model
-  ): AgentHarness {
+  ): AgentDependencies {
     const resolved = resolveProfileProviderSelection({
       defaultProviderId: this.userConfig?.defaultProviderId,
       profileModel: selectedModel,

--- a/packages/agent/src/chat-abort.test.ts
+++ b/packages/agent/src/chat-abort.test.ts
@@ -6,7 +6,7 @@ import type {
   ToolContext,
   ToolDefinition,
 } from "@nakama/core";
-import { createAgentHarness } from "./index";
+import { createAgentChatSession } from "./index";
 
 function createCountingProvider(responses: ChatCompletionResult[]): {
   provider: ProviderClient;
@@ -80,8 +80,10 @@ describe("agent chat cancellation", () => {
     };
 
     const { provider, getCallCount } = createCountingProvider(callThenReply);
-    const harness = createAgentHarness({ provider, tools: [slowTool] });
-    const session = harness.createChatSession({ tools: [slowTool] });
+    const session = createAgentChatSession(
+      { provider, tools: [slowTool] },
+      { tools: [slowTool] }
+    );
 
     const promise = session.sendStream(
       "run it",
@@ -117,8 +119,10 @@ describe("agent chat cancellation", () => {
       },
     };
 
-    const harness = createAgentHarness({ provider, tools: [] });
-    const session = harness.createChatSession({ tools: [] });
+    const session = createAgentChatSession(
+      { provider, tools: [] },
+      { tools: [] }
+    );
 
     await session.sendStream(
       "hello",
@@ -141,8 +145,10 @@ describe("agent chat cancellation", () => {
     };
 
     const { provider } = createCountingProvider(callThenReply);
-    const harness = createAgentHarness({ provider, tools: [tool] });
-    const session = harness.createChatSession({ tools: [tool] });
+    const session = createAgentChatSession(
+      { provider, tools: [tool] },
+      { tools: [tool] }
+    );
 
     const reply = await session.sendStream(
       "run it",

--- a/packages/agent/src/chat-context-usage.test.ts
+++ b/packages/agent/src/chat-context-usage.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { ChatCompletionResult, ProviderClient } from "@nakama/core";
-import { createAgentHarness } from "./index";
+import { createAgentChatSession } from "./index";
 
 const REASONING = "r".repeat(400);
 
@@ -29,13 +29,15 @@ function providerReplayingThinking(
 }
 
 async function usedTokensFor(name: ProviderClient["name"]): Promise<number> {
-  const harness = createAgentHarness({
-    provider: providerReplayingThinking(name),
-  });
-  const session = harness.createChatSession({
-    compaction: { contextWindow: 100_000, maxOutputTokens: 8000 },
-    enableToolLoop: false,
-  });
+  const session = createAgentChatSession(
+    {
+      provider: providerReplayingThinking(name),
+    },
+    {
+      compaction: { contextWindow: 100_000, maxOutputTokens: 8000 },
+      enableToolLoop: false,
+    }
+  );
 
   // The estimate for a turn is taken before its own reply lands, so the trace
   // only reaches the history the turn after it was produced.
@@ -46,17 +48,19 @@ async function usedTokensFor(name: ProviderClient["name"]): Promise<number> {
 }
 
 function usedTokensFromInitialHistory(name: ProviderClient["name"]): number {
-  const harness = createAgentHarness({
-    provider: providerReplayingThinking(name),
-  });
-  const session = harness.createChatSession({
-    compaction: { contextWindow: 100_000, maxOutputTokens: 8000 },
-    enableToolLoop: false,
-    initialHistory: [
-      { content: "hi", role: "user" },
-      { content: "Hello", role: "assistant", thinking: REASONING },
-    ],
-  });
+  const session = createAgentChatSession(
+    {
+      provider: providerReplayingThinking(name),
+    },
+    {
+      compaction: { contextWindow: 100_000, maxOutputTokens: 8000 },
+      enableToolLoop: false,
+      initialHistory: [
+        { content: "hi", role: "user" },
+        { content: "Hello", role: "assistant", thinking: REASONING },
+      ],
+    }
+  );
 
   return session.getContextUsage()?.usedTokens ?? 0;
 }
@@ -91,17 +95,19 @@ function providerReturning(
 
 describe("chat context usage", () => {
   test("tracks provider usage against usable context", async () => {
-    const harness = createAgentHarness({
-      provider: providerReturning({
-        inputTokens: 12_000,
-        outputTokens: 40,
-        totalTokens: 12_040,
-      }),
-    });
-    const session = harness.createChatSession({
-      compaction: { contextWindow: 100_000, maxOutputTokens: 8000 },
-      enableToolLoop: false,
-    });
+    const session = createAgentChatSession(
+      {
+        provider: providerReturning({
+          inputTokens: 12_000,
+          outputTokens: 40,
+          totalTokens: 12_040,
+        }),
+      },
+      {
+        compaction: { contextWindow: 100_000, maxOutputTokens: 8000 },
+        enableToolLoop: false,
+      }
+    );
 
     await session.send("hi");
 
@@ -114,13 +120,15 @@ describe("chat context usage", () => {
   });
 
   test("falls back to an estimate when provider omits usage", async () => {
-    const harness = createAgentHarness({
-      provider: providerReturning(undefined),
-    });
-    const session = harness.createChatSession({
-      compaction: { contextWindow: 100_000, maxOutputTokens: 8000 },
-      enableToolLoop: false,
-    });
+    const session = createAgentChatSession(
+      {
+        provider: providerReturning(undefined),
+      },
+      {
+        compaction: { contextWindow: 100_000, maxOutputTokens: 8000 },
+        enableToolLoop: false,
+      }
+    );
 
     await session.send("hello world");
 
@@ -131,14 +139,16 @@ describe("chat context usage", () => {
   });
 
   test("estimates from history before any turn when compaction is configured", () => {
-    const harness = createAgentHarness({
-      provider: providerReturning(undefined),
-    });
-    const session = harness.createChatSession({
-      compaction: { contextWindow: 100_000, maxOutputTokens: 20_000 },
-      enableToolLoop: false,
-      initialHistory: [{ content: "a".repeat(400), role: "user" }],
-    });
+    const session = createAgentChatSession(
+      {
+        provider: providerReturning(undefined),
+      },
+      {
+        compaction: { contextWindow: 100_000, maxOutputTokens: 20_000 },
+        enableToolLoop: false,
+        initialHistory: [{ content: "a".repeat(400), role: "user" }],
+      }
+    );
 
     const usage = session.getContextUsage();
     expect(usage?.source).toBe("estimate");

--- a/packages/agent/src/chat-learn.test.ts
+++ b/packages/agent/src/chat-learn.test.ts
@@ -4,7 +4,7 @@ import type {
   GenerateChatInput,
   ProviderClient,
 } from "@nakama/core";
-import { createAgentHarness } from "./index";
+import { createAgentChatSession } from "./index";
 import { expandLearnInLastUserMessage } from "./learn-prompt";
 
 function createCapturingProvider(
@@ -39,11 +39,13 @@ describe("/learn provider expansion", () => {
       toolCalls: [],
     });
 
-    const harness = createAgentHarness({ provider });
-    const session = harness.createChatSession({
-      rehydrateMessagesForProvider: (messages) =>
-        Promise.resolve(expandLearnInLastUserMessage([...messages])),
-    });
+    const session = createAgentChatSession(
+      { provider },
+      {
+        rehydrateMessagesForProvider: (messages) =>
+          Promise.resolve(expandLearnInLastUserMessage([...messages])),
+      }
+    );
 
     const typed = "/learn filing an expense";
     await session.send(typed);

--- a/packages/agent/src/chat-provider-web-search.test.ts
+++ b/packages/agent/src/chat-provider-web-search.test.ts
@@ -6,7 +6,7 @@ import type {
   ToolDefinition,
 } from "@nakama/core";
 import { webSearchTool } from "@nakama/core";
-import { createAgentHarness } from "./index";
+import { createAgentChatSession } from "./index";
 
 function createCapturingProvider(
   response: ChatCompletionResult,
@@ -44,8 +44,10 @@ describe("provider-native web search", () => {
       toolCalls: [],
     });
 
-    const harness = createAgentHarness({ provider, tools: [webSearchTool] });
-    const session = harness.createChatSession({ tools: [webSearchTool] });
+    const session = createAgentChatSession(
+      { provider, tools: [webSearchTool] },
+      { tools: [webSearchTool] }
+    );
     const reply = await session.send("What's new in AI?");
 
     expect(reply).toBe("Latest news summary.");
@@ -71,13 +73,15 @@ describe("provider-native web search", () => {
       toolCalls: [],
     });
 
-    const harness = createAgentHarness({
-      provider,
-      tools: [localTool, webSearchTool],
-    });
-    const session = harness.createChatSession({
-      tools: [localTool, webSearchTool],
-    });
+    const session = createAgentChatSession(
+      {
+        provider,
+        tools: [localTool, webSearchTool],
+      },
+      {
+        tools: [localTool, webSearchTool],
+      }
+    );
     await session.send("hello");
 
     expect(provider.lastInput?.providerOptions).toEqual({ webSearch: true });
@@ -99,8 +103,10 @@ describe("provider-native web search", () => {
       "gemini"
     );
 
-    const harness = createAgentHarness({ provider, tools: [webSearchTool] });
-    const session = harness.createChatSession({ tools: [webSearchTool] });
+    const session = createAgentChatSession(
+      { provider, tools: [webSearchTool] },
+      { tools: [webSearchTool] }
+    );
     await session.send("What's new in AI?");
 
     expect(provider.lastInput?.providerOptions).toEqual({ webSearch: true });
@@ -117,8 +123,10 @@ describe("provider-native web search", () => {
       "openrouter"
     );
 
-    const harness = createAgentHarness({ provider, tools: [webSearchTool] });
-    const session = harness.createChatSession({ tools: [webSearchTool] });
+    const session = createAgentChatSession(
+      { provider, tools: [webSearchTool] },
+      { tools: [webSearchTool] }
+    );
     await session.send("What's new in AI?");
 
     expect(provider.lastInput?.providerOptions).toBeUndefined();
@@ -145,13 +153,15 @@ describe("provider-native web search", () => {
       "openrouter"
     );
 
-    const harness = createAgentHarness({
-      provider,
-      tools: [webFetch, webSearchTool],
-    });
-    const session = harness.createChatSession({
-      tools: [webFetch, webSearchTool],
-    });
+    const session = createAgentChatSession(
+      {
+        provider,
+        tools: [webFetch, webSearchTool],
+      },
+      {
+        tools: [webFetch, webSearchTool],
+      }
+    );
     await session.send("hello");
 
     expect(provider.lastInput?.system).toContain("read it with web_fetch");
@@ -164,8 +174,10 @@ describe("provider-native web search", () => {
       toolCalls: [],
     });
 
-    const harness = createAgentHarness({ provider, tools: [webSearchTool] });
-    const session = harness.createChatSession({ tools: [webSearchTool] });
+    const session = createAgentChatSession(
+      { provider, tools: [webSearchTool] },
+      { tools: [webSearchTool] }
+    );
     await session.send("hello");
 
     expect(provider.lastInput?.providerOptions).toEqual({ webSearch: true });
@@ -193,11 +205,13 @@ describe("provider-native web search", () => {
       "openrouter"
     );
 
-    const harness = createAgentHarness({
-      provider,
-      tools: [customWebSearch],
-    });
-    const session = harness.createChatSession({ tools: [customWebSearch] });
+    const session = createAgentChatSession(
+      {
+        provider,
+        tools: [customWebSearch],
+      },
+      { tools: [customWebSearch] }
+    );
     await session.send("hello");
 
     expect(provider.lastInput?.tools?.map((tool) => tool.name)).toEqual([
@@ -229,13 +243,15 @@ describe("provider-native web search", () => {
       "gemini"
     );
 
-    const harness = createAgentHarness({
-      provider,
-      tools: [localTool, webSearchTool],
-    });
-    const session = harness.createChatSession({
-      tools: [localTool, webSearchTool],
-    });
+    const session = createAgentChatSession(
+      {
+        provider,
+        tools: [localTool, webSearchTool],
+      },
+      {
+        tools: [localTool, webSearchTool],
+      }
+    );
     await session.send("hello");
 
     expect(provider.lastInput?.providerOptions).toBeUndefined();

--- a/packages/agent/src/chat-thinking.test.ts
+++ b/packages/agent/src/chat-thinking.test.ts
@@ -4,7 +4,7 @@ import type {
   GenerateChatInput,
   ProviderClient,
 } from "@nakama/core";
-import { createAgentHarness } from "./index";
+import { createAgentChatSession } from "./index";
 
 function createCapturingProvider(
   response: ChatCompletionResult
@@ -37,13 +37,15 @@ describe("thinking provider options", () => {
       toolCalls: [],
     });
 
-    const harness = createAgentHarness({
-      chatOptions: { thinking: { effort: "high", enabled: true } },
-      provider,
-    });
-    const session = harness.createChatSession({
-      enableToolLoop: false,
-    });
+    const session = createAgentChatSession(
+      {
+        chatOptions: { thinking: { effort: "high", enabled: true } },
+        provider,
+      },
+      {
+        enableToolLoop: false,
+      }
+    );
 
     const events: string[] = [];
     await session.sendStream("hello", {
@@ -64,11 +66,13 @@ describe("thinking provider options", () => {
       toolCalls: [],
     });
 
-    const harness = createAgentHarness({
-      chatOptions: { thinking: { effort: "medium", enabled: true } },
-      provider,
-    });
-    const session = harness.createChatSession({ enableToolLoop: false });
+    const session = createAgentChatSession(
+      {
+        chatOptions: { thinking: { effort: "medium", enabled: true } },
+        provider,
+      },
+      { enableToolLoop: false }
+    );
 
     await session.send({
       images: [{ data: "aGVsbG8=", mediaType: "image/png" }],

--- a/packages/agent/src/chat-tool-loop.test.ts
+++ b/packages/agent/src/chat-tool-loop.test.ts
@@ -6,7 +6,7 @@ import type {
   ProviderClient,
   ToolDefinition,
 } from "@nakama/core";
-import { createAgentHarness } from "./index";
+import { createAgentChatSession } from "./index";
 
 function createMockProvider(responses: ChatCompletionResult[]): ProviderClient {
   let callIndex = 0;
@@ -94,8 +94,10 @@ describe("agent chat tool loop", () => {
       },
     ]);
 
-    const harness = createAgentHarness({ provider, tools: [sampleTool] });
-    const session = harness.createChatSession({ tools: [sampleTool] });
+    const session = createAgentChatSession(
+      { provider, tools: [sampleTool] },
+      { tools: [sampleTool] }
+    );
     const reply = await session.send("say hi");
 
     expect(reply).toBe("Done");
@@ -138,8 +140,10 @@ describe("agent chat tool loop", () => {
       },
     ]);
 
-    const harness = createAgentHarness({ provider, tools: [sampleTool] });
-    const session = harness.createChatSession({ tools: [sampleTool] });
+    const session = createAgentChatSession(
+      { provider, tools: [sampleTool] },
+      { tools: [sampleTool] }
+    );
     const events: string[] = [];
 
     await session.sendStream("go", {
@@ -204,8 +208,10 @@ describe("agent chat tool loop", () => {
       },
     ]);
 
-    const harness = createAgentHarness({ provider, tools: [parallelTool] });
-    const session = harness.createChatSession({ tools: [parallelTool] });
+    const session = createAgentChatSession(
+      { provider, tools: [parallelTool] },
+      { tools: [parallelTool] }
+    );
     const events: string[] = [];
 
     await session.sendStream("go", {
@@ -280,8 +286,10 @@ describe("agent chat tool loop", () => {
       },
     ]);
 
-    const harness = createAgentHarness({ provider, tools: [parallelTool] });
-    const session = harness.createChatSession({ tools: [parallelTool] });
+    const session = createAgentChatSession(
+      { provider, tools: [parallelTool] },
+      { tools: [parallelTool] }
+    );
     const reply = await session.send("run both");
 
     expect(reply).toBe("Done");
@@ -371,13 +379,15 @@ describe("agent chat tool loop", () => {
       },
     ]);
 
-    const harness = createAgentHarness({
-      provider,
-      tools: [parallelTool, sequentialTool],
-    });
-    const session = harness.createChatSession({
-      tools: [parallelTool, sequentialTool],
-    });
+    const session = createAgentChatSession(
+      {
+        provider,
+        tools: [parallelTool, sequentialTool],
+      },
+      {
+        tools: [parallelTool, sequentialTool],
+      }
+    );
     await session.send("run mixed");
 
     expect(maxActive).toBe(1);
@@ -400,8 +410,10 @@ describe("agent chat tool loop", () => {
       },
     ]);
 
-    const harness = createAgentHarness({ provider, tools: [sampleTool] });
-    const session = harness.createChatSession({ tools: [sampleTool] });
+    const session = createAgentChatSession(
+      { provider, tools: [sampleTool] },
+      { tools: [sampleTool] }
+    );
 
     await expect(session.send("say hi")).rejects.toThrow(
       "Unexpected provider call 2"
@@ -433,11 +445,13 @@ describe("agent chat tool loop", () => {
       },
     };
 
-    const harness = createAgentHarness({ provider });
-    const session = harness.createChatSession({
-      resolvePromptContext: () =>
-        "# Active Task Plan\n- [pending] Ship (id: 1)",
-    });
+    const session = createAgentChatSession(
+      { provider },
+      {
+        resolvePromptContext: () =>
+          "# Active Task Plan\n- [pending] Ship (id: 1)",
+      }
+    );
 
     await session.send("hello");
 

--- a/packages/agent/src/chat-vision-fallback.test.ts
+++ b/packages/agent/src/chat-vision-fallback.test.ts
@@ -4,7 +4,7 @@ import {
   replaceImagePartsWithDescriptions,
   resolveMessagesForNonVisionProvider,
 } from "@nakama/core";
-import { createAgentHarness } from "./index";
+import { createAgentChatSession } from "./index";
 
 const tinyPngBase64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
@@ -54,23 +54,25 @@ describe("preprocessUserContent vision fallback", () => {
       },
     };
 
-    const harness = createAgentHarness({ provider: wrappedProvider });
-    const session = harness.createChatSession({
-      preprocessUserContent: async (content) => {
-        if (typeof content === "string") {
-          return content;
-        }
+    const session = createAgentChatSession(
+      { provider: wrappedProvider },
+      {
+        preprocessUserContent: async (content) => {
+          if (typeof content === "string") {
+            return content;
+          }
 
-        const hasImage = content.some((part) => part.type === "image");
-        if (!hasImage) {
-          return content;
-        }
+          const hasImage = content.some((part) => part.type === "image");
+          if (!hasImage) {
+            return content;
+          }
 
-        return replaceImagePartsWithDescriptions(content, [
-          "A small red square.",
-        ]);
-      },
-    });
+          return replaceImagePartsWithDescriptions(content, [
+            "A small red square.",
+          ]);
+        },
+      }
+    );
 
     const reply = await session.send({
       images: [{ data: tinyPngBase64, mediaType: "image/png" }],

--- a/packages/agent/src/chat.ts
+++ b/packages/agent/src/chat.ts
@@ -46,11 +46,12 @@ import {
   providerReplaysThinking,
   usableContextTokens,
 } from "./history-compaction";
+import { parseAutomationResponse } from "./parse";
 import {
-  canRunToolCallsInParallel,
-  executeToolCall,
-  serializeToolResult,
-} from "./tool-loop";
+  buildAutomationSystemPrompt,
+  buildAutomationUserPrompt,
+} from "./prompt";
+import { canRunToolCallsInParallel, executeToolCall } from "./tool-loop";
 
 const MAX_TOOL_ITERATIONS = 100;
 
@@ -127,14 +128,30 @@ export interface AgentChatSessionOptions {
   userTimezone?: string;
 }
 
+export async function createAutomationFromPrompt(
+  dependencies: AgentDependencies,
+  request: AgentRequest,
+  options?: { tools?: ToolDefinition[] }
+): Promise<AutomationDefinition> {
+  const tools = options?.tools ?? dependencies.tools ?? [];
+
+  if (!dependencies.provider) {
+    throw new Error("Provider is not configured.");
+  }
+
+  const result = await dependencies.provider.generateText({
+    prompt: buildAutomationUserPrompt(request.prompt, request.channel),
+    system: buildAutomationSystemPrompt(tools),
+  });
+
+  return parseAutomationResponse(result.content, {
+    prompt: request.prompt,
+    tools,
+  });
+}
+
 export function createAgentChatSession(
   dependencies: AgentDependencies,
-  harness: {
-    createAutomationFromPrompt(
-      request: AgentRequest,
-      options?: { tools?: ToolDefinition[] }
-    ): Promise<AutomationDefinition>;
-  },
   options: AgentChatSessionOptions = {}
 ): AgentChatSession {
   const channel = options.channel ?? "cli";
@@ -276,7 +293,11 @@ export function createAgentChatSession(
       return runCompaction(options?.force ?? false);
     },
     createAutomation(prompt) {
-      return harness.createAutomationFromPrompt({ channel, prompt }, { tools });
+      return createAutomationFromPrompt(
+        dependencies,
+        { channel, prompt },
+        { tools }
+      );
     },
     getContextUsage() {
       return lastContextUsage ?? estimateCurrentContextUsage();
@@ -639,7 +660,7 @@ async function executeToolCalls(
 
     for (const call of toolCalls) {
       history.push({
-        content: serializeToolResult(resultsByCallId.get(call.id)),
+        content: JSON.stringify(resultsByCallId.get(call.id)),
         name: call.name,
         role: "tool",
         toolCallId: call.id,
@@ -665,7 +686,7 @@ async function executeToolCalls(
     });
 
     history.push({
-      content: serializeToolResult(result),
+      content: JSON.stringify(result),
       name: call.name,
       role: "tool",
       toolCallId: call.id,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,61 +1,13 @@
-import type { AutomationDefinition, ToolDefinition } from "@nakama/core";
-import {
-  type AgentChatSession,
-  type AgentChatSessionOptions,
-  type AgentDependencies,
-  type AgentRequest,
-  createAgentChatSession,
-} from "./chat";
-import { parseAutomationResponse } from "./parse";
-import {
-  buildAutomationSystemPrompt,
-  buildAutomationUserPrompt,
-} from "./prompt";
-
-export interface AgentHarness {
-  createAutomationFromPrompt(
-    request: AgentRequest,
-    options?: { tools?: ToolDefinition[] }
-  ): Promise<AutomationDefinition>;
-  createChatSession(options?: AgentChatSessionOptions): AgentChatSession;
-}
-
-export function createAgentHarness(
-  dependencies: AgentDependencies = {}
-): AgentHarness {
-  const defaultTools = dependencies.tools ?? [];
-  const harness: AgentHarness = {
-    async createAutomationFromPrompt(request, options) {
-      const tools = options?.tools ?? defaultTools;
-
-      if (!dependencies.provider) {
-        throw new Error("Provider is not configured.");
-      }
-
-      const result = await dependencies.provider.generateText({
-        prompt: buildAutomationUserPrompt(request.prompt, request.channel),
-        system: buildAutomationSystemPrompt(tools),
-      });
-
-      return parseAutomationResponse(result.content, {
-        prompt: request.prompt,
-        tools,
-      });
-    },
-    createChatSession(options) {
-      return createAgentChatSession(dependencies, harness, options);
-    },
-  };
-
-  return harness;
-}
-
 export type {
   AgentChatSession,
   AgentChatSessionOptions,
   AgentDependencies,
   AgentRequest,
   ResolvePromptContextInput,
+} from "./chat";
+export {
+  createAgentChatSession,
+  createAutomationFromPrompt,
 } from "./chat";
 export type { CompactionConfig } from "./history-compaction";
 export { usableContextTokens } from "./history-compaction";

--- a/packages/agent/src/tool-loop.ts
+++ b/packages/agent/src/tool-loop.ts
@@ -1,13 +1,6 @@
 import type { ToolCall, ToolContext, ToolDefinition } from "@nakama/core";
 import * as core from "@nakama/core";
 
-export function findTool(
-  tools: ToolDefinition[],
-  name: string
-): ToolDefinition | undefined {
-  return tools.find((tool) => tool.name === name);
-}
-
 export function canRunToolCallsInParallel(
   tools: ToolDefinition[],
   toolCalls: ToolCall[]
@@ -17,7 +10,8 @@ export function canRunToolCallsInParallel(
   }
 
   return toolCalls.every(
-    (call) => findTool(tools, call.name)?.parallelSafe === true
+    (call) =>
+      tools.find((tool) => tool.name === call.name)?.parallelSafe === true
   );
 }
 
@@ -26,7 +20,7 @@ export async function executeToolCall(
   call: ToolCall,
   context: ToolContext = {}
 ): Promise<unknown> {
-  const tool = findTool(tools, call.name);
+  const tool = tools.find((item) => item.name === call.name);
 
   if (!tool) {
     return { error: `Unknown tool: ${call.name}` };
@@ -54,8 +48,4 @@ export async function executeToolCall(
       error: error instanceof Error ? error.message : String(error),
     };
   }
-}
-
-export function serializeToolResult(result: unknown): string {
-  return JSON.stringify(result);
 }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -197,6 +197,7 @@ import type {
   WhatsAppSettingsResponse,
   WorkerLogsResponse,
 } from "@nakama/core/contract";
+import { withDisabledFetchIdle } from "@nakama/core/fetch-idle";
 import { loadLocalAuthToken } from "@nakama/core/local-auth";
 import { resolveServerUrl } from "@nakama/core/runtime";
 import { readBrowserOrigin, readCookie } from "./browser";
@@ -206,11 +207,8 @@ import {
   readStreamEvents,
   resolveSendMessageBody,
   retryWhileTurnIsStopping,
-  withStreamFetchIdle,
 } from "./stream";
 import type {
-  BinaryBufferSource,
-  FetchCredentials,
   NakamaClientOptions,
   RemoteChatSession,
   SendMessageArg,
@@ -222,7 +220,7 @@ import type {
 export class NakamaClient {
   readonly baseUrl: string;
   private readonly fetchImpl: typeof fetch;
-  private readonly credentials: FetchCredentials;
+  private readonly credentials: RequestCredentials;
   private readonly clientOrigin: string | null;
   private authToken: string | null;
   private orgId: string | null;
@@ -342,7 +340,7 @@ export class NakamaClient {
   }
 
   async previewDataImport(
-    data: Blob | BinaryBufferSource | string
+    data: Blob | BufferSource | string
   ): Promise<DataImportPreviewResponse> {
     const request: PreviewDataImportRequest = {
       data: await encodeArchiveData(data),
@@ -357,7 +355,7 @@ export class NakamaClient {
   }
 
   async restoreDataImport(
-    data: Blob | BinaryBufferSource | string,
+    data: Blob | BufferSource | string,
     options: { confirm: boolean }
   ): Promise<RestoreDataImportResponse> {
     const request: RestoreDataImportRequest = {
@@ -374,7 +372,7 @@ export class NakamaClient {
   }
 
   async previewSetupDataImport(
-    data: Blob | BinaryBufferSource | string
+    data: Blob | BufferSource | string
   ): Promise<DataImportPreviewResponse> {
     const request: PreviewDataImportRequest = {
       data: await encodeArchiveData(data),
@@ -389,7 +387,7 @@ export class NakamaClient {
   }
 
   async restoreSetupDataImport(
-    data: Blob | BinaryBufferSource | string,
+    data: Blob | BufferSource | string,
     options: { confirm: boolean }
   ): Promise<SetupRestoreDataImportResponse> {
     const request: RestoreDataImportRequest = {
@@ -421,7 +419,7 @@ export class NakamaClient {
   }
 
   async previewProfilePackImport(
-    data: Blob | BinaryBufferSource | string,
+    data: Blob | BufferSource | string,
     options: { name?: string } = {}
   ): Promise<ProfilePackPreviewResponse> {
     const request: { data: string; name?: string } = {
@@ -440,7 +438,7 @@ export class NakamaClient {
   }
 
   async importProfilePack(
-    data: Blob | BinaryBufferSource | string,
+    data: Blob | BufferSource | string,
     options: { confirm: boolean; name?: string }
   ): Promise<ProfilePackImportResponse> {
     const request: ProfilePackImportRequest = {
@@ -619,7 +617,7 @@ export class NakamaClient {
     });
     const response = await this.fetchImpl(
       `${this.baseUrl}/v1/sessions/${encodeURIComponent(sessionId)}/stream`,
-      withStreamFetchIdle({
+      withDisabledFetchIdle({
         credentials: this.credentials,
         headers,
         method: "GET",
@@ -1294,7 +1292,7 @@ export class NakamaClient {
           async () => {
             const attempt = await this.fetchImpl(
               `${this.baseUrl}/v1/sessions/${sessionId}/messages?stream=true`,
-              withStreamFetchIdle({
+              withDisabledFetchIdle({
                 body: JSON.stringify(body),
                 credentials: this.credentials,
                 headers,
@@ -1387,7 +1385,7 @@ export class NakamaClient {
   async runAutomation(automationId: string): Promise<AutomationRunRecord> {
     const response = await this.request<RunAutomationResponse>(
       `/v1/automations/${encodeURIComponent(automationId)}/run`,
-      withStreamFetchIdle({ method: "POST" })
+      withDisabledFetchIdle({ method: "POST" })
     );
     return response.run;
   }
@@ -1404,7 +1402,7 @@ export class NakamaClient {
   ): Promise<void> {
     await this.request(
       `/v1/internal/automations/${encodeURIComponent(automationId)}/run?orgId=${encodeURIComponent(orgId)}`,
-      withStreamFetchIdle({
+      withDisabledFetchIdle({
         method: "POST",
       })
     );
@@ -1810,7 +1808,7 @@ export class NakamaClient {
   ): Promise<AgentBrowserStatusResponse> {
     const response = await this.fetchImpl(
       `${this.baseUrl}/v1/settings/agent-browser/install`,
-      withStreamFetchIdle({
+      withDisabledFetchIdle({
         credentials: this.credentials,
         headers: this.buildHeaders("POST", {
           Accept: "text/event-stream",
@@ -2501,7 +2499,7 @@ function isMutatingMethod(method: string): boolean {
 }
 
 async function encodeArchiveData(
-  data: Blob | BinaryBufferSource | string
+  data: Blob | BufferSource | string
 ): Promise<string> {
   if (typeof data === "string") {
     return data;
@@ -2533,6 +2531,6 @@ function readContentDispositionFilename(headers: Headers): string | null {
   return match?.[1] ?? null;
 }
 
-function isBlobLike(value: Blob | BinaryBufferSource): value is Blob {
+function isBlobLike(value: Blob | BufferSource): value is Blob {
   return typeof Blob !== "undefined" && value instanceof Blob;
 }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,8 +1,4 @@
-export {
-  formatClientError as formatError,
-  NakamaApiError,
-  NakamaAuthExpiredError,
-} from "@nakama/core/api-error";
+export { NakamaApiError, NakamaAuthExpiredError } from "@nakama/core/api-error";
 export { NakamaClient } from "./client";
 export type {
   NakamaClientOptions,

--- a/packages/client/src/stream.ts
+++ b/packages/client/src/stream.ts
@@ -5,26 +5,10 @@ import type {
   SendMessageInput,
   StreamEvent,
 } from "@nakama/core/contract";
-import {
-  BUN_FETCH_DISABLE_IDLE_TIMEOUT_S,
-  withDisabledFetchIdle,
-} from "@nakama/core/fetch-idle";
 import { readBrowserOrigin } from "./browser";
 import type { SendMessageArg, StreamHandler, StreamHandlers } from "./types";
 
 const DEFAULT_STREAM_IDLE_MS = DEFAULT_CHAT_STREAM_TIMEOUT_MS;
-
-/**
- * Bun fetch idleTimeout is in seconds (max 255). SSE tool runs can sit quiet
- * longer than that, so stream requests disable it.
- */
-export const STREAM_FETCH_IDLE_TIMEOUT_S = BUN_FETCH_DISABLE_IDLE_TIMEOUT_S;
-
-export type StreamFetchInit = RequestInit & { idleTimeout?: number };
-
-export function withStreamFetchIdle(init: RequestInit): StreamFetchInit {
-  return withDisabledFetchIdle(init);
-}
 
 /** How long a 409 is treated as a turn that is still stopping rather than a real conflict. */
 const TURN_CONFLICT_RETRY_MS = 3000;

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -8,18 +8,12 @@ import type {
   SendMessageInput,
 } from "@nakama/core/contract";
 
-/** Fetch `credentials` option (same values as the standard `RequestCredentials` type). */
-export type FetchCredentials = "omit" | "same-origin" | "include";
-
-/** Binary buffer input (same values as the standard `BufferSource` type). */
-export type BinaryBufferSource = ArrayBuffer | ArrayBufferView;
-
 export interface NakamaClientOptions {
   authToken?: string;
   baseUrl?: string;
   /** Browser-style origin for OAuth callbacks when this client has no window (e.g. Telegram bridge). */
   clientOrigin?: string;
-  credentials?: FetchCredentials;
+  credentials?: RequestCredentials;
   fetch?: typeof fetch;
   orgId?: string | null;
 }

--- a/packages/db/src/database-url.ts
+++ b/packages/db/src/database-url.ts
@@ -13,7 +13,7 @@ export function resolveDatabasePath(
 ): string {
   const trimmed = databaseUrl.trim();
 
-  if (trimmed === ":memory:" || trimmed === "memory:") {
+  if (trimmed === ":memory:") {
     return ":memory:";
   }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -3,7 +3,6 @@ import {
   type ResolveDatabasePathOptions,
   resolveDatabasePath,
 } from "./database-url";
-import type { DatabaseAdapter } from "./types";
 
 /** Same as `createSqliteMemoryAdapter` — kept for existing test imports. */
 export {
@@ -20,12 +19,7 @@ export * from "./seed";
 export * from "./types";
 export * from "./workspace-settings";
 
-export interface Database {
-  adapter: DatabaseAdapter;
-  close(): void;
-  /** Re-open the on-disk database after files under the data root were replaced. */
-  reopen(): Promise<void>;
-}
+export type Database = SqliteDatabase;
 
 export async function createDatabase(
   databaseUrl: string,

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -55,16 +55,14 @@ export async function seedDatabase(db: DatabaseAdapter): Promise<void> {
   await ensureOrgSuperBotProfiles(db);
 }
 
-export async function removeLegacyBuiltinTools(
-  db: DatabaseAdapter
+async function removeToolsMatching(
+  db: DatabaseAdapter,
+  shouldRemove: (tool: { handlerType: string; name: string }) => boolean
 ): Promise<void> {
   const tools = await db.listTools();
 
   for (const tool of tools) {
-    if (
-      tool.handlerType !== "builtin" ||
-      !LEGACY_BUILTIN_TOOL_NAMES.has(tool.name)
-    ) {
+    if (!shouldRemove(tool)) {
       continue;
     }
 
@@ -73,49 +71,42 @@ export async function removeLegacyBuiltinTools(
   }
 }
 
+export async function removeLegacyBuiltinTools(
+  db: DatabaseAdapter
+): Promise<void> {
+  await removeToolsMatching(
+    db,
+    (tool) =>
+      tool.handlerType === "builtin" && LEGACY_BUILTIN_TOOL_NAMES.has(tool.name)
+  );
+}
+
 export async function removeDeprecatedBuiltinTools(
   db: DatabaseAdapter
 ): Promise<void> {
-  const tools = await db.listTools();
-
-  for (const tool of tools) {
-    if (
-      tool.handlerType !== "builtin" ||
-      !DEPRECATED_BUILTIN_TOOL_NAMES.has(tool.name)
-    ) {
-      continue;
-    }
-
-    await db.deleteTool(tool.id);
-  }
+  await removeToolsMatching(
+    db,
+    (tool) =>
+      tool.handlerType === "builtin" &&
+      DEPRECATED_BUILTIN_TOOL_NAMES.has(tool.name)
+  );
 }
 
 export async function removeDeprecatedServerTools(
   db: DatabaseAdapter
 ): Promise<void> {
-  const tools = await db.listTools();
-
-  for (const tool of tools) {
-    if (!DEPRECATED_SERVER_TOOL_NAMES.has(tool.name)) {
-      continue;
-    }
-
-    await db.deleteTool(tool.id);
-  }
+  await removeToolsMatching(db, (tool) =>
+    DEPRECATED_SERVER_TOOL_NAMES.has(tool.name)
+  );
 }
 
 export async function removeUnsupportedTools(
   db: DatabaseAdapter
 ): Promise<void> {
-  const tools = await db.listTools();
-
-  for (const tool of tools) {
-    if (SUPPORTED_TOOL_HANDLER_TYPES.has(tool.handlerType)) {
-      continue;
-    }
-
-    await db.deleteTool(tool.id);
-  }
+  await removeToolsMatching(
+    db,
+    (tool) => !SUPPORTED_TOOL_HANDLER_TYPES.has(tool.handlerType)
+  );
 }
 
 export async function ensureBuiltinToolDefinitions(


### PR DESCRIPTION
## Summary

Call `createAgentChatSession` / `createAutomationFromPrompt` directly — no harness object in the way.

**Before:** `createAgentHarness` plus client/db aliases (`formatError`, `withStreamFetchIdle`, `Database` wrapper, `findTool`).
**After:** session + automation functions; fetch idle and error formatting from `@nakama/core`; `Database` is `SqliteDatabase`.

Why safe:
1. Same generateText / parseAutomation / tool-result JSON path
2. Server already swapped to the new functions
3. Package tests: 218 pass

Only re-add a harness if a second caller needs to share one object for session + automation.

## Test plan
- [x] `bun test packages/agent packages/client packages/db` (218 pass)
- [ ] Start a chat turn that uses a tool — reply still completes
