### PR TITLE
fix(web): mask notification webhook secrets by default

### DIFF
--- a/apps/web/src/components/NotificationDestinationsCard.tsx
+++ b/apps/web/src/components/NotificationDestinationsCard.tsx
@@ -554,7 +554,12 @@ function NotificationDestinationItem({
       ) : null}
 
       {latestSecret?.destination.id === destination.id ? (
-        <LatestSecret latestSecret={latestSecret} />
+        {latestSecret ? (
+          <LatestSecret
+            key={latestSecret.apiKey}
+            latestSecret={latestSecret}
+          />
+        ) : null}
       ) : null}
     </div>
   );

--- a/apps/web/src/components/NotificationDestinationsCard.tsx
+++ b/apps/web/src/components/NotificationDestinationsCard.tsx
@@ -25,7 +25,6 @@ import { formatError } from "@/lib/client";
 import {
   buildNotificationWebhookUrl,
   formatTelegramDestinationLabel,
-  LATEST_WEBHOOK_SECRET_TTL_MS,
   maskWebhookApiKey,
   parseTelegramTopicLink,
 } from "@/lib/notification-destinations";
@@ -88,18 +87,6 @@ function LatestSecret({
     `    "level": "info"`,
     `  }'`,
   ].join("\n");
-  const displayCurlExample = revealed
-    ? curlExample
-    : [
-        `curl -X POST '${webhookUrl}' \\`,
-        `  -H 'Content-Type: application/json' \\`,
-        `  -H 'X-API-Key: ${maskWebhookApiKey(apiKey)}' \\`,
-        `  -d '{`,
-        `    "title": "New notification",`,
-        `    "body": "Hello from Nakama",`,
-        `    "level": "info"`,
-        `  }'`,
-      ].join("\n");
 
   async function copyCurlExample() {
     try {
@@ -188,7 +175,7 @@ function LatestSecret({
           <div>
             <p className="text-muted-foreground text-xs">Example curl</p>
             <pre className="mt-1 overflow-x-auto rounded-md border border-border bg-background p-3 text-foreground text-xs">
-              <code>{displayCurlExample}</code>
+              <code>{curlExample.replace(apiKey, displayApiKey)}</code>
             </pre>
           </div>
         </div>
@@ -222,7 +209,7 @@ export function NotificationDestinationsCard() {
 
     const timer = window.setTimeout(() => {
       setLatestSecret(null);
-    }, LATEST_WEBHOOK_SECRET_TTL_MS);
+    }, 60_000);
 
     return () => {
       window.clearTimeout(timer);
@@ -554,12 +541,7 @@ function NotificationDestinationItem({
       ) : null}
 
       {latestSecret?.destination.id === destination.id ? (
-        {latestSecret ? (
-          <LatestSecret
-            key={latestSecret.apiKey}
-            latestSecret={latestSecret}
-          />
-        ) : null}
+        <LatestSecret key={latestSecret.apiKey} latestSecret={latestSecret} />
       ) : null}
     </div>
   );

--- a/apps/web/src/components/NotificationDestinationsCard.tsx
+++ b/apps/web/src/components/NotificationDestinationsCard.tsx
@@ -7,8 +7,10 @@ import {
   Copy01Icon,
   Delete02Icon,
   RefreshIcon,
+  ViewIcon,
+  ViewOffIcon,
 } from "hugeicons-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
@@ -23,6 +25,8 @@ import { formatError } from "@/lib/client";
 import {
   buildNotificationWebhookUrl,
   formatTelegramDestinationLabel,
+  LATEST_WEBHOOK_SECRET_TTL_MS,
+  maskWebhookApiKey,
   parseTelegramTopicLink,
 } from "@/lib/notification-destinations";
 import { cn } from "@/lib/utils";
@@ -61,12 +65,14 @@ function LatestSecret({
 }) {
   const [copiedCurl, setCopiedCurl] = useState(false);
   const [copiedApiKey, setCopiedApiKey] = useState(false);
+  const [revealed, setRevealed] = useState(false);
 
   if (!latestSecret) {
     return null;
   }
 
   const apiKey = latestSecret.apiKey;
+  const displayApiKey = revealed ? apiKey : maskWebhookApiKey(apiKey);
   const origin = typeof window === "undefined" ? "" : window.location.origin;
   const webhookUrl = buildNotificationWebhookUrl(
     origin,
@@ -82,6 +88,18 @@ function LatestSecret({
     `    "level": "info"`,
     `  }'`,
   ].join("\n");
+  const displayCurlExample = revealed
+    ? curlExample
+    : [
+        `curl -X POST '${webhookUrl}' \\`,
+        `  -H 'Content-Type: application/json' \\`,
+        `  -H 'X-API-Key: ${maskWebhookApiKey(apiKey)}' \\`,
+        `  -d '{`,
+        `    "title": "New notification",`,
+        `    "body": "Hello from Nakama",`,
+        `    "level": "info"`,
+        `  }'`,
+      ].join("\n");
 
   async function copyCurlExample() {
     try {
@@ -110,12 +128,23 @@ function LatestSecret({
           <p className="font-medium text-foreground text-sm">
             Latest webhook credentials ready
           </p>
-          <p className="text-muted-foreground text-xs [text-wrap:pretty]">
-            Copy the curl command, or expand details if you need the raw URL and
-            API key.
-          </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
+          <Button
+            aria-label={revealed ? "Hide API key" : "Reveal API key"}
+            className="min-w-[6.75rem] justify-center"
+            onClick={() => setRevealed((current) => !current)}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            {revealed ? (
+              <ViewOffIcon className="size-3.5" />
+            ) : (
+              <ViewIcon className="size-3.5" />
+            )}
+            {revealed ? "Hide" : "Reveal"}
+          </Button>
           <Button
             className="min-w-[6.75rem] justify-center"
             onClick={() => void copyCurlExample()}
@@ -153,13 +182,13 @@ function LatestSecret({
           <div>
             <p className="text-muted-foreground text-xs">API key</p>
             <code className="block break-all text-foreground text-xs">
-              {apiKey}
+              {displayApiKey}
             </code>
           </div>
           <div>
             <p className="text-muted-foreground text-xs">Example curl</p>
             <pre className="mt-1 overflow-x-auto rounded-md border border-border bg-background p-3 text-foreground text-xs">
-              <code>{curlExample}</code>
+              <code>{displayCurlExample}</code>
             </pre>
           </div>
         </div>
@@ -185,6 +214,20 @@ export function NotificationDestinationsCard() {
   const [editingError, setEditingError] = useState<string | null>(null);
 
   const destinations = data?.destinations ?? [];
+
+  useEffect(() => {
+    if (!latestSecret) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      setLatestSecret(null);
+    }, LATEST_WEBHOOK_SECRET_TTL_MS);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [latestSecret]);
 
   function resetForm() {
     setName("");

--- a/apps/web/src/lib/notification-destinations.test.ts
+++ b/apps/web/src/lib/notification-destinations.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 import {
   buildNotificationWebhookUrl,
   formatTelegramDestinationLabel,
+  LATEST_WEBHOOK_SECRET_TTL_MS,
+  maskWebhookApiKey,
 } from "./notification-destinations";
 
 describe("buildNotificationWebhookUrl", () => {
@@ -21,5 +23,19 @@ describe("formatTelegramDestinationLabel", () => {
     expect(formatTelegramDestinationLabel({ chatId: 1001, topicId: 22 })).toBe(
       "Chat 1001 / Topic 22"
     );
+  });
+});
+
+describe("maskWebhookApiKey", () => {
+  test("masks long keys and keeps a short suffix", () => {
+    expect(maskWebhookApiKey("nk_live_abcdefghij")).toBe("••••ghij");
+  });
+
+  test("fully masks short keys", () => {
+    expect(maskWebhookApiKey("abc")).toBe("••••");
+  });
+
+  test("exports a one-minute clear window", () => {
+    expect(LATEST_WEBHOOK_SECRET_TTL_MS).toBe(60_000);
   });
 });

--- a/apps/web/src/lib/notification-destinations.test.ts
+++ b/apps/web/src/lib/notification-destinations.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test";
 import {
   buildNotificationWebhookUrl,
   formatTelegramDestinationLabel,
-  LATEST_WEBHOOK_SECRET_TTL_MS,
   maskWebhookApiKey,
 } from "./notification-destinations";
 
@@ -33,9 +32,5 @@ describe("maskWebhookApiKey", () => {
 
   test("fully masks short keys", () => {
     expect(maskWebhookApiKey("abc")).toBe("••••");
-  });
-
-  test("exports a one-minute clear window", () => {
-    expect(LATEST_WEBHOOK_SECRET_TTL_MS).toBe(60_000);
   });
 });

--- a/apps/web/src/lib/notification-destinations.ts
+++ b/apps/web/src/lib/notification-destinations.ts
@@ -1,5 +1,16 @@
 import type { TelegramNotificationDestinationConfig } from "@nakama/core/contract";
 
+/** Clear newly minted webhook secrets from React state after this window. */
+export const LATEST_WEBHOOK_SECRET_TTL_MS = 60_000;
+
+export function maskWebhookApiKey(apiKey: string): string {
+  const trimmed = apiKey.trim();
+  if (trimmed.length <= 4) {
+    return "••••";
+  }
+  return `••••${trimmed.slice(-4)}`;
+}
+
 export function buildNotificationWebhookUrl(
   origin: string,
   webhookPath: string

--- a/apps/web/src/lib/notification-destinations.ts
+++ b/apps/web/src/lib/notification-destinations.ts
@@ -1,8 +1,5 @@
 import type { TelegramNotificationDestinationConfig } from "@nakama/core/contract";
 
-/** Clear newly minted webhook secrets from React state after this window. */
-export const LATEST_WEBHOOK_SECRET_TTL_MS = 60_000;
-
 export function maskWebhookApiKey(apiKey: string): string {
   const trimmed = apiKey.trim();
   if (trimmed.length <= 4) {


### PR DESCRIPTION
## Summary

Newly minted notification webhook API keys stay masked until Reveal, then clear from React state after 60s. Fixes #521.

**Before:** `latestSecret.apiKey` sat in plaintext in the details panel (and curl example) for as long as the card stayed mounted.
**After:** default mask (`••••` + last 4), Reveal/Hide toggle, Copy still uses the real key, inline 60s clear, and rotate remounts so Reveal resets.

Why safe:
1. Copy curl / Copy API key still paste the real secret for the operator who just created it
2. Webhook URL stays visible (not secret); only the key is masked
3. Timer resets when a new secret is minted (rotate/create)

Only lengthen the TTL if operators report keys vanishing before they finish wiring Telegram.

## Test plan
- [x] `bun test apps/web/src/lib/notification-destinations.test.ts` (5 pass)
- [x] Owner YAGNI: single curl string + replace, direct `<LatestSecret />`, inline `60_000`
- [ ] Create/rotate destination → masked key + curl; Reveal; Copy still real; clears ~60s