### PR TITLE
fix(db): settle runs interrupted by a restart

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -107,6 +107,15 @@ const database = await createDatabase(config.databaseUrl, {
 
 await seedDatabase(database.adapter);
 
+// Runs are only completed by the process that started them, so a crash or a
+// kill leaves rows claiming work nothing is doing. Settle them before serving.
+// ponytail: correct while this is a single process; two servers would mean one
+// boot settling the other's live runs, which needs a heartbeat to tell apart.
+const interruptedRuns = await database.adapter.failInterruptedRuns();
+if (interruptedRuns > 0) {
+  console.log(`Settled ${interruptedRuns} run(s) interrupted by a restart`);
+}
+
 const authService = new AuthService();
 
 const llmUsageTracker = await LlmUsageTracker.create(database.adapter);

--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -49,6 +49,9 @@ export interface SqliteDatabase {
   reopen(): Promise<void>;
 }
 
+const INTERRUPTED_RUN_ERROR =
+  "Interrupted: the server process running this exited before it finished.";
+
 interface AutomationRow {
   created_at: string;
   definition: string;
@@ -588,6 +591,21 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
   const deleteWorkflowRunStmt = db.prepare(`
     DELETE FROM workflow_runs
     WHERE workflow_id = ? AND id = ?
+  `);
+  const failInterruptedAutomationRunsStmt = db.prepare(`
+    UPDATE automation_runs
+    SET status = 'failed', completed_at = ?, error = ?
+    WHERE status = 'running'
+  `);
+  const failInterruptedWorkflowRunsStmt = db.prepare(`
+    UPDATE workflow_runs
+    SET status = 'failed', completed_at = ?, error = ?
+    WHERE status = 'running'
+  `);
+  const failInterruptedWorkflowRunStepsStmt = db.prepare(`
+    UPDATE workflow_run_steps
+    SET status = 'failed', completed_at = ?, error = ?
+    WHERE status = 'running'
   `);
 
   const listWorkflowRunStepsStmt = db.prepare(`
@@ -2078,6 +2096,25 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
     async deleteWorkflowRun(workflowId, runId) {
       const result = deleteWorkflowRunStmt.run(workflowId, runId);
       return result.changes > 0;
+    },
+
+    async failInterruptedRuns() {
+      const completedAt = new Date().toISOString();
+      const automations = failInterruptedAutomationRunsStmt.run(
+        completedAt,
+        INTERRUPTED_RUN_ERROR
+      );
+      const workflows = failInterruptedWorkflowRunsStmt.run(
+        completedAt,
+        INTERRUPTED_RUN_ERROR
+      );
+      // Steps follow their run: a failed run whose steps still read `running`
+      // renders as work in progress under a finished run.
+      failInterruptedWorkflowRunStepsStmt.run(
+        completedAt,
+        INTERRUPTED_RUN_ERROR
+      );
+      return automations.changes + workflows.changes;
     },
 
     async getActiveArtifactShareByPath(orgId, profileId, sourcePath) {

--- a/packages/db/src/fail-interrupted-runs.test.ts
+++ b/packages/db/src/fail-interrupted-runs.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import { createInMemoryDatabaseAdapter } from "./index";
+
+describe("failInterruptedRuns", () => {
+  test("settles runs a dead process left running and leaves finished ones alone", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const now = new Date().toISOString();
+
+    await db.upsertProfile({
+      createdAt: now,
+      id: "profile_a",
+      isSuper: false,
+      model: null,
+      name: "A",
+      systemPrompt: "a",
+      updatedAt: now,
+    });
+    await db.upsertAutomation({
+      createdAt: now,
+      definition: { trigger: { type: "manual" } },
+      enabled: true,
+      id: "auto_a",
+      name: "Auto",
+      profileId: "profile_a",
+      updatedAt: now,
+      version: 1,
+    });
+    await db.upsertWorkflow({
+      createdAt: now,
+      definition: { steps: [] },
+      enabled: true,
+      id: "wf_a",
+      name: "Flow",
+      profileId: "profile_a",
+      updatedAt: now,
+      version: 1,
+    });
+
+    await db.insertAutomationRun({
+      automationId: "auto_a",
+      completedAt: null,
+      error: null,
+      id: "arun_live",
+      output: null,
+      startedAt: now,
+      status: "running",
+    });
+    await db.insertWorkflowRun({
+      completedAt: null,
+      error: null,
+      id: "wfrun_live",
+      input: "{}",
+      output: null,
+      startedAt: now,
+      status: "running",
+      workflowId: "wf_a",
+    });
+    await db.insertWorkflowRunStep({
+      completedAt: null,
+      error: null,
+      id: "wfstep_live",
+      input: null,
+      kind: "tool",
+      output: null,
+      position: 0,
+      runId: "wfrun_live",
+      startedAt: now,
+      status: "running",
+      stepId: "fetch",
+    });
+    await db.insertWorkflowRun({
+      completedAt: now,
+      error: null,
+      id: "wfrun_done",
+      input: "{}",
+      output: "done",
+      startedAt: now,
+      status: "completed",
+      workflowId: "wf_a",
+    });
+
+    const settled = await db.failInterruptedRuns();
+
+    // Two runs, not three: the step is not a run and the finished one is not touched.
+    expect(settled).toBe(2);
+
+    const automationRuns = await db.listAutomationRuns("auto_a", 10);
+    expect(automationRuns[0]?.status).toBe("failed");
+    expect(automationRuns[0]?.error).toBeTruthy();
+    expect(automationRuns[0]?.completedAt).toBeTruthy();
+
+    const workflowRuns = await db.listWorkflowRuns("wf_a", 10);
+    const live = workflowRuns.find((run) => run.id === "wfrun_live");
+    expect(live?.status).toBe("failed");
+    expect(live?.error).toBeTruthy();
+    expect(live?.completedAt).toBeTruthy();
+
+    const steps = await db.listWorkflowRunSteps("wfrun_live");
+    expect(steps[0]?.status).toBe("failed");
+    expect(steps[0]?.error).toBeTruthy();
+
+    const done = workflowRuns.find((run) => run.id === "wfrun_done");
+    expect(done?.status).toBe("completed");
+    expect(done?.error).toBeNull();
+    expect(done?.output).toBe("done");
+  });
+});

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -629,6 +629,14 @@ export interface DatabaseAdapter {
   deleteTool(id: string): Promise<boolean>;
   deleteWorkflow(id: string): Promise<boolean>;
   deleteWorkflowRun(workflowId: string, runId: string): Promise<boolean>;
+  /**
+   * Settles runs left `running` by a process that exited mid-run. Only a
+   * `finally` in the owning process completes a run, so a kill leaves the row
+   * claiming work nothing is doing. Call once at boot, before serving.
+   *
+   * Returns the number of automation and workflow runs settled.
+   */
+  failInterruptedRuns(): Promise<number>;
   getActiveArtifactShareByPath(
     orgId: string,
     profileId: string,


### PR DESCRIPTION
Closes #873.

A run row is written with status `running` and only the `finally` in the owning process completes it, so a kill leaves automation and workflow runs claiming work nothing is doing. `failInterruptedRuns` settles them once at boot, before the server accepts requests. Steps settle with their run, so a failed run cannot hold a step that still reads `running`.

Same throwaway instance, same endpoint, across a `kill -9` and a restart.

Before:

```json
{"completedAt":null,"error":null,"id":"run_orphan","status":"running",
 "steps":[{"id":"step_orphan","status":"running","completedAt":null}]}
```

After, with `Settled 1 run(s) interrupted by a restart` in the boot log:

```json
{"completedAt":"2026-09-07T04:02:18.091Z","status":"failed",
 "error":"Interrupted: the server process running this exited before it finished.",
 "steps":[{"id":"step_orphan","status":"failed","completedAt":"2026-09-07T04:02:18.091Z"}]}
```

The new test bites: with the sweep neutered it fails on `expected 2, received 0`, and passes with it back. `bun run test` is green across all 11 workspaces, 2915 pass 0 fail.

The `ponytail:` comment at the call site marks the single process assumption. Two servers would mean one boot settling the other's live runs, which needs a heartbeat to tell apart.
