### PR TITLE
chore(core): bump pinned tool-output optimiser to 0.7.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Entries marked *(in review)* come from a pull request that is open but not merge
 
 ## [Unreleased]
 
+### Changed
+
+- Pinned tool-output optimiser bumped to 0.7.9: a fold always leaves part of the
+  result readable, and non-ASCII output no longer panics the cut ([#875])
+
 ## [0.4.8] - 2026-09-06
 
 ### Added
@@ -976,3 +981,4 @@ First tagged release. The baseline it established:
 [#858]: https://github.com/ahmadrosid/nakama/pull/858
 [#859]: https://github.com/ahmadrosid/nakama/pull/859
 [#860]: https://github.com/ahmadrosid/nakama/pull/860
+[#875]: https://github.com/ahmadrosid/nakama/pull/875

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /app
 # when the toggle is switched on, unless NAKAMA_OMNI_AUTO_INSTALL=0.
 # The release is a static musl build, which runs on this glibc base, and the
 # published checksum is verified rather than the download trusted.
-ARG OMNI_VERSION="0.7.5"
+ARG OMNI_VERSION="0.7.9"
 RUN if [ -n "$OMNI_VERSION" ]; then \
       set -eu; \
       apt-get update && apt-get install -y --no-install-recommends curl ca-certificates; \

--- a/packages/core/src/omni-install.ts
+++ b/packages/core/src/omni-install.ts
@@ -31,7 +31,7 @@ import { getUserConfigDir } from "./user-config";
  * restart is not reproducible, and the Dockerfile pins the same way, so the two
  * routes to the same binary agree.
  */
-const DEFAULT_VERSION = "0.7.5";
+const DEFAULT_VERSION = "0.7.9";
 const RELEASES = "https://github.com/fajarhide/omni/releases/download";
 const DOWNLOAD_TIMEOUT_MS = 60_000;
 


### PR DESCRIPTION
## Summary

The pinned tool-output optimiser moves from 0.7.5 to 0.7.9.

**Before:** 0.7.5 could fold a whole tool result away when the project ledger had already seen part of it, leaving the agent a marker and nothing to read around it, and a byte-index cut panicked on non-ASCII output.
**After:** a fold always leaves part of the result readable, and the cut is UTF-8 safe. Both pins move together: `DEFAULT_VERSION` in `packages/core/src/omni-install.ts` and `ARG OMNI_VERSION` in the Dockerfile.

Why safe:
1. `omni-install.test.ts` already asserts the Dockerfile ARG equals `DEFAULT_VERSION`, so the two pins cannot drift.
2. v0.7.9 publishes all four targets this repo installs plus `SHA256SUMS`, and every archive verifies.
3. Distillation fails open, so a bad install leaves the raw tool result untouched.

## Test plan
- [x] `bun run test`: 2914 pass, 0 fail
- [x] Downloaded the four release archives and checked each digest against the v0.7.9 `SHA256SUMS`, the same check `installOmni` runs:

```
OK   omni-v0.7.9-aarch64-apple-darwin.tar.gz
OK   omni-v0.7.9-x86_64-apple-darwin.tar.gz
OK   omni-v0.7.9-aarch64-unknown-linux-musl.tar.gz
OK   omni-v0.7.9-x86_64-unknown-linux-musl.tar.gz
```
