### PR TITLE
docs: restore Discord link in README and fix expired invite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Nakama is a multi-tenant Bun + TypeScript platform for running AI agent teams (o
 - [README.md](./README.md) — product overview and quick start
 - [ARCHITECTURE.md](./ARCHITECTURE.md) — system design
 - [AGENTS.md](./AGENTS.md) — authoritative agent/dev notes (layout, tests, docs conventions)
-- Discord: https://discord.gg/qhKbMFEUc
+- Discord: https://discord.gg/Cwq3erYvh
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 <p align="center">
   <a href="https://github.com/ahmadrosid/nakama/releases"><img src="https://img.shields.io/github/v/release/ahmadrosid/nakama?display_name=tag&sort=semver" alt="Latest release"></a>
   <a href="https://github.com/ahmadrosid/nakama/graphs/contributors"><img src="https://img.shields.io/github/contributors/ahmadrosid/nakama?style=flat-square" alt="Contributors"></a>
+  <a href="https://discord.com/invite/Cwq3erYvh"><img src="https://img.shields.io/badge/Discord-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord"></a>
 </p>
 
 # Nakama

--- a/docs/website/content/docs/contributing.mdx
+++ b/docs/website/content/docs/contributing.mdx
@@ -64,4 +64,4 @@ Docs-only changes: register new MDX pages in `meta.json`, link them from the [Do
 
 - [GitHub repository](https://github.com/ahmadrosid/nakama)
 - [CONTRIBUTING.md](https://github.com/ahmadrosid/nakama/blob/main/CONTRIBUTING.md)
-- [Discord](https://discord.gg/qhKbMFEUc)
+- [Discord](https://discord.gg/Cwq3erYvh)


### PR DESCRIPTION
## Summary

Anyone reading the README, CONTRIBUTING.md, or the docs site can reach the Nakama Discord again.

**Before:** the README badge row had no Discord link since #870, and CONTRIBUTING.md plus `contributing.mdx` pointed at `discord.gg/qhKbMFEUc`, which Discord reports as expired.
**After:** the Discord badge sits next to the release and contributors badges, and all three files share the one invite that resolves (`Cwq3erYvh`).

Why safe:
1. Markdown only, three lines touched, no code path changes
2. Badge markup is the same `<a><img></a>` shape as the two badges beside it, `flat-square` to match
3. Invite resolves to guild "Nakama" today (Discord invites API)

Only follow up with a permanent invite: `Cwq3erYvh` expires on 2026-09-12, so a no-expiry code from a server admin needs to replace it in these three lines before then.

Fixes #878. No other issue reports this; #870 is the PR that dropped the badge.

## Test plan
- [x] `curl -s https://discord.com/api/v10/invites/Cwq3erYvh | jq -r .guild.name` (Nakama)
- [x] `curl -s -o /dev/null -w '%{http_code}' 'https://img.shields.io/badge/Discord-5865F2?style=flat-square&logo=discord&logoColor=white'` (200)
- [x] `git grep -n qhKbMFEUc` (no matches)
- [ ] Open the README rich diff in "Files changed" and click the Discord badge
