### PR TITLE
fix(openrouter): serialize user multimodal content

### DIFF
--- a/apps/server/src/providers/openrouter/index.test.ts
+++ b/apps/server/src/providers/openrouter/index.test.ts
@@ -87,6 +87,110 @@ describe("createOpenRouterProvider", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  test("serializes user image parts with the OpenRouter SDK shape", async () => {
+    const fetchMock = mock(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request =
+          input instanceof Request ? input : new Request(input, init);
+        const body = (await request.json()) as {
+          messages: Array<{ content: unknown; role: string }>;
+        };
+
+        expect(body.messages[1]).toEqual({
+          content: [
+            { text: "What is this?", type: "text" },
+            {
+              image_url: {
+                url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB",
+              },
+              type: "image_url",
+            },
+          ],
+          role: "user",
+        });
+
+        return new Response(chatCompletionResponse("A tiny image"), {
+          headers: { "Content-Type": "application/json" },
+          status: 200,
+        });
+      }
+    );
+    const provider = createOpenRouterProvider({
+      apiKey: "test-key",
+      fetcher: fetchMock as typeof fetch,
+    });
+
+    await provider.generateChat({
+      messages: [
+        {
+          content: [
+            { text: "What is this?", type: "text" },
+            {
+              data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB",
+              mediaType: "image/png",
+              type: "image",
+            },
+          ],
+          role: "user",
+        },
+      ],
+      system: "You are helpful.",
+    });
+  });
+
+  test("serializes user document parts with the OpenRouter SDK shape", async () => {
+    const fetchMock = mock(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request =
+          input instanceof Request ? input : new Request(input, init);
+        const body = (await request.json()) as {
+          messages: Array<{ content: unknown; role: string }>;
+        };
+
+        expect(body.messages[1]).toEqual({
+          content: [
+            { text: "Summarize this report", type: "text" },
+            {
+              file: {
+                file_data: "data:application/pdf;base64,JVBERi0=",
+                filename: "report.pdf",
+              },
+              type: "file",
+            },
+          ],
+          role: "user",
+        });
+
+        return new Response(chatCompletionResponse("A short report"), {
+          headers: { "Content-Type": "application/json" },
+          status: 200,
+        });
+      }
+    );
+    const provider = createOpenRouterProvider({
+      apiKey: "test-key",
+      fetcher: fetchMock as typeof fetch,
+    });
+
+    await provider.generateChat({
+      messages: [
+        {
+          content: [
+            { text: "Summarize this report", type: "text" },
+            {
+              data: "JVBERi0=",
+              filename: "report.pdf",
+              mediaType: "application/pdf",
+              type: "document",
+            },
+          ],
+          role: "user",
+        },
+      ],
+      system: "You are helpful.",
+    });
+  });
+
   test("returns tool calls from generateChat", async () => {
     const fetchMock = mock(
       async () =>

--- a/apps/server/src/providers/openrouter/index.ts
+++ b/apps/server/src/providers/openrouter/index.ts
@@ -108,6 +108,14 @@ function toSdkTools(
   }));
 }
 
+function isImageUrl(value: unknown): value is { url: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { url?: unknown }).url === "string"
+  );
+}
+
 function toSdkUserContent(
   content: Extract<OpenAIMessage, { role: "user" }>["content"]
 ): string | ChatContentItems[] {
@@ -116,12 +124,7 @@ function toSdkUserContent(
   }
 
   return content.map((part): ChatContentItems => {
-    if (
-      part.type === "image_url" &&
-      typeof part.image_url === "object" &&
-      part.image_url !== null &&
-      typeof part.image_url.url === "string"
-    ) {
+    if (part.type === "image_url" && isImageUrl(part.image_url)) {
       return {
         imageUrl: { url: part.image_url.url },
         type: "image_url",

--- a/apps/server/src/providers/openrouter/index.ts
+++ b/apps/server/src/providers/openrouter/index.ts
@@ -14,6 +14,7 @@ import type {
 import type { Fetcher } from "@openrouter/sdk";
 import { HTTPClient, OpenRouter } from "@openrouter/sdk";
 import type {
+  ChatContentItems,
   ChatFunctionTool,
   ChatMessages,
   ChatRequest,
@@ -107,7 +108,50 @@ function toSdkTools(
   }));
 }
 
+function toSdkUserContent(
+  content: Extract<OpenAIMessage, { role: "user" }>["content"]
+): string | ChatContentItems[] {
+  if (typeof content === "string") {
+    return content;
+  }
+
+  return content.map((part): ChatContentItems => {
+    if (
+      part.type === "image_url" &&
+      typeof part.image_url === "object" &&
+      part.image_url !== null &&
+      typeof part.image_url.url === "string"
+    ) {
+      return {
+        imageUrl: { url: part.image_url.url },
+        type: "image_url",
+      };
+    }
+
+    if (part.type === "input_file" && typeof part.file_data === "string") {
+      return {
+        file: {
+          fileData: part.file_data,
+          ...(typeof part.filename === "string"
+            ? { filename: part.filename }
+            : {}),
+        },
+        type: "file",
+      };
+    }
+
+    return part as ChatContentItems;
+  });
+}
+
 function openAIMessageToSdkMessage(message: OpenAIMessage): ChatMessages {
+  if (message.role === "user") {
+    return {
+      content: toSdkUserContent(message.content),
+      role: "user",
+    };
+  }
+
   if (message.role === "assistant") {
     return {
       content: message.content,


### PR DESCRIPTION
## Summary
- convert user image and document parts to the shapes expected by `@openrouter/sdk`
- preserve text-only user messages
- add regression coverage for image and PDF document requests

Closes #844

## Validation
- `bun test apps/server/src/providers/openrouter/index.test.ts`
- `bun test apps/server/src` (1111 pass)
- `bun x ultracite check apps/server/src/providers/openrouter/index.ts apps/server/src/providers/openrouter/index.test.ts`
- `bun run --filter @nakama/server build`