### PR TITLE
fix(chat): persist user-scoped composer drafts

### DIFF
--- a/apps/server/src/app.test.ts
+++ b/apps/server/src/app.test.ts
@@ -154,8 +154,10 @@ describe("browser session auth", () => {
     const setupBody = (await setupResponse.json()) as {
       activeOrgId: string;
       email: string;
+      id: string;
     };
     expect(setupBody.activeOrgId).toStartWith("org_");
+    expect(setupBody.id).toStartWith("user_");
     const setCookies = extractSetCookies(setupResponse);
     expect(
       setCookies.some((cookie) => cookie.startsWith("nakama_session="))
@@ -174,10 +176,12 @@ describe("browser session auth", () => {
     expect(meResponse.status).toBe(200);
     const meBody = (await meResponse.json()) as {
       email: string;
+      id: string;
       activeOrgId?: string;
       isPlatformAdmin?: boolean;
       orgId?: string;
     };
+    expect(meBody.id).toBe(setupBody.id);
     expect(meBody.email).toBe("admin@example.com");
     expect(meBody.activeOrgId).toStartWith("org_");
     expect(meBody.orgId).toBe(meBody.activeOrgId);

--- a/apps/server/src/http/routes/auth.ts
+++ b/apps/server/src/http/routes/auth.ts
@@ -47,6 +47,7 @@ export function registerAuthRoutes(app: HonoApp, options: ServerOptions): void {
     .object({
       activeOrgId: z.string().nullable().optional(),
       email: z.string(),
+      id: z.string(),
       isPlatformAdmin: z.boolean().optional(),
       name: z.string().nullable().optional(),
       orgId: z.string().nullable().optional(),

--- a/apps/server/src/services/org-service.test.ts
+++ b/apps/server/src/services/org-service.test.ts
@@ -430,6 +430,7 @@ describe("OrgService", () => {
       phone: "",
     });
 
+    expect(updated.id).toBe(userId);
     expect(updated.name).toBe("Updated Admin");
     expect(updated.email).toBe("updated@acme.com");
     expect(updated.phone).toBeNull();

--- a/apps/server/src/services/org-service.ts
+++ b/apps/server/src/services/org-service.ts
@@ -331,6 +331,7 @@ export class OrgService {
     return {
       activeOrgId,
       email: user.email,
+      id: user.id,
       isPlatformAdmin: Boolean(user.isPlatformAdmin),
       name: user.name ?? null,
       orgId: activeOrgId,

--- a/apps/web/src/components/chat/chat-composer.tsx
+++ b/apps/web/src/components/chat/chat-composer.tsx
@@ -17,14 +17,7 @@ import {
   Image01Icon,
   WifiOff01Icon,
 } from "hugeicons-react";
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   PromptInput,
   PromptInputBody,
@@ -75,7 +68,7 @@ import {
   type SkillSlashRange,
 } from "@/lib/chat-composer-skills";
 import type { ChatContextUsage } from "@/lib/chat-context-usage";
-import { type ComposerPrefill, storeComposerDraft } from "@/lib/chat-history";
+import { storeComposerDraft } from "@/lib/chat-history";
 import {
   ALL_ATTACHMENT_ACCEPT,
   DOCUMENT_ACCEPT,
@@ -110,12 +103,10 @@ interface ChatComposerBaseProps {
   draftStorageKey?: string | null;
   error: string | null;
   footerClassName?: string;
-  onPrefillConsumed?: (prefill: ComposerPrefill) => void;
   onStop?: () => void;
   onSubmit: (text: string, files: FileUIPart[]) => void;
   onSubmitQuestionnaire?: (answers: AgentQuestionAnswer[]) => void;
   placeholder?: string;
-  prefill?: ComposerPrefill | null;
   questionnaire?: AgentQuestionnaire | null;
   queuedMessages?: QueuedComposerMessage[];
   todos?: AgentTodo[];
@@ -548,18 +539,9 @@ function ChatComposerMain({
 
 export function ChatComposer(props: ChatComposerProps) {
   const { textInput } = usePromptInputController();
-  const { prefill, onPrefillConsumed } = props;
-  useLayoutEffect(() => {
-    if (prefill) {
-      textInput.setInput(prefill.text);
-      onPrefillConsumed?.(prefill);
-    }
-  }, [prefill, onPrefillConsumed, textInput.setInput]);
   useEffect(() => {
-    if (!prefill) {
-      storeComposerDraft(props.draftStorageKey ?? null, textInput.value);
-    }
-  }, [props.draftStorageKey, prefill, textInput.value]);
+    storeComposerDraft(props.draftStorageKey ?? null, textInput.value);
+  }, [props.draftStorageKey, textInput.value]);
 
   function clearDraft() {
     if (!props.draftStorageKey) {

--- a/apps/web/src/components/chat/chat-composer.tsx
+++ b/apps/web/src/components/chat/chat-composer.tsx
@@ -567,9 +567,6 @@ export function ChatComposer(props: ChatComposerProps) {
     }
     storeComposerDraft(props.draftStorageKey, "");
     textInput.clear();
-    if (prefill) {
-      onPrefillConsumed?.(prefill);
-    }
   }
 
   const composerProps: ChatComposerProps = {

--- a/apps/web/src/components/chat/chat-composer.tsx
+++ b/apps/web/src/components/chat/chat-composer.tsx
@@ -17,7 +17,14 @@ import {
   Image01Icon,
   WifiOff01Icon,
 } from "hugeicons-react";
-import { useCallback, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   PromptInput,
   PromptInputBody,
@@ -68,6 +75,7 @@ import {
   type SkillSlashRange,
 } from "@/lib/chat-composer-skills";
 import type { ChatContextUsage } from "@/lib/chat-context-usage";
+import { type ComposerPrefill, storeComposerDraft } from "@/lib/chat-history";
 import {
   ALL_ATTACHMENT_ACCEPT,
   DOCUMENT_ACCEPT,
@@ -99,12 +107,15 @@ interface ChatComposerBaseProps {
   chatStatus: ChatStatus;
   className?: string;
   disabled?: boolean;
+  draftStorageKey?: string | null;
   error: string | null;
   footerClassName?: string;
+  onPrefillConsumed?: (prefill: ComposerPrefill) => void;
   onStop?: () => void;
   onSubmit: (text: string, files: FileUIPart[]) => void;
   onSubmitQuestionnaire?: (answers: AgentQuestionAnswer[]) => void;
   placeholder?: string;
+  prefill?: ComposerPrefill | null;
   questionnaire?: AgentQuestionnaire | null;
   queuedMessages?: QueuedComposerMessage[];
   todos?: AgentTodo[];
@@ -536,6 +547,44 @@ function ChatComposerMain({
 }
 
 export function ChatComposer(props: ChatComposerProps) {
+  const { textInput } = usePromptInputController();
+  const { prefill, onPrefillConsumed } = props;
+  useLayoutEffect(() => {
+    if (prefill) {
+      textInput.setInput(prefill.text);
+      onPrefillConsumed?.(prefill);
+    }
+  }, [prefill, onPrefillConsumed, textInput.setInput]);
+  useEffect(() => {
+    if (!prefill) {
+      storeComposerDraft(props.draftStorageKey ?? null, textInput.value);
+    }
+  }, [props.draftStorageKey, prefill, textInput.value]);
+
+  function clearDraft() {
+    if (!props.draftStorageKey) {
+      return;
+    }
+    storeComposerDraft(props.draftStorageKey, "");
+    textInput.clear();
+    if (prefill) {
+      onPrefillConsumed?.(prefill);
+    }
+  }
+
+  const composerProps: ChatComposerProps = {
+    ...props,
+    onSubmit: (text, files) => {
+      clearDraft();
+      props.onSubmit(text, files);
+    },
+    onSubmitQuestionnaire: props.onSubmitQuestionnaire
+      ? (answers) => {
+          clearDraft();
+          props.onSubmitQuestionnaire?.(answers);
+        }
+      : undefined,
+  };
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
   const displayError = props.error ?? attachmentError;
   const layout = resolveChatComposerLayout(props, displayError);
@@ -548,7 +597,7 @@ export function ChatComposer(props: ChatComposerProps) {
       <ChatComposerMain
         displayError={displayError}
         layout={layout}
-        props={props}
+        props={composerProps}
         setAttachmentError={setAttachmentError}
       />
     </div>

--- a/apps/web/src/lib/chat-history-route.test.ts
+++ b/apps/web/src/lib/chat-history-route.test.ts
@@ -3,6 +3,7 @@ import {
   buildChatPath,
   buildNewChatPath,
   CHAT_DRAFT_STORAGE_PREFIX,
+  chatComposerDraftKey,
   chatProfileIdFromPath,
   consumeStoredChatDraft,
   isChatSessionPath,
@@ -10,6 +11,7 @@ import {
   lastChatModelStorageKey,
   parseChatRouteParams,
   pickKnownProfileId,
+  readComposerDraft,
   readInitialDraftChatProfileId,
   readLastChatModel,
   readRequestedDraftFromNewChatSearch,
@@ -20,11 +22,52 @@ import {
   resolveHistoryProfileId,
   resolveProfilesPageProfileId,
   storeChatDraft,
+  storeComposerDraft,
   writeLastChatModel,
   writeStoredActiveChatProfileId,
 } from "./chat-history";
 
 describe("chat history route helpers", () => {
+  test("composer drafts restore without consuming, isolate identities and clear", () => {
+    const store = new Map<string, string>();
+    const previous = globalThis.localStorage;
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: (key: string) => store.get(key) ?? null,
+        removeItem: (key: string) => store.delete(key),
+        setItem: (key: string, value: string) => store.set(key, value),
+      },
+    });
+    try {
+      const key = chatComposerDraftKey("alice", "org", "profile", "session");
+      storeComposerDraft(key, "unfinished thought");
+      expect(readComposerDraft(key)).toBe("unfinished thought");
+      expect(readComposerDraft(key)).toBe("unfinished thought");
+      for (const other of [
+        chatComposerDraftKey("bob", "org", "profile", "session"),
+        chatComposerDraftKey("alice", "other-org", "profile", "session"),
+        chatComposerDraftKey("alice", "org", "other-profile", "session"),
+        chatComposerDraftKey("alice", "org", "profile", "other-session"),
+        chatComposerDraftKey("alice", "org", "profile", null),
+      ]) {
+        expect(readComposerDraft(other)).toBe("");
+      }
+      expect(
+        chatComposerDraftKey(undefined, "org", "profile", null)
+      ).toBeNull();
+      storeComposerDraft(null, "not authenticated");
+      storeComposerDraft(key, "");
+      expect(store.size).toBe(0);
+      expect(readComposerDraft(key)).toBe("");
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", {
+        configurable: true,
+        value: previous,
+      });
+    }
+  });
+
   test("builds and parses chat routes consistently", () => {
     expect(buildChatPath("profile 1", "session/2")).toBe(
       "/chat/profile%201/session%2F2"

--- a/apps/web/src/lib/chat-history.ts
+++ b/apps/web/src/lib/chat-history.ts
@@ -103,6 +103,45 @@ export function storeChatDraft(draft: string): string {
   return key;
 }
 
+export interface ComposerPrefill {
+  scopeKey: string;
+  text: string;
+}
+
+export function chatComposerDraftKey(
+  userId: string | undefined,
+  orgId: string | undefined,
+  profileId: string,
+  sessionId: string | null
+): string | null {
+  return userId && orgId && profileId
+    ? `nakama:composer-draft:${JSON.stringify([userId, orgId, profileId, sessionId])}`
+    : null;
+}
+
+export function readComposerDraft(key: string | null): string {
+  try {
+    return key ? (localStorage.getItem(key) ?? "") : "";
+  } catch {
+    return "";
+  }
+}
+
+export function storeComposerDraft(key: string | null, text: string): void {
+  if (!key) {
+    return;
+  }
+  try {
+    if (text) {
+      localStorage.setItem(key, text);
+    } else {
+      localStorage.removeItem(key);
+    }
+  } catch {
+    // Storage can be disabled or full; the composer must still work.
+  }
+}
+
 export const MAX_URL_CHAT_DRAFT_LENGTH = 1500;
 
 export function chatProfileIdFromPath(pathname: string): string | null {

--- a/apps/web/src/lib/chat-history.ts
+++ b/apps/web/src/lib/chat-history.ts
@@ -103,11 +103,6 @@ export function storeChatDraft(draft: string): string {
   return key;
 }
 
-export interface ComposerPrefill {
-  scopeKey: string;
-  text: string;
-}
-
 export function chatComposerDraftKey(
   userId: string | undefined,
   orgId: string | undefined,

--- a/apps/web/src/pages/chat/chat-page-content.tsx
+++ b/apps/web/src/pages/chat/chat-page-content.tsx
@@ -5,10 +5,7 @@ import { ChatComposer } from "@/components/chat/chat-composer";
 import { ChatMessageList } from "@/components/chat/chat-message-list";
 import { ChatAttachmentPanelProvider } from "@/context/chat-attachment-panel-context";
 import { usePostTurnSkillReviewOverlay } from "@/hooks/use-post-turn-skill-review-overlay";
-import {
-  formatSessionChannelLabel,
-  readComposerDraft,
-} from "@/lib/chat-history";
+import { formatSessionChannelLabel } from "@/lib/chat-history";
 import { extractModelId } from "@/lib/models";
 import { ChatPageColumn, ChatWelcome } from "@/pages/chat/chat-page-layout";
 import type { ChatPageState } from "@/pages/chat/use-chat-page";
@@ -28,8 +25,7 @@ export function ChatPageContent(state: ChatPageState) {
     canStop,
     error,
     composerDraftKey,
-    composerPrefill,
-    consumeComposerPrefill,
+    composerEntry,
     queuedMessages,
     branchingMessageId,
     showOfflineHint,
@@ -95,7 +91,6 @@ export function ChatPageContent(state: ChatPageState) {
         error={error}
         onModelChange={handleModelChange}
         onNavigateSetup={navigateSetup}
-        onPrefillConsumed={consumeComposerPrefill}
         onStop={stopStreaming}
         onSubmit={(text, files) => {
           void sendMessage(text, files);
@@ -110,11 +105,6 @@ export function ChatPageContent(state: ChatPageState) {
           );
         }}
         onThinkingEffortChange={handleThinkingEffortChange}
-        prefill={
-          composerPrefill?.scopeKey === composerDraftKey
-            ? composerPrefill
-            : null
-        }
         primarySupportsVision={activeModelSupportsVision}
         profileModelId={extractModelId(currentModelSelection)}
         providerConfigured={health?.providerConfigured}
@@ -181,8 +171,8 @@ export function ChatPageContent(state: ChatPageState) {
 
   return (
     <PromptInputProvider
-      initialInput={readComposerDraft(composerDraftKey)}
-      key={composerDraftKey}
+      initialInput={composerEntry.initialInput}
+      key={`${composerDraftKey}:${composerEntry.revision}`}
     >
       {content}
     </PromptInputProvider>

--- a/apps/web/src/pages/chat/chat-page-content.tsx
+++ b/apps/web/src/pages/chat/chat-page-content.tsx
@@ -5,7 +5,10 @@ import { ChatComposer } from "@/components/chat/chat-composer";
 import { ChatMessageList } from "@/components/chat/chat-message-list";
 import { ChatAttachmentPanelProvider } from "@/context/chat-attachment-panel-context";
 import { usePostTurnSkillReviewOverlay } from "@/hooks/use-post-turn-skill-review-overlay";
-import { formatSessionChannelLabel } from "@/lib/chat-history";
+import {
+  formatSessionChannelLabel,
+  readComposerDraft,
+} from "@/lib/chat-history";
 import { extractModelId } from "@/lib/models";
 import { ChatPageColumn, ChatWelcome } from "@/pages/chat/chat-page-layout";
 import type { ChatPageState } from "@/pages/chat/use-chat-page";
@@ -24,8 +27,9 @@ export function ChatPageContent(state: ChatPageState) {
     turnStartedAt,
     canStop,
     error,
-    composerDraft,
-    setComposerDraft,
+    composerDraftKey,
+    composerPrefill,
+    consumeComposerPrefill,
     queuedMessages,
     branchingMessageId,
     showOfflineHint,
@@ -71,10 +75,7 @@ export function ChatPageContent(state: ChatPageState) {
   ) : null;
 
   const composer = (
-    <PromptInputProvider
-      initialInput={composerDraft}
-      key={composerDraft || "empty"}
-    >
+    <>
       {skillReviewBanner}
       {readOnlyBanner}
       <ChatComposer
@@ -90,16 +91,16 @@ export function ChatPageContent(state: ChatPageState) {
         contextUsage={contextUsage}
         currentModelSelection={currentModelSelection}
         disabled={composerDisabled}
+        draftStorageKey={composerDraftKey}
         error={error}
         onModelChange={handleModelChange}
         onNavigateSetup={navigateSetup}
+        onPrefillConsumed={consumeComposerPrefill}
         onStop={stopStreaming}
         onSubmit={(text, files) => {
-          setComposerDraft("");
           void sendMessage(text, files);
         }}
         onSubmitQuestionnaire={(answers) => {
-          setComposerDraft("");
           void sendMessage(
             formatAgentQuestionnaireAnswersMessage(answers),
             [],
@@ -109,6 +110,11 @@ export function ChatPageContent(state: ChatPageState) {
           );
         }}
         onThinkingEffortChange={handleThinkingEffortChange}
+        prefill={
+          composerPrefill?.scopeKey === composerDraftKey
+            ? composerPrefill
+            : null
+        }
         primarySupportsVision={activeModelSupportsVision}
         profileModelId={extractModelId(currentModelSelection)}
         providerConfigured={health?.providerConfigured}
@@ -123,29 +129,25 @@ export function ChatPageContent(state: ChatPageState) {
         thinkingEffortVisible={thinkingEffortVisible}
         todos={agentTodos}
       />
-    </PromptInputProvider>
+    </>
   );
 
-  if (isEmptyState) {
-    return (
-      <ChatAttachmentPanelProvider key={session?.id ?? "new"}>
-        <ChatPageColumn centered>
-          <div className="mx-auto mb-12 flex w-full max-w-3xl flex-col gap-1">
-            <ChatWelcome
-              onProfileSwitch={handleProfileSwitch}
-              profile={activeProfile}
-              profileId={profileId}
-              profileSwitchDisabled={busy}
-              profiles={profiles}
-            />
-            {composer}
-          </div>
-        </ChatPageColumn>
-      </ChatAttachmentPanelProvider>
-    );
-  }
-
-  return (
+  const content = isEmptyState ? (
+    <ChatAttachmentPanelProvider key={session?.id ?? "new"}>
+      <ChatPageColumn centered>
+        <div className="mx-auto mb-12 flex w-full max-w-3xl flex-col gap-1">
+          <ChatWelcome
+            onProfileSwitch={handleProfileSwitch}
+            profile={activeProfile}
+            profileId={profileId}
+            profileSwitchDisabled={busy}
+            profiles={profiles}
+          />
+          {composer}
+        </div>
+      </ChatPageColumn>
+    </ChatAttachmentPanelProvider>
+  ) : (
     <ChatAttachmentPanelProvider key={session?.id ?? "new"}>
       <ArtifactStreamingPanelBridge messages={messages} profileId={profileId} />
       <ChatPageColumn>
@@ -175,5 +177,14 @@ export function ChatPageContent(state: ChatPageState) {
         </div>
       </ChatPageColumn>
     </ChatAttachmentPanelProvider>
+  );
+
+  return (
+    <PromptInputProvider
+      initialInput={readComposerDraft(composerDraftKey)}
+      key={composerDraftKey}
+    >
+      {content}
+    </PromptInputProvider>
   );
 }

--- a/apps/web/src/pages/chat/use-chat-page.ts
+++ b/apps/web/src/pages/chat/use-chat-page.ts
@@ -42,7 +42,6 @@ import {
   buildChatPath,
   buildNewChatPath,
   type ChatListItem,
-  type ComposerPrefill,
   chatComposerDraftKey,
   chatMessagesToListItems,
   clearFailedChatTurn,
@@ -50,6 +49,7 @@ import {
   isReadOnlySessionChannel,
   parseChatRouteParams,
   pickKnownProfileId,
+  readComposerDraft,
   readFailedChatTurn,
   readInitialDraftChatProfileId,
   readLastChatModel,
@@ -59,6 +59,7 @@ import {
   readStoredActiveChatProfileId,
   resolveDefaultProfileId,
   sessionStorageKey,
+  storeComposerDraft,
   storeFailedChatTurn,
   writeLastChatModel,
 } from "@/lib/chat-history";
@@ -159,8 +160,6 @@ export function useChatPage() {
   );
   const [canStop, setCanStop] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [composerPrefill, setComposerPrefill] =
-    useState<ComposerPrefill | null>(null);
   const composerDraftKey = chatComposerDraftKey(
     user?.id,
     activeOrg?.id,
@@ -169,14 +168,18 @@ export function useChatPage() {
       profileId,
     routeSession?.sessionId ?? null
   );
-  const consumeComposerPrefill = useCallback((consumed: ComposerPrefill) => {
-    setComposerPrefill((current) => (current === consumed ? null : current));
-  }, []);
-  useEffect(() => {
-    setComposerPrefill((current) =>
-      current?.scopeKey === composerDraftKey ? current : null
-    );
-  }, [composerDraftKey]);
+  const [composerEntry, setComposerEntry] = useState(() => ({
+    initialInput: readComposerDraft(composerDraftKey),
+    revision: 0,
+    scopeKey: composerDraftKey,
+  }));
+  if (composerEntry.scopeKey !== composerDraftKey) {
+    setComposerEntry({
+      initialInput: readComposerDraft(composerDraftKey),
+      revision: 0,
+      scopeKey: composerDraftKey,
+    });
+  }
   const [queuedMessages, setQueuedMessages] = useState<QueuedComposerMessage[]>(
     []
   );
@@ -708,7 +711,12 @@ export function useChatPage() {
     }
 
     if (requestedDraft !== null) {
-      setComposerPrefill({ scopeKey: targetDraftKey, text: requestedDraft });
+      storeComposerDraft(targetDraftKey, requestedDraft);
+      setComposerEntry((current) => ({
+        initialInput: requestedDraft,
+        revision: current.revision + 1,
+        scopeKey: targetDraftKey,
+      }));
     }
 
     navigate(buildChatBasePath(), { replace: true });
@@ -1127,8 +1135,7 @@ export function useChatPage() {
     chatStatus,
     composerDisabled,
     composerDraftKey,
-    composerPrefill,
-    consumeComposerPrefill,
+    composerEntry,
     contextUsage: isEmptyState ? null : contextUsage,
     currentModelSelection,
     error,

--- a/apps/web/src/pages/chat/use-chat-page.ts
+++ b/apps/web/src/pages/chat/use-chat-page.ts
@@ -25,6 +25,7 @@ import {
 import type { QueuedComposerMessage } from "@/components/chat/ChatMessageQueuePanel";
 import { useActiveChatProfile } from "@/context/use-active-chat-profile";
 import { useAppContext } from "@/context/use-app-context";
+import { useAuth } from "@/context/use-auth";
 import {
   buildThinkingSettingsPayload,
   useProfileQuery,
@@ -41,6 +42,8 @@ import {
   buildChatPath,
   buildNewChatPath,
   type ChatListItem,
+  type ComposerPrefill,
+  chatComposerDraftKey,
   chatMessagesToListItems,
   clearFailedChatTurn,
   consumeStoredChatDraft,
@@ -52,6 +55,7 @@ import {
   readLastChatModel,
   readRequestedDraftFromNewChatSearch,
   readRequestedDraftKeyFromNewChatSearch,
+  readRequestedProfileFromNewChatSearch,
   readStoredActiveChatProfileId,
   resolveDefaultProfileId,
   sessionStorageKey,
@@ -122,6 +126,7 @@ export function useChatPage() {
   const [searchParams] = useSearchParams();
   const routeSession = useMemo(() => parseChatRouteParams(params), [params]);
   const { health, models } = useAppContext();
+  const { user, activeOrg } = useAuth();
   const {
     profileId: liveChatProfileId,
     setProfileId: setLiveChatProfileId,
@@ -154,7 +159,24 @@ export function useChatPage() {
   );
   const [canStop, setCanStop] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [composerDraft, setComposerDraft] = useState("");
+  const [composerPrefill, setComposerPrefill] =
+    useState<ComposerPrefill | null>(null);
+  const composerDraftKey = chatComposerDraftKey(
+    user?.id,
+    activeOrg?.id,
+    readRequestedProfileFromNewChatSearch(location.search) ??
+      routeSession?.profileId ??
+      profileId,
+    routeSession?.sessionId ?? null
+  );
+  const consumeComposerPrefill = useCallback((consumed: ComposerPrefill) => {
+    setComposerPrefill((current) => (current === consumed ? null : current));
+  }, []);
+  useEffect(() => {
+    setComposerPrefill((current) =>
+      current?.scopeKey === composerDraftKey ? current : null
+    );
+  }, [composerDraftKey]);
   const [queuedMessages, setQueuedMessages] = useState<QueuedComposerMessage[]>(
     []
   );
@@ -644,14 +666,25 @@ export function useChatPage() {
       return;
     }
     const requestedProfile = searchParams.get("profile")?.trim() || null;
+    const targetProfileId = requestedProfile || profileId;
+    const targetDraftKey = chatComposerDraftKey(
+      user?.id,
+      activeOrg?.id,
+      targetProfileId,
+      null
+    );
+    if (!targetDraftKey) {
+      return;
+    }
     const inlineDraft = readRequestedDraftFromNewChatSearch(location.search);
     const draftKey = readRequestedDraftKeyFromNewChatSearch(location.search);
     const storedDraft = draftKey ? consumeStoredChatDraft(draftKey) : null;
     const requestedDraft = inlineDraft ?? storedDraft;
-    const targetProfileId = requestedProfile || profileIdRef.current;
 
-    if (targetProfileId) {
+    try {
       localStorage.removeItem(sessionStorageKey(targetProfileId));
+    } catch {
+      // Starting a new chat must still work when browser storage is disabled.
     }
     skipNextProfileSessionRef.current = true;
     loadedRouteRef.current = null;
@@ -674,12 +707,20 @@ export function useChatPage() {
       setProfileId(requestedProfile);
     }
 
-    if (requestedDraft) {
-      setComposerDraft(requestedDraft);
+    if (requestedDraft !== null) {
+      setComposerPrefill({ scopeKey: targetDraftKey, text: requestedDraft });
     }
 
     navigate(buildChatBasePath(), { replace: true });
-  }, [searchParams, navigate, location.search, restoreLastChatModel]);
+  }, [
+    searchParams,
+    navigate,
+    location.search,
+    restoreLastChatModel,
+    profileId,
+    user?.id,
+    activeOrg?.id,
+  ]);
 
   useEffect(() => {
     if (!profileId || routeSession) {
@@ -1085,7 +1126,9 @@ export function useChatPage() {
     canStop,
     chatStatus,
     composerDisabled,
-    composerDraft,
+    composerDraftKey,
+    composerPrefill,
+    consumeComposerPrefill,
     contextUsage: isEmptyState ? null : contextUsage,
     currentModelSelection,
     error,
@@ -1108,7 +1151,6 @@ export function useChatPage() {
     sendMessage,
     session,
     sessionChannel,
-    setComposerDraft,
     showOfflineHint,
     showThinking,
     stopStreaming,

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -461,6 +461,7 @@ export interface WebPublicUrlSettingsResponse {
 export interface AuthUserResponse {
   activeOrgId?: string | null;
   email: string;
+  id: string;
   isPlatformAdmin?: boolean;
   name?: string | null;
   orgId?: string | null;


### PR DESCRIPTION
## Summary

Keep unfinished chat text across refresh without mixing accounts or organizations. Fixes #861.

**Before:** refresh erased typed text; `draftKey` only supported a consume-once navigation handoff.
**After:** live composer text restores per user, org, profile, and chat; sending or deleting text removes the draft.

Why safe:
1. Auth responses expose the stable user ID used in draft keys; no email-based identity or database migration.
2. The existing input provider owns live text; navigation prefills are applied and acknowledged once.
3. Draft-storage failures do not block editing; existing consume-once handoffs remain separate.

Residual: drafts live in browser storage, not encrypted or synced across devices. Storage denial means refresh persistence is unavailable.

## Test plan
- [x] `bun test apps/web/src apps/server/src/app.test.ts apps/server/src/services/org-service.test.ts` (404 pass after rebasing onto current main).
- [x] `bun x tsc --noEmit -p apps/web/tsconfig.json` and targeted `bun x ultracite check` on all 10 changed files.
- [x] Local browser checks before rebase: new/existing-chat refresh, send/delete clearing, account/org isolation, editable consume-once prefills, and denied draft storage. Send requests were blocked before the model call; this verifies clearing, not successful AI replies.
- [ ] CI and fresh draft review before marking ready for review.
- [ ] Type a draft, refresh, then clear it and refresh again: text restores once and stays cleared.