### PR TITLE
feat(providers): ChatGPT Plus/Pro via Codex OAuth

### DIFF
--- a/apps/server/src/http/routes/models.ts
+++ b/apps/server/src/http/routes/models.ts
@@ -1349,7 +1349,9 @@ export function registerModelRoutes(
 
     try {
       const chatgptOAuth = await completeChatgptOAuthDeviceSession(sessionId);
-      const models = await fetchChatgptCodexModels(chatgptOAuth);
+      const models = await fetchChatgptCodexModels(chatgptOAuth).catch(
+        () => []
+      );
       return json({ chatgptOAuth, models });
     } catch (error) {
       if (error instanceof NakamaApiError) {

--- a/apps/server/src/http/routes/models.ts
+++ b/apps/server/src/http/routes/models.ts
@@ -44,11 +44,12 @@ import {
   type WebSearchSettingsResponse,
   type WhatsAppSettingsResponse,
 } from "@nakama/core";
+import { installAgentBrowser } from "../../services/agent-browser-service";
 import {
   completeChatgptOAuthDeviceSession,
   startChatgptOAuthDeviceSession,
-} from "../../providers/chatgpt/oauth";
-import { installAgentBrowser } from "../../services/agent-browser-service";
+} from "../../services/chatgpt-oauth-service";
+
 import {
   getExternalModelCatalog,
   isExternalModelCatalogId,

--- a/apps/server/src/http/routes/models.ts
+++ b/apps/server/src/http/routes/models.ts
@@ -44,12 +44,12 @@ import {
   type WebSearchSettingsResponse,
   type WhatsAppSettingsResponse,
 } from "@nakama/core";
-import { installAgentBrowser } from "../../services/agent-browser-service";
 import {
   completeChatgptOAuthDeviceSession,
+  fetchChatgptCodexModels,
   startChatgptOAuthDeviceSession,
-} from "../../services/chatgpt-oauth-service";
-
+} from "../../providers/chatgpt/oauth";
+import { installAgentBrowser } from "../../services/agent-browser-service";
 import {
   getExternalModelCatalog,
   isExternalModelCatalogId,
@@ -1349,7 +1349,8 @@ export function registerModelRoutes(
 
     try {
       const chatgptOAuth = await completeChatgptOAuthDeviceSession(sessionId);
-      return json({ chatgptOAuth });
+      const models = await fetchChatgptCodexModels(chatgptOAuth);
+      return json({ chatgptOAuth, models });
     } catch (error) {
       if (error instanceof NakamaApiError) {
         return errorResponse(error.message, error.status);

--- a/apps/server/src/http/routes/models.ts
+++ b/apps/server/src/http/routes/models.ts
@@ -44,6 +44,10 @@ import {
   type WebSearchSettingsResponse,
   type WhatsAppSettingsResponse,
 } from "@nakama/core";
+import {
+  completeChatgptOAuthDeviceSession,
+  startChatgptOAuthDeviceSession,
+} from "../../providers/chatgpt/oauth";
 import { installAgentBrowser } from "../../services/agent-browser-service";
 import {
   getExternalModelCatalog,
@@ -1316,6 +1320,43 @@ export function registerModelRoutes(
     return json<DeleteProviderResponse>(
       await agent.deleteProvider(decodeURIComponent(c.req.param("providerId")))
     );
+  });
+
+  app.post("/v1/chatgpt-oauth/device/start", async (c) => {
+    requireOrgAdminOrPlatformAdminFromContext(c);
+
+    try {
+      return json(await startChatgptOAuthDeviceSession());
+    } catch (error) {
+      if (error instanceof NakamaApiError) {
+        return errorResponse(error.message, error.status);
+      }
+
+      const message = error instanceof Error ? error.message : String(error);
+      return errorResponse(message, 400);
+    }
+  });
+
+  app.post("/v1/chatgpt-oauth/device/complete", async (c) => {
+    requireOrgAdminOrPlatformAdminFromContext(c);
+    const body = await readJson<{ sessionId?: string }>(c.req.raw);
+    const sessionId = body.sessionId?.trim();
+
+    if (!sessionId) {
+      return errorResponse("sessionId is required.", 400);
+    }
+
+    try {
+      const chatgptOAuth = await completeChatgptOAuthDeviceSession(sessionId);
+      return json({ chatgptOAuth });
+    } catch (error) {
+      if (error instanceof NakamaApiError) {
+        return errorResponse(error.message, error.status);
+      }
+
+      const message = error instanceof Error ? error.message : String(error);
+      return errorResponse(message, 400);
+    }
   });
 
   app.put("/v1/settings/provider", async (c) => {

--- a/apps/server/src/providers/chatgpt/index.ts
+++ b/apps/server/src/providers/chatgpt/index.ts
@@ -61,7 +61,6 @@ export function createChatgptProvider(
       input,
       label: "ChatGPT",
       model,
-      store: false,
       stream,
       ...(handlers ? { handlers } : {}),
       supportsThinking: true,

--- a/apps/server/src/providers/chatgpt/index.ts
+++ b/apps/server/src/providers/chatgpt/index.ts
@@ -1,0 +1,82 @@
+import type {
+  ChatCompletionResult,
+  GenerateChatInput,
+  ProviderClient,
+  StreamChatHandlers,
+} from "@nakama/core";
+import {
+  type ChatgptOAuthCredentials,
+  chatgptOAuthNeedsRefresh,
+} from "@nakama/core";
+import { generateOpenAIResponsesChat } from "../openai/responses";
+import { CHATGPT_CODEX_BASE_URL, refreshChatgptOAuthToken } from "./oauth";
+
+export interface ChatgptProviderOptions {
+  getOAuth: () => ChatgptOAuthCredentials | null;
+  model: string;
+  onTokenRefresh?: (oauth: ChatgptOAuthCredentials) => Promise<void>;
+}
+
+async function resolveAccessToken(
+  options: ChatgptProviderOptions
+): Promise<ChatgptOAuthCredentials> {
+  const current = options.getOAuth();
+
+  if (!current) {
+    throw new Error(
+      "ChatGPT provider is not connected. Reconnect in Settings → LLM providers."
+    );
+  }
+
+  if (!chatgptOAuthNeedsRefresh(current)) {
+    return current;
+  }
+
+  const refreshed = await refreshChatgptOAuthToken(current.refreshToken);
+  await options.onTokenRefresh?.(refreshed);
+  return refreshed;
+}
+
+export function createChatgptProvider(
+  options: ChatgptProviderOptions
+): ProviderClient {
+  const model = options.model;
+
+  async function runChat(
+    input: GenerateChatInput,
+    stream: boolean,
+    handlers?: StreamChatHandlers
+  ): Promise<ChatCompletionResult> {
+    const oauth = await resolveAccessToken(options);
+
+    return generateOpenAIResponsesChat({
+      apiKey: oauth.accessToken,
+      baseUrl: CHATGPT_CODEX_BASE_URL,
+      extraHeaders: {
+        "ChatGPT-Account-ID": oauth.accountId,
+        "OpenAI-Beta": "responses=v1",
+        originator: "nakama",
+        version: "1.0.0",
+      },
+      input,
+      label: "ChatGPT",
+      model,
+      stream,
+      ...(handlers ? { handlers } : {}),
+      supportsThinking: true,
+    });
+  }
+
+  return {
+    generateChat(input) {
+      return runChat(input, false);
+    },
+    generateText() {
+      throw new Error("ChatGPT provider does not support generateText.");
+    },
+    name: "chatgpt",
+    streamChat(input, handlers) {
+      return runChat(input, true, handlers);
+    },
+  };
+}

--- a/apps/server/src/providers/chatgpt/index.ts
+++ b/apps/server/src/providers/chatgpt/index.ts
@@ -61,6 +61,7 @@ export function createChatgptProvider(
       input,
       label: "ChatGPT",
       model,
+      store: false,
       stream,
       ...(handlers ? { handlers } : {}),
       supportsThinking: true,

--- a/apps/server/src/providers/chatgpt/oauth.test.ts
+++ b/apps/server/src/providers/chatgpt/oauth.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  CHATGPT_JWT_CLAIM_PATH,
+  readChatgptAccountIdFromAccessToken,
+} from "./oauth";
+
+function buildJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(
+    JSON.stringify({ alg: "none", typ: "JWT" })
+  ).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.signature`;
+}
+
+describe("readChatgptAccountIdFromAccessToken", () => {
+  test("reads chatgpt_account_id from access token payload", () => {
+    const token = buildJwt({
+      [CHATGPT_JWT_CLAIM_PATH]: {
+        chatgpt_account_id: "acct_123",
+      },
+    });
+
+    expect(readChatgptAccountIdFromAccessToken(token)).toBe("acct_123");
+  });
+
+  test("returns null when claim is missing", () => {
+    expect(readChatgptAccountIdFromAccessToken(buildJwt({}))).toBeNull();
+  });
+});
+
+describe("completeChatgptDeviceAuth", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("exchanges device auth for oauth credentials", async () => {
+    const token = buildJwt({
+      [CHATGPT_JWT_CLAIM_PATH]: {
+        chatgpt_account_id: "acct_456",
+      },
+    });
+
+    globalThis.fetch = (async (input, init) => {
+      const url = String(input);
+
+      if (url.includes("/deviceauth/token")) {
+        return new Response(
+          JSON.stringify({
+            authorization_code: "auth-code",
+            code_verifier: "verifier",
+          }),
+          { status: 200 }
+        );
+      }
+
+      if (url.includes("/oauth/token")) {
+        expect(init?.method).toBe("POST");
+        return new Response(
+          JSON.stringify({
+            access_token: token,
+            expires_in: 3600,
+            refresh_token: "refresh-token",
+          }),
+          { status: 200 }
+        );
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const { completeChatgptDeviceAuth } = await import("./oauth");
+    const result = await completeChatgptDeviceAuth(
+      {
+        deviceAuthId: "device-auth-id",
+        intervalSeconds: 0,
+        userCode: "ABCD-1234",
+      },
+      { timeoutMs: 1000 }
+    );
+
+    expect(result.accountId).toBe("acct_456");
+    expect(result.refreshToken).toBe("refresh-token");
+    expect(result.accessToken).toBe(token);
+  });
+});

--- a/apps/server/src/providers/chatgpt/oauth.test.ts
+++ b/apps/server/src/providers/chatgpt/oauth.test.ts
@@ -13,6 +13,30 @@ function buildJwt(payload: Record<string, unknown>): string {
   return `${header}.${body}.signature`;
 }
 
+describe("fetchChatgptCodexModels", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("throws when Codex returns an error status", async () => {
+    globalThis.fetch = (async () =>
+      new Response("nope", { status: 403 })) as typeof fetch;
+
+    const { fetchChatgptCodexModels } = await import("./oauth");
+
+    await expect(
+      fetchChatgptCodexModels({
+        accessToken: "token",
+        accountId: "acct_1",
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        refreshToken: "refresh",
+      })
+    ).rejects.toThrow("ChatGPT models failed (403)");
+  });
+});
+
 describe("parseChatgptCodexModelsPayload", () => {
   test("reads slug, display name, and skips unsupported models", () => {
     expect(

--- a/apps/server/src/providers/chatgpt/oauth.test.ts
+++ b/apps/server/src/providers/chatgpt/oauth.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
   CHATGPT_JWT_CLAIM_PATH,
+  parseChatgptCodexModelsPayload,
   readChatgptAccountIdFromAccessToken,
 } from "./oauth";
 
@@ -11,6 +12,23 @@ function buildJwt(payload: Record<string, unknown>): string {
   const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
   return `${header}.${body}.signature`;
 }
+
+describe("parseChatgptCodexModelsPayload", () => {
+  test("reads slug, display name, and skips unsupported models", () => {
+    expect(
+      parseChatgptCodexModelsPayload({
+        models: [
+          { display_name: "GPT-5.4", slug: "gpt-5.4" },
+          { id: "hidden", supported_in_api: false },
+          { display_name: "GPT-5.4 mini", slug: "gpt-5.4-mini" },
+        ],
+      })
+    ).toEqual([
+      { id: "gpt-5.4", name: "GPT-5.4" },
+      { id: "gpt-5.4-mini", name: "GPT-5.4 mini" },
+    ]);
+  });
+});
 
 describe("readChatgptAccountIdFromAccessToken", () => {
   test("reads chatgpt_account_id from access token payload", () => {

--- a/apps/server/src/providers/chatgpt/oauth.ts
+++ b/apps/server/src/providers/chatgpt/oauth.ts
@@ -3,19 +3,18 @@ import type { ChatgptOAuthCredentials } from "@nakama/core";
 import { NakamaApiError } from "@nakama/core";
 import type { ChatgptOAuthDeviceStartResponse } from "@nakama/core/contract";
 
-export const CHATGPT_CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+const CHATGPT_CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 export const CHATGPT_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex";
-export const CHATGPT_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token";
-export const CHATGPT_DEVICE_USER_CODE_URL =
+const CHATGPT_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token";
+const CHATGPT_DEVICE_USER_CODE_URL =
   "https://auth.openai.com/api/accounts/deviceauth/usercode";
-export const CHATGPT_DEVICE_TOKEN_URL =
+const CHATGPT_DEVICE_TOKEN_URL =
   "https://auth.openai.com/api/accounts/deviceauth/token";
-export const CHATGPT_DEVICE_VERIFICATION_URI =
-  "https://auth.openai.com/codex/device";
-export const CHATGPT_DEVICE_REDIRECT_URI =
+const CHATGPT_DEVICE_VERIFICATION_URI = "https://auth.openai.com/codex/device";
+const CHATGPT_DEVICE_REDIRECT_URI =
   "https://auth.openai.com/deviceauth/callback";
 export const CHATGPT_JWT_CLAIM_PATH = "https://api.openai.com/auth";
-export const CHATGPT_DEVICE_CODE_TIMEOUT_MS = 15 * 60 * 1000;
+const CHATGPT_DEVICE_CODE_TIMEOUT_MS = 15 * 60 * 1000;
 
 export interface ChatgptDeviceAuthSession {
   deviceAuthId: string;
@@ -109,7 +108,7 @@ async function readTokenResponse(
   };
 }
 
-export async function startChatgptDeviceAuth(): Promise<ChatgptDeviceAuthSession> {
+async function startChatgptDeviceAuth(): Promise<ChatgptDeviceAuthSession> {
   const response = await fetch(CHATGPT_DEVICE_USER_CODE_URL, {
     body: JSON.stringify({ client_id: CHATGPT_CODEX_CLIENT_ID }),
     headers: { "Content-Type": "application/json" },
@@ -223,7 +222,7 @@ async function pollChatgptDeviceAuthOnce(
   };
 }
 
-export async function exchangeChatgptAuthorizationCode(
+async function exchangeChatgptAuthorizationCode(
   authorizationCode: string,
   codeVerifier: string,
   redirectUri: string

--- a/apps/server/src/providers/chatgpt/oauth.ts
+++ b/apps/server/src/providers/chatgpt/oauth.ts
@@ -293,29 +293,33 @@ export function parseChatgptCodexModelsPayload(
 export async function fetchChatgptCodexModels(
   oauth: ChatgptOAuthCredentials
 ): Promise<CustomModelEntry[]> {
-  try {
-    const response = await fetch(
-      `${CHATGPT_CODEX_BASE_URL}/models?client_version=1.0.0`,
-      {
-        headers: {
-          Accept: "application/json",
-          Authorization: `Bearer ${oauth.accessToken}`,
-          "ChatGPT-Account-ID": oauth.accountId,
-          "OpenAI-Beta": "responses=v1",
-          originator: "nakama",
-          version: "1.0.0",
-        },
-      }
-    );
-
-    if (!response.ok) {
-      return [];
+  const response = await fetch(
+    `${CHATGPT_CODEX_BASE_URL}/models?client_version=1.0.0`,
+    {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${oauth.accessToken}`,
+        "ChatGPT-Account-ID": oauth.accountId,
+        "OpenAI-Beta": "responses=v1",
+        originator: "codex_cli_rs",
+      },
     }
+  );
 
-    return parseChatgptCodexModelsPayload(await response.json());
-  } catch {
-    return [];
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(
+      `ChatGPT models failed (${response.status})${text ? `: ${text}` : ""}`
+    );
   }
+
+  const models = parseChatgptCodexModelsPayload(await response.json());
+
+  if (models.length === 0) {
+    throw new Error("ChatGPT returned no models for this account.");
+  }
+
+  return models;
 }
 
 export async function refreshChatgptOAuthToken(

--- a/apps/server/src/providers/chatgpt/oauth.ts
+++ b/apps/server/src/providers/chatgpt/oauth.ts
@@ -1,0 +1,337 @@
+import { randomUUID } from "node:crypto";
+import type { ChatgptOAuthCredentials } from "@nakama/core";
+import { NakamaApiError } from "@nakama/core";
+import type { ChatgptOAuthDeviceStartResponse } from "@nakama/core/contract";
+
+export const CHATGPT_CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+export const CHATGPT_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex";
+export const CHATGPT_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token";
+export const CHATGPT_DEVICE_USER_CODE_URL =
+  "https://auth.openai.com/api/accounts/deviceauth/usercode";
+export const CHATGPT_DEVICE_TOKEN_URL =
+  "https://auth.openai.com/api/accounts/deviceauth/token";
+export const CHATGPT_DEVICE_VERIFICATION_URI =
+  "https://auth.openai.com/codex/device";
+export const CHATGPT_DEVICE_REDIRECT_URI =
+  "https://auth.openai.com/deviceauth/callback";
+export const CHATGPT_JWT_CLAIM_PATH = "https://api.openai.com/auth";
+export const CHATGPT_DEVICE_CODE_TIMEOUT_MS = 15 * 60 * 1000;
+
+export interface ChatgptDeviceAuthSession {
+  deviceAuthId: string;
+  intervalSeconds: number;
+  userCode: string;
+}
+
+type DeviceTokenSuccess = {
+  authorizationCode: string;
+  codeVerifier: string;
+};
+
+type TokenResponseJson = {
+  access_token?: string;
+  expires_in?: number;
+  refresh_token?: string;
+};
+
+type JwtPayload = {
+  [CHATGPT_JWT_CLAIM_PATH]?: {
+    chatgpt_account_id?: string;
+  };
+};
+
+function decodeJwtPayload(token: string): JwtPayload | null {
+  try {
+    const parts = token.split(".");
+
+    if (parts.length !== 3) {
+      return null;
+    }
+
+    const payload = parts[1] ?? "";
+    const normalized = payload.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized.padEnd(
+      normalized.length + ((4 - (normalized.length % 4)) % 4),
+      "="
+    );
+    const decoded = Buffer.from(padded, "base64").toString("utf8");
+    return JSON.parse(decoded) as JwtPayload;
+  } catch {
+    return null;
+  }
+}
+
+export function readChatgptAccountIdFromAccessToken(
+  accessToken: string
+): string | null {
+  const payload = decodeJwtPayload(accessToken);
+  const accountId = payload?.[CHATGPT_JWT_CLAIM_PATH]?.chatgpt_account_id;
+  return typeof accountId === "string" && accountId.length > 0
+    ? accountId
+    : null;
+}
+
+async function readTokenResponse(
+  response: Response,
+  operation: "exchange" | "refresh"
+): Promise<ChatgptOAuthCredentials> {
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(
+      `ChatGPT OAuth token ${operation} failed (${response.status})${
+        text ? `: ${text}` : ""
+      }`
+    );
+  }
+
+  const json = (await response.json()) as TokenResponseJson;
+
+  if (
+    !(json.access_token && json.refresh_token) ||
+    typeof json.expires_in !== "number"
+  ) {
+    throw new Error(
+      `ChatGPT OAuth token ${operation} response missing fields.`
+    );
+  }
+
+  const accountId = readChatgptAccountIdFromAccessToken(json.access_token);
+
+  if (!accountId) {
+    throw new Error("ChatGPT OAuth token is missing chatgpt_account_id.");
+  }
+
+  return {
+    accessToken: json.access_token,
+    accountId,
+    expiresAt: new Date(Date.now() + json.expires_in * 1000).toISOString(),
+    refreshToken: json.refresh_token,
+  };
+}
+
+export async function startChatgptDeviceAuth(): Promise<ChatgptDeviceAuthSession> {
+  const response = await fetch(CHATGPT_DEVICE_USER_CODE_URL, {
+    body: JSON.stringify({ client_id: CHATGPT_CODEX_CLIENT_ID }),
+    headers: { "Content-Type": "application/json" },
+    method: "POST",
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(
+      `ChatGPT device auth start failed (${response.status})${
+        text ? `: ${text}` : ""
+      }`
+    );
+  }
+
+  const json = (await response.json()) as {
+    device_auth_id?: string;
+    interval?: number | string;
+    user_code?: string;
+  };
+  const intervalSeconds =
+    typeof json.interval === "string"
+      ? Number(json.interval.trim())
+      : json.interval;
+
+  if (
+    !(json.device_auth_id && json.user_code) ||
+    typeof intervalSeconds !== "number" ||
+    !Number.isFinite(intervalSeconds) ||
+    intervalSeconds < 0
+  ) {
+    throw new Error("ChatGPT device auth returned an invalid response.");
+  }
+
+  return {
+    deviceAuthId: json.device_auth_id,
+    intervalSeconds,
+    userCode: json.user_code,
+  };
+}
+
+async function pollChatgptDeviceAuthOnce(
+  device: ChatgptDeviceAuthSession
+): Promise<
+  | { status: "complete"; value: DeviceTokenSuccess }
+  | { status: "pending" }
+  | { status: "slow_down" }
+  | { status: "failed"; message: string }
+> {
+  const response = await fetch(CHATGPT_DEVICE_TOKEN_URL, {
+    body: JSON.stringify({
+      device_auth_id: device.deviceAuthId,
+      user_code: device.userCode,
+    }),
+    headers: { "Content-Type": "application/json" },
+    method: "POST",
+  });
+
+  if (response.ok) {
+    const json = (await response.json()) as {
+      authorization_code?: string;
+      code_verifier?: string;
+    };
+
+    if (!(json.authorization_code && json.code_verifier)) {
+      return {
+        message: "ChatGPT device auth returned an incomplete token response.",
+        status: "failed",
+      };
+    }
+
+    return {
+      status: "complete",
+      value: {
+        authorizationCode: json.authorization_code,
+        codeVerifier: json.code_verifier,
+      },
+    };
+  }
+
+  if (response.status === 403 || response.status === 404) {
+    return { status: "pending" };
+  }
+
+  const responseBody = await response.text().catch(() => "");
+  let errorCode: unknown;
+
+  try {
+    const json = JSON.parse(responseBody) as {
+      error?: string | { code?: string };
+    };
+    const error = json.error;
+    errorCode = typeof error === "object" ? error?.code : error;
+  } catch {
+    errorCode = undefined;
+  }
+
+  if (errorCode === "deviceauth_authorization_pending") {
+    return { status: "pending" };
+  }
+
+  if (errorCode === "slow_down") {
+    return { status: "slow_down" };
+  }
+
+  return {
+    message: `ChatGPT device auth failed (${response.status})${
+      responseBody ? `: ${responseBody}` : ""
+    }`,
+    status: "failed",
+  };
+}
+
+export async function exchangeChatgptAuthorizationCode(
+  authorizationCode: string,
+  codeVerifier: string,
+  redirectUri: string
+): Promise<ChatgptOAuthCredentials> {
+  const response = await fetch(CHATGPT_OAUTH_TOKEN_URL, {
+    body: new URLSearchParams({
+      client_id: CHATGPT_CODEX_CLIENT_ID,
+      code: authorizationCode,
+      code_verifier: codeVerifier,
+      grant_type: "authorization_code",
+      redirect_uri: redirectUri,
+    }),
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    method: "POST",
+  });
+
+  return readTokenResponse(response, "exchange");
+}
+
+export async function refreshChatgptOAuthToken(
+  refreshToken: string
+): Promise<ChatgptOAuthCredentials> {
+  const response = await fetch(CHATGPT_OAUTH_TOKEN_URL, {
+    body: new URLSearchParams({
+      client_id: CHATGPT_CODEX_CLIENT_ID,
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }),
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    method: "POST",
+  });
+
+  return readTokenResponse(response, "refresh");
+}
+
+export async function completeChatgptDeviceAuth(
+  device: ChatgptDeviceAuthSession,
+  options: {
+    signal?: AbortSignal;
+    timeoutMs?: number;
+  } = {}
+): Promise<ChatgptOAuthCredentials> {
+  const timeoutMs = options.timeoutMs ?? CHATGPT_DEVICE_CODE_TIMEOUT_MS;
+  const startedAt = Date.now();
+  let intervalMs = Math.max(device.intervalSeconds, 1) * 1000;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (options.signal?.aborted) {
+      throw new Error("ChatGPT sign-in was cancelled.");
+    }
+
+    const result = await pollChatgptDeviceAuthOnce(device);
+
+    if (result.status === "complete") {
+      return exchangeChatgptAuthorizationCode(
+        result.value.authorizationCode,
+        result.value.codeVerifier,
+        CHATGPT_DEVICE_REDIRECT_URI
+      );
+    }
+
+    if (result.status === "failed") {
+      throw new Error(result.message);
+    }
+
+    if (result.status === "slow_down") {
+      intervalMs = Math.min(intervalMs + 5000, 15_000);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  throw new Error("ChatGPT sign-in timed out. Try again.");
+}
+
+const deviceSessions = new Map<
+  string,
+  { createdAt: number; device: ChatgptDeviceAuthSession }
+>();
+
+export async function startChatgptOAuthDeviceSession(): Promise<ChatgptOAuthDeviceStartResponse> {
+  const device = await startChatgptDeviceAuth();
+  const sessionId = randomUUID();
+  deviceSessions.set(sessionId, { createdAt: Date.now(), device });
+
+  return {
+    intervalSeconds: device.intervalSeconds,
+    sessionId,
+    userCode: device.userCode,
+    verificationUri: CHATGPT_DEVICE_VERIFICATION_URI,
+  };
+}
+
+export async function completeChatgptOAuthDeviceSession(
+  sessionId: string
+): Promise<ChatgptOAuthCredentials> {
+  const session = deviceSessions.get(sessionId);
+
+  if (!session) {
+    throw new NakamaApiError(
+      "ChatGPT sign-in session expired. Start again.",
+      400
+    );
+  }
+
+  try {
+    return await completeChatgptDeviceAuth(session.device);
+  } finally {
+    deviceSessions.delete(sessionId);
+  }
+}

--- a/apps/server/src/providers/chatgpt/oauth.ts
+++ b/apps/server/src/providers/chatgpt/oauth.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type { ChatgptOAuthCredentials } from "@nakama/core";
+import type { ChatgptOAuthCredentials, CustomModelEntry } from "@nakama/core";
 import { NakamaApiError } from "@nakama/core";
 import type { ChatgptOAuthDeviceStartResponse } from "@nakama/core/contract";
 
@@ -240,6 +240,82 @@ async function exchangeChatgptAuthorizationCode(
   });
 
   return readTokenResponse(response, "exchange");
+}
+
+export function parseChatgptCodexModelsPayload(
+  payload: unknown
+): CustomModelEntry[] {
+  if (!payload || typeof payload !== "object") {
+    return [];
+  }
+
+  const record = payload as { models?: unknown };
+  const rows = Array.isArray(record.models) ? record.models : [];
+  const unique = new Map<string, CustomModelEntry>();
+
+  for (const row of rows) {
+    if (!row || typeof row !== "object") {
+      continue;
+    }
+
+    const item = row as {
+      display_name?: unknown;
+      id?: unknown;
+      slug?: unknown;
+      supported_in_api?: unknown;
+    };
+
+    if (item.supported_in_api === false) {
+      continue;
+    }
+
+    const id =
+      (typeof item.slug === "string" && item.slug.trim()) ||
+      (typeof item.id === "string" && item.id.trim()) ||
+      "";
+
+    if (!id || unique.has(id)) {
+      continue;
+    }
+
+    unique.set(id, {
+      id,
+      name:
+        typeof item.display_name === "string" && item.display_name.trim()
+          ? item.display_name.trim()
+          : id,
+    });
+  }
+
+  return [...unique.values()];
+}
+
+export async function fetchChatgptCodexModels(
+  oauth: ChatgptOAuthCredentials
+): Promise<CustomModelEntry[]> {
+  try {
+    const response = await fetch(
+      `${CHATGPT_CODEX_BASE_URL}/models?client_version=1.0.0`,
+      {
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${oauth.accessToken}`,
+          "ChatGPT-Account-ID": oauth.accountId,
+          "OpenAI-Beta": "responses=v1",
+          originator: "nakama",
+          version: "1.0.0",
+        },
+      }
+    );
+
+    if (!response.ok) {
+      return [];
+    }
+
+    return parseChatgptCodexModelsPayload(await response.json());
+  } catch {
+    return [];
+  }
 }
 
 export async function refreshChatgptOAuthToken(

--- a/apps/server/src/providers/compatible-models.test.ts
+++ b/apps/server/src/providers/compatible-models.test.ts
@@ -79,6 +79,25 @@ describe("getModelsForProviderInstance openai", () => {
   });
 });
 
+describe("getModelsForProviderInstance chatgpt", () => {
+  test("uses shortlist when custom models are saved", () => {
+    const models = getModelsForProviderInstance({
+      apiKey: "",
+      chatgptAccountId: "acct_1",
+      chatgptRefreshToken: "refresh",
+      createdAt: "2026-06-07T10:00:00.000Z",
+      customModels: [{ default: true, id: "gpt-5.4", name: "GPT-5.4" }],
+      id: "chatgpt-1",
+      label: "ChatGPT",
+      type: "chatgpt",
+    });
+
+    expect(models).toHaveLength(1);
+    expect(models[0]?.id).toBe("gpt-5.4");
+    expect(models[0]?.providerId).toBe("chatgpt-1");
+  });
+});
+
 describe("getModelsForProviderInstance opencode_go", () => {
   test("uses shortlist when custom models are saved", () => {
     const models = getModelsForProviderInstance({

--- a/apps/server/src/providers/compatible-models.ts
+++ b/apps/server/src/providers/compatible-models.ts
@@ -323,6 +323,7 @@ export function getModelsForProviderInstance(
 
   if (
     instance.type === "openai" ||
+    instance.type === "chatgpt" ||
     instance.type === "anthropic" ||
     instance.type === "gemini" ||
     instance.type === "deepseek" ||

--- a/apps/server/src/providers/create.ts
+++ b/apps/server/src/providers/create.ts
@@ -1,17 +1,21 @@
 import {
   apiKeyEnvVarForProvider,
   getActiveProviderInstance,
+  isChatgptProviderConnected,
   isOllamaCloudInstance,
   type ProviderClient,
   type ProviderInstance,
   type ProviderName,
+  readChatgptOAuthFromInstance,
   readEnvValue,
   type UserConfig,
 } from "@nakama/core";
+import type { ChatgptOAuthCredentials } from "@nakama/core/contract";
 import { defaultDiscoveryBaseUrl } from "@nakama/core/discovery-providers";
 import { resolveDefaultModelForInstance } from "../services/provider-instance-helpers";
 import { createAnthropicProvider } from "./anthropic";
 import { CEREBRAS_CHAT_BASE_URL } from "./cerebras";
+import { createChatgptProvider } from "./chatgpt";
 import { createCloudflareProvider } from "./cloudflare";
 import { compatibleModelSupportsThinking } from "./compatible-models";
 import { FIREWORKS_INFERENCE_BASE_URL } from "./fireworks";
@@ -176,11 +180,40 @@ export function readApiKeyForInstance(
   return readEnvValue(env, envVar);
 }
 
+export interface CreateProviderForInstanceOptions {
+  onChatgptTokenRefresh?: (
+    instanceId: string,
+    oauth: ChatgptOAuthCredentials
+  ) => Promise<void>;
+  resolveInstance?: (instanceId: string) => ProviderInstance | null;
+}
+
 export function createProviderForInstance(
   instance: ProviderInstance,
   model: string,
-  env: Record<string, string | undefined> = process.env
+  env: Record<string, string | undefined> = process.env,
+  options?: CreateProviderForInstanceOptions
 ): ProviderClient | null {
+  if (instance.type === "chatgpt") {
+    if (!isChatgptProviderConnected(instance)) {
+      return null;
+    }
+
+    return createChatgptProvider({
+      getOAuth: () => {
+        const latest = options?.resolveInstance?.(instance.id) ?? instance;
+        return readChatgptOAuthFromInstance(latest);
+      },
+      model,
+      ...(options?.onChatgptTokenRefresh
+        ? {
+            onTokenRefresh: (oauth) =>
+              options.onChatgptTokenRefresh!(instance.id, oauth),
+          }
+        : {}),
+    });
+  }
+
   const apiKey = readApiKeyForInstance(instance, env);
 
   if (

--- a/apps/server/src/providers/index.ts
+++ b/apps/server/src/providers/index.ts
@@ -1,5 +1,6 @@
 export * from "./anthropic";
 export * from "./cerebras";
+export * from "./chatgpt";
 export * from "./cloudflare";
 export * from "./compatible-models";
 export * from "./create";

--- a/apps/server/src/providers/models.ts
+++ b/apps/server/src/providers/models.ts
@@ -38,7 +38,52 @@ function withVisionDefaults(
   }));
 }
 
-export const AVAILABLE_MODELS: ProviderModelOption[] = withVisionDefaults([
+const CHATGPT_SHARED_MODEL_IDS = [
+  "gpt-5.4",
+  "gpt-5.5",
+  "gpt-5.6-luna",
+] as const;
+
+function deriveChatgptModels(
+  catalog: ProviderModelOption[]
+): ProviderModelOption[] {
+  const openaiById = new Map(
+    catalog
+      .filter((model) => model.provider === "openai")
+      .map((model) => [model.id, model])
+  );
+
+  const shared = CHATGPT_SHARED_MODEL_IDS.map((id) => {
+    const source = openaiById.get(id);
+
+    if (!source) {
+      throw new Error(`Missing OpenAI catalog model for ChatGPT: ${id}`);
+    }
+
+    return {
+      ...source,
+      default: id === "gpt-5.4",
+      inputPerMillionUsd: 0,
+      outputPerMillionUsd: 0,
+      provider: "chatgpt" as const,
+    };
+  });
+
+  return [
+    ...shared,
+    {
+      contextWindow: 128_000,
+      id: "gpt-5.4-mini",
+      inputPerMillionUsd: 0,
+      maxOutputTokens: 8192,
+      name: "GPT-5.4 mini",
+      outputPerMillionUsd: 0,
+      provider: "chatgpt" as const,
+    },
+  ];
+}
+
+const BASE_MODELS: ProviderModelOption[] = withVisionDefaults([
   {
     contextWindow: 200_000,
     default: true,
@@ -429,6 +474,11 @@ export const AVAILABLE_MODELS: ProviderModelOption[] = withVisionDefaults([
   },
 ]);
 
+export const AVAILABLE_MODELS: ProviderModelOption[] = [
+  ...BASE_MODELS,
+  ...deriveChatgptModels(BASE_MODELS),
+];
+
 export function validateOpenRouterCustomModels(
   entries: unknown
 ): CustomModelEntry[] {
@@ -675,7 +725,8 @@ export function resolveModel(
     (provider === "openai" ||
       provider === "anthropic" ||
       provider === "gemini" ||
-      provider === "opencode_go")
+      provider === "opencode_go" ||
+      provider === "chatgpt")
   ) {
     return trimmed;
   }

--- a/apps/server/src/providers/openai-responses-replay.test.ts
+++ b/apps/server/src/providers/openai-responses-replay.test.ts
@@ -88,4 +88,31 @@ describe("OpenAI Responses assistant replay", () => {
       type: "message",
     });
   });
+
+  test("includes store when set", async () => {
+    const fetchMock = mock(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/responses") && init?.body) {
+          const body = JSON.parse(String(init.body)) as { store?: boolean };
+          expect(body.store).toBe(false);
+        }
+        return new Response(JSON.stringify(RESPONSE_PAYLOAD), {
+          headers: { "Content-Type": "application/json" },
+          status: 200,
+        });
+      }
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await generateOpenAIResponsesChat({
+      apiKey: "sk-test",
+      input: { messages: [{ content: "hi", role: "user" }], system: "s" },
+      model: "gpt-5.4",
+      store: false,
+      stream: false,
+    });
+
+    expect(fetchMock).toHaveBeenCalled();
+  });
 });

--- a/apps/server/src/providers/openai-responses-replay.test.ts
+++ b/apps/server/src/providers/openai-responses-replay.test.ts
@@ -89,30 +89,25 @@ describe("OpenAI Responses assistant replay", () => {
     });
   });
 
-  test("includes store when set", async () => {
-    const fetchMock = mock(
-      async (input: RequestInfo | URL, init?: RequestInit) => {
-        const url = String(input);
-        if (url.endsWith("/responses") && init?.body) {
-          const body = JSON.parse(String(init.body)) as { store?: boolean };
-          expect(body.store).toBe(false);
-        }
+  test("sends store false", async () => {
+    let body: { store?: boolean } = {};
+    globalThis.fetch = mock(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        body = JSON.parse(String(init?.body)) as { store?: boolean };
         return new Response(JSON.stringify(RESPONSE_PAYLOAD), {
           headers: { "Content-Type": "application/json" },
           status: 200,
         });
       }
-    );
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    ) as unknown as typeof fetch;
 
     await generateOpenAIResponsesChat({
       apiKey: "sk-test",
       input: { messages: [{ content: "hi", role: "user" }], system: "s" },
       model: "gpt-5.4",
-      store: false,
       stream: false,
     });
 
-    expect(fetchMock).toHaveBeenCalled();
+    expect(body.store).toBe(false);
   });
 });

--- a/apps/server/src/providers/openai/responses.ts
+++ b/apps/server/src/providers/openai/responses.ts
@@ -39,6 +39,7 @@ export async function generateOpenAIResponsesChat(options: {
   customModels?: CustomModelEntry[];
   /** Asks the model for a JSON object, mirroring chat `response_format`. */
   jsonOutput?: boolean;
+  extraHeaders?: Record<string, string>;
   /**
    * Overrides the OpenAI model-id heuristic. Compatible endpoints serve model
    * ids the heuristic has never seen, and it answers false for those.
@@ -60,6 +61,7 @@ export async function generateOpenAIResponsesChat(options: {
     headers: {
       Authorization: `Bearer ${options.apiKey}`,
       "Content-Type": "application/json",
+      ...(options.extraHeaders ?? {}),
     },
     method: "POST",
     signal: options.input.signal,

--- a/apps/server/src/providers/openai/responses.ts
+++ b/apps/server/src/providers/openai/responses.ts
@@ -45,6 +45,8 @@ export async function generateOpenAIResponsesChat(options: {
    * ids the heuristic has never seen, and it answers false for those.
    */
   supportsThinking?: boolean;
+  /** ChatGPT Codex requires `false`. Omit for the OpenAI API default. */
+  store?: boolean;
 }): Promise<ChatCompletionResult> {
   const label = options.label ?? "OpenAI";
   const baseUrl = options.baseUrl ?? DEFAULT_OPENAI_RESPONSES_BASE_URL;
@@ -54,7 +56,8 @@ export async function generateOpenAIResponsesChat(options: {
     options.stream,
     options.customModels,
     options.supportsThinking,
-    options.jsonOutput
+    options.jsonOutput,
+    options.store
   );
   const response = await fetchWithoutIdleTimeout(`${baseUrl}/responses`, {
     body: JSON.stringify(body),
@@ -102,7 +105,8 @@ async function buildResponsesRequestBody(
   stream: boolean,
   customModels?: CustomModelEntry[],
   supportsThinking?: boolean,
-  jsonOutput?: boolean
+  jsonOutput?: boolean,
+  store?: boolean
 ) {
   const tools = buildResponsesTools(
     input.tools,
@@ -122,6 +126,7 @@ async function buildResponsesRequestBody(
     ),
     ...(jsonOutput ? { text: { format: { type: "json_object" } } } : {}),
     ...(stream ? { stream: true } : {}),
+    ...(store === undefined ? {} : { store }),
   };
 }
 

--- a/apps/server/src/providers/openai/responses.ts
+++ b/apps/server/src/providers/openai/responses.ts
@@ -45,8 +45,6 @@ export async function generateOpenAIResponsesChat(options: {
    * ids the heuristic has never seen, and it answers false for those.
    */
   supportsThinking?: boolean;
-  /** ChatGPT Codex requires `false`. Omit for the OpenAI API default. */
-  store?: boolean;
 }): Promise<ChatCompletionResult> {
   const label = options.label ?? "OpenAI";
   const baseUrl = options.baseUrl ?? DEFAULT_OPENAI_RESPONSES_BASE_URL;
@@ -56,8 +54,7 @@ export async function generateOpenAIResponsesChat(options: {
     options.stream,
     options.customModels,
     options.supportsThinking,
-    options.jsonOutput,
-    options.store
+    options.jsonOutput
   );
   const response = await fetchWithoutIdleTimeout(`${baseUrl}/responses`, {
     body: JSON.stringify(body),
@@ -105,8 +102,7 @@ async function buildResponsesRequestBody(
   stream: boolean,
   customModels?: CustomModelEntry[],
   supportsThinking?: boolean,
-  jsonOutput?: boolean,
-  store?: boolean
+  jsonOutput?: boolean
 ) {
   const tools = buildResponsesTools(
     input.tools,
@@ -117,6 +113,7 @@ async function buildResponsesRequestBody(
     input: await toResponsesInput(input.messages),
     instructions: input.system,
     model,
+    store: false,
     ...(tools.length > 0 ? { tools } : {}),
     ...buildOpenAIReasoningRequest(
       model,
@@ -126,7 +123,6 @@ async function buildResponsesRequestBody(
     ),
     ...(jsonOutput ? { text: { format: { type: "json_object" } } } : {}),
     ...(stream ? { stream: true } : {}),
-    ...(store === undefined ? {} : { store }),
   };
 }
 

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -112,6 +112,7 @@ import {
   buildThinkingProviderOptions,
   buildToolExecutionContext,
   buildUserContextStatus,
+  chatgptOAuthNeedsRefresh,
   composeKnowledgeBaseCatalog,
   composeSoulSystemPrompt,
   createErrorTrackingSink,
@@ -157,6 +158,7 @@ import {
   persistInlineAttachmentsInContent,
   readArtifactFile,
   readBundledSkillBody,
+  readChatgptOAuthFromInstance,
   readEnvValue,
   refreshErrorTrackingEnabled,
   regenerateDiscordHandshake,
@@ -204,6 +206,10 @@ import {
   getModelsForProviderInstance,
   isCostEstimated,
 } from "../providers";
+import {
+  fetchChatgptCodexModels,
+  refreshChatgptOAuthToken,
+} from "../providers/chatgpt/oauth";
 import { isAllowedImageGenerationSelection } from "../providers/models";
 import { wrapProviderForNonVision } from "../providers/non-vision-wrap";
 import { wrapProviderWithUsageTracking } from "../providers/usage-tracking";
@@ -2235,6 +2241,35 @@ export class AgentService {
         displayName: instance.label,
         models,
         provider: "fireworks",
+        providers: [],
+      };
+    }
+
+    if (instance.type === "chatgpt") {
+      let oauth = readChatgptOAuthFromInstance(instance);
+
+      if (!oauth) {
+        throw new NakamaApiError(
+          "Sign in with ChatGPT before discovering models.",
+          400
+        );
+      }
+
+      if (chatgptOAuthNeedsRefresh(oauth)) {
+        oauth = await refreshChatgptOAuthToken(oauth.refreshToken);
+        await this.persistChatgptOAuth(providerId, oauth);
+      }
+
+      const entries = await fetchChatgptCodexModels(oauth);
+      const models = catalogCustomModelsToCatalog(entries, [], "chatgpt");
+
+      return {
+        catalog: AVAILABLE_MODELS,
+        currentProviderId: providerId,
+        customModels: entries,
+        displayName: instance.label,
+        models,
+        provider: "chatgpt",
         providers: [],
       };
     }

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -18,6 +18,7 @@ import type {
   AssignToolRequest,
   BranchSessionResponse,
   ChatContextUsage,
+  ChatgptOAuthCredentials,
   ChatMessage,
   CloneProfileRequest,
   CompactionResponse,
@@ -106,6 +107,7 @@ import type {
 import {
   apiKeyEnvVarForProvider,
   appendOrgMemorySection,
+  applyChatgptOAuthToInstance,
   buildErrorReport,
   buildThinkingProviderOptions,
   buildToolExecutionContext,
@@ -2387,6 +2389,31 @@ export class AgentService {
     return { defaultProviderId };
   }
 
+  async persistChatgptOAuth(
+    providerId: string,
+    oauth: ChatgptOAuthCredentials
+  ): Promise<void> {
+    if (!this.userConfig) {
+      throw new Error("Provider is not configured.");
+    }
+
+    const current = findProviderInstance(this.userConfig, providerId);
+
+    if (!current || current.type !== "chatgpt") {
+      throw new Error("ChatGPT provider not found.");
+    }
+
+    const updated = applyChatgptOAuthToInstance(current, oauth);
+    this.userConfig = {
+      ...this.userConfig,
+      providers: this.userConfig.providers.map((instance) =>
+        instance.id === providerId ? updated : instance
+      ),
+    };
+    await saveUserConfig(this.userConfig);
+    this.refreshHarness();
+  }
+
   async getModels(
     options: { source?: "catalog" | "remote" } = {}
   ): Promise<ModelsResponse> {
@@ -3430,7 +3457,14 @@ export class AgentService {
 
         let visionProvider = createProviderForInstance(
           visionSelection.instance,
-          visionSelection.model
+          visionSelection.model,
+          process.env,
+          {
+            onChatgptTokenRefresh: (instanceId, oauth) =>
+              this.persistChatgptOAuth(instanceId, oauth),
+            resolveInstance: (instanceId) =>
+              findProviderInstance(this.userConfig, instanceId),
+          }
         );
 
         if (this.llmUsageTracker) {
@@ -3743,7 +3777,14 @@ export class AgentService {
 
     const provider = createProviderForInstance(
       resolved.instance,
-      resolved.model
+      resolved.model,
+      process.env,
+      {
+        onChatgptTokenRefresh: (instanceId, oauth) =>
+          this.persistChatgptOAuth(instanceId, oauth),
+        resolveInstance: (instanceId) =>
+          findProviderInstance(this.userConfig, instanceId),
+      }
     );
     const primarySupportsVision = resolvePrimaryModelVisionSupport(
       this.userConfig,

--- a/apps/server/src/services/chatgpt-oauth-service.ts
+++ b/apps/server/src/services/chatgpt-oauth-service.ts
@@ -1,0 +1,4 @@
+export {
+  completeChatgptOAuthDeviceSession,
+  startChatgptOAuthDeviceSession,
+} from "../providers/chatgpt/oauth";

--- a/apps/server/src/services/chatgpt-oauth-service.ts
+++ b/apps/server/src/services/chatgpt-oauth-service.ts
@@ -1,4 +1,0 @@
-export {
-  completeChatgptOAuthDeviceSession,
-  startChatgptOAuthDeviceSession,
-} from "../providers/chatgpt/oauth";

--- a/apps/server/src/services/provider-instance-helpers.test.ts
+++ b/apps/server/src/services/provider-instance-helpers.test.ts
@@ -397,4 +397,24 @@ describe("buildProviderInstanceFromCreateRequest", () => {
       )
     ).toThrow(/valid OpenAI API key/i);
   });
+
+  test("creates a chatgpt provider from oauth credentials", () => {
+    const instance = buildProviderInstanceFromCreateRequest(
+      {
+        apiKey: "",
+        chatgptOAuth: {
+          accessToken: "access",
+          accountId: "acct_1",
+          expiresAt: "2026-01-01T01:00:00.000Z",
+          refreshToken: "refresh",
+        },
+        type: "chatgpt",
+      },
+      []
+    );
+
+    expect(instance.type).toBe("chatgpt");
+    expect(instance.chatgptRefreshToken).toBe("refresh");
+    expect(instance.chatgptAccountId).toBe("acct_1");
+  });
 });

--- a/apps/server/src/services/provider-instance-helpers.ts
+++ b/apps/server/src/services/provider-instance-helpers.ts
@@ -309,6 +309,7 @@ export function applyProviderInstanceUpdate(
       next.customModels = validateOpenCodeGoCustomModels(request.customModels);
     } else if (
       instance.type === "openai" ||
+      instance.type === "chatgpt" ||
       instance.type === "anthropic" ||
       instance.type === "gemini" ||
       instance.type === "deepseek"

--- a/apps/server/src/services/provider-instance-helpers.ts
+++ b/apps/server/src/services/provider-instance-helpers.ts
@@ -1,9 +1,11 @@
 import {
+  applyChatgptOAuthToInstance,
   createProviderInstanceId,
   defaultOllamaBaseUrl,
   defaultOllamaLabel,
   findCustomModel,
   findProviderInstance,
+  isChatgptProviderConnected,
   isOllamaCloudInstance,
   isValidBaseUrl,
   NakamaApiError,
@@ -42,16 +44,22 @@ import {
   validateOpenCodeGoCustomModels,
   validateOpenRouterCustomModels,
 } from "../providers";
-import { createProviderForInstance } from "../providers/create";
+import {
+  type CreateProviderForInstanceOptions,
+  createProviderForInstance,
+} from "../providers/create";
 
 export function toProviderInstanceSummary(
   instance: ProviderInstance,
   modelCount: number
 ): ProviderInstanceSummary {
+  const chatgptConnected = isChatgptProviderConnected(instance);
+
   return {
     baseUrl: instance.baseUrl ?? null,
     hasApiKey:
       Boolean(instance.apiKey.trim()) ||
+      chatgptConnected ||
       instance.type === "openai_compatible" ||
       (instance.type === "ollama" && !isOllamaCloudInstance(instance)),
     hostMode:
@@ -178,8 +186,37 @@ export function buildProviderInstanceFromCreateRequest(
 
   const apiKey = request.apiKey?.trim() ?? "";
 
-  if (!apiKey && type !== "openai_compatible" && type !== "ollama") {
+  if (
+    !apiKey &&
+    type !== "openai_compatible" &&
+    type !== "ollama" &&
+    type !== "chatgpt"
+  ) {
     throw new NakamaApiError("API key is required.", 400);
+  }
+
+  if (type === "chatgpt") {
+    if (!request.chatgptOAuth) {
+      throw new NakamaApiError(
+        "Sign in with ChatGPT before saving this provider.",
+        400
+      );
+    }
+
+    const label = request.label?.trim()
+      ? validateProviderInstanceLabel(request.label, type)
+      : normalizeProviderInstanceLabel(type, "ChatGPT (Plus/Pro)", existing);
+
+    return applyChatgptOAuthToInstance(
+      {
+        apiKey: "",
+        createdAt: new Date().toISOString(),
+        id: createProviderInstanceId(),
+        label,
+        type,
+      },
+      request.chatgptOAuth
+    );
   }
 
   if (apiKey) {
@@ -230,6 +267,10 @@ export function applyProviderInstanceUpdate(
 
   if (request.apiKey !== undefined && request.apiKey.trim()) {
     next.apiKey = validateProviderApiKeyFormat(request.apiKey, instance.type);
+  }
+
+  if (request.chatgptOAuth && instance.type === "chatgpt") {
+    return applyChatgptOAuthToInstance(next, request.chatgptOAuth);
   }
 
   if (request.baseUrl !== undefined) {
@@ -579,7 +620,8 @@ export function resolveProfileProviderSelection(options: {
 export async function createProviderForProfile(
   db: DatabaseAdapter,
   profileId: string,
-  userConfig: UserConfig | null
+  userConfig: UserConfig | null,
+  options?: CreateProviderForInstanceOptions
 ): Promise<ProviderClient | null> {
   if (!userConfig) {
     return null;
@@ -601,5 +643,10 @@ export async function createProviderForProfile(
     return null;
   }
 
-  return createProviderForInstance(selection.instance, selection.model);
+  return createProviderForInstance(
+    selection.instance,
+    selection.model,
+    process.env,
+    options
+  );
 }

--- a/apps/web/src/components/CatalogProviderModelFields.tsx
+++ b/apps/web/src/components/CatalogProviderModelFields.tsx
@@ -88,7 +88,8 @@ export function CatalogProviderModelFields({
   const { data: modelsResponse } = useModelsQuery();
   const providerLabel = formatProviderLabel(provider);
   const canDiscoverRemote =
-    provider === "openai" && Boolean(providerInstanceId);
+    (provider === "openai" || provider === "chatgpt") &&
+    Boolean(providerInstanceId);
 
   const staticCatalog = useMemo(() => {
     const fromApi = filterModelsByProvider(
@@ -124,7 +125,7 @@ export function CatalogProviderModelFields({
     }
 
     return mergeBrowseModels(
-      staticCatalog,
+      provider === "chatgpt" ? [] : staticCatalog,
       remoteResponse?.models ?? [],
       provider
     );
@@ -152,9 +153,9 @@ export function CatalogProviderModelFields({
   };
 
   const browseFooter = remoteError
-    ? "Could not load models from OpenAI. Check the API key and try again."
+    ? `Could not load models from ${providerLabel}.`
     : remoteLoading
-      ? "Loading models from OpenAI…"
+      ? `Loading models from ${providerLabel}…`
       : `Choose which ${providerLabel} models appear in chat for this provider.`;
 
   return (

--- a/apps/web/src/components/ChatgptSignInPanel.tsx
+++ b/apps/web/src/components/ChatgptSignInPanel.tsx
@@ -1,0 +1,167 @@
+import type { ChatgptOAuthCredentials } from "@nakama/core/contract";
+import { useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { FormField } from "@/components/ui/form-field";
+import { Spinner } from "@/components/ui/spinner";
+import { client, formatError } from "@/lib/client";
+
+type ChatgptSignInPhase = "idle" | "waiting" | "connected" | "error";
+
+interface ChatgptSignInPanelProps {
+  density?: "default" | "compact";
+  disabled?: boolean;
+  oauth: ChatgptOAuthCredentials | null;
+  onOAuthChange: (oauth: ChatgptOAuthCredentials | null) => void;
+}
+
+export function ChatgptSignInPanel({
+  density = "default",
+  disabled = false,
+  oauth,
+  onOAuthChange,
+}: ChatgptSignInPanelProps) {
+  const [phase, setPhase] = useState<ChatgptSignInPhase>(
+    oauth ? "connected" : "idle"
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [userCode, setUserCode] = useState<string | null>(null);
+  const [verificationUri, setVerificationUri] = useState<string | null>(null);
+  const signInAbortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (oauth) {
+      setPhase("connected");
+      return;
+    }
+
+    setPhase("idle");
+  }, [oauth]);
+
+  useEffect(
+    () => () => {
+      signInAbortRef.current?.abort();
+    },
+    []
+  );
+
+  const startSignIn = async () => {
+    signInAbortRef.current?.abort();
+    const controller = new AbortController();
+    signInAbortRef.current = controller;
+
+    setError(null);
+    setPhase("waiting");
+    onOAuthChange(null);
+    setUserCode(null);
+    setVerificationUri(null);
+
+    try {
+      const start = await client.startChatgptOAuthDevice();
+      if (controller.signal.aborted) {
+        return;
+      }
+
+      setUserCode(start.userCode);
+      setVerificationUri(start.verificationUri);
+
+      const result = await client.completeChatgptOAuthDevice({
+        sessionId: start.sessionId,
+      });
+      if (controller.signal.aborted) {
+        return;
+      }
+
+      onOAuthChange(result.chatgptOAuth);
+      setPhase("connected");
+      setError(null);
+    } catch (err) {
+      if (controller.signal.aborted) {
+        return;
+      }
+
+      setPhase("error");
+      setError(formatError(err));
+    }
+  };
+
+  const cancelSignIn = () => {
+    signInAbortRef.current?.abort();
+    setPhase(oauth ? "connected" : "idle");
+    setUserCode(null);
+    setVerificationUri(null);
+  };
+
+  return (
+    <FormField
+      density={density}
+      footer={
+        error ? (
+          <p className="text-destructive text-sm" role="alert">
+            {error}
+          </p>
+        ) : (
+          <p className="text-muted-foreground text-xs">
+            One ChatGPT Plus/Pro account for this Nakama instance. Uses your
+            plan quota, not OpenAI API credits.
+          </p>
+        )
+      }
+      label="ChatGPT account"
+    >
+      {phase === "connected" ? (
+        <div className="flex flex-wrap items-center gap-2">
+          <p className="text-sm">Connected</p>
+          <Button
+            disabled={disabled}
+            onClick={() => {
+              onOAuthChange(null);
+              void startSignIn();
+            }}
+            type="button"
+            variant="outline"
+          >
+            Reconnect
+          </Button>
+        </div>
+      ) : phase === "waiting" ? (
+        <div className="space-y-3 rounded-md border p-3">
+          <p className="text-sm">
+            Open{" "}
+            <a
+              className="underline"
+              href={verificationUri ?? "https://auth.openai.com/codex/device"}
+              rel="noreferrer"
+              target="_blank"
+            >
+              auth.openai.com/codex/device
+            </a>{" "}
+            and enter this code:
+          </p>
+          <p className="font-mono text-lg tracking-widest">{userCode}</p>
+          <div className="flex flex-wrap gap-2">
+            <Button disabled type="button" variant="outline">
+              <Spinner className="mr-2" />
+              Waiting for sign-in…
+            </Button>
+            <Button
+              disabled={disabled}
+              onClick={cancelSignIn}
+              type="button"
+              variant="ghost"
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <Button
+          disabled={disabled}
+          onClick={() => void startSignIn()}
+          type="button"
+        >
+          Sign in with ChatGPT
+        </Button>
+      )}
+    </FormField>
+  );
+}

--- a/apps/web/src/components/ChatgptSignInPanel.tsx
+++ b/apps/web/src/components/ChatgptSignInPanel.tsx
@@ -1,4 +1,7 @@
-import type { ChatgptOAuthCredentials } from "@nakama/core/contract";
+import type {
+  ChatgptOAuthCredentials,
+  CustomModelEntry,
+} from "@nakama/core/contract";
 import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { FormField } from "@/components/ui/form-field";
@@ -7,10 +10,13 @@ import { client, formatError } from "@/lib/client";
 
 type ChatgptSignInFlow = "idle" | "waiting" | "error";
 
+const CHATGPT_DEVICE_LOGIN_URL = "https://auth.openai.com/codex/device";
+
 interface ChatgptSignInPanelProps {
   density?: "default" | "compact";
   disabled?: boolean;
   oauth: ChatgptOAuthCredentials | null;
+  onModelsChange?: (models: CustomModelEntry[]) => void;
   onOAuthChange: (oauth: ChatgptOAuthCredentials | null) => void;
 }
 
@@ -19,6 +25,7 @@ export function ChatgptSignInPanel({
   disabled = false,
   oauth,
   onOAuthChange,
+  onModelsChange,
 }: ChatgptSignInPanelProps) {
   const [flow, setFlow] = useState<ChatgptSignInFlow>("idle");
   const [error, setError] = useState<string | null>(null);
@@ -42,8 +49,10 @@ export function ChatgptSignInPanel({
     setError(null);
     setFlow("waiting");
     onOAuthChange(null);
+    onModelsChange?.([]);
     setUserCode(null);
     setVerificationUri(null);
+    window.open(CHATGPT_DEVICE_LOGIN_URL, "_blank", "noopener,noreferrer");
 
     try {
       const start = await client.startChatgptOAuthDevice();
@@ -62,6 +71,7 @@ export function ChatgptSignInPanel({
       }
 
       onOAuthChange(result.chatgptOAuth);
+      onModelsChange?.(result.models ?? []);
       setFlow("idle");
       setError(null);
     } catch (err) {
@@ -119,7 +129,7 @@ export function ChatgptSignInPanel({
             Open{" "}
             <a
               className="underline"
-              href={verificationUri ?? "https://auth.openai.com/codex/device"}
+              href={verificationUri ?? CHATGPT_DEVICE_LOGIN_URL}
               rel="noreferrer"
               target="_blank"
             >

--- a/apps/web/src/components/ChatgptSignInPanel.tsx
+++ b/apps/web/src/components/ChatgptSignInPanel.tsx
@@ -5,7 +5,7 @@ import { FormField } from "@/components/ui/form-field";
 import { Spinner } from "@/components/ui/spinner";
 import { client, formatError } from "@/lib/client";
 
-type ChatgptSignInPhase = "idle" | "waiting" | "connected" | "error";
+type ChatgptSignInFlow = "idle" | "waiting" | "error";
 
 interface ChatgptSignInPanelProps {
   density?: "default" | "compact";
@@ -20,22 +20,12 @@ export function ChatgptSignInPanel({
   oauth,
   onOAuthChange,
 }: ChatgptSignInPanelProps) {
-  const [phase, setPhase] = useState<ChatgptSignInPhase>(
-    oauth ? "connected" : "idle"
-  );
+  const [flow, setFlow] = useState<ChatgptSignInFlow>("idle");
   const [error, setError] = useState<string | null>(null);
   const [userCode, setUserCode] = useState<string | null>(null);
   const [verificationUri, setVerificationUri] = useState<string | null>(null);
   const signInAbortRef = useRef<AbortController | null>(null);
-
-  useEffect(() => {
-    if (oauth) {
-      setPhase("connected");
-      return;
-    }
-
-    setPhase("idle");
-  }, [oauth]);
+  const connected = Boolean(oauth) && flow !== "waiting";
 
   useEffect(
     () => () => {
@@ -50,7 +40,7 @@ export function ChatgptSignInPanel({
     signInAbortRef.current = controller;
 
     setError(null);
-    setPhase("waiting");
+    setFlow("waiting");
     onOAuthChange(null);
     setUserCode(null);
     setVerificationUri(null);
@@ -72,21 +62,21 @@ export function ChatgptSignInPanel({
       }
 
       onOAuthChange(result.chatgptOAuth);
-      setPhase("connected");
+      setFlow("idle");
       setError(null);
     } catch (err) {
       if (controller.signal.aborted) {
         return;
       }
 
-      setPhase("error");
+      setFlow("error");
       setError(formatError(err));
     }
   };
 
   const cancelSignIn = () => {
     signInAbortRef.current?.abort();
-    setPhase(oauth ? "connected" : "idle");
+    setFlow("idle");
     setUserCode(null);
     setVerificationUri(null);
   };
@@ -108,7 +98,7 @@ export function ChatgptSignInPanel({
       }
       label="ChatGPT account"
     >
-      {phase === "connected" ? (
+      {connected ? (
         <div className="flex flex-wrap items-center gap-2">
           <p className="text-sm">Connected</p>
           <Button
@@ -123,7 +113,7 @@ export function ChatgptSignInPanel({
             Reconnect
           </Button>
         </div>
-      ) : phase === "waiting" ? (
+      ) : flow === "waiting" ? (
         <div className="space-y-3 rounded-md border p-3">
           <p className="text-sm">
             Open{" "}

--- a/apps/web/src/components/OrgSwitcher.tsx
+++ b/apps/web/src/components/OrgSwitcher.tsx
@@ -1,6 +1,6 @@
 import type { UserOrgSummary } from "@nakama/core/contract";
 import { Add01Icon, ArrowDown01Icon, Edit03Icon } from "hugeicons-react";
-import { useEffect, useRef, useState } from "react";
+import { type ComponentProps, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -64,14 +64,16 @@ interface OrgSwitcherProps {
 }
 
 function OrgSwitcherTrigger({
+  className,
   collapsed,
   initial,
   label,
+  ...props
 }: {
   collapsed: boolean;
   initial: string;
   label: string;
-}) {
+} & ComponentProps<typeof Button>) {
   return (
     <Button
       aria-label={collapsed ? `Current organization: ${label}` : undefined}
@@ -79,11 +81,13 @@ function OrgSwitcherTrigger({
         "font-normal hover:bg-sidebar-accent/60 motion-reduce:transition-none",
         collapsed
           ? "sidebar-nav-link sidebar-nav-link--collapsed p-0"
-          : "h-auto w-full min-w-0 justify-start gap-2 px-2 py-1.5 text-left"
+          : "h-auto w-full min-w-0 justify-start gap-2 px-2 py-1.5 text-left",
+        className
       )}
       title={collapsed ? label : undefined}
       type="button"
       variant="ghost"
+      {...props}
     >
       {collapsed ? (
         <span className="flex size-8 items-center justify-center rounded-md bg-muted font-semibold text-foreground text-xs">

--- a/apps/web/src/components/ProviderSetupForm.tsx
+++ b/apps/web/src/components/ProviderSetupForm.tsx
@@ -2,6 +2,7 @@ import type { CreateProviderResponse } from "@nakama/core/contract";
 import { ollamaRequiresApiKey } from "@nakama/core/ollama-provider-config";
 import { ViewIcon, ViewOffIcon } from "hugeicons-react";
 import { useState } from "react";
+import { ChatgptSignInPanel } from "@/components/ChatgptSignInPanel";
 import { CustomProviderFields } from "@/components/CustomProviderFields";
 import { ModelsBrowseList } from "@/components/ModelsBrowseList";
 import { OllamaProviderModelFields } from "@/components/OllamaProviderModelFields";
@@ -53,8 +54,12 @@ export function ProviderSetupForm({
   const ollamaKeyRequired = ollamaRequiresApiKey(form.ollamaHostMode);
   const apiKeyOptional =
     form.selectedProvider === "openai_compatible" ||
+    form.selectedProvider === "chatgpt" ||
     (form.selectedProvider === "ollama" && !ollamaKeyRequired);
-  const canPickModels = apiKeyOptional || form.apiKey.trim().length > 0;
+  const canConnect =
+    form.selectedProvider === "chatgpt"
+      ? Boolean(form.chatgptOAuth)
+      : apiKeyOptional || form.apiKey.trim().length > 0;
 
   const formSpacing = density === "compact" ? "space-y-4" : "space-y-5";
 
@@ -111,7 +116,7 @@ export function ProviderSetupForm({
       ) : (
         <ProviderSetupDetails
           apiKeyOptional={apiKeyOptional}
-          canPickModels={canPickModels}
+          canConnect={canConnect}
           density={density}
           form={form}
           submitLabel={submitLabel}
@@ -219,15 +224,15 @@ function CloudflareAccountIdField({
 }
 
 function OpenRouterModelFields({
-  canPickModels,
+  canConnect,
   density,
   form,
 }: {
-  canPickModels: boolean;
+  canConnect: boolean;
   density: "default" | "compact";
   form: ReturnType<typeof useProviderSetupForm>;
 }) {
-  if (!canPickModels) {
+  if (!canConnect) {
     return null;
   }
 
@@ -243,11 +248,11 @@ function OpenRouterModelFields({
 }
 
 function OllamaSetupFields({
-  canPickModels,
+  canConnect,
   density,
   form,
 }: {
-  canPickModels: boolean;
+  canConnect: boolean;
   density: "default" | "compact";
   form: ReturnType<typeof useProviderSetupForm>;
 }) {
@@ -262,7 +267,7 @@ function OllamaSetupFields({
         onBaseUrlChange={form.setBaseUrl}
         onHostModeChange={form.handleOllamaHostModeChange}
       />
-      {canPickModels ? (
+      {canConnect ? (
         <OllamaProviderModelFields
           apiKey={form.apiKey}
           baseUrl={form.baseUrl}
@@ -279,15 +284,15 @@ function OllamaSetupFields({
 }
 
 function ShortlistModelFields({
-  canPickModels,
+  canConnect,
   density,
   form,
 }: {
-  canPickModels: boolean;
+  canConnect: boolean;
   density: "default" | "compact";
   form: ReturnType<typeof useProviderSetupForm>;
 }) {
-  if (!(canPickModels && isShortlistBrowseProvider(form.selectedProvider))) {
+  if (!(canConnect && isShortlistBrowseProvider(form.selectedProvider))) {
     return null;
   }
 
@@ -337,11 +342,11 @@ function DefaultModelSelectField({
 }
 
 function ProviderSetupExtraFields({
-  canPickModels,
+  canConnect,
   density,
   form,
 }: {
-  canPickModels: boolean;
+  canConnect: boolean;
   density: "default" | "compact";
   form: ReturnType<typeof useProviderSetupForm>;
 }) {
@@ -365,7 +370,7 @@ function ProviderSetupExtraFields({
         onCustomModelsChange={form.setCustomModels}
         onDisplayNameChange={form.setDisplayName}
         onWireApiChange={form.setWireApi}
-        showModelsEditor={canPickModels}
+        showModelsEditor={canConnect}
         wireApi={form.wireApi}
       />
     );
@@ -374,7 +379,7 @@ function ProviderSetupExtraFields({
   if (form.selectedProvider === "openrouter") {
     return (
       <OpenRouterModelFields
-        canPickModels={canPickModels}
+        canConnect={canConnect}
         density={density}
         form={form}
       />
@@ -384,7 +389,7 @@ function ProviderSetupExtraFields({
   if (form.selectedProvider === "ollama") {
     return (
       <OllamaSetupFields
-        canPickModels={canPickModels}
+        canConnect={canConnect}
         density={density}
         form={form}
       />
@@ -394,7 +399,7 @@ function ProviderSetupExtraFields({
   if (isShortlistBrowseProvider(form.selectedProvider)) {
     return (
       <ShortlistModelFields
-        canPickModels={canPickModels}
+        canConnect={canConnect}
         density={density}
         form={form}
       />
@@ -406,26 +411,35 @@ function ProviderSetupExtraFields({
 
 function ProviderSetupDetails({
   apiKeyOptional,
-  canPickModels,
+  canConnect,
   density,
   form,
   submitLabel,
 }: {
   apiKeyOptional: boolean;
-  canPickModels: boolean;
+  canConnect: boolean;
   density: "default" | "compact";
   form: ReturnType<typeof useProviderSetupForm>;
   submitLabel: string;
 }) {
   return (
     <>
-      <ProviderSetupApiKeyField
-        apiKeyOptional={apiKeyOptional}
-        density={density}
-        form={form}
-      />
+      {form.selectedProvider === "chatgpt" ? (
+        <ChatgptSignInPanel
+          density={density}
+          disabled={form.busy}
+          oauth={form.chatgptOAuth}
+          onOAuthChange={form.setChatgptOAuth}
+        />
+      ) : (
+        <ProviderSetupApiKeyField
+          apiKeyOptional={apiKeyOptional}
+          density={density}
+          form={form}
+        />
+      )}
       <ProviderSetupExtraFields
-        canPickModels={canPickModels}
+        canConnect={canConnect}
         density={density}
         form={form}
       />
@@ -435,10 +449,7 @@ function ProviderSetupDetails({
         </p>
       ) : null}
       <div className="flex flex-wrap gap-2 pt-1">
-        <Button
-          disabled={form.busy || !(apiKeyOptional || form.apiKey.trim())}
-          type="submit"
-        >
+        <Button disabled={form.busy || !canConnect} type="submit">
           {form.busy ? (
             <>
               <Spinner className="mr-2" />

--- a/apps/web/src/components/ProviderSetupForm.tsx
+++ b/apps/web/src/components/ProviderSetupForm.tsx
@@ -406,6 +406,10 @@ function ProviderSetupExtraFields({
     );
   }
 
+  if (form.selectedProvider === "chatgpt" && !canConnect) {
+    return null;
+  }
+
   return <DefaultModelSelectField density={density} form={form} />;
 }
 
@@ -429,6 +433,7 @@ function ProviderSetupDetails({
           density={density}
           disabled={form.busy}
           oauth={form.chatgptOAuth}
+          onModelsChange={form.handleChatgptModelsChange}
           onOAuthChange={form.setChatgptOAuth}
         />
       ) : (

--- a/apps/web/src/components/catalog-provider-model-fields.shared.ts
+++ b/apps/web/src/components/catalog-provider-model-fields.shared.ts
@@ -2,6 +2,7 @@ import type { SelectedProvider } from "@/lib/models";
 
 export const CATALOG_SHORTLIST_PROVIDERS = [
   "openai",
+  "chatgpt",
   "anthropic",
   "gemini",
   "deepseek",

--- a/apps/web/src/components/settings/provider-instance-card.tsx
+++ b/apps/web/src/components/settings/provider-instance-card.tsx
@@ -138,7 +138,15 @@ function ProviderInstanceTableRow({
             </ProviderActionButton>
           ) : null}
           <ProviderActionButton
-            label={instance.hasApiKey ? "Update key" : "Add key"}
+            label={
+              card.isChatgpt
+                ? instance.hasApiKey
+                  ? "Reconnect ChatGPT"
+                  : "Connect ChatGPT"
+                : instance.hasApiKey
+                  ? "Update key"
+                  : "Add key"
+            }
             onClick={() => card.setReplaceKeyOpen(true)}
           >
             <Key01Icon className="size-3.5" />
@@ -247,9 +255,11 @@ function ProviderInstanceCardDialogs({
       <ProviderReplaceKeyDialog
         apiKey={card.apiKey}
         busy={card.busy}
+        chatgptOAuth={card.chatgptOAuth}
         dialogError={card.dialogError}
         instance={instance}
         onApiKeyChange={card.setApiKey}
+        onChatgptOAuthChange={card.setChatgptOAuth}
         onOpenChange={card.setReplaceKeyOpen}
         onSave={() => void card.handleReplaceKey()}
         onToggleShowApiKey={() => card.setShowApiKey((current) => !current)}

--- a/apps/web/src/components/settings/provider-instance-dialogs.tsx
+++ b/apps/web/src/components/settings/provider-instance-dialogs.tsx
@@ -1,6 +1,11 @@
-import type { ProviderInstanceSummary, WireApi } from "@nakama/core/contract";
+import type {
+  ChatgptOAuthCredentials,
+  ProviderInstanceSummary,
+  WireApi,
+} from "@nakama/core/contract";
 import { ViewIcon, ViewOffIcon } from "hugeicons-react";
 import type { ReactNode } from "react";
+import { ChatgptSignInPanel } from "@/components/ChatgptSignInPanel";
 import { CustomProviderFields } from "@/components/CustomProviderFields";
 import type { ModelListRow } from "@/components/ModelListEditor";
 import { Button } from "@/components/ui/button";
@@ -27,10 +32,12 @@ export function ProviderReplaceKeyDialog({
   providerType,
   apiKey,
   showApiKey,
+  chatgptOAuth,
   busy,
   dialogError,
   onOpenChange,
   onApiKeyChange,
+  onChatgptOAuthChange,
   onToggleShowApiKey,
   onSave,
 }: {
@@ -39,41 +46,54 @@ export function ProviderReplaceKeyDialog({
   providerType: SelectedProvider;
   apiKey: string;
   showApiKey: boolean;
+  chatgptOAuth?: ChatgptOAuthCredentials | null;
   busy: boolean;
   dialogError: string | null;
   onOpenChange: (open: boolean) => void;
   onApiKeyChange: (value: string) => void;
+  onChatgptOAuthChange?: (oauth: ChatgptOAuthCredentials | null) => void;
   onToggleShowApiKey: () => void;
   onSave: () => void;
 }) {
+  const isChatgpt = providerType === "chatgpt";
+
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>
-            {instance.hasApiKey ? "Update API key" : "Add API key"} for{" "}
-            {instance.label}
+            {isChatgpt
+              ? `Reconnect ${instance.label}`
+              : `${instance.hasApiKey ? "Update API key" : "Add API key"} for ${instance.label}`}
           </DialogTitle>
         </DialogHeader>
-        <InputGroup>
-          <InputGroupInput
-            autoComplete="off"
+        {isChatgpt ? (
+          <ChatgptSignInPanel
             disabled={busy}
-            onChange={(event) => onApiKeyChange(event.target.value)}
-            placeholder={apiKeyPlaceholder(providerType)}
-            type={showApiKey ? "text" : "password"}
-            value={apiKey}
+            oauth={chatgptOAuth ?? null}
+            onOAuthChange={onChatgptOAuthChange ?? (() => {})}
           />
-          <InputGroupAddon align="inline-end">
-            <InputGroupButton
-              aria-label={showApiKey ? "Hide API key" : "Show API key"}
-              onClick={onToggleShowApiKey}
-              size="icon-sm"
-            >
-              {showApiKey ? <ViewOffIcon /> : <ViewIcon />}
-            </InputGroupButton>
-          </InputGroupAddon>
-        </InputGroup>
+        ) : (
+          <InputGroup>
+            <InputGroupInput
+              autoComplete="off"
+              disabled={busy}
+              onChange={(event) => onApiKeyChange(event.target.value)}
+              placeholder={apiKeyPlaceholder(providerType)}
+              type={showApiKey ? "text" : "password"}
+              value={apiKey}
+            />
+            <InputGroupAddon align="inline-end">
+              <InputGroupButton
+                aria-label={showApiKey ? "Hide API key" : "Show API key"}
+                onClick={onToggleShowApiKey}
+                size="icon-sm"
+              >
+                {showApiKey ? <ViewOffIcon /> : <ViewIcon />}
+              </InputGroupButton>
+            </InputGroupAddon>
+          </InputGroup>
+        )}
         {dialogError ? (
           <p className="text-destructive text-sm" role="alert">
             {dialogError}
@@ -89,7 +109,7 @@ export function ProviderReplaceKeyDialog({
             Cancel
           </Button>
           <Button
-            disabled={busy || !apiKey.trim()}
+            disabled={busy || (isChatgpt ? !chatgptOAuth : !apiKey.trim())}
             onClick={onSave}
             type="button"
           >

--- a/apps/web/src/components/settings/use-provider-instance-card.ts
+++ b/apps/web/src/components/settings/use-provider-instance-card.ts
@@ -1,4 +1,5 @@
 import type {
+  ChatgptOAuthCredentials,
   ProviderInstanceSummary,
   ProviderModelOption,
   UpdateProviderRequest,
@@ -53,6 +54,8 @@ export function useProviderInstanceCard({
   const [busy, setBusy] = useState(false);
   const [dialogError, setDialogError] = useState<string | null>(null);
   const [apiKey, setApiKey] = useState("");
+  const [chatgptOAuth, setChatgptOAuth] =
+    useState<ChatgptOAuthCredentials | null>(null);
   const [showApiKey, setShowApiKey] = useState(false);
   const [editLabel, setEditLabel] = useState("");
   const [editBaseUrl, setEditBaseUrl] = useState("");
@@ -60,6 +63,7 @@ export function useProviderInstanceCard({
   const [manageModels, setManageModels] = useState<ModelListRow[]>([]);
 
   const providerType = instance.type as SelectedProvider;
+  const isChatgpt = providerType === "chatgpt";
   const isOllama = providerType === "ollama";
   // Discovery providers (OpenAI-compatible, MiniMax, …) fetch model lists
   // live from the platform's /models endpoint, so their instances use the
@@ -144,6 +148,19 @@ export function useProviderInstanceCard({
   };
 
   const handleReplaceKey = async () => {
+    if (isChatgpt) {
+      if (!chatgptOAuth) {
+        setDialogError("Sign in with ChatGPT before saving.");
+        return;
+      }
+
+      await runUpdate({ chatgptOAuth }, () => {
+        setReplaceKeyOpen(false);
+        setChatgptOAuth(null);
+      });
+      return;
+    }
+
     const nextError = validateApiKeyForProvider(apiKey, providerType, {
       ollamaHostMode: instance.hostMode ?? undefined,
     });
@@ -237,6 +254,7 @@ export function useProviderInstanceCard({
     apiKey,
     busy,
     catalogModelsForType,
+    chatgptOAuth,
     deleteOpen,
     dialogError,
     editBaseUrl,
@@ -248,6 +266,7 @@ export function useProviderInstanceCard({
     handleManageModelsChange,
     handleReplaceKey,
     isCatalogShortlist,
+    isChatgpt,
     isCompatibleLike,
     isOllama,
     isOpenRouter,
@@ -261,6 +280,7 @@ export function useProviderInstanceCard({
     saveCompatible,
     saveManageModels,
     setApiKey,
+    setChatgptOAuth,
     setDeleteOpen,
     setEditBaseUrl,
     setEditLabel,

--- a/apps/web/src/hooks/use-provider-setup-form.ts
+++ b/apps/web/src/hooks/use-provider-setup-form.ts
@@ -1,5 +1,6 @@
 import { resolveCloudflareAccountInput } from "@nakama/core/cloudflare-provider-config";
 import type {
+  ChatgptOAuthCredentials,
   CreateProviderResponse,
   OllamaHostMode,
   ProviderModelOption,
@@ -96,6 +97,8 @@ export function useProviderSetupForm(
   const [modelsError, setModelsError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
+  const [chatgptOAuth, setChatgptOAuth] =
+    useState<ChatgptOAuthCredentials | null>(null);
 
   useEffect(() => {
     if (catalogQueryError) {
@@ -444,6 +447,11 @@ export function useProviderSetupForm(
         return;
       }
 
+      if (selectedProvider === "chatgpt" && !chatgptOAuth) {
+        setFormError("Sign in with ChatGPT before saving.");
+        return;
+      }
+
       const modelToSave =
         selectedProvider === "openrouter"
           ? resolveOpenRouterSetupModel(openRouterModels, selectedModel)
@@ -465,6 +473,7 @@ export function useProviderSetupForm(
           buildCreateProviderRequest({
             apiKey: trimmedKey,
             baseUrl: resolvedCloudflareBaseUrl ?? baseUrl,
+            chatgptOAuth: chatgptOAuth ?? undefined,
             customModels:
               selectedProvider === "openai_compatible" ||
               selectedProvider === "ollama"
@@ -497,6 +506,7 @@ export function useProviderSetupForm(
         setApiKey("");
         setApiKeyTouched(false);
         setShowApiKey(false);
+        setChatgptOAuth(null);
         setOpenRouterModels([]);
         setShortlistModels([]);
         setCustomModels([]);
@@ -511,6 +521,7 @@ export function useProviderSetupForm(
     [
       apiKey,
       baseUrl,
+      chatgptOAuth,
       openRouterModels,
       shortlistModels,
       ollamaHostMode,
@@ -534,6 +545,7 @@ export function useProviderSetupForm(
     baseUrlError,
     busy,
     catalog,
+    chatgptOAuth,
     configuredTypes,
     customModels,
     displayName,
@@ -558,6 +570,7 @@ export function useProviderSetupForm(
     selectedModel,
     selectedProvider,
     setBaseUrl,
+    setChatgptOAuth,
     setCustomModels,
     setDisplayName,
     setSelectedModel,

--- a/apps/web/src/hooks/use-provider-setup-form.ts
+++ b/apps/web/src/hooks/use-provider-setup-form.ts
@@ -2,6 +2,7 @@ import { resolveCloudflareAccountInput } from "@nakama/core/cloudflare-provider-
 import type {
   ChatgptOAuthCredentials,
   CreateProviderResponse,
+  CustomModelEntry,
   OllamaHostMode,
   ProviderModelOption,
   WireApi,
@@ -92,6 +93,7 @@ export function useProviderSetupForm(
   const [wireApi, setWireApi] = useState<WireApi>("chat");
   const [customModels, setCustomModels] = useState<ModelListRow[]>([]);
   const [extraModels, setExtraModels] = useState<ProviderModelOption[]>([]);
+  const [chatgptModels, setChatgptModels] = useState<ProviderModelOption[]>([]);
   const [displayNameError, setDisplayNameError] = useState<string | null>(null);
   const [baseUrlError, setBaseUrlError] = useState<string | null>(null);
   const [modelsError, setModelsError] = useState<string | null>(null);
@@ -136,6 +138,10 @@ export function useProviderSetupForm(
       return modelsFromShortlistRows(selectedProvider, shortlistModels);
     }
 
+    if (selectedProvider === "chatgpt" && chatgptModels.length > 0) {
+      return chatgptModels;
+    }
+
     const catalogModels = filterModelsByProvider(catalog, selectedProvider);
     const catalogIds = new Set(catalogModels.map((model) => model.id));
     const extras = extraModels.filter(
@@ -150,6 +156,7 @@ export function useProviderSetupForm(
     openRouterModels,
     shortlistModels,
     extraModels,
+    chatgptModels,
   ]);
 
   const ollamaApiKeyOptions = useMemo(
@@ -242,8 +249,27 @@ export function useProviderSetupForm(
         setBaseUrl("");
         setCustomModels([]);
       }
+
+      if (provider !== "chatgpt") {
+        setChatgptOAuth(null);
+        setChatgptModels([]);
+      }
     },
     [configuredTypes]
+  );
+
+  const handleChatgptModelsChange = useCallback(
+    (entries: CustomModelEntry[]) => {
+      setChatgptModels(
+        entries.map((entry, index) => ({
+          default: entry.default === true || index === 0,
+          id: entry.id,
+          name: entry.name?.trim() || entry.id,
+          provider: "chatgpt" as const,
+        }))
+      );
+    },
+    []
   );
 
   const selectOpenRouterModel = useCallback(
@@ -507,6 +533,7 @@ export function useProviderSetupForm(
         setApiKeyTouched(false);
         setShowApiKey(false);
         setChatgptOAuth(null);
+        setChatgptModels([]);
         setOpenRouterModels([]);
         setShortlistModels([]);
         setCustomModels([]);
@@ -557,6 +584,7 @@ export function useProviderSetupForm(
     handleApiKeyBlur,
     handleApiKeyChange,
     handleBrowseSelect,
+    handleChatgptModelsChange,
     handleOllamaHostModeChange,
     handleOpenRouterModelsChange,
     handleProviderSelect,

--- a/apps/web/src/lib/models.test.ts
+++ b/apps/web/src/lib/models.test.ts
@@ -298,12 +298,13 @@ describe("firstAvailableProviderOption", () => {
 
   test("falls through to the next free builtin, then custom", () => {
     expect(firstAvailableProviderOption(new Set(["openai"]), "openai")).toBe(
-      "anthropic"
+      "chatgpt"
     );
     expect(
       firstAvailableProviderOption(
         new Set([
           "openai",
+          "chatgpt",
           "anthropic",
           "openrouter",
           "gemini",

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -55,6 +55,7 @@ export function formatProviderLabel(
     provider === "ollama" ||
     provider === "openai_compatible" ||
     provider === "opencode_go" ||
+    provider === "chatgpt" ||
     provider === "minimax" ||
     provider === "minimax_cn" ||
     provider === "zhipu" ||
@@ -70,6 +71,7 @@ export function formatProviderLabel(
 export const PROVIDER_OPTIONS: Array<{ id: SelectedProvider; label: string }> =
   [
     { id: "openai", label: "OpenAI" },
+    { id: "chatgpt", label: "ChatGPT (Plus/Pro)" },
     { id: "anthropic", label: "Anthropic" },
     { id: "openrouter", label: "OpenRouter" },
     { id: "gemini", label: "Gemini" },
@@ -187,6 +189,10 @@ export function apiKeyPlaceholder(provider: SelectedProvider): string {
     return "Optional for local Ollama";
   }
 
+  if (provider === "chatgpt") {
+    return "Use Sign in with ChatGPT";
+  }
+
   if (provider === "gemini") {
     return "AIza…";
   }
@@ -208,6 +214,10 @@ export function validateApiKeyForProvider(
   options?: { ollamaHostMode?: OllamaHostMode }
 ): string | null {
   if (provider === "openai_compatible") {
+    return null;
+  }
+
+  if (provider === "chatgpt") {
     return null;
   }
 
@@ -578,12 +588,14 @@ export function buildCreateProviderRequest(options: {
   hostMode?: OllamaHostMode;
   customModels?: ConfigureProviderRequest["customModels"];
   wireApi?: WireApi;
+  chatgptOAuth?: CreateProviderRequest["chatgptOAuth"];
 }): CreateProviderRequest {
   const request = buildConfigureProviderRequest(options);
 
   return {
     apiKey: request.apiKey,
     type: request.provider,
+    ...(options.chatgptOAuth ? { chatgptOAuth: options.chatgptOAuth } : {}),
     ...(request.model ? { model: request.model } : {}),
     ...(options.displayName?.trim()
       ? { label: options.displayName.trim() }

--- a/docs/website/content/docs/providers.mdx
+++ b/docs/website/content/docs/providers.mdx
@@ -26,6 +26,7 @@ Nakama supports these built-in provider types:
 | Provider | Notes |
 |---|---|
 | OpenAI | GPT models; required for OpenAI audio transcription (Telegram voice notes) |
+| ChatGPT (Plus/Pro) | Sign in with ChatGPT; uses your plan quota via Codex (not API credits). One account per Nakama instance |
 | Anthropic | Claude models |
 | OpenRouter | Route to many models through one API key |
 | Gemini | Google Gemini models |
@@ -43,8 +44,8 @@ Most built-in types allow one configured instance each. **Ollama** and **Custom 
 
 Some capabilities depend on the active provider:
 
-- **Web search** (`web_search` tool) — OpenAI or Anthropic with a valid API key; not available on OpenRouter. Configure a custom back-end (Exa, Firecrawl, or any JSON search endpoint) in **Settings → Web search** to lift this restriction
-- **Audio transcription** (Telegram voice notes) — requires an OpenAI provider and a transcription model in **Settings → Audio transcription model**
+- **Web search** (`web_search` tool) — OpenAI or Anthropic with a valid API key; not available on OpenRouter or ChatGPT (Plus/Pro). Configure a custom back-end (Exa, Firecrawl, or any JSON search endpoint) in **Settings → Web search** to lift this restriction
+- **Audio transcription** (Telegram voice notes) — requires an OpenAI provider and a transcription model in **Settings → Audio transcription model** (ChatGPT Plus/Pro cannot replace this)
 - **Image parsing** — used when the chat model cannot see images. Set **Settings → Image parsing model**. The list only includes models marked as vision-capable. For a custom endpoint, turn **Vision** on for that model under **Settings → LLM providers**
 - **Responses API endpoints**: a custom endpoint that serves `/responses` rather than `/chat/completions`. Set **API** to Responses under **Settings → LLM providers**, or answer `responses` in the CLI setup wizard. Required for endpoints that do not serve chat/completions at all, and it keeps reasoning available alongside tools on models that reject the pair on chat/completions
 - **Coding agent provider passthrough** — spawn-time credentials for Claude Code / Codex / OpenCode; see [Coding agent](/coding-agent)
@@ -54,6 +55,15 @@ Some capabilities depend on the active provider:
 Each profile selects its own model from the configured providers. Two profiles in the same org can use different providers or models.
 
 Platform admins manage provider credentials globally. Org members use the models assigned to their profiles.
+
+## ChatGPT (Plus/Pro)
+
+ChatGPT Plus/Pro is **not** an OpenAI API key. In **Settings → LLM providers**, choose **ChatGPT (Plus/Pro)**, click **Sign in with ChatGPT**, open the device link, enter the code, then save.
+
+- One ChatGPT account covers the whole Nakama instance (operator use, not per-user login)
+- Usage comes from your ChatGPT plan quota, not pay-as-you-go API billing
+- Whisper transcription and image generation still need a regular OpenAI API key provider
+- Coding-agent provider passthrough does not apply to this provider type — use **Integrations → Coding agents → harness login** with `codex login` for Codex CLI subscription use
 
 ## Next steps
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -26,6 +26,9 @@ import type {
   BranchSessionRequest,
   BranchSessionResponse,
   ChangePasswordRequest,
+  ChatgptOAuthDeviceCompleteRequest,
+  ChatgptOAuthDeviceCompleteResponse,
+  ChatgptOAuthDeviceStartResponse,
   CloneProfileRequest,
   CodingHarnessSettingsResponse,
   CompactionResponse,
@@ -564,6 +567,25 @@ export class NakamaClient {
     return this.request<DeleteProviderResponse>(
       `/v1/providers/${encodeURIComponent(providerId)}`,
       { method: "DELETE" }
+    );
+  }
+
+  async startChatgptOAuthDevice(): Promise<ChatgptOAuthDeviceStartResponse> {
+    return this.request<ChatgptOAuthDeviceStartResponse>(
+      "/v1/chatgpt-oauth/device/start",
+      { method: "POST" }
+    );
+  }
+
+  async completeChatgptOAuthDevice(
+    request: ChatgptOAuthDeviceCompleteRequest
+  ): Promise<ChatgptOAuthDeviceCompleteResponse> {
+    return this.request<ChatgptOAuthDeviceCompleteResponse>(
+      "/v1/chatgpt-oauth/device/complete",
+      {
+        body: JSON.stringify(request),
+        method: "POST",
+      }
     );
   }
 

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -2241,6 +2241,7 @@ export interface ChatgptOAuthDeviceCompleteRequest {
 
 export interface ChatgptOAuthDeviceCompleteResponse {
   chatgptOAuth: ChatgptOAuthCredentials;
+  models?: CustomModelEntry[];
 }
 
 export type OllamaHostMode = "local" | "cloud";

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -1659,6 +1659,7 @@ export interface ListProvidersResponse {
 export interface CreateProviderRequest {
   apiKey: string;
   baseUrl?: string;
+  chatgptOAuth?: ChatgptOAuthCredentials;
   customModels?: CustomModelEntry[];
   hostMode?: OllamaHostMode;
   label?: string;
@@ -1676,6 +1677,7 @@ export interface CreateProviderResponse {
 export interface UpdateProviderRequest {
   apiKey?: string;
   baseUrl?: string;
+  chatgptOAuth?: ChatgptOAuthCredentials;
   customModels?: CustomModelEntry[];
   hostMode?: OllamaHostMode;
   label?: string;
@@ -2212,11 +2214,34 @@ export type ProviderName =
   | "openai_compatible"
   | "opencode_go"
   | "cloudflare"
+  | "chatgpt"
   | "minimax"
   | "minimax_cn"
   | "zhipu"
   | "zhipu_cn"
   | "xai";
+
+export interface ChatgptOAuthCredentials {
+  accessToken: string;
+  accountId: string;
+  expiresAt: string;
+  refreshToken: string;
+}
+
+export interface ChatgptOAuthDeviceStartResponse {
+  intervalSeconds: number;
+  sessionId: string;
+  userCode: string;
+  verificationUri: string;
+}
+
+export interface ChatgptOAuthDeviceCompleteRequest {
+  sessionId: string;
+}
+
+export interface ChatgptOAuthDeviceCompleteResponse {
+  chatgptOAuth: ChatgptOAuthCredentials;
+}
 
 export type OllamaHostMode = "local" | "cloud";
 

--- a/packages/core/src/provider-label.ts
+++ b/packages/core/src/provider-label.ts
@@ -6,6 +6,7 @@ const BUILTIN_LABELS: Record<
 > = {
   anthropic: "Anthropic",
   cerebras: "Cerebras",
+  chatgpt: "ChatGPT (Plus/Pro)",
   cloudflare: "Cloudflare Worker AI",
   deepseek: "DeepSeek",
   fireworks: "Fireworks",

--- a/packages/core/src/provider-resolution.test.ts
+++ b/packages/core/src/provider-resolution.test.ts
@@ -9,6 +9,7 @@ import {
 describe("parseProviderName", () => {
   test("accepts known providers", () => {
     expect(parseProviderName("openai")).toBe("openai");
+    expect(parseProviderName("chatgpt")).toBe("chatgpt");
     expect(parseProviderName("Anthropic")).toBe("anthropic");
     expect(parseProviderName(" GEMINI ")).toBe("gemini");
     expect(parseProviderName("openai_compatible")).toBe("openai_compatible");

--- a/packages/core/src/provider-resolution.ts
+++ b/packages/core/src/provider-resolution.ts
@@ -15,6 +15,7 @@ export const USER_PROVIDER_NAMES: readonly UserProviderName[] = [
   "openai_compatible",
   "opencode_go",
   "cloudflare",
+  "chatgpt",
   "minimax",
   "minimax_cn",
   "zhipu",
@@ -45,6 +46,7 @@ export function parseProviderName(
     normalized === "openai_compatible" ||
     normalized === "opencode_go" ||
     normalized === "cloudflare" ||
+    normalized === "chatgpt" ||
     normalized === "minimax" ||
     normalized === "minimax_cn" ||
     normalized === "zhipu" ||

--- a/packages/core/src/user-config.test.ts
+++ b/packages/core/src/user-config.test.ts
@@ -5,12 +5,16 @@ import { join } from "node:path";
 import { NakamaApiError } from "./api-error";
 import { pathExists } from "./fs";
 import {
+  applyChatgptOAuthToInstance,
+  chatgptOAuthNeedsRefresh,
   createProviderInstanceId,
   ensureUserConfigDir,
   getUserConfigPath,
+  isChatgptProviderConnected,
   loadUserConfig,
   loadUserWebPublicUrl,
   normalizeProviderInstanceLabel,
+  readChatgptOAuthFromInstance,
   saveUserConfig,
   saveUserTimezone,
   saveUserWebPublicUrl,
@@ -279,5 +283,71 @@ created_at=2026-06-15T00:00:00.000Z
     await expect(loadUserWebPublicUrl()).resolves.toBe(
       "https://gateway.devscale.id/v1"
     );
+  });
+});
+
+describe("chatgpt oauth helpers", () => {
+  test("isChatgptProviderConnected requires refresh token and account id", () => {
+    expect(
+      isChatgptProviderConnected({
+        apiKey: "",
+        chatgptAccountId: "acct_1",
+        chatgptRefreshToken: "refresh",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        id: "chatgpt-1",
+        label: "ChatGPT",
+        type: "chatgpt",
+      })
+    ).toBe(true);
+  });
+
+  test("readChatgptOAuthFromInstance returns null when fields are missing", () => {
+    expect(
+      readChatgptOAuthFromInstance({
+        apiKey: "",
+        chatgptRefreshToken: "refresh",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        id: "chatgpt-1",
+        label: "ChatGPT",
+        type: "chatgpt",
+      })
+    ).toBeNull();
+  });
+
+  test("applyChatgptOAuthToInstance stores oauth fields and clears api key", () => {
+    const updated = applyChatgptOAuthToInstance(
+      {
+        apiKey: "sk-old",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        id: "chatgpt-1",
+        label: "ChatGPT",
+        type: "chatgpt",
+      },
+      {
+        accessToken: "access",
+        accountId: "acct_1",
+        expiresAt: "2026-01-02T00:00:00.000Z",
+        refreshToken: "refresh",
+      }
+    );
+
+    expect(updated.apiKey).toBe("");
+    expect(updated.chatgptAccountId).toBe("acct_1");
+  });
+
+  test("chatgptOAuthNeedsRefresh is true within five minutes of expiry", () => {
+    const expiresAt = new Date("2026-01-01T00:04:00.000Z").toISOString();
+
+    expect(
+      chatgptOAuthNeedsRefresh(
+        {
+          accessToken: "access",
+          accountId: "acct_1",
+          expiresAt,
+          refreshToken: "refresh",
+        },
+        Date.parse("2026-01-01T00:00:00.000Z")
+      )
+    ).toBe(true);
   });
 });

--- a/packages/core/src/user-config.ts
+++ b/packages/core/src/user-config.ts
@@ -11,6 +11,7 @@ import {
   validateDisplayName,
 } from "./compatible-provider-config";
 import type {
+  ChatgptOAuthCredentials,
   CustomModelEntry,
   ProviderChatOptions,
   ThinkingEffort,
@@ -43,6 +44,10 @@ export {
 export interface ProviderInstance {
   apiKey: string;
   baseUrl?: string;
+  chatgptAccessToken?: string;
+  chatgptAccountId?: string;
+  chatgptRefreshToken?: string;
+  chatgptTokenExpiresAt?: string;
   createdAt: string;
   customModels?: CustomModelEntry[];
   hostMode?: import("./contract").OllamaHostMode;
@@ -74,6 +79,7 @@ const PROVIDER_SECTION_PREFIX = "provider.";
 const PROVIDER_TYPE_LABELS: Record<UserProviderName, string> = {
   anthropic: "Anthropic",
   cerebras: "Cerebras",
+  chatgpt: "ChatGPT (Plus/Pro)",
   cloudflare: "Cloudflare Worker AI",
   deepseek: "DeepSeek",
   fireworks: "Fireworks",
@@ -643,6 +649,18 @@ function loadProvidersFromSections(
       id,
       label,
       type,
+      ...(values.chatgpt_access_token?.trim()
+        ? { chatgptAccessToken: values.chatgpt_access_token.trim() }
+        : {}),
+      ...(values.chatgpt_refresh_token?.trim()
+        ? { chatgptRefreshToken: values.chatgpt_refresh_token.trim() }
+        : {}),
+      ...(values.chatgpt_account_id?.trim()
+        ? { chatgptAccountId: values.chatgpt_account_id.trim() }
+        : {}),
+      ...(values.chatgpt_token_expires_at?.trim()
+        ? { chatgptTokenExpiresAt: values.chatgpt_token_expires_at.trim() }
+        : {}),
       ...(baseUrl ? { baseUrl } : {}),
       ...(hostMode ? { hostMode } : {}),
       ...(wireApi ? { wireApi } : {}),
@@ -680,6 +698,22 @@ function buildProviderSectionValues(
 
   if (provider.customModels?.length) {
     values.models_json = serializeCustomModels(provider.customModels);
+  }
+
+  if (provider.chatgptAccessToken?.trim()) {
+    values.chatgpt_access_token = provider.chatgptAccessToken.trim();
+  }
+
+  if (provider.chatgptRefreshToken?.trim()) {
+    values.chatgpt_refresh_token = provider.chatgptRefreshToken.trim();
+  }
+
+  if (provider.chatgptAccountId?.trim()) {
+    values.chatgpt_account_id = provider.chatgptAccountId.trim();
+  }
+
+  if (provider.chatgptTokenExpiresAt?.trim()) {
+    values.chatgpt_token_expires_at = provider.chatgptTokenExpiresAt.trim();
   }
 
   return values;
@@ -835,4 +869,61 @@ export function validateProviderApiKeyFormat(
   }
 
   return trimmed;
+}
+
+export function isChatgptProviderConnected(
+  instance: ProviderInstance
+): boolean {
+  return (
+    instance.type === "chatgpt" &&
+    Boolean(instance.chatgptRefreshToken?.trim()) &&
+    Boolean(instance.chatgptAccountId?.trim())
+  );
+}
+
+export function readChatgptOAuthFromInstance(
+  instance: ProviderInstance
+): ChatgptOAuthCredentials | null {
+  const refreshToken = instance.chatgptRefreshToken?.trim();
+  const accessToken = instance.chatgptAccessToken?.trim();
+  const accountId = instance.chatgptAccountId?.trim();
+  const expiresAt = instance.chatgptTokenExpiresAt?.trim();
+
+  if (!(refreshToken && accessToken && accountId && expiresAt)) {
+    return null;
+  }
+
+  return {
+    accessToken,
+    accountId,
+    expiresAt,
+    refreshToken,
+  };
+}
+
+export function applyChatgptOAuthToInstance(
+  instance: ProviderInstance,
+  oauth: ChatgptOAuthCredentials
+): ProviderInstance {
+  return {
+    ...instance,
+    apiKey: "",
+    chatgptAccessToken: oauth.accessToken.trim(),
+    chatgptAccountId: oauth.accountId.trim(),
+    chatgptRefreshToken: oauth.refreshToken.trim(),
+    chatgptTokenExpiresAt: oauth.expiresAt.trim(),
+  };
+}
+
+export function chatgptOAuthNeedsRefresh(
+  oauth: ChatgptOAuthCredentials,
+  now = Date.now()
+): boolean {
+  const expiresAt = Date.parse(oauth.expiresAt);
+
+  if (!Number.isFinite(expiresAt)) {
+    return true;
+  }
+
+  return expiresAt - now <= 5 * 60 * 1000;
 }


### PR DESCRIPTION
## Summary

Operators add **ChatGPT (Plus/Pro)** as an LLM provider → one device-code sign-in per instance → chat runs on plan quota via Codex, not an OpenAI API key.

**Before:** Nakama chat needed a paid OpenAI API key; a ChatGPT Plus/Pro subscription couldn't power org chat.
**After:** Settings → Add provider → **ChatGPT (Plus/Pro)** → sign in; tokens live on the provider instance with server-side refresh (`createChatgptProvider` → Codex `/responses`).

Why safe:
1. Reuses the existing OpenAI Responses helper with Codex base URL + account headers — no parallel chat stack
2. ChatGPT OAuth tokens stay on the provider instance; they are not passed to coding-agent `OPENAI_API_KEY`
3. Token refresh persists to `config.ini`; reconnect uses the same replace-key dialog as other providers

Only re-add work if OpenAI changes or blocks the unofficial Codex device OAuth flow (monitor auth errors after deploy).

## Test plan
- [x] `bun test packages/core/src/user-config.test.ts apps/server/src/providers/chatgpt/oauth.test.ts apps/server/src/providers/models.test.ts` (45 pass)
- [x] `bun test apps/server/src/services/provider-instance-helpers.test.ts` (16 pass)
- [x] Settings → Add provider → **ChatGPT (Plus/Pro)** → sign in → save → send one chat message
