### PR TITLE
chore(server): drop tool registries and cookie helpers

### DIFF
--- a/apps/server/src/http/openapi.ts
+++ b/apps/server/src/http/openapi.ts
@@ -1,41 +1,8 @@
-import { OpenAPIHono } from "@hono/zod-openapi";
 import { DEFAULT_SERVER_URL, NAKAMA_API_VERSION } from "@nakama/core";
-import type { ServerOptions } from "./context";
-import { registerAuthRoutes } from "./routes/auth";
-import { registerAutomationRoutes } from "./routes/automations";
-import { registerMcpRoutes } from "./routes/mcp";
-import { registerModelRoutes } from "./routes/models";
-import { registerOrgCuratorRoutes } from "./routes/org-curator";
-import { registerProfileRoutes } from "./routes/profiles";
-import { registerSessionRoutes } from "./routes/sessions";
-import { registerSkillRoutes } from "./routes/skills";
-import { registerSystemRoutes } from "./routes/system";
-import { registerToolRoutes } from "./routes/tools";
-import { registerUserContextRoutes } from "./routes/user-context";
-import { registerWorkerRoutes } from "./routes/workers";
 import type { HonoApp } from "./types";
 
-function buildNativeOpenApiApp(): HonoApp {
-  const app = new OpenAPIHono() as HonoApp;
-  const options = {} as ServerOptions;
-  registerSystemRoutes(app, options);
-  registerAuthRoutes(app, options);
-  registerWorkerRoutes(app, options);
-  registerModelRoutes(app, options);
-  registerUserContextRoutes(app, options);
-  registerSessionRoutes(app, options);
-  registerProfileRoutes(app, options);
-  registerMcpRoutes(app, options);
-  registerSkillRoutes(app, options);
-  registerToolRoutes(app, options);
-  registerAutomationRoutes(app, options);
-  registerOrgCuratorRoutes(app, options);
-  return app;
-}
-
-export function buildHttpOpenApiSpec(app?: HonoApp, serverUrl?: string) {
-  const openApiApp = app ?? buildNativeOpenApiApp();
-  return openApiApp.getOpenAPI31Document({
+export function buildHttpOpenApiSpec(app: HonoApp, serverUrl?: string) {
+  return app.getOpenAPI31Document({
     info: {
       description: "HTTP API for the Nakama personal AI assistant.",
       title: "Nakama API",
@@ -67,7 +34,7 @@ export function buildHttpOpenApiSpec(app?: HonoApp, serverUrl?: string) {
 }
 
 export function serializeHttpOpenApiSpec(
-  app?: HonoApp,
+  app: HonoApp,
   serverUrl?: string
 ): string {
   return JSON.stringify(buildHttpOpenApiSpec(app, serverUrl), null, 2);

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -67,11 +67,6 @@ import { SkillProposalService } from "./services/skill-proposal-service";
 import { SkillSuggestionService } from "./services/skill-suggestion-service";
 import { SkillsService } from "./services/skills-service";
 import { SystemStatusService } from "./services/system-status-service";
-import {
-  registerGenerateImageTool,
-  registerSessionTools,
-  registerSubAgentTool,
-} from "./services/tool-resolver";
 import { WorkerManagerService } from "./services/worker-manager-service";
 import { ensureProviderConfigured } from "./setup";
 import { resolveWebDistDir } from "./static-web";
@@ -118,18 +113,18 @@ const agent = new AgentService(
   database.adapter,
   llmUsageTracker
 );
-registerSubAgentTool(createSubAgentTool(agent));
-registerSessionTools(createSessionTools(agent));
-registerGenerateImageTool(
-  createGenerateImageTool({
+agent.setServerTools({
+  generateImage: createGenerateImageTool({
     db: database.adapter,
     ensureSettingsLoaded: () => agent.ensureImageGenerationSettingsLoaded(),
     getUserConfig: () => agent.getUserConfig(),
     recordUsage: (modelId, inputTokens, outputTokens) => {
       llmUsageTracker.record(modelId, inputTokens, outputTokens);
     },
-  })
-);
+  }),
+  session: createSessionTools(agent),
+  subAgent: createSubAgentTool(agent),
+});
 await agent.ensureVisionSettingsLoaded();
 await agent.ensureTranscriptionSettingsLoaded();
 await agent.ensureImageGenerationSettingsLoaded();

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -261,7 +261,6 @@ import {
   resolveImageGenerationSelection,
 } from "./image-generation";
 import {
-  createVisionFallbackProvider,
   describeImagesWithVisionModel,
   resolvePrimaryModelVisionSupport,
   resolveVisionProviderSelection,
@@ -302,7 +301,10 @@ import type { SkillProposalService } from "./skill-proposal-service";
 import type { SkillSuggestionService } from "./skill-suggestion-service";
 import type { SkillsService } from "./skills-service";
 import { SuperBotSessionState } from "./super-bot-session-state";
-import { resolveProfileStoredTools } from "./tool-resolver";
+import {
+  resolveProfileStoredTools,
+  type ServerToolOverrides,
+} from "./tool-resolver";
 
 interface StoredSession {
   channel: AgentChannel;
@@ -344,6 +346,7 @@ export class AgentService {
   private readonly sessions = new Map<string, StoredSession>();
   private readonly sessionTitleService: SessionTitleService;
   private skillPostTurnReviewService: SkillPostTurnReviewService;
+  private serverTools: ServerToolOverrides = {};
   private _providerConfigured: boolean;
   private visionSettingsPromise: Promise<void> | null = null;
   private transcriptionSettingsPromise: Promise<void> | null = null;
@@ -466,6 +469,10 @@ export class AgentService {
   setAutomationTools(tools: ToolDefinition[]): void {
     this.automationTools = tools;
     this.sessions.clear();
+  }
+
+  setServerTools(tools: ServerToolOverrides): void {
+    this.serverTools = tools;
   }
 
   setAutomationRunHistoryTools(tools: ToolDefinition[]): void {
@@ -3088,6 +3095,7 @@ export class AgentService {
   ): Promise<ToolDefinition[]> {
     const storedTools = await this.db.listToolsForProfile(profile.id);
     const tools = await resolveProfileStoredTools(storedTools, this.db, [], {
+      serverTools: this.serverTools,
       userConfig: this.userConfig,
     });
     const includeAutomationTools = options.includeAutomationTools ?? true;
@@ -3295,7 +3303,10 @@ export class AgentService {
           throw new NakamaApiError(VISION_MODEL_REQUIRED_MESSAGE, 400);
         }
 
-        let visionProvider = createVisionFallbackProvider(visionSelection);
+        let visionProvider = createProviderForInstance(
+          visionSelection.instance,
+          visionSelection.model
+        );
 
         if (this.llmUsageTracker) {
           visionProvider = wrapProviderWithUsageTracking(

--- a/apps/server/src/services/auth-service.ts
+++ b/apps/server/src/services/auth-service.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 
 const SALT_ROUNDS = 10;
 const SESSION_EXPIRY_DAYS = 7;
@@ -35,5 +35,5 @@ export class AuthService {
 }
 
 function generateOpaqueToken(): string {
-  return `${crypto.randomUUID().replace(/-/g, "")}${crypto.randomUUID().replace(/-/g, "")}`;
+  return randomBytes(32).toString("hex");
 }

--- a/apps/server/src/services/custom-tool-handlers.ts
+++ b/apps/server/src/services/custom-tool-handlers.ts
@@ -5,16 +5,12 @@ import type {
   ToolSourceResponse,
 } from "@nakama/core";
 import type { StoredToolRecord } from "@nakama/db";
+import { resolveCustomToolModulePath } from "./custom-tool-shared";
 import {
   loadJavascriptTool,
-  resolveJavascriptModulePath,
   validateJavascriptToolModule,
 } from "./javascript-tool-loader";
-import {
-  loadPythonTool,
-  resolvePythonModulePath,
-  validatePythonToolModule,
-} from "./python-tool-loader";
+import { loadPythonTool, validatePythonToolModule } from "./python-tool-loader";
 
 // Registry of custom tool handler types. Adding a new handler type means
 // adding an entry here plus its loader module — no call-site edits.
@@ -33,14 +29,14 @@ export const CUSTOM_TOOL_HANDLERS = {
     extension: ".js",
     language: "javascript",
     load: loadJavascriptTool,
-    resolveModulePath: resolveJavascriptModulePath,
+    resolveModulePath: resolveCustomToolModulePath,
     validateModule: validateJavascriptToolModule,
   },
   python: {
     extension: ".py",
     language: "python",
     load: loadPythonTool,
-    resolveModulePath: resolvePythonModulePath,
+    resolveModulePath: resolveCustomToolModulePath,
     validateModule: validatePythonToolModule,
   },
 } satisfies Record<string, CustomToolHandler>;

--- a/apps/server/src/services/image-vision-fallback.ts
+++ b/apps/server/src/services/image-vision-fallback.ts
@@ -5,7 +5,6 @@ import {
   type ProviderClient,
   type UserConfig,
 } from "@nakama/core";
-import { createProviderForInstance } from "../providers/create";
 import { modelSupportsVision } from "../providers/models";
 import {
   type ResolvedProfileProviderSelection,
@@ -75,12 +74,6 @@ export function resolvePrimaryModelVisionSupport(
     resolved.instance.type,
     resolved.instance.customModels
   );
-}
-
-export function createVisionFallbackProvider(
-  selection: ResolvedProfileProviderSelection
-): ProviderClient {
-  return createProviderForInstance(selection.instance, selection.model);
 }
 
 export async function describeImagesWithVisionModel(

--- a/apps/server/src/services/javascript-tool-loader.test.ts
+++ b/apps/server/src/services/javascript-tool-loader.test.ts
@@ -4,10 +4,8 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { StoredToolRecord } from "@nakama/db";
-import {
-  loadJavascriptTool,
-  resolveJavascriptModulePath,
-} from "./javascript-tool-loader";
+import { resolveCustomToolModulePath } from "./custom-tool-shared";
+import { loadJavascriptTool } from "./javascript-tool-loader";
 
 const originalConfigDir = process.env.NAKAMA_CONFIG_DIR;
 
@@ -107,7 +105,7 @@ describe("javascript tool loader", () => {
     const { configDir: dir } = await setupToolsDir();
     configDir = dir;
 
-    expect(() => resolveJavascriptModulePath("../escape.js")).toThrow(
+    expect(() => resolveCustomToolModulePath("../escape.js")).toThrow(
       /must stay inside/i
     );
   });

--- a/apps/server/src/services/javascript-tool-loader.ts
+++ b/apps/server/src/services/javascript-tool-loader.ts
@@ -22,7 +22,7 @@ export async function loadJavascriptTool(
   return loadCustomSubprocessTool({
     allowParallelSafe: true,
     record,
-    resolveModulePath: resolveJavascriptModulePath,
+    resolveModulePath: resolveCustomToolModulePath,
     run: runJavascriptTool,
     validateModule: validateJavascriptToolModule,
   });
@@ -31,7 +31,7 @@ export async function loadJavascriptTool(
 export async function validateJavascriptToolModule(
   modulePath: string
 ): Promise<void> {
-  const resolvedPath = resolveJavascriptModulePath(modulePath);
+  const resolvedPath = resolveCustomToolModulePath(modulePath);
 
   if (!(await pathExists(resolvedPath))) {
     throw new Error(`Tool module not found: ${modulePath}`);
@@ -48,10 +48,6 @@ export async function validateJavascriptToolModule(
   ) {
     throw new Error("Tool module must export a run(input, context) function.");
   }
-}
-
-export function resolveJavascriptModulePath(modulePath: string): string {
-  return resolveCustomToolModulePath(modulePath);
 }
 
 async function runJavascriptTool(

--- a/apps/server/src/services/provider-instance-helpers.ts
+++ b/apps/server/src/services/provider-instance-helpers.ts
@@ -11,6 +11,7 @@ import {
   normalizeProviderInstanceLabel,
   type OllamaHostMode,
   ollamaRequiresApiKey,
+  type ProviderClient,
   type ProviderInstance,
   parseWireApi,
   resolveOllamaHostMode,
@@ -26,6 +27,7 @@ import type {
   ProviderModelOption,
   UpdateProviderRequest,
 } from "@nakama/core/contract";
+import type { DatabaseAdapter } from "@nakama/db";
 import {
   getDefaultModel,
   getModelById,
@@ -40,6 +42,7 @@ import {
   validateOpenCodeGoCustomModels,
   validateOpenRouterCustomModels,
 } from "../providers";
+import { createProviderForInstance } from "../providers/create";
 
 export function toProviderInstanceSummary(
   instance: ProviderInstance,
@@ -571,4 +574,32 @@ export function resolveProfileProviderSelection(options: {
     instance: fallbackInstance,
     model: resolveDefaultModelForInstance(fallbackInstance),
   };
+}
+
+export async function createProviderForProfile(
+  db: DatabaseAdapter,
+  profileId: string,
+  userConfig: UserConfig | null
+): Promise<ProviderClient | null> {
+  if (!userConfig) {
+    return null;
+  }
+
+  const profile = await db.getProfile(profileId);
+
+  if (!profile) {
+    return null;
+  }
+
+  const selection = resolveProfileProviderSelection({
+    defaultProviderId: userConfig.defaultProviderId,
+    profileModel: profile.model,
+    providers: userConfig.providers,
+  });
+
+  if (!selection) {
+    return null;
+  }
+
+  return createProviderForInstance(selection.instance, selection.model);
 }

--- a/apps/server/src/services/python-tool-loader.test.ts
+++ b/apps/server/src/services/python-tool-loader.test.ts
@@ -4,7 +4,8 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { StoredToolRecord } from "@nakama/db";
-import { loadPythonTool, resolvePythonModulePath } from "./python-tool-loader";
+import { resolveCustomToolModulePath } from "./custom-tool-shared";
+import { loadPythonTool } from "./python-tool-loader";
 
 const originalConfigDir = process.env.NAKAMA_CONFIG_DIR;
 
@@ -336,7 +337,7 @@ if __name__ == "__main__":
     const { configDir: dir } = await setupToolsDir();
     configDir = dir;
 
-    expect(() => resolvePythonModulePath("../escape.py")).toThrow(
+    expect(() => resolveCustomToolModulePath("../escape.py")).toThrow(
       /must stay inside/i
     );
   });

--- a/apps/server/src/services/python-tool-loader.ts
+++ b/apps/server/src/services/python-tool-loader.ts
@@ -17,7 +17,7 @@ export async function loadPythonTool(
 ): Promise<ToolDefinition | null> {
   return loadCustomSubprocessTool({
     record,
-    resolveModulePath: resolvePythonModulePath,
+    resolveModulePath: resolveCustomToolModulePath,
     run: runPythonTool,
     validateModule: validatePythonToolModule,
   });
@@ -26,7 +26,7 @@ export async function loadPythonTool(
 export async function validatePythonToolModule(
   modulePath: string
 ): Promise<void> {
-  const resolvedPath = resolvePythonModulePath(modulePath);
+  const resolvedPath = resolveCustomToolModulePath(modulePath);
 
   if (!(await pathExists(resolvedPath))) {
     throw new Error(`Tool module not found: ${modulePath}`);
@@ -49,10 +49,6 @@ export async function validatePythonToolModule(
       'Python tools must include an if __name__ == "__main__" harness that reads JSON from sys.stdin and writes JSON to sys.stdout.'
     );
   }
-}
-
-export function resolvePythonModulePath(modulePath: string): string {
-  return resolveCustomToolModulePath(modulePath);
 }
 
 async function runPythonTool(

--- a/apps/server/src/services/session-title-service.ts
+++ b/apps/server/src/services/session-title-service.ts
@@ -1,8 +1,7 @@
 import { generateSessionTitleFromMessages } from "@nakama/agent";
 import type { ChatMessage, UserConfig } from "@nakama/core";
 import type { DatabaseAdapter } from "@nakama/db";
-import { createProviderForInstance } from "../providers/create";
-import { resolveProfileProviderSelection } from "./provider-instance-helpers";
+import { createProviderForProfile } from "./provider-instance-helpers";
 
 export const SESSION_TITLE_FALLBACK = "Untitled";
 
@@ -46,10 +45,10 @@ export class SessionTitleService {
         return;
       }
 
-      const userConfig = this.getUserConfig();
-      const provider = await this.resolveProviderForProfile(
+      const provider = await createProviderForProfile(
+        this.db,
         session.profileId,
-        userConfig
+        this.getUserConfig()
       );
 
       if (!provider) {
@@ -68,37 +67,6 @@ export class SessionTitleService {
     } finally {
       this.inFlight.delete(sessionId);
     }
-  }
-
-  private async resolveProviderForProfile(
-    profileId: string,
-    userConfig: UserConfig | null
-  ) {
-    if (!userConfig) {
-      return null;
-    }
-
-    const profile = await this.db.getProfile(profileId);
-
-    if (!profile) {
-      return null;
-    }
-
-    const selection = resolveProfileProviderSelection({
-      defaultProviderId: userConfig.defaultProviderId,
-      profileModel: profile.model,
-      providers: userConfig.providers,
-    });
-
-    if (!selection) {
-      return null;
-    }
-
-    return createProviderForInstance(
-      selection.instance,
-      selection.model,
-      process.env
-    );
   }
 }
 

--- a/apps/server/src/services/skill-post-turn-review-service.test.ts
+++ b/apps/server/src/services/skill-post-turn-review-service.test.ts
@@ -145,13 +145,10 @@ describe("SkillPostTurnReviewService", () => {
       await seedEligibleTurn(db, channel);
 
       let ran = 0;
-      const service = new SkillPostTurnReviewService(
-        db,
-        () => null,
-        async () => {
-          ran += 1;
-        }
-      );
+      const service = new SkillPostTurnReviewService(db, () => null);
+      service.setRunner(async () => {
+        ran += 1;
+      });
 
       expect(await service.runPostTurnSkillReview("session_1")).toBe("ran");
       expect(ran).toBe(1);
@@ -167,13 +164,10 @@ describe("SkillPostTurnReviewService", () => {
       await seedEligibleTurn(db, channel);
 
       let ran = 0;
-      const service = new SkillPostTurnReviewService(
-        db,
-        () => null,
-        async () => {
-          ran += 1;
-        }
-      );
+      const service = new SkillPostTurnReviewService(db, () => null);
+      service.setRunner(async () => {
+        ran += 1;
+      });
 
       expect(await service.runPostTurnSkillReview("session_1")).toBe(
         "channel_not_interactive"
@@ -187,13 +181,10 @@ describe("SkillPostTurnReviewService", () => {
     await seedEligibleTurn(db, "sms");
 
     let ran = 0;
-    const service = new SkillPostTurnReviewService(
-      db,
-      () => null,
-      async () => {
-        ran += 1;
-      }
-    );
+    const service = new SkillPostTurnReviewService(db, () => null);
+    service.setRunner(async () => {
+      ran += 1;
+    });
 
     expect(await service.runPostTurnSkillReview("session_1")).toBe(
       "channel_not_interactive"
@@ -240,13 +231,10 @@ describe("SkillPostTurnReviewService", () => {
     });
 
     let ran = 0;
-    const service = new SkillPostTurnReviewService(
-      db,
-      () => null,
-      async () => {
-        ran += 1;
-      }
-    );
+    const service = new SkillPostTurnReviewService(db, () => null);
+    service.setRunner(async () => {
+      ran += 1;
+    });
 
     expect(await service.runPostTurnSkillReview("session_1")).toBe(
       "channel_not_interactive"
@@ -289,13 +277,10 @@ describe("SkillPostTurnReviewService", () => {
     });
 
     let ran = 0;
-    const service = new SkillPostTurnReviewService(
-      db,
-      () => null,
-      async () => {
-        ran += 1;
-      }
-    );
+    const service = new SkillPostTurnReviewService(db, () => null);
+    service.setRunner(async () => {
+      ran += 1;
+    });
     expect(await service.runPostTurnSkillReview("session_1")).toBe(
       "flag_disabled"
     );
@@ -311,14 +296,11 @@ describe("SkillPostTurnReviewService", () => {
       release = resolve;
     });
     let ran = 0;
-    const service = new SkillPostTurnReviewService(
-      db,
-      () => null,
-      async () => {
-        ran += 1;
-        await gate;
-      }
-    );
+    const service = new SkillPostTurnReviewService(db, () => null);
+    service.setRunner(async () => {
+      ran += 1;
+      await gate;
+    });
 
     const first = service.runPostTurnSkillReview("session_1");
     await Promise.resolve();

--- a/apps/server/src/services/skill-post-turn-review-service.ts
+++ b/apps/server/src/services/skill-post-turn-review-service.ts
@@ -11,8 +11,7 @@ import {
   type UserConfig,
 } from "@nakama/core";
 import type { DatabaseAdapter } from "@nakama/db";
-import { createProviderForInstance } from "../providers/create";
-import { resolveProfileProviderSelection } from "./provider-instance-helpers";
+import { createProviderForProfile } from "./provider-instance-helpers";
 
 /**
  * Which channels run the post-turn skill review. Total over `AgentChannel`, so
@@ -160,10 +159,9 @@ export class SkillPostTurnReviewService {
 
   constructor(
     private readonly db: DatabaseAdapter,
-    private readonly getUserConfig: () => UserConfig | null,
-    runner?: PostTurnReviewRunner
+    private readonly getUserConfig: () => UserConfig | null
   ) {
-    this.runner = runner ?? ((context) => this.reviewTurnWithLlm(context));
+    this.runner = (context) => this.reviewTurnWithLlm(context);
   }
 
   /** Test/injection hook — U4 wraps this to stage/suggest after the LLM outcome. */
@@ -268,27 +266,7 @@ export class SkillPostTurnReviewService {
     }
   }
 
-  async resolveProviderForProfile(profileId: string) {
-    const userConfig = this.getUserConfig();
-    if (!userConfig) {
-      return null;
-    }
-
-    const profile = await this.db.getProfile(profileId);
-    if (!profile) {
-      return null;
-    }
-
-    const selection = resolveProfileProviderSelection({
-      defaultProviderId: userConfig.defaultProviderId,
-      profileModel: profile.model,
-      providers: userConfig.providers,
-    });
-
-    if (!selection) {
-      return null;
-    }
-
-    return createProviderForInstance(selection.instance, selection.model);
+  resolveProviderForProfile(profileId: string) {
+    return createProviderForProfile(this.db, profileId, this.getUserConfig());
   }
 }

--- a/apps/server/src/services/skill-proposal-service.ts
+++ b/apps/server/src/services/skill-proposal-service.ts
@@ -55,6 +55,25 @@ export interface StageSkillProposalResult {
   warnings?: string[];
 }
 
+export async function isSkillWriteApprovalRequired(
+  database: DatabaseAdapter,
+  orgId: string,
+  profileId: string
+): Promise<boolean> {
+  const org = await database.getOrganizationById(orgId);
+  if (!org) {
+    throw new NakamaApiError("Organization not found.", 404);
+  }
+  const profile = await database.getProfileForOrg(profileId, orgId);
+  if (!profile) {
+    throw new NakamaApiError("Profile not found.", 404);
+  }
+  return resolveProfileOrgBooleanOverride(
+    profile.skillsWriteApproval ?? null,
+    org.skillsWriteApproval ?? false
+  );
+}
+
 export class SkillProposalService {
   constructor(
     private readonly database: DatabaseAdapter | null = null,
@@ -65,18 +84,10 @@ export class SkillProposalService {
     orgId: string,
     profileId: string
   ): Promise<boolean> {
-    const db = this.requireDatabase();
-    const org = await db.getOrganizationById(orgId);
-    if (!org) {
-      throw new NakamaApiError("Organization not found.", 404);
-    }
-    const profile = await db.getProfileForOrg(profileId, orgId);
-    if (!profile) {
-      throw new NakamaApiError("Profile not found.", 404);
-    }
-    return resolveProfileOrgBooleanOverride(
-      profile.skillsWriteApproval ?? null,
-      org.skillsWriteApproval ?? false
+    return isSkillWriteApprovalRequired(
+      this.requireDatabase(),
+      orgId,
+      profileId
     );
   }
 

--- a/apps/server/src/services/skill-suggestion-service.ts
+++ b/apps/server/src/services/skill-suggestion-service.ts
@@ -4,7 +4,6 @@ import {
   isPathWithinProfileSkillsDir,
   NakamaApiError,
   parseRawProfileSkillContent,
-  resolveProfileOrgBooleanOverride,
 } from "@nakama/core";
 import type {
   ApplySkillSuggestionOutcome,
@@ -19,7 +18,10 @@ import type {
   SkillSuggestionAction,
   StoredSkillSuggestion,
 } from "@nakama/db";
-import type { SkillProposalService } from "./skill-proposal-service";
+import {
+  isSkillWriteApprovalRequired,
+  type SkillProposalService,
+} from "./skill-proposal-service";
 import type { SkillsService } from "./skills-service";
 
 export function toSkillSuggestion(
@@ -58,18 +60,10 @@ export class SkillSuggestionService {
     orgId: string,
     profileId: string
   ): Promise<boolean> {
-    const db = this.requireDatabase();
-    const org = await db.getOrganizationById(orgId);
-    if (!org) {
-      throw new NakamaApiError("Organization not found.", 404);
-    }
-    const profile = await db.getProfileForOrg(profileId, orgId);
-    if (!profile) {
-      throw new NakamaApiError("Profile not found.", 404);
-    }
-    return resolveProfileOrgBooleanOverride(
-      profile.skillsWriteApproval ?? null,
-      org.skillsWriteApproval ?? false
+    return isSkillWriteApprovalRequired(
+      this.requireDatabase(),
+      orgId,
+      profileId
     );
   }
 

--- a/apps/server/src/services/tool-resolver-session.test.ts
+++ b/apps/server/src/services/tool-resolver-session.test.ts
@@ -6,7 +6,7 @@ import {
 import { createInMemoryDatabaseAdapter } from "@nakama/db";
 import { createSessionTools } from "../tools/session-tools";
 import { AgentService } from "./agent-service";
-import { registerSessionTools, resolveToolsFromStorage } from "./tool-resolver";
+import { resolveToolsFromStorage } from "./tool-resolver";
 
 function sessionTools() {
   return createSessionTools(
@@ -39,12 +39,13 @@ async function seedSessionToolRows(
 describe("resolveToolsFromStorage session", () => {
   test("resolves both registered session tools from storage", async () => {
     const db = createInMemoryDatabaseAdapter();
-    registerSessionTools(sessionTools());
     await seedSessionToolRows(db);
 
-    const names = (await resolveToolsFromStorage(await db.listTools(), db)).map(
-      (tool) => tool.name
-    );
+    const names = (
+      await resolveToolsFromStorage(await db.listTools(), db, [], {
+        serverTools: { session: sessionTools() },
+      })
+    ).map((tool) => tool.name);
 
     expect(names).toContain("list_profile_sessions");
     expect(names).toContain("read_profile_session");
@@ -52,17 +53,15 @@ describe("resolveToolsFromStorage session", () => {
 
   test("resolves nothing when the tools were never registered", async () => {
     const db = createInMemoryDatabaseAdapter();
-    registerSessionTools([]);
     await seedSessionToolRows(db);
 
-    const names = (await resolveToolsFromStorage(await db.listTools(), db)).map(
-      (tool) => tool.name
-    );
+    const names = (
+      await resolveToolsFromStorage(await db.listTools(), db, [], {
+        serverTools: { session: [] },
+      })
+    ).map((tool) => tool.name);
 
     expect(names).not.toContain("list_profile_sessions");
     expect(names).not.toContain("read_profile_session");
-
-    // Leave the registry as the rest of the suite expects to find it.
-    registerSessionTools(sessionTools());
   });
 });

--- a/apps/server/src/services/tool-resolver-sub-agent.test.ts
+++ b/apps/server/src/services/tool-resolver-sub-agent.test.ts
@@ -2,22 +2,20 @@ import { describe, expect, test } from "bun:test";
 import { SUB_AGENT_TOOL_ID } from "@nakama/core/tools/protected";
 import { createInMemoryDatabaseAdapter } from "@nakama/db";
 import { createSubAgentTool } from "../tools/sub-agent-tool";
-import { registerSubAgentTool, resolveToolsFromStorage } from "./tool-resolver";
+import { resolveToolsFromStorage } from "./tool-resolver";
 
 describe("resolveToolsFromStorage sub_agent", () => {
   test("resolves registered sub_agent tool from storage", async () => {
     const db = createInMemoryDatabaseAdapter();
     const now = new Date().toISOString();
 
-    registerSubAgentTool(
-      createSubAgentTool({
-        runSubAgentPrompt: async () => ({
-          output: "ok",
-          status: "success",
-          summary: "ok",
-        }),
-      } as never)
-    );
+    const subAgent = createSubAgentTool({
+      runSubAgentPrompt: async () => ({
+        output: "ok",
+        status: "success",
+        summary: "ok",
+      }),
+    } as never);
 
     await db.upsertTool({
       createdAt: now,
@@ -29,7 +27,9 @@ describe("resolveToolsFromStorage sub_agent", () => {
       updatedAt: now,
     });
 
-    const tools = await resolveToolsFromStorage(await db.listTools(), db);
+    const tools = await resolveToolsFromStorage(await db.listTools(), db, [], {
+      serverTools: { subAgent },
+    });
 
     expect(tools.map((tool) => tool.name)).toContain("sub_agent");
   });

--- a/apps/server/src/services/tool-resolver.ts
+++ b/apps/server/src/services/tool-resolver.ts
@@ -16,21 +16,11 @@ import { bashTool, runBash } from "../tools/bash";
 import { enrichCodingAgentBashInput } from "./coding-agent-bash-env";
 import { getCustomToolHandler } from "./custom-tool-handlers";
 
-let registeredSubAgentTool: ToolDefinition | null = null;
-let registeredGenerateImageTool: ToolDefinition | null = null;
-let registeredSessionTools: ToolDefinition[] = [];
-
-export function registerSubAgentTool(tool: ToolDefinition): void {
-  registeredSubAgentTool = tool;
-}
-
-export function registerGenerateImageTool(tool: ToolDefinition | null): void {
-  registeredGenerateImageTool = tool;
-}
-
-export function registerSessionTools(tools: ToolDefinition[]): void {
-  registeredSessionTools = tools;
-}
+export type ServerToolOverrides = {
+  generateImage?: ToolDefinition | null;
+  session?: ToolDefinition[];
+  subAgent?: ToolDefinition | null;
+};
 
 export function omitUnavailableBuiltinTools(
   tools: ToolDefinition[],
@@ -47,7 +37,10 @@ export async function resolveProfileStoredTools(
   records: StoredToolRecord[],
   db?: DatabaseAdapter,
   builtinOverrides: ToolDefinition[] = [],
-  options: { userConfig?: UserConfig | null } = {}
+  options: {
+    serverTools?: ServerToolOverrides;
+    userConfig?: UserConfig | null;
+  } = {}
 ): Promise<ToolDefinition[]> {
   // A configured search back-end replaces the provider-hosted web_search stub
   // for every caller; without one the stub stays and the provider searches.
@@ -70,12 +63,19 @@ export async function resolveToolsFromStorage(
   records: StoredToolRecord[],
   db?: DatabaseAdapter,
   builtinOverrides: ToolDefinition[] = [],
-  options: { userConfig?: UserConfig | null } = {}
+  options: {
+    serverTools?: ServerToolOverrides;
+    userConfig?: UserConfig | null;
+  } = {}
 ): Promise<ToolDefinition[]> {
   const builtinMap = new Map(
     [...builtinTools, ...builtinOverrides].map((tool) => [tool.name, tool])
   );
-  const serverTools = buildServerTools(db, options.userConfig);
+  const serverTools = buildServerTools(
+    db,
+    options.userConfig,
+    options.serverTools
+  );
   const resolved: ToolDefinition[] = [];
 
   for (const record of records) {
@@ -118,20 +118,21 @@ async function resolveStoredTool(
 
 function buildServerTools(
   db?: DatabaseAdapter,
-  userConfig?: UserConfig | null
+  userConfig?: UserConfig | null,
+  overrides: ServerToolOverrides = {}
 ): Map<string, ToolDefinition> {
   const bash = db ? createCodingAgentAwareBashTool(db, userConfig) : bashTool;
   const map = new Map<string, ToolDefinition>([[bash.name, bash]]);
 
-  if (registeredSubAgentTool) {
-    map.set(registeredSubAgentTool.name, registeredSubAgentTool);
+  if (overrides.subAgent) {
+    map.set(overrides.subAgent.name, overrides.subAgent);
   }
 
-  if (registeredGenerateImageTool) {
-    map.set(registeredGenerateImageTool.name, registeredGenerateImageTool);
+  if (overrides.generateImage) {
+    map.set(overrides.generateImage.name, overrides.generateImage);
   }
 
-  for (const tool of registeredSessionTools) {
+  for (const tool of overrides.session ?? []) {
     map.set(tool.name, tool);
   }
 

--- a/apps/server/src/tools/generate-image-tool.test.ts
+++ b/apps/server/src/tools/generate-image-tool.test.ts
@@ -19,10 +19,7 @@ import {
 } from "@nakama/db";
 import { IMAGE_GENERATION_SELECTION } from "../providers/models";
 import { IMAGE_MODEL_REQUIRED_MESSAGE } from "../services/image-generation";
-import {
-  registerGenerateImageTool,
-  resolveToolsFromStorage,
-} from "../services/tool-resolver";
+import { resolveToolsFromStorage } from "../services/tool-resolver";
 import {
   createGenerateImageTool,
   GENERATE_IMAGE_TOOL_NAME,
@@ -52,9 +49,15 @@ const openaiConfig = (overrides?: Partial<UserConfig>): UserConfig => ({
   ...overrides,
 });
 
-afterEach(() => {
-  registerGenerateImageTool(null);
-});
+function generateImageTool(
+  db: ReturnType<typeof createInMemoryDatabaseAdapter>
+) {
+  return createGenerateImageTool({
+    db,
+    ensureSettingsLoaded: async () => {},
+    getUserConfig: () => null,
+  });
+}
 
 describe("generate_image tool seed and resolver (U3)", () => {
   test("seed creates generate_image tool definition", async () => {
@@ -93,14 +96,6 @@ describe("generate_image tool seed and resolver (U3)", () => {
     const db = createInMemoryDatabaseAdapter();
     const now = new Date().toISOString();
 
-    registerGenerateImageTool(
-      createGenerateImageTool({
-        db,
-        ensureSettingsLoaded: async () => {},
-        getUserConfig: () => null,
-      })
-    );
-
     await ensureGenerateImageToolDefinition(db);
     await db.upsertProfile({
       createdAt: now,
@@ -117,7 +112,9 @@ describe("generate_image tool seed and resolver (U3)", () => {
 
     const assigned = await resolveToolsFromStorage(
       await db.listToolsForProfile("profile_assigned"),
-      db
+      db,
+      [],
+      { serverTools: { generateImage: generateImageTool(db) } }
     );
     const tool = assigned.find(
       (entry) => entry.name === GENERATE_IMAGE_TOOL_NAME
@@ -131,14 +128,6 @@ describe("generate_image tool seed and resolver (U3)", () => {
   test("unassigned profile session does not expose generate_image", async () => {
     const db = createInMemoryDatabaseAdapter();
     const now = new Date().toISOString();
-
-    registerGenerateImageTool(
-      createGenerateImageTool({
-        db,
-        ensureSettingsLoaded: async () => {},
-        getUserConfig: () => null,
-      })
-    );
 
     await ensureGenerateImageToolDefinition(db);
     await db.upsertProfile({


### PR DESCRIPTION
## Summary

Chat and playground resolve server tools from `setServerTools` — no process-wide registries.

**Before:** `registerSubAgentTool` / `registerSessionTools` / `registerGenerateImageTool` plus copied provider/approval helpers.
**After:** `ServerToolOverrides` on `resolveToolsFromStorage`, plus shared `createProviderForProfile` and `isSkillWriteApprovalRequired`.

Why safe:
1. Same handler types still resolve only when the agent passes the tools in
2. OpenAPI is built from the live Hono app (`serializeHttpOpenApiSpec(app)`)
3. Session tokens stay 64 hex chars (`randomBytes(32)`)

Only re-add / follow up if a test or boot path still expected a global `register*` side effect.

## Test plan
- [x] `bun test` on the touched server resolver/loader/skill/auth/app tests (134 pass)
- [ ] Assign `generate_image` or `sub_agent` to a profile and send one chat turn — tool still appears
