### PR TITLE
feat(core): the token optimiser is on by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Entries marked *(in review)* come from a pull request that is open but not merge
 
 ## [Unreleased]
 
+### Changed
+
+- The token optimiser is on by default; `NAKAMA_OMNI=0` or the Integrations
+  toggle turns it off ([#881])
+
 ## [0.4.8] - 2026-09-06
 
 ### Added
@@ -976,3 +981,4 @@ First tagged release. The baseline it established:
 [#858]: https://github.com/ahmadrosid/nakama/pull/858
 [#859]: https://github.com/ahmadrosid/nakama/pull/859
 [#860]: https://github.com/ahmadrosid/nakama/pull/860
+[#881]: https://github.com/ahmadrosid/nakama/pull/881

--- a/README.md
+++ b/README.md
@@ -98,10 +98,11 @@ docker run -d -p 4310:4310 -v nakama-data:/nakama/data --name nakama ghcr.io/ahm
 Open the dashboard at http://localhost:4310.
 
 The image carries [omni](https://github.com/fajarhide/omni), which shortens `bash`
-and `read_file` output before it reaches the model. Turn it on under Integrations,
-or with `NAKAMA_OMNI=1`. Build with `--build-arg OMNI_VERSION=` to leave the binary
-out; the server then downloads it, checksum verified, the first time the toggle is
-switched on. Set `NAKAMA_OMNI_AUTO_INSTALL=0` to forbid that download.
+and `read_file` output before it reaches the model. It is on by default; switch it
+off under Integrations, or with `NAKAMA_OMNI=0`. Build with
+`--build-arg OMNI_VERSION=` to leave the binary out; the server then downloads it,
+checksum verified, the first time the toggle is switched on. Set
+`NAKAMA_OMNI_AUTO_INSTALL=0` to forbid that download.
 
 ### Integrations
 

--- a/docs/website/content/docs/token-optimiser.mdx
+++ b/docs/website/content/docs/token-optimiser.mdx
@@ -3,9 +3,9 @@ title: "Token optimiser"
 description: "Shorten bash and read_file output before it reaches the model, measure what that saves, and expand anything folded."
 ---
 
-Long tool output is the most expensive thing in an agent turn, and most of it is output the model has already been shown. The optional **token optimiser** folds that away before it is inserted into the conversation, and keeps a handle so the agent can read the full text if it needs to.
+Long tool output is the most expensive thing in an agent turn, and most of it is output the model has already been shown. The **token optimiser** folds that away before it is inserted into the conversation, and keeps a handle so the agent can read the full text if it needs to.
 
-It is off by default.
+It is on by default. Nothing is lost when it runs: folded text is archived and the agent can expand it by handle.
 
 ## What it touches
 
@@ -15,11 +15,11 @@ That narrowness is measured, not cautious. Replayed against real sessions, the s
 
 The optimiser runs in process. It is not an MCP server, deliberately: that server publishes 26 tools and 8,241 bytes of definitions that ride on every single request, which costs more than the folding saves and makes tool selection worse at the same time.
 
-## Turning it on
+## Turning it off
 
-**Integrations → Context savings** carries the toggle and the numbers. Switching it on is an org-admin action, because it changes what every session in the org does.
+**Integrations → Context savings** carries the toggle and the numbers. Changing it is an org-admin action, because it changes what every session in the org does.
 
-`NAKAMA_OMNI=1` sets the server-wide default for orgs that have not chosen. An explicit org setting wins in both directions, so an admin who switched it off in the dashboard is not overridden by the environment, and the reverse holds too.
+`NAKAMA_OMNI=0` turns it off server-wide for orgs that have not chosen. An explicit org setting wins in both directions, so an admin who switched it off in the dashboard is not overridden by the environment, and the reverse holds too.
 
 ## Reading the panel
 
@@ -54,7 +54,7 @@ Handles are per org. The ledger lives at `omni.db` under the org memory director
 The optimiser is a separate binary, pinned to a single version rather than resolved to latest, so an install does not change under a restart.
 
 - **In the image.** The Docker build carries it by default. Override with `docker build --build-arg OMNI_VERSION=...`.
-- **At runtime.** An instance already deployed cannot be talked into a rebuild, so switching the toggle on fetches the binary and reports the reason when it cannot. Set `NAKAMA_OMNI_AUTO_INSTALL=0` to refuse that and rely on the image alone.
+- **At runtime.** An instance already deployed cannot be talked into a rebuild, so switching the toggle on fetches the binary and reports the reason when it cannot. A source checkout that never touches the toggle has no binary to run: the optimiser then fails open and the panel says it is missing. Set `NAKAMA_OMNI_AUTO_INSTALL=0` to refuse the download and rely on the image alone.
 
 The download is checked against the `SHA256SUMS` published with the same release. Stated plainly: that catches a truncated or corrupted download. It is not a defence against a compromised release, since whoever can replace the archive can replace the sums. Operators who need more than that disable auto-install and build the binary into the image.
 

--- a/packages/core/src/omni.test.ts
+++ b/packages/core/src/omni.test.ts
@@ -17,17 +17,19 @@ afterEach(() => {
 const REAL_PATH = process.env.PATH ?? "";
 
 describe("omni gating", () => {
-  test("off unless NAKAMA_OMNI=1", () => {
+  test("on unless NAKAMA_OMNI=0", () => {
     delete process.env.NAKAMA_OMNI;
-    expect(isOmniEnabled()).toBe(false);
-    process.env.NAKAMA_OMNI = "true";
-    expect(isOmniEnabled()).toBe(false);
+    expect(isOmniEnabled()).toBe(true);
     process.env.NAKAMA_OMNI = "1";
     expect(isOmniEnabled()).toBe(true);
+    process.env.NAKAMA_OMNI = "0";
+    expect(isOmniEnabled()).toBe(false);
+    process.env.NAKAMA_OMNI = " 0 ";
+    expect(isOmniEnabled()).toBe(false);
   });
 
   test("disabled returns the result untouched", async () => {
-    delete process.env.NAKAMA_OMNI;
+    process.env.NAKAMA_OMNI = "0";
     const result = { exitCode: 0, stdout: LONG };
     expect(await distillToolResult("bash", result, CTX)).toBe(result);
   });

--- a/packages/core/src/omni.ts
+++ b/packages/core/src/omni.ts
@@ -70,9 +70,14 @@ export const OPTIMIZER_ID = "omni";
  */
 export const CONTROL_ID = "none";
 
-/** The server-wide default, used when no org has chosen. */
+/**
+ * The server-wide default, used when no org has chosen. On unless an operator
+ * sets `NAKAMA_OMNI=0`, matching `NAKAMA_OMNI_AUTO_INSTALL`: the image already
+ * carries the binary, folding is reversible through `omni_retrieve`, and an org
+ * that wants raw output switches it off in Integrations.
+ */
 export function isOmniEnabled(): boolean {
-  return process.env.NAKAMA_OMNI === "1";
+  return process.env.NAKAMA_OMNI?.trim() !== "0";
 }
 
 let installedProbe: Promise<boolean> | null = null;

--- a/packages/core/src/tools/builtin.ts
+++ b/packages/core/src/tools/builtin.ts
@@ -875,10 +875,9 @@ export const builtinTools: ToolDefinition[] = [
   webFetchTool,
   emailTool,
   extractDocumentTextTool,
-  // Gated on the server-wide env var, not the per-org toggle: the env var says
-  // the binary exists here, the toggle says whether an org uses it. Publishing
-  // the expander per-org would let an org flip folding on and have no way to
-  // read back what was folded until a restart.
+  // Gated on the server-wide env var, not the per-org toggle: the toggle says
+  // whether an org folds, and publishing the expander per-org would let an org
+  // flip folding on with no way to read back what was folded until a restart.
   ...(isOmniEnabled() ? [omniRetrieveTool] : []),
 ];
 


### PR DESCRIPTION
## Summary

The token optimiser ships on. `NAKAMA_OMNI` now reads the way `NAKAMA_OMNI_AUTO_INSTALL` already does: off only on an explicit `0`.

**Before:** `isOmniEnabled()` was `NAKAMA_OMNI === "1"`, and the Dockerfile sets no such variable, so a stock install carried the binary in the image and never used it.
**After:** on unless an operator sets `NAKAMA_OMNI=0` or an org admin switches it off under Integrations. An explicit org setting still wins over the env var in both directions.

Same fake `omni` binary, same 7400 byte `bash` result, `packages/core/src/omni.ts`:

```
                     before                          after
NAKAMA_OMNI unset    7400 bytes, folded: false       14 bytes, folded: true
NAKAMA_OMNI=0        7400 bytes, folded: false       7400 bytes, folded: false
NAKAMA_OMNI=1        14 bytes,   folded: true        14 bytes, folded: true
```

Why safe:
1. Folding is reversible. `omni_retrieve` expands any marker by handle, and that tool is published on the same env var, so it is on wherever folding is.
2. Distillation fails open. A missing binary, a timeout or a parse failure returns the caller's own bytes, and the panel reports the binary as missing rather than showing an idle day.
3. Output under 1,000 characters and every tool other than `bash` and `read_file` are untouched.

Only follow up if a source checkout should fetch the binary without the toggle being touched. Today it does not, so distillation there fails open at the cost of one spawn ending in ENOENT, 0.24ms median over 50 runs.

## Test plan
- [x] `bun run test`: 2914 pass, 0 fail
- [x] Reverted `isOmniEnabled` to the old body and confirmed the gating test goes red, so it is not vacuous: `(fail) omni gating > on unless NAKAMA_OMNI=0`
