### PR TITLE
fix(agent): inherit parent role in sub-agents

### DIFF
--- a/apps/server/src/services/agent-service.test.ts
+++ b/apps/server/src/services/agent-service.test.ts
@@ -4,9 +4,12 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import {
   ensureBundledSkillFiles,
+  type GenerateChatInput,
   loadDiscordConfigFile,
   loadTelegramConfigFile,
   loadWhatsAppConfigFile,
+  type ToolContext,
+  type ToolDefinition,
 } from "@nakama/core";
 import type { StoredProfileRecord } from "@nakama/db";
 import {
@@ -16,6 +19,7 @@ import {
 } from "@nakama/db";
 import { createMinimalHonoApp } from "../http/test-app-helpers";
 import { setupFreshInstallSession } from "../http/test-session-helpers";
+import { setupTestConfigDir } from "../test-config-dir";
 import { AgentService } from "./agent-service";
 import { sessionTurnRegistry } from "./session-turn-registry";
 import { SkillsService } from "./skills-service";
@@ -36,6 +40,70 @@ function createDefaultProfile(): StoredProfileRecord {
     updatedAt: now,
   };
 }
+
+describe("AgentService sub-agent roles", () => {
+  setupTestConfigDir("nakama-sub-agent-role-");
+
+  test("uses the inherited role for the child prompt and tool execution", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    await db.upsertProfile(createDefaultProfile());
+    const service = new AgentService(null, null, db);
+    let promptRole: ToolContext["orgRole"];
+    let toolRole: ToolContext["orgRole"];
+    const tool: ToolDefinition = {
+      description: "Observe child context",
+      name: "observe_role",
+      parameters: { properties: {}, type: "object" },
+      run(_input, context) {
+        toolRole = context.orgRole;
+        return Promise.resolve({ ok: true });
+      },
+    };
+    Object.assign(service, {
+      _providerConfigured: true,
+      createHarnessForProfile: () => ({
+        provider: {
+          name: "openai",
+          streamChat(input: GenerateChatInput) {
+            const done = input.messages.at(-1)?.role === "tool";
+            const content = done ? "Done" : "";
+            const toolCalls = done
+              ? []
+              : [{ arguments: {}, id: "call_role", name: tool.name }];
+            return Promise.resolve({
+              assistantMessage: { content, role: "assistant", toolCalls },
+              content,
+              toolCalls,
+            });
+          },
+        },
+      }),
+      resolveProfileSystemPrompt: (
+        _orgId: string,
+        _profileId: string,
+        _prompt: string,
+        orgRole: ToolContext["orgRole"]
+      ) => {
+        promptRole = orgRole;
+        return Promise.resolve({ soulActive: false, systemPrompt: "Test" });
+      },
+      resolveProfileTools: () => Promise.resolve([tool]),
+    });
+
+    for (const orgRole of ["admin", "member", "viewer", undefined] as const) {
+      const result = await service.runSubAgentPrompt({
+        agentDepth: 1,
+        orgId: ORG_ID,
+        orgRole,
+        profileId: "profile_default",
+        task: "Observe the child role",
+      });
+      expect(result.status).toBe("success");
+      expect(promptRole).toBe(orgRole);
+      expect(toolRole).toBe(orgRole);
+    }
+  });
+});
 
 describe("AgentService branching", () => {
   test("keeps model selection scoped to the chat session", async () => {

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -1498,7 +1498,7 @@ export class AgentService {
       input.orgId,
       input.profileId,
       profile.systemPrompt,
-      "member"
+      input.orgRole
     );
     const childSystemPrompt = [
       systemPrompt.trim(),
@@ -1524,7 +1524,7 @@ export class AgentService {
         agentDepth: input.agentDepth,
         clientOrigin: input.clientOrigin,
         orgId: input.orgId,
-        orgRole: "member",
+        orgRole: input.orgRole,
         profileId: input.profileId,
         recordToolOutputSavings: this.savingsRecorderFor(input.orgId),
         recordTurnUsage: this.turnUsageRecorderFor(input.orgId),

--- a/apps/server/src/tools/org-memory-tools.ts
+++ b/apps/server/src/tools/org-memory-tools.ts
@@ -16,9 +16,8 @@ function requireOrgId(context: ToolContext): string {
 
 /**
  * Deny-by-default role gate for org-memory tools. Viewers are blocked; an
- * undefined role (no user context) also blocks — callers that genuinely act
- * with member privileges (automation/task/sub-agent runners) pass an explicit
- * `orgRole: "member"` in the tool context.
+ * undefined role (no user context) also blocks. Automation/task runners pass
+ * an explicit `orgRole: "member"`; sub-agents inherit the parent role.
  */
 function requireOrgMemoryAccess(context: ToolContext): {
   orgId: string;

--- a/apps/server/src/tools/sub-agent-shared.ts
+++ b/apps/server/src/tools/sub-agent-shared.ts
@@ -1,3 +1,5 @@
+import type { OrgRole } from "@nakama/core";
+
 export const DEFAULT_SUB_AGENT_TIMEOUT_MS = 300_000;
 export const MAX_SUB_AGENT_TIMEOUT_MS = 600_000;
 export const MAX_SUB_AGENT_OUTPUT_CHARS = 32_000;
@@ -10,6 +12,7 @@ export interface SubAgentRunInput {
   context?: string;
   onActivity?: (label: string) => void;
   orgId: string;
+  orgRole?: OrgRole;
   profileId: string;
   sessionId?: string;
   task: string;

--- a/apps/server/src/tools/sub-agent-tool.test.ts
+++ b/apps/server/src/tools/sub-agent-tool.test.ts
@@ -76,6 +76,24 @@ describe("sub_agent tool", () => {
     expect(capturedTimeout).toBe(600_000);
   });
 
+  test("inherits the trusted parent role, not a role supplied in tool arguments", async () => {
+    for (const orgRole of ["admin", "member", "viewer", undefined] as const) {
+      let captured: unknown;
+      const agent = createMockAgentService(async (input) => {
+        captured = input;
+        return { output: "ok", status: "success", summary: "ok" };
+      });
+
+      await runSubAgentTool(
+        { orgRole: "admin", task: "delegated" },
+        { ...TOOL_CONTEXT, orgRole },
+        agent
+      );
+
+      expect(captured).toMatchObject({ orgRole });
+    }
+  });
+
   test("is parallelSafe so sibling sub-agents can run concurrently from the parent", () => {
     const tool = createSubAgentTool(
       createMockAgentService(async () => ({

--- a/apps/server/src/tools/sub-agent-tool.ts
+++ b/apps/server/src/tools/sub-agent-tool.ts
@@ -87,6 +87,7 @@ export async function runSubAgentTool(
       context: scopedContext,
       onActivity: context.emitSubAgentActivity,
       orgId,
+      orgRole: context.orgRole,
       profileId,
       sessionId: context.sessionId,
       task,


### PR DESCRIPTION
## Summary

Sub-agents keep the parent caller's organization role instead of becoming members. Fixes #509.

**Before:** delegation dropped `orgRole`; the child prompt and tool context hard-coded `member`.
**After:** `runSubAgentTool` forwards the trusted context role to both child consumers, including when no role is present.

Why safe:
1. Role comes from execution context, never model-supplied tool arguments; spoofed arguments are covered.
2. Existing route authorization and nested-delegation guards are unchanged. This fixes lost role context, not a demonstrated public viewer exploit.
3. Both regressions fail before the fix and pass afterward, including actual child tool execution with an offline provider.

Residual: absent roles remain absent; this does not introduce a new authorization policy for background callers.

## Test plan
- [x] Linux Podman, Bun 1.3.14: `bun test apps/server/src/services/agent-service.test.ts apps/server/src/tools/sub-agent-tool.test.ts apps/server/src/services/tool-resolver-sub-agent.test.ts --timeout 20000` (35 pass; npm installed in the disposable container for existing CLI-detection expectations).
- [x] `bun x ultracite check` on all five changed files and `bun run knip` (clean in Podman); local server Bun build passed.
- [x] Role regressions cover admin/member/viewer/undefined and spoofed tool arguments, without live LLM calls. Two Windows shell-fixture failures also occur with the unchanged baseline tests; both pass on Linux.
- [x] CI passed on the final commit; ponytail review and fresh correctness/spec review completed. The stale role comment was corrected before publication.