### PR TITLE
feat(web): refresh a workflow run while it is still running

### DIFF
--- a/apps/web/src/hooks/use-workflows.test.ts
+++ b/apps/web/src/hooks/use-workflows.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import type { WorkflowRunRecord } from "@nakama/core/contract";
+import { workflowRunsRefetchInterval } from "./use-workflows";
+
+function run(
+  id: string,
+  status: WorkflowRunRecord["status"]
+): WorkflowRunRecord {
+  return {
+    completedAt: status === "running" ? null : "2026-09-07T00:00:01.000Z",
+    error: null,
+    id,
+    input: null,
+    output: null,
+    startedAt: "2026-09-07T00:00:00.000Z",
+    status,
+    workflowId: "wf_a",
+  };
+}
+
+describe("workflowRunsRefetchInterval", () => {
+  test("polls only while a run is in flight", () => {
+    const interval = workflowRunsRefetchInterval([
+      run("wfrun_live", "running"),
+      run("wfrun_done", "completed"),
+    ]);
+    expect(interval).toBeGreaterThan(0);
+
+    // The panel is open on history alone, so every settled state stops the timer.
+    expect(
+      workflowRunsRefetchInterval([
+        run("wfrun_done", "completed"),
+        run("wfrun_bad", "failed"),
+      ])
+    ).toBe(false);
+
+    // First render has no data yet, and an empty list is a workflow never run.
+    expect(workflowRunsRefetchInterval(undefined)).toBe(false);
+    expect(workflowRunsRefetchInterval([])).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/use-workflows.ts
+++ b/apps/web/src/hooks/use-workflows.ts
@@ -1,4 +1,7 @@
-import type { UpdateWorkflowRequest } from "@nakama/core/contract";
+import type {
+  UpdateWorkflowRequest,
+  WorkflowRunRecord,
+} from "@nakama/core/contract";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/context/use-auth";
 import { client } from "@/lib/client";
@@ -25,11 +28,26 @@ export function useWorkflowSqliteQuery(table: string | null, enabled: boolean) {
   });
 }
 
+const RUN_POLL_INTERVAL_MS = 2000;
+
+/**
+ * A run settles on the server, so the panel has to ask. Poll while one is in
+ * flight and stop as soon as none is, which keeps a finished workflow at zero
+ * requests without holding a second stream open for the page.
+ */
+export function workflowRunsRefetchInterval(
+  runs: WorkflowRunRecord[] | undefined
+): number | false {
+  const running = runs?.some((run) => run.status === "running") ?? false;
+  return running ? RUN_POLL_INTERVAL_MS : false;
+}
+
 export function useWorkflowRunsQuery(workflowId: string | null) {
   return useQuery({
     enabled: Boolean(workflowId),
     queryFn: () => client.listWorkflowRuns(workflowId!),
     queryKey: queryKeys.workflows.runs(workflowId ?? ""),
+    refetchInterval: (query) => workflowRunsRefetchInterval(query.state.data),
   });
 }
 


### PR DESCRIPTION
Closes #874.

`WorkflowRunHistoryDetail` already renders `runStatusLabel(step.status)` for every step, so the panel could always show a run progressing. The query behind it never refetched, which is why Run now looks dead until the recipe settles.

The whole change is one option on the existing query: poll while any run reads `running`, return `false` the moment none does. A finished workflow makes zero requests, `refetchIntervalInBackground` stays off so a hidden tab pauses, and leaving the page unmounts the query. No new dependency, and no second streaming surface.

`workflowRunsRefetchInterval` is exported so the decision is testable without a DOM. The test bites: with the predicate stubbed to `false` it fails on `Expected and actual values must be numbers`, and passes with it back. `bun run test` is green across 11 workspaces, 2916 pass 0 fail.

What I could not capture on this machine, so you can judge it rather than take my word: the request count in a real browser. Playwright is not installed here, and a bare `query-core` harness does not run interval timers at all, a static `refetchInterval: 500` fetched once in three seconds there too. So the polling decision is proven and the one line that hands it to `useQuery` is only proven by types.
