### PR TITLE
fix(web): make successful turn stamps monotonic

### DIFF
--- a/apps/web/src/pages/chat/chat-page.shared.test.ts
+++ b/apps/web/src/pages/chat/chat-page.shared.test.ts
@@ -190,4 +190,8 @@ describe("nextSuccessfulTurnAt", () => {
   test("bumps by 1ms when two turns finish in the same millisecond", () => {
     expect(nextSuccessfulTurnAt(1000, 1000)).toBe(1001);
   });
+
+  test("stays monotonic when wall clock moves backwards", () => {
+    expect(nextSuccessfulTurnAt(1000, 999)).toBe(1001);
+  });
 });

--- a/apps/web/src/pages/chat/chat-page.shared.test.ts
+++ b/apps/web/src/pages/chat/chat-page.shared.test.ts
@@ -10,6 +10,7 @@ import {
   findFailedRetryPrompt,
   markStreamingTurnFailed,
   messagesWithoutFailedTurn,
+  nextSuccessfulTurnAt,
 } from "@/pages/chat/chat-page.shared";
 
 function user(
@@ -174,5 +175,19 @@ describe("failed chat turn storage", () => {
 
       expect(readFailedChatTurn(sessionId)).toBeNull();
     });
+  });
+});
+
+describe("nextSuccessfulTurnAt", () => {
+  test("uses wall clock when there is no previous stamp", () => {
+    expect(nextSuccessfulTurnAt(null, 1000)).toBe(1000);
+  });
+
+  test("keeps wall clock when time advances", () => {
+    expect(nextSuccessfulTurnAt(1000, 1005)).toBe(1005);
+  });
+
+  test("bumps by 1ms when two turns finish in the same millisecond", () => {
+    expect(nextSuccessfulTurnAt(1000, 1000)).toBe(1001);
   });
 });

--- a/apps/web/src/pages/chat/chat-page.shared.ts
+++ b/apps/web/src/pages/chat/chat-page.shared.ts
@@ -148,3 +148,14 @@ export function messagesWithoutFailedTurn(
 
   return [...messages.slice(0, start), ...messages.slice(failedIndex + 1)];
 }
+
+/**
+ * Wall-clock stamp for post-turn polling, bumped by 1ms when two turns finish
+ * in the same millisecond so consumers never see a duplicate key.
+ */
+export function nextSuccessfulTurnAt(
+  previous: number | null,
+  now = Date.now()
+): number {
+  return previous != null && now <= previous ? previous + 1 : now;
+}

--- a/apps/web/src/pages/chat/use-chat-page.ts
+++ b/apps/web/src/pages/chat/use-chat-page.ts
@@ -96,6 +96,7 @@ import {
   findRetryPrompt,
   markStreamingTurnFailed,
   messagesWithoutFailedTurn,
+  nextSuccessfulTurnAt,
 } from "@/pages/chat/chat-page.shared";
 
 interface SendMessageOptions {
@@ -537,7 +538,9 @@ export function useChatPage() {
             setSessionModel(refreshed.model);
 
             if (reconnected) {
-              setLastSuccessfulTurnAt(Date.now());
+              setLastSuccessfulTurnAt((previous) =>
+                nextSuccessfulTurnAt(previous)
+              );
             }
           }
         }
@@ -810,7 +813,7 @@ export function useChatPage() {
         setAgentQuestionnaire(questionnaire);
         setContextUsage(nextContextUsage ?? null);
         setSessionModel(nextSessionModel);
-        setLastSuccessfulTurnAt(Date.now());
+        setLastSuccessfulTurnAt((previous) => nextSuccessfulTurnAt(previous));
       } catch (err) {
         if (isAbortError(err)) {
           setMessages((current) => finalizeStreamingMessages(current));


### PR DESCRIPTION
## Summary

`lastSuccessfulTurnAt` stays a wall-clock poll window start, but never collides when two turns finish in the same ms. Fixes #572.

**Before:** `setLastSuccessfulTurnAt(Date.now())` could assign the same stamp twice in one millisecond.
**After:** `nextSuccessfulTurnAt(previous)` returns `now`, or `previous + 1` when `now <= previous`, used from both send + reconnect success paths.

Why safe:
1. Post-turn skill-review polling still uses a real timestamp + 45s window
2. Pure helper with unit coverage; no storage / API shape change
3. Same setter site count as before (reconnect + successful send)

Only switch to a pure counter if polling stops depending on wall clock.

## Test plan
- [x] `bun test apps/web/src/pages/chat/chat-page.shared.test.ts` (12 pass)
- [x] CI `test` / `knip` / `sync` / `react-doctor` green on `99df3dd6`
- [x] Monotonic across same-ms + clock-skew; wired on send + reconnect success paths
