### PR TITLE
fix(web): validate public artifact-share fetch origins

### DIFF
--- a/apps/web/src/hooks/use-public-artifact-share.ts
+++ b/apps/web/src/hooks/use-public-artifact-share.ts
@@ -8,6 +8,7 @@ import {
   resolveArtifactMimeType,
 } from "@/lib/chat-artifacts";
 import { client } from "@/lib/client";
+import { buildPublicArtifactShareUrl } from "@/lib/public-artifact-share-url";
 
 export interface PublicShareMetadata {
   filename: string;
@@ -25,7 +26,7 @@ async function loadPublicArtifactShare(
   token: string
 ): Promise<PublicArtifactShareData> {
   const metaResponse = await fetch(
-    `${client.baseUrl}/v1/public/artifact-shares/${encodeURIComponent(token)}?meta=1`
+    buildPublicArtifactShareUrl(client.baseUrl, token, "meta=1")
   );
 
   if (!metaResponse.ok) {
@@ -52,7 +53,7 @@ async function loadPublicArtifactShare(
   }
 
   const contentResponse = await fetch(
-    `${client.baseUrl}/v1/public/artifact-shares/${encodeURIComponent(token)}`
+    buildPublicArtifactShareUrl(client.baseUrl, token)
   );
 
   if (!contentResponse.ok) {

--- a/apps/web/src/lib/public-artifact-share-url.test.ts
+++ b/apps/web/src/lib/public-artifact-share-url.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   buildPublicArtifactShareUrl,
   resolvePublicArtifactShareOrigin,
+  tryBuildPublicArtifactShareUrl,
 } from "./public-artifact-share-url";
 
 describe("resolvePublicArtifactShareOrigin", () => {
@@ -64,5 +65,18 @@ describe("buildPublicArtifactShareUrl", () => {
     expect(
       buildPublicArtifactShareUrl("https://app.example.com", "tok/2")
     ).toBe("https://app.example.com/v1/public/artifact-shares/tok%2F2");
+  });
+});
+
+describe("tryBuildPublicArtifactShareUrl", () => {
+  test("returns null for rejected origins instead of throwing", () => {
+    expect(
+      tryBuildPublicArtifactShareUrl("file:///etc/passwd", "tok_1")
+    ).toBeNull();
+    expect(
+      tryBuildPublicArtifactShareUrl("http://localhost:4310", "tok_1", undefined, {
+        isProd: true,
+      })
+    ).toBeNull();
   });
 });

--- a/apps/web/src/lib/public-artifact-share-url.test.ts
+++ b/apps/web/src/lib/public-artifact-share-url.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildPublicArtifactShareUrl,
+  resolvePublicArtifactShareOrigin,
+} from "./public-artifact-share-url";
+
+describe("resolvePublicArtifactShareOrigin", () => {
+  test("allows empty baseUrl for same-origin relative fetches", () => {
+    expect(resolvePublicArtifactShareOrigin("")).toBe("");
+    expect(resolvePublicArtifactShareOrigin("  ")).toBe("");
+  });
+
+  test("allows http(s) absolute origins", () => {
+    expect(resolvePublicArtifactShareOrigin("https://app.example.com/")).toBe(
+      "https://app.example.com"
+    );
+    expect(resolvePublicArtifactShareOrigin("http://app.example.com")).toBe(
+      "http://app.example.com"
+    );
+  });
+
+  test("rejects non-http protocols", () => {
+    expect(() =>
+      resolvePublicArtifactShareOrigin("file:///etc/passwd")
+    ).toThrow("unavailable");
+    expect(() =>
+      resolvePublicArtifactShareOrigin("javascript:alert(1)")
+    ).toThrow("unavailable");
+  });
+
+  test("rejects invalid URLs", () => {
+    expect(() => resolvePublicArtifactShareOrigin("not a url")).toThrow(
+      "unavailable"
+    );
+  });
+
+  test("rejects localhost in production", () => {
+    expect(() =>
+      resolvePublicArtifactShareOrigin("http://localhost:4310", {
+        isProd: true,
+      })
+    ).toThrow("unavailable");
+    expect(() =>
+      resolvePublicArtifactShareOrigin("http://127.0.0.1:4310", {
+        isProd: true,
+      })
+    ).toThrow("unavailable");
+  });
+
+  test("allows localhost outside production", () => {
+    expect(
+      resolvePublicArtifactShareOrigin("http://localhost:4310", {
+        isProd: false,
+      })
+    ).toBe("http://localhost:4310");
+  });
+});
+
+describe("buildPublicArtifactShareUrl", () => {
+  test("builds relative and absolute share URLs", () => {
+    expect(buildPublicArtifactShareUrl("", "tok_1", "meta=1")).toBe(
+      "/v1/public/artifact-shares/tok_1?meta=1"
+    );
+    expect(
+      buildPublicArtifactShareUrl("https://app.example.com", "tok/2")
+    ).toBe("https://app.example.com/v1/public/artifact-shares/tok%2F2");
+  });
+});

--- a/apps/web/src/lib/public-artifact-share-url.test.ts
+++ b/apps/web/src/lib/public-artifact-share-url.test.ts
@@ -1,48 +1,45 @@
 import { describe, expect, test } from "bun:test";
-import {
-  buildPublicArtifactShareUrl,
-  resolvePublicArtifactShareOrigin,
-  tryBuildPublicArtifactShareUrl,
-} from "./public-artifact-share-url";
+import { buildPublicArtifactShareUrl } from "./public-artifact-share-url";
 
-describe("resolvePublicArtifactShareOrigin", () => {
-  test("allows empty baseUrl for same-origin relative fetches", () => {
-    expect(resolvePublicArtifactShareOrigin("")).toBe("");
-    expect(resolvePublicArtifactShareOrigin("  ")).toBe("");
-  });
-
-  test("allows http(s) absolute origins", () => {
-    expect(resolvePublicArtifactShareOrigin("https://app.example.com/")).toBe(
-      "https://app.example.com"
+describe("buildPublicArtifactShareUrl", () => {
+  test("builds relative and absolute share URLs", () => {
+    expect(buildPublicArtifactShareUrl("", "tok_1", "meta=1")).toBe(
+      "/v1/public/artifact-shares/tok_1?meta=1"
     );
-    expect(resolvePublicArtifactShareOrigin("http://app.example.com")).toBe(
-      "http://app.example.com"
+    expect(buildPublicArtifactShareUrl("  ", "tok_1")).toBe(
+      "/v1/public/artifact-shares/tok_1"
+    );
+    expect(
+      buildPublicArtifactShareUrl("https://app.example.com/", "tok/2")
+    ).toBe("https://app.example.com/v1/public/artifact-shares/tok%2F2");
+    expect(buildPublicArtifactShareUrl("http://app.example.com", "tok_1")).toBe(
+      "http://app.example.com/v1/public/artifact-shares/tok_1"
     );
   });
 
   test("rejects non-http protocols", () => {
     expect(() =>
-      resolvePublicArtifactShareOrigin("file:///etc/passwd")
+      buildPublicArtifactShareUrl("file:///etc/passwd", "tok_1")
     ).toThrow("unavailable");
     expect(() =>
-      resolvePublicArtifactShareOrigin("javascript:alert(1)")
+      buildPublicArtifactShareUrl("javascript:alert(1)", "tok_1")
     ).toThrow("unavailable");
   });
 
   test("rejects invalid URLs", () => {
-    expect(() => resolvePublicArtifactShareOrigin("not a url")).toThrow(
+    expect(() => buildPublicArtifactShareUrl("not a url", "tok_1")).toThrow(
       "unavailable"
     );
   });
 
   test("rejects localhost in production", () => {
     expect(() =>
-      resolvePublicArtifactShareOrigin("http://localhost:4310", {
+      buildPublicArtifactShareUrl("http://localhost:4310", "tok_1", undefined, {
         isProd: true,
       })
     ).toThrow("unavailable");
     expect(() =>
-      resolvePublicArtifactShareOrigin("http://127.0.0.1:4310", {
+      buildPublicArtifactShareUrl("http://127.0.0.1:4310", "tok_1", undefined, {
         isProd: true,
       })
     ).toThrow("unavailable");
@@ -50,33 +47,9 @@ describe("resolvePublicArtifactShareOrigin", () => {
 
   test("allows localhost outside production", () => {
     expect(
-      resolvePublicArtifactShareOrigin("http://localhost:4310", {
+      buildPublicArtifactShareUrl("http://localhost:4310", "tok_1", undefined, {
         isProd: false,
       })
-    ).toBe("http://localhost:4310");
-  });
-});
-
-describe("buildPublicArtifactShareUrl", () => {
-  test("builds relative and absolute share URLs", () => {
-    expect(buildPublicArtifactShareUrl("", "tok_1", "meta=1")).toBe(
-      "/v1/public/artifact-shares/tok_1?meta=1"
-    );
-    expect(
-      buildPublicArtifactShareUrl("https://app.example.com", "tok/2")
-    ).toBe("https://app.example.com/v1/public/artifact-shares/tok%2F2");
-  });
-});
-
-describe("tryBuildPublicArtifactShareUrl", () => {
-  test("returns null for rejected origins instead of throwing", () => {
-    expect(
-      tryBuildPublicArtifactShareUrl("file:///etc/passwd", "tok_1")
-    ).toBeNull();
-    expect(
-      tryBuildPublicArtifactShareUrl("http://localhost:4310", "tok_1", undefined, {
-        isProd: true,
-      })
-    ).toBeNull();
+    ).toBe("http://localhost:4310/v1/public/artifact-shares/tok_1");
   });
 });

--- a/apps/web/src/lib/public-artifact-share-url.ts
+++ b/apps/web/src/lib/public-artifact-share-url.ts
@@ -49,3 +49,17 @@ export function buildPublicArtifactShareUrl(
   const suffix = query ? `?${query}` : "";
   return `${origin}${path}${suffix}`;
 }
+
+/** Same as buildPublicArtifactShareUrl, or null when the origin is rejected. */
+export function tryBuildPublicArtifactShareUrl(
+  baseUrl: string,
+  token: string,
+  query?: string,
+  options?: { isProd?: boolean }
+): string | null {
+  try {
+    return buildPublicArtifactShareUrl(baseUrl, token, query, options);
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/lib/public-artifact-share-url.ts
+++ b/apps/web/src/lib/public-artifact-share-url.ts
@@ -1,0 +1,51 @@
+const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+
+function isLocalHostname(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  return LOCAL_HOSTS.has(host) || host.endsWith(".localhost");
+}
+
+/**
+ * Resolve a safe API origin for unauthenticated public artifact-share fetches.
+ * Empty / relative baseUrl stays same-origin. Absolute URLs must be http(s);
+ * localhost is rejected in production builds.
+ */
+export function resolvePublicArtifactShareOrigin(
+  baseUrl: string,
+  options?: { isProd?: boolean }
+): string {
+  const trimmed = baseUrl.trim().replace(/\/$/, "");
+  if (!trimmed) {
+    return "";
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error("This share link is unavailable.");
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("This share link is unavailable.");
+  }
+
+  const isProd = options?.isProd ?? import.meta.env.PROD;
+  if (isProd && isLocalHostname(parsed.hostname)) {
+    throw new Error("This share link is unavailable.");
+  }
+
+  return trimmed;
+}
+
+export function buildPublicArtifactShareUrl(
+  baseUrl: string,
+  token: string,
+  query?: string,
+  options?: { isProd?: boolean }
+): string {
+  const origin = resolvePublicArtifactShareOrigin(baseUrl, options);
+  const path = `/v1/public/artifact-shares/${encodeURIComponent(token)}`;
+  const suffix = query ? `?${query}` : "";
+  return `${origin}${path}${suffix}`;
+}

--- a/apps/web/src/lib/public-artifact-share-url.ts
+++ b/apps/web/src/lib/public-artifact-share-url.ts
@@ -10,7 +10,7 @@ function isLocalHostname(hostname: string): boolean {
  * Empty / relative baseUrl stays same-origin. Absolute URLs must be http(s);
  * localhost is rejected in production builds.
  */
-export function resolvePublicArtifactShareOrigin(
+function resolvePublicArtifactShareOrigin(
   baseUrl: string,
   options?: { isProd?: boolean }
 ): string {
@@ -48,18 +48,4 @@ export function buildPublicArtifactShareUrl(
   const path = `/v1/public/artifact-shares/${encodeURIComponent(token)}`;
   const suffix = query ? `?${query}` : "";
   return `${origin}${path}${suffix}`;
-}
-
-/** Same as buildPublicArtifactShareUrl, or null when the origin is rejected. */
-export function tryBuildPublicArtifactShareUrl(
-  baseUrl: string,
-  token: string,
-  query?: string,
-  options?: { isProd?: boolean }
-): string | null {
-  try {
-    return buildPublicArtifactShareUrl(baseUrl, token, query, options);
-  } catch {
-    return null;
-  }
 }

--- a/apps/web/src/pages/PublicArtifactSharePage.tsx
+++ b/apps/web/src/pages/PublicArtifactSharePage.tsx
@@ -18,7 +18,7 @@ import {
   resolveArtifactMimeType,
 } from "@/lib/chat-artifacts";
 import { client } from "@/lib/client";
-import { tryBuildPublicArtifactShareUrl } from "@/lib/public-artifact-share-url";
+import { buildPublicArtifactShareUrl } from "@/lib/public-artifact-share-url";
 import { cn } from "@/lib/utils";
 
 function publicShareError(token: string, loadError: unknown): string | null {
@@ -286,7 +286,12 @@ export function PublicArtifactSharePage() {
     };
   }, []);
 
-  const downloadUrl = tryBuildPublicArtifactShareUrl(client.baseUrl, token);
+  let downloadUrl: string | null = null;
+  try {
+    downloadUrl = buildPublicArtifactShareUrl(client.baseUrl, token);
+  } catch {
+    downloadUrl = null;
+  }
   const fillViewport = preview.isHtml || preview.isSpreadsheet;
 
   return (

--- a/apps/web/src/pages/PublicArtifactSharePage.tsx
+++ b/apps/web/src/pages/PublicArtifactSharePage.tsx
@@ -18,7 +18,7 @@ import {
   resolveArtifactMimeType,
 } from "@/lib/chat-artifacts";
 import { client } from "@/lib/client";
-import { buildPublicArtifactShareUrl } from "@/lib/public-artifact-share-url";
+import { tryBuildPublicArtifactShareUrl } from "@/lib/public-artifact-share-url";
 import { cn } from "@/lib/utils";
 
 function publicShareError(token: string, loadError: unknown): string | null {
@@ -84,13 +84,13 @@ function PublicArtifactShareHeader({
 }: {
   filename: string;
   token: string;
-  downloadUrl: string;
+  downloadUrl: string | null;
 }) {
   return (
     <header className="border-border border-b px-3 py-1.5">
       <div className="flex items-center justify-between gap-3">
         <p className="truncate font-medium text-xs">{filename}</p>
-        {token ? (
+        {token && downloadUrl ? (
           <a
             className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border px-2 py-1 font-medium text-xs hover:bg-muted"
             href={downloadUrl}
@@ -120,7 +120,7 @@ function PublicArtifactPreview({
     sizeBytes: number;
   };
   content: string | null;
-  downloadUrl: string;
+  downloadUrl: string | null;
   preview: SharePreview;
 }) {
   const {
@@ -138,7 +138,7 @@ function PublicArtifactPreview({
         artifact={artifact}
         canPreview={canPreview}
         error={null}
-        imagePreviewUrl={downloadUrl}
+        imagePreviewUrl={downloadUrl ?? undefined}
         kind="image"
         loading={false}
       />
@@ -153,7 +153,7 @@ function PublicArtifactPreview({
         error={null}
         kind="video"
         loading={false}
-        videoPreviewUrl={downloadUrl}
+        videoPreviewUrl={downloadUrl ?? undefined}
       />
     );
   }
@@ -216,7 +216,7 @@ function PublicArtifactShareMain({
     sizeBytes: number;
   } | null;
   content: string | null;
-  downloadUrl: string;
+  downloadUrl: string | null;
   error: string | null;
   filename?: string;
   loading: boolean;
@@ -286,7 +286,7 @@ export function PublicArtifactSharePage() {
     };
   }, []);
 
-  const downloadUrl = buildPublicArtifactShareUrl(client.baseUrl, token);
+  const downloadUrl = tryBuildPublicArtifactShareUrl(client.baseUrl, token);
   const fillViewport = preview.isHtml || preview.isSpreadsheet;
 
   return (

--- a/apps/web/src/pages/PublicArtifactSharePage.tsx
+++ b/apps/web/src/pages/PublicArtifactSharePage.tsx
@@ -18,6 +18,7 @@ import {
   resolveArtifactMimeType,
 } from "@/lib/chat-artifacts";
 import { client } from "@/lib/client";
+import { buildPublicArtifactShareUrl } from "@/lib/public-artifact-share-url";
 import { cn } from "@/lib/utils";
 
 function publicShareError(token: string, loadError: unknown): string | null {
@@ -285,7 +286,7 @@ export function PublicArtifactSharePage() {
     };
   }, []);
 
-  const downloadUrl = `${client.baseUrl}/v1/public/artifact-shares/${encodeURIComponent(token)}`;
+  const downloadUrl = buildPublicArtifactShareUrl(client.baseUrl, token);
   const fillViewport = preview.isHtml || preview.isSpreadsheet;
 
   return (


### PR DESCRIPTION
## Summary

Public artifact-share fetches validate `client.baseUrl` before hitting `/v1/public/artifact-shares/...`. Fixes #576.

**Before:** any absolute `client.baseUrl` (including `file:` / prod `localhost`) was interpolated straight into the unauthenticated share fetch URL.
**After:** `buildPublicArtifactShareUrl` allows empty/relative same-origin, http(s) only, rejects localhost in production; `PublicArtifactSharePage` try/catch keeps download UI stable when build rejects.

Why safe:
1. Default web client still uses `baseUrl: ""` (relative) — happy path unchanged
2. Rejected origins throw into the existing “unavailable” share error; page catch → null download link (same as before)
3. One exported builder + module-local origin check — no wrapper export

Only re-add localhost in prod if a documented reverse-proxy setup requires it. Private LAN IPs are still allowed if misconfigured as an absolute http(s) origin.

## Test plan
- [x] `bun test apps/web/src/lib/public-artifact-share-url.test.ts` (5 pass)
- [x] CI `test` / `knip` / `sync` / `react-doctor` green on prior head; re-run on `83417fbf`
- [ ] Smoke: relative + https OK; `file:` / prod localhost → page download link null (no crash)
