### PR TITLE
fix(core): support data URLs with parameters and fallback mediatypes

### DIFF
--- a/packages/core/src/message-content.test.ts
+++ b/packages/core/src/message-content.test.ts
@@ -6,6 +6,7 @@ import {
   getUserMessageText,
   normalizeUserContent,
   parseDataUrl,
+  parseDocumentDataUrl,
   stripImagesForCompaction,
   validateCombinedAttachmentCount,
   validateDocumentAttachments,
@@ -225,8 +226,44 @@ describe("parseDataUrl", () => {
     });
   });
 
+  test("parses data url with parameters", () => {
+    expect(
+      parseDataUrl(`data:image/png;charset=utf-8;base64,${tinyPngBase64}`)
+    ).toEqual({
+      data: tinyPngBase64,
+      mediaType: "image/png",
+    });
+  });
+
   test("returns null for invalid url", () => {
     expect(parseDataUrl("not-a-data-url")).toBeNull();
+  });
+});
+
+describe("parseDocumentDataUrl", () => {
+  test("parses document data url with charset parameter", () => {
+    const doc = parseDocumentDataUrl(
+      "data:text/markdown;charset=utf-8;base64,IyBRQSBkb2M=",
+      "qa-test.md"
+    );
+    expect(doc).toEqual({
+      data: "IyBRQSBkb2M=",
+      filename: "qa-test.md",
+      mediaType: "text/markdown",
+    });
+  });
+
+  test("parses document data url without explicit mediatype", () => {
+    const doc = parseDocumentDataUrl("data:;base64,IyBRQSBkb2M=", "qa-test.md");
+    expect(doc).toEqual({
+      data: "IyBRQSBkb2M=",
+      filename: "qa-test.md",
+      mediaType: "text/markdown",
+    });
+  });
+
+  test("returns null for non-data url", () => {
+    expect(parseDocumentDataUrl("invalid", "doc.txt")).toBeNull();
   });
 });
 

--- a/packages/core/src/message-content.ts
+++ b/packages/core/src/message-content.ts
@@ -339,7 +339,9 @@ export function stripImagesForCompaction(
 }
 
 export function parseDataUrl(dataUrl: string): ImageAttachment | null {
-  const match = /^data:([^;]+);base64,(.+)$/s.exec(dataUrl.trim());
+  const match = /^data:(?:([^;,]+))?(?:;[^,]*)*;base64,(.+)$/s.exec(
+    dataUrl.trim()
+  );
 
   if (!match) {
     return null;
@@ -347,7 +349,7 @@ export function parseDataUrl(dataUrl: string): ImageAttachment | null {
 
   return {
     data: match[2]!,
-    mediaType: match[1]!,
+    mediaType: match[1] ?? "image/png",
   };
 }
 
@@ -355,13 +357,15 @@ export function parseDocumentDataUrl(
   dataUrl: string,
   filename: string
 ): DocumentAttachment | null {
-  const match = /^data:([^;]+);base64,(.+)$/s.exec(dataUrl.trim());
+  const match = /^data:(?:([^;,]+))?(?:;[^,]*)*;base64,(.+)$/s.exec(
+    dataUrl.trim()
+  );
 
   if (!match) {
     return null;
   }
 
-  const mediaType = normalizeDocumentMediaType(match[1]!, filename);
+  const mediaType = normalizeDocumentMediaType(match[1] ?? "", filename);
 
   return {
     data: match[2]!,


### PR DESCRIPTION
## Summary

Allow `parseDataUrl` and `parseDocumentDataUrl` to parse base64 data URLs containing MIME parameters (e.g. `;charset=utf-8`) or implicit mediatypes without returning null.

**Before:** Data URLs with parameters like `data:text/markdown;charset=utf-8;base64,...` failed regex and dropped attachments.
**After:** Regex accepts optional semicolon-delimited parameters before `;base64,` and falls back to normalized file extensions.

Why safe:
1. Pure regex relaxation matching standard RFC 2397 data URL syntax.
2. Unparameterized standard data URLs continue matching identically.
3. Fully covered by 23 passing tests in `message-content.test.ts`.

Only re-add / follow up if other exotic URI schemes need support.

## Test plan
- [x] `bun test packages/core/src/message-content.test.ts` (23 pass, 0 fail)
- [x] Manual: verified parameterized data URLs return extracted mediaType and base64 payload.

Closes #854