### PR TITLE
fix(web): recover from already-revoked artifact links

### DIFF
--- a/apps/web/src/components/chat/use-artifact-share-controls.ts
+++ b/apps/web/src/components/chat/use-artifact-share-controls.ts
@@ -200,7 +200,7 @@ export function useArtifactShareControls({
     }
 
     try {
-      await revokeMutation.mutateAsync({
+      const { revoked } = await revokeMutation.mutateAsync({
         path: artifactPath,
         profileId,
         shareId,
@@ -208,6 +208,12 @@ export function useArtifactShareControls({
       clearStoredArtifactShare({ artifactPath, orgId, profileId });
       setStoredUrl(null);
       storedShareIdRef.current = null;
+
+      if (!revoked) {
+        closePublishDialog();
+        toast("This share link was already revoked. Open sharing again.");
+        return;
+      }
 
       const result = await publishMutation.mutateAsync({
         path: artifactPath,
@@ -233,7 +239,7 @@ export function useArtifactShareControls({
       }
 
       closePublishDialog();
-      toast("New share link created");
+      toast("Share link changed. Open sharing again.");
     } catch (error) {
       toast(formatError(error));
     }
@@ -246,7 +252,7 @@ export function useArtifactShareControls({
     }
 
     try {
-      await revokeMutation.mutateAsync({
+      const { revoked } = await revokeMutation.mutateAsync({
         path: artifactPath,
         profileId,
         shareId,
@@ -254,7 +260,9 @@ export function useArtifactShareControls({
       clearStoredArtifactShare({ artifactPath, orgId, profileId });
       setStoredUrl(null);
       storedShareIdRef.current = null;
-      toast("Share link revoked");
+      toast(
+        revoked ? "Share link revoked" : "This share link was already revoked."
+      );
     } catch (error) {
       toast(formatError(error));
     }

--- a/apps/web/src/hooks/use-resource-mutations.test.ts
+++ b/apps/web/src/hooks/use-resource-mutations.test.ts
@@ -84,18 +84,15 @@ test.each([200, 404])(
   }
 );
 
-test.each([401, 403, 500])(
-  "revoke preserves HTTP %s failures rather than allowing rotation to continue",
-  async (status) => {
-    queryClient.setQueryData(queryKey, { active: true, id: variables.shareId });
-    const error = new NakamaApiError("Request failed", status);
-    revoke.mockRejectedValue(error);
+test("revoke preserves HTTP 403 failures rather than allowing rotation to continue", async () => {
+  queryClient.setQueryData(queryKey, { active: true, id: variables.shareId });
+  const error = new NakamaApiError("Request failed", 403);
+  revoke.mockRejectedValue(error);
 
-    const mutate = renderMutation();
-    await expect(mutate()).rejects.toBe(error);
-    expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(false);
-  }
-);
+  const mutate = renderMutation();
+  await expect(mutate()).rejects.toBe(error);
+  expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(false);
+});
 
 describe("artifact share controls with a stale share ID", () => {
   const unusedAuthAction = mock(async () => {});

--- a/apps/web/src/hooks/use-resource-mutations.test.ts
+++ b/apps/web/src/hooks/use-resource-mutations.test.ts
@@ -1,13 +1,29 @@
-import { afterAll, afterEach, expect, spyOn, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
 import { NakamaApiError } from "@nakama/core/api-error";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createElement } from "react";
 import { renderToString } from "react-dom/server";
+import { useArtifactShareControls } from "@/components/chat/use-artifact-share-controls";
+import {
+  AuthContext,
+  type AuthContextValue,
+} from "@/context/auth-context-shared";
+import { artifactShareStorageKey } from "@/lib/artifact-share-storage";
 import { client } from "@/lib/client";
 import { queryKeys } from "@/lib/query-keys";
 import { useRevokeArtifactShareMutation } from "./use-resource-mutations";
 
 const revoke = spyOn(client, "revokeProfileArtifactShare");
+const publish = spyOn(client, "publishProfileArtifactShare");
 const queryClient = new QueryClient({
   defaultOptions: { mutations: { retry: false } },
 });
@@ -23,10 +39,14 @@ const queryKey = queryKeys.artifacts.shareStatus(
 
 afterEach(() => {
   revoke.mockReset();
+  publish.mockReset();
   queryClient.clear();
 });
 
-afterAll(() => revoke.mockRestore());
+afterAll(() => {
+  revoke.mockRestore();
+  publish.mockRestore();
+});
 
 function renderMutation() {
   let mutation: ReturnType<typeof useRevokeArtifactShareMutation>;
@@ -76,3 +96,150 @@ test.each([401, 403, 500])(
     expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(false);
   }
 );
+
+describe("artifact share controls with a stale share ID", () => {
+  const unusedAuthAction = mock(async () => {});
+  const auth: AuthContextValue = {
+    activeOrg: {
+      createdAt: "2026-09-06T00:00:00Z",
+      id: "org",
+      name: "Test",
+      role: "admin",
+      slug: "test",
+      updatedAt: "2026-09-06T00:00:00Z",
+    },
+    archiveOrg: unusedAuthAction,
+    createOrg: unusedAuthAction,
+    isAuthenticated: true,
+    isLoading: false,
+    login: unusedAuthAction,
+    logout: unusedAuthAction,
+    orgs: [],
+    refreshSession: unusedAuthAction,
+    setup: unusedAuthAction,
+    switchOrg: unusedAuthAction,
+    updateOrg: unusedAuthAction,
+    user: null,
+  };
+  const storageKey = artifactShareStorageKey(
+    "org",
+    variables.profileId,
+    variables.path
+  );
+  const store = new Map<string, string>();
+  let previousLocalStorage: Storage;
+
+  beforeEach(() => {
+    previousLocalStorage = globalThis.localStorage;
+    store.clear();
+    store.set(
+      storageKey,
+      JSON.stringify({
+        shareId: variables.shareId,
+        shareUrl: "https://example.com/s/old",
+      })
+    );
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: (key: string) => store.get(key) ?? null,
+        removeItem: (key: string) => store.delete(key),
+        setItem: (key: string, value: string) => store.set(key, value),
+      },
+    });
+    queryClient.setQueryData(queryKey, { active: true, id: variables.shareId });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: previousLocalStorage,
+    });
+  });
+
+  function renderControls() {
+    let controls: ReturnType<typeof useArtifactShareControls>;
+    function Probe() {
+      controls = useArtifactShareControls({
+        artifactPath: variables.path,
+        profileId: variables.profileId,
+      });
+      return null;
+    }
+    renderToString(
+      createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        createElement(
+          AuthContext.Provider,
+          { value: auth },
+          createElement(Probe)
+        )
+      )
+    );
+    return {
+      revoke: () => controls.handleRevoke(),
+      rotate: () => controls.handleRotateLink(),
+    };
+  }
+
+  test.each(["rotate", "revoke"] as const)(
+    "%s leaves a replacement share alone when the old ID returns 404",
+    async (action) => {
+      const replacement = { active: true, id: "replacement-share" };
+      revoke.mockImplementation(() => {
+        queryClient.setQueryData(queryKey, replacement);
+        return Promise.reject(new NakamaApiError("Not found", 404));
+      });
+      publish.mockResolvedValue({
+        id: replacement.id,
+        refreshed: true,
+        sharePath: "",
+        shareUrl: null,
+        token: "",
+        webPublicUrlConfigured: true,
+      });
+
+      await renderControls()[action]();
+
+      expect(revoke).toHaveBeenCalledWith(
+        variables.profileId,
+        variables.shareId
+      );
+      expect(publish).not.toHaveBeenCalled();
+      expect(store.has(storageKey)).toBe(false);
+      expect(queryClient.getQueryData<typeof replacement>(queryKey)).toEqual(
+        replacement
+      );
+    }
+  );
+
+  test("rotation still publishes after successfully revoking the current link", async () => {
+    revoke.mockResolvedValue({ id: variables.shareId, revoked: true });
+    publish.mockResolvedValue({
+      id: "new-share",
+      refreshed: false,
+      sharePath: "/s/new",
+      shareUrl: "https://example.com/s/new",
+      token: "new",
+      webPublicUrlConfigured: true,
+    });
+
+    await renderControls().rotate();
+
+    expect(publish).toHaveBeenCalledWith(variables.profileId, variables.path);
+    expect(JSON.parse(store.get(storageKey) ?? "null")).toEqual({
+      shareId: "new-share",
+      shareUrl: "https://example.com/s/new",
+    });
+  });
+
+  test("rotation does not clear or publish on a permission failure", async () => {
+    revoke.mockRejectedValue(new NakamaApiError("Forbidden", 403));
+
+    await renderControls().rotate();
+
+    expect(publish).not.toHaveBeenCalled();
+    expect(store.has(storageKey)).toBe(true);
+  });
+});

--- a/apps/web/src/hooks/use-resource-mutations.test.ts
+++ b/apps/web/src/hooks/use-resource-mutations.test.ts
@@ -1,0 +1,78 @@
+import { afterAll, afterEach, expect, spyOn, test } from "bun:test";
+import { NakamaApiError } from "@nakama/core/api-error";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement } from "react";
+import { renderToString } from "react-dom/server";
+import { client } from "@/lib/client";
+import { queryKeys } from "@/lib/query-keys";
+import { useRevokeArtifactShareMutation } from "./use-resource-mutations";
+
+const revoke = spyOn(client, "revokeProfileArtifactShare");
+const queryClient = new QueryClient({
+  defaultOptions: { mutations: { retry: false } },
+});
+const variables = {
+  path: "report.html",
+  profileId: "profile",
+  shareId: "old-share",
+};
+const queryKey = queryKeys.artifacts.shareStatus(
+  variables.profileId,
+  variables.path
+);
+
+afterEach(() => {
+  revoke.mockReset();
+  queryClient.clear();
+});
+
+afterAll(() => revoke.mockRestore());
+
+function renderMutation() {
+  let mutation: ReturnType<typeof useRevokeArtifactShareMutation>;
+  function Probe() {
+    mutation = useRevokeArtifactShareMutation();
+    return null;
+  }
+  renderToString(
+    createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      createElement(Probe)
+    )
+  );
+  return () => mutation.mutateAsync(variables);
+}
+
+test.each([200, 404])(
+  "revoke completes and invalidates stale share status on HTTP %s",
+  async (status) => {
+    queryClient.setQueryData(queryKey, { active: true, id: variables.shareId });
+    if (status === 404) {
+      revoke.mockRejectedValue(new NakamaApiError("Not found", 404));
+    } else {
+      revoke.mockResolvedValue({ id: variables.shareId, revoked: true });
+    }
+
+    const mutate = renderMutation();
+    await expect(mutate()).resolves.toEqual({
+      id: variables.shareId,
+      revoked: status === 200,
+    });
+    expect(revoke).toHaveBeenCalledWith(variables.profileId, variables.shareId);
+    expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(true);
+  }
+);
+
+test.each([401, 403, 500])(
+  "revoke preserves HTTP %s failures rather than allowing rotation to continue",
+  async (status) => {
+    queryClient.setQueryData(queryKey, { active: true, id: variables.shareId });
+    const error = new NakamaApiError("Request failed", status);
+    revoke.mockRejectedValue(error);
+
+    const mutate = renderMutation();
+    await expect(mutate()).rejects.toBe(error);
+    expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(false);
+  }
+);

--- a/apps/web/src/hooks/use-resource-mutations.ts
+++ b/apps/web/src/hooks/use-resource-mutations.ts
@@ -607,14 +607,24 @@ export function useRevokeArtifactShareMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({
+    mutationFn: async ({
       profileId,
       shareId,
     }: {
       profileId: string;
       shareId: string;
       path?: string;
-    }) => client.revokeProfileArtifactShare(profileId, shareId),
+    }) => {
+      try {
+        return await client.revokeProfileArtifactShare(profileId, shareId);
+      } catch (error) {
+        // Another tab may have revoked this link; still clear stale share state.
+        if (error instanceof NakamaApiError && error.status === 404) {
+          return { id: shareId, revoked: false };
+        }
+        throw error;
+      }
+    },
     onSuccess: async (_data, variables) => {
       if (variables.path) {
         await queryClient.invalidateQueries({


### PR DESCRIPTION
## Summary

Rotate an already-revoked artifact link without getting stuck or disturbing a replacement link.

**Before:** a cached share ID returned 404, leaving rotation stuck and local sharing state stale.
**After:** 404 refreshes share status, clears the obsolete local link, and closes rotation with an already-revoked message; reopening sharing uses the current state.

Why safe:
1. Only revoke 404 is recovered; authentication, permission, and server errors still fail.
2. Stale rotation never publishes or revokes a replacement share; normal successful rotation still creates a link.

Concurrent revoke/publish remains non-atomic; if publishing returns no new URL, the UI asks users to reopen sharing rather than claiming a new link was created.

Fixes #573.

## Test plan
- [x] `bun test apps/web` (326 pass); targeted Ultracite check and `bun run knip` pass.
- [x] Isolated API + Vite with `agent-browser`: stale rotation closes with an already-revoked message and sends zero publish requests; old token returns 404 and replacement remains 200. Reopen and rotate normally: a new URL is displayed and returns 200.
- [ ] Full web typecheck: blocked by 21 pre-existing errors, previously reproduced on unchanged `origin/main` with the same dependencies; no diagnostics in the corrected files.
