### PR TITLE
feat(web): edit a sent user message and regenerate the reply

### DIFF
--- a/apps/web/src/components/chat/chat-message-list.tsx
+++ b/apps/web/src/components/chat/chat-message-list.tsx
@@ -1,6 +1,7 @@
 import {
   CheckmarkCircle01Icon,
   Copy01Icon,
+  Edit03Icon,
   File01Icon,
   GitBranchIcon,
   MoreHorizontalIcon,
@@ -27,14 +28,20 @@ import { AssistantTurnSegmentView } from "@/components/chat/assistant-tool-group
 import { segmentAssistantTurn } from "@/components/chat/assistant-tool-group.shared";
 import { ImageAttachmentPreview } from "@/components/chat/image-attachment-preview";
 import { TextAttachmentPreview } from "@/components/chat/text-attachment-preview";
+import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Textarea } from "@/components/ui/textarea";
 import { extractTurnArtifacts } from "@/lib/chat-artifacts";
-import { type ChatListItem, formatSessionTimestamp } from "@/lib/chat-history";
+import {
+  type ChatListItem,
+  formatSessionTimestamp,
+  isEditableUserMessage,
+} from "@/lib/chat-history";
 import {
   followOutputBehavior,
   listOverflowsViewport,
@@ -98,6 +105,7 @@ interface ChatMessageListProps {
   messages: ChatListItem[];
   modelLabel?: string | null;
   onBranchMessage?: (message: ChatListItem) => void;
+  onEditMessage?: (message: ChatListItem, text: string) => void;
   onRetryMessage?: (message: ChatListItem) => void;
   profileId?: string | null;
   showThinking?: boolean;
@@ -121,6 +129,7 @@ function ChatMessageListSession({
   streamActive = false,
   turnStartedAt = null,
   onBranchMessage,
+  onEditMessage,
   onRetryMessage,
   emptyMessage,
   className,
@@ -238,7 +247,12 @@ function ChatMessageListSession({
       if (turn.kind === "user") {
         return (
           <div className={itemClassName}>
-            <ChatMessageRow message={turn.message} />
+            <ChatMessageRow
+              busy={branchingMessageId != null || streamActive}
+              disabled={actionsDisabled}
+              message={turn.message}
+              onEditMessage={onEditMessage}
+            />
           </div>
         );
       }
@@ -427,7 +441,79 @@ function TurnAwaitingElapsed({ startedAt }: { startedAt?: string | null }) {
   );
 }
 
-function ChatMessageRow({ message }: { message: ChatListItem }) {
+function ChatMessageRow({
+  message,
+  busy = false,
+  disabled = false,
+  onEditMessage,
+}: {
+  message: ChatListItem;
+  busy?: boolean;
+  disabled?: boolean;
+  onEditMessage?: (message: ChatListItem, text: string) => void;
+}) {
+  const [draft, setDraft] = useState<string | null>(null);
+  const canEdit =
+    Boolean(onEditMessage) && !disabled && isEditableUserMessage(message);
+
+  if (draft !== null && onEditMessage) {
+    const trimmed = draft.trim();
+    const unchanged = trimmed === message.content.trim();
+
+    function submit() {
+      if (!trimmed || unchanged) {
+        return;
+      }
+      setDraft(null);
+      onEditMessage?.(message, trimmed);
+    }
+
+    return (
+      <Message
+        className="mr-0 ml-auto w-full min-w-0 max-w-full items-end justify-end overflow-visible"
+        from="user"
+      >
+        <div className="w-full space-y-2 rounded-2xl border border-border bg-muted/40 p-2">
+          <Textarea
+            autoFocus
+            className="max-h-64 border-0 bg-transparent focus-visible:ring-0"
+            onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Escape") {
+                event.preventDefault();
+                setDraft(null);
+                return;
+              }
+              if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+                event.preventDefault();
+                submit();
+              }
+            }}
+            value={draft}
+          />
+          <div className="flex justify-end gap-2">
+            <Button
+              onClick={() => setDraft(null)}
+              size="sm"
+              type="button"
+              variant="ghost"
+            >
+              Cancel
+            </Button>
+            <Button
+              disabled={!trimmed || unchanged || busy || disabled}
+              onClick={submit}
+              size="sm"
+              type="button"
+            >
+              Send
+            </Button>
+          </div>
+        </div>
+      </Message>
+    );
+  }
+
   return (
     <Message
       className="mr-0 ml-auto min-w-0 max-w-full items-end justify-end overflow-visible"
@@ -436,6 +522,18 @@ function ChatMessageRow({ message }: { message: ChatListItem }) {
       <MessageContent className="ml-auto min-w-0 max-w-full overflow-visible group-[.is-user]:ml-auto">
         <UserMessageContent message={message} />
       </MessageContent>
+      {canEdit ? (
+        <button
+          aria-label="Edit message"
+          className="mr-1 inline-flex size-8 items-center justify-center self-end rounded-full text-muted-foreground opacity-0 transition-colors transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-40 group-focus-within:opacity-100 group-hover:opacity-60 group-hover:hover:opacity-100"
+          disabled={busy}
+          onClick={() => setDraft(message.content)}
+          title="Edit message"
+          type="button"
+        >
+          <Edit03Icon aria-hidden className="size-4" />
+        </button>
+      ) : null}
     </Message>
   );
 }

--- a/apps/web/src/lib/chat-history.test.ts
+++ b/apps/web/src/lib/chat-history.test.ts
@@ -3,10 +3,12 @@ import type { ChatMessage, SessionMessageMeta } from "@nakama/core/contract";
 import { AGENT_CHANNELS } from "@nakama/core/contract";
 import { extractTurnArtifacts } from "./chat-artifacts";
 import {
+  type ChatListItem,
   chatMessagesToListItems,
   formatSessionRelativeTime,
   formatSessionTimestamp,
   HISTORY_SESSION_CHANNELS,
+  isEditableUserMessage,
   isReadOnlySessionChannel,
 } from "./chat-history";
 
@@ -458,5 +460,76 @@ describe("session channel tables", () => {
     );
 
     expect(readOnly).toEqual(["telegram", "whatsapp", "discord"]);
+  });
+});
+
+describe("isEditableUserMessage", () => {
+  function userMessage(overrides: Partial<ChatListItem> = {}): ChatListItem {
+    return {
+      content: "What is the deploy command?",
+      historyIndex: 2,
+      id: "m1",
+      role: "user",
+      ...overrides,
+    };
+  }
+
+  test("accepts a stored text-only prompt", () => {
+    expect(isEditableUserMessage(userMessage())).toBe(true);
+  });
+
+  test("rejects a prompt that is not in server history yet", () => {
+    expect(
+      isEditableUserMessage(userMessage({ historyIndex: undefined }))
+    ).toBe(false);
+  });
+
+  test("rejects assistant and tool rows", () => {
+    expect(isEditableUserMessage(userMessage({ role: "assistant" }))).toBe(
+      false
+    );
+    expect(isEditableUserMessage(userMessage({ role: "tool" }))).toBe(false);
+  });
+
+  test("rejects a failed turn", () => {
+    expect(isEditableUserMessage(userMessage({ failed: true }))).toBe(false);
+  });
+
+  test("rejects blank content", () => {
+    expect(isEditableUserMessage(userMessage({ content: "   " }))).toBe(false);
+  });
+
+  test("rejects prompts carrying attachments", () => {
+    expect(
+      isEditableUserMessage(
+        userMessage({ images: [{ mediaType: "image/png", url: "blob:x" }] })
+      )
+    ).toBe(false);
+    expect(
+      isEditableUserMessage(
+        userMessage({
+          imageAttachments: [{ mediaType: "image/png", url: "blob:x" }],
+        })
+      )
+    ).toBe(false);
+    expect(
+      isEditableUserMessage(
+        userMessage({
+          documents: [{ filename: "spec.pdf", mediaType: "application/pdf" }],
+        })
+      )
+    ).toBe(false);
+  });
+
+  test("rejects a questionnaire answer bubble", () => {
+    expect(
+      isEditableUserMessage(
+        userMessage({
+          questionnaireAnswers: [
+            { answer: "yes", prompt: "Ship it?", questionId: "q1" },
+          ],
+        })
+      )
+    ).toBe(false);
   });
 });

--- a/apps/web/src/lib/chat-history.ts
+++ b/apps/web/src/lib/chat-history.ts
@@ -464,6 +464,24 @@ const READ_ONLY_SESSION_CHANNEL = {
   whatsapp: true,
 } as const satisfies Record<AgentChannel, boolean>;
 
+/**
+ * Text-only prompts that already live in server history are the ones Edit can
+ * branch and resend. Attachments and unsent/failed turns have no history index
+ * to branch from.
+ */
+export function isEditableUserMessage(message: ChatListItem): boolean {
+  return (
+    message.role === "user" &&
+    typeof message.historyIndex === "number" &&
+    !message.failed &&
+    !message.questionnaireAnswers?.length &&
+    !message.images?.length &&
+    !message.imageAttachments?.length &&
+    !message.documents?.length &&
+    message.content.trim().length > 0
+  );
+}
+
 export function isReadOnlySessionChannel(channel: AgentChannel): boolean {
   return READ_ONLY_SESSION_CHANNEL[channel];
 }

--- a/apps/web/src/pages/chat/chat-page-content.tsx
+++ b/apps/web/src/pages/chat/chat-page-content.tsx
@@ -47,6 +47,7 @@ export function ChatPageContent(state: ChatPageState) {
     handleThinkingEffortChange,
     renderModelLabel,
     handleBranchMessage,
+    handleEditMessage,
     handleTryAgainMessage,
     sendMessage,
     stopStreaming,
@@ -161,6 +162,9 @@ export function ChatPageContent(state: ChatPageState) {
                   : null
               }
               onBranchMessage={(message) => void handleBranchMessage(message)}
+              onEditMessage={(message, text) =>
+                void handleEditMessage(message, text)
+              }
               onRetryMessage={(message) => void handleTryAgainMessage(message)}
               profileId={profileId}
               showThinking={showThinking}

--- a/apps/web/src/pages/chat/chat-page.shared.test.ts
+++ b/apps/web/src/pages/chat/chat-page.shared.test.ts
@@ -7,10 +7,12 @@ import {
 } from "@/lib/chat-history";
 import {
   appendFailedTurnIfNeeded,
+  editedPromptText,
   findFailedRetryPrompt,
   markStreamingTurnFailed,
   messagesWithoutFailedTurn,
   nextSuccessfulTurnAt,
+  planPromptBranch,
 } from "@/pages/chat/chat-page.shared";
 
 function user(
@@ -193,5 +195,72 @@ describe("nextSuccessfulTurnAt", () => {
 
   test("stays monotonic when wall clock moves backwards", () => {
     expect(nextSuccessfulTurnAt(1000, 999)).toBe(1001);
+  });
+});
+
+describe("the edit flow", () => {
+  /** Two finished turns, so editing the second prompt has somewhere to branch. */
+  function transcript(): ChatListItem[] {
+    return [
+      user("deploy command?", { historyIndex: 0 }),
+      assistant("bun run deploy", { historyIndex: 1 }),
+      user("and for staging?", { historyIndex: 2 }),
+      assistant("bun run deploy:staging", { historyIndex: 3 }),
+    ];
+  }
+
+  test("branches before the edited prompt and carries the turns before it", () => {
+    const messages = transcript();
+    const edited = messages[2]!;
+
+    const plan = planPromptBranch(messages, edited);
+
+    expect(plan?.messageIndex).toBe(1);
+    expect(
+      plan?.initialMessages.map((message) => message.historyIndex)
+    ).toEqual([0, 1]);
+  });
+
+  test("sends the trimmed edit, not the original text", () => {
+    const messages = transcript();
+    const edited = messages[2]!;
+
+    expect(editedPromptText(edited, "  and for production?  ")).toBe(
+      "and for production?"
+    );
+  });
+
+  test("stops before branching when the text did not change", () => {
+    const messages = transcript();
+    const edited = messages[2]!;
+
+    expect(editedPromptText(edited, "and for staging?")).toBeNull();
+    expect(editedPromptText(edited, "  and for staging?  ")).toBeNull();
+    expect(editedPromptText(edited, "   ")).toBeNull();
+  });
+
+  test("starts a fresh session when the edited prompt opens the session", () => {
+    const messages = transcript();
+
+    expect(planPromptBranch(messages, messages[0]!)).toBeNull();
+  });
+
+  test("starts a fresh session for a prompt that is not in history yet", () => {
+    const messages = transcript();
+
+    expect(planPromptBranch(messages, user("not sent yet"))).toBeNull();
+  });
+
+  test("ignores rows the branch cannot replay", () => {
+    const messages = [
+      ...transcript(),
+      user("unsent follow-up"),
+      assistant("failed", { failed: true }),
+    ];
+    const edited = messages[2]!;
+
+    const plan = planPromptBranch(messages, edited);
+
+    expect(plan?.initialMessages).toHaveLength(2);
   });
 });

--- a/apps/web/src/pages/chat/chat-page.shared.ts
+++ b/apps/web/src/pages/chat/chat-page.shared.ts
@@ -19,7 +19,7 @@ export function findRetryPrompt(
   );
 }
 
-export function findRetryCheckpoint(
+function findRetryCheckpoint(
   messages: ChatListItem[],
   promptMessage: ChatListItem
 ): ChatListItem | null {
@@ -34,6 +34,57 @@ export function findRetryCheckpoint(
         message.historyIndex < promptMessage.historyIndex!
     ) ?? null
   );
+}
+
+/** Where to branch a session when resending a prompt, and what the branch keeps. */
+export interface PromptBranchPlan {
+  /** Messages already in history that the branch starts with. */
+  initialMessages: ChatListItem[];
+  /** History index the branch is cut at. */
+  messageIndex: number;
+}
+
+/**
+ * Plan for resending `prompt`: branch at the row before it and carry everything
+ * up to that row. Null when nothing precedes the prompt in history, which means
+ * a fresh session rather than a branch.
+ */
+export function planPromptBranch(
+  messages: ChatListItem[],
+  prompt: ChatListItem
+): PromptBranchPlan | null {
+  const checkpoint = findRetryCheckpoint(messages, prompt);
+  const messageIndex = checkpoint?.historyIndex;
+
+  if (typeof messageIndex !== "number") {
+    return null;
+  }
+
+  return {
+    initialMessages: messages.filter(
+      (item) =>
+        typeof item.historyIndex === "number" &&
+        item.historyIndex <= messageIndex
+    ),
+    messageIndex,
+  };
+}
+
+/**
+ * The text an edit should resend, or null when the edit changes nothing and the
+ * flow should stop before branching.
+ */
+export function editedPromptText(
+  message: ChatListItem,
+  text: string
+): string | null {
+  const next = text.trim();
+
+  if (!next || next === message.content.trim()) {
+    return null;
+  }
+
+  return next;
 }
 
 function buildFailedAssistantMessage(error: string): ChatListItem {

--- a/apps/web/src/pages/chat/use-chat-page.ts
+++ b/apps/web/src/pages/chat/use-chat-page.ts
@@ -44,6 +44,7 @@ import {
   chatMessagesToListItems,
   clearFailedChatTurn,
   consumeStoredChatDraft,
+  isEditableUserMessage,
   isReadOnlySessionChannel,
   parseChatRouteParams,
   pickKnownProfileId,
@@ -94,6 +95,7 @@ import {
 } from "@/lib/thinking-settings";
 import {
   appendFailedTurnIfNeeded,
+  editedPromptText,
   findFailedRetryPrompt,
   findRetryPrompt,
   markStreamingTurnFailed,
@@ -1090,14 +1092,16 @@ export function useChatPage() {
         return;
       }
 
-      const nextText = text.trim();
+      const nextText = editedPromptText(message, text);
 
-      if (!nextText || nextText === message.content.trim()) {
+      if (nextText === null) {
         return;
       }
 
-      if (message.images?.length || message.documents?.length) {
-        setError("Editing is available for text-only messages.");
+      // The list only offers Edit on eligible rows. The handler repeats the
+      // check so an attachment or an unsent turn can never reach the branch.
+      if (!isEditableUserMessage(message)) {
+        setError("Editing is available for text-only messages already sent.");
         return;
       }
 

--- a/apps/web/src/pages/chat/use-chat-page.ts
+++ b/apps/web/src/pages/chat/use-chat-page.ts
@@ -95,11 +95,11 @@ import {
 import {
   appendFailedTurnIfNeeded,
   findFailedRetryPrompt,
-  findRetryCheckpoint,
   findRetryPrompt,
   markStreamingTurnFailed,
   messagesWithoutFailedTurn,
   nextSuccessfulTurnAt,
+  planPromptBranch,
 } from "@/pages/chat/chat-page.shared";
 
 interface SendMessageOptions {
@@ -968,9 +968,9 @@ export function useChatPage() {
         return;
       }
 
-      const checkpoint = findRetryCheckpoint(messages, prompt);
+      const plan = planPromptBranch(messages, prompt);
 
-      if (checkpoint && !session) {
+      if (plan && !session) {
         setError(
           "Chat session is unavailable. Please send a new message instead."
         );
@@ -984,19 +984,15 @@ export function useChatPage() {
         let retrySession: RemoteChatSession;
         let initialMessages: ChatListItem[] = [];
 
-        if (checkpoint && session) {
+        if (plan && session) {
           const result = await branchSessionMutation.mutateAsync({
             channel: "web",
-            messageIndex: checkpoint.historyIndex!,
+            messageIndex: plan.messageIndex,
             profileId,
             sessionId: session.id,
           });
           retrySession = client.createChatSession(result.sessionId, "web");
-          initialMessages = messages.filter(
-            (item) =>
-              typeof item.historyIndex === "number" &&
-              item.historyIndex <= checkpoint.historyIndex!
-          );
+          initialMessages = plan.initialMessages;
         } else {
           retrySession = await client.createSession("web", {
             model: sessionModel ?? undefined,

--- a/apps/web/src/pages/chat/use-chat-page.ts
+++ b/apps/web/src/pages/chat/use-chat-page.ts
@@ -962,7 +962,9 @@ export function useChatPage() {
    */
   const branchAndSendPrompt = useCallback(
     async (prompt: ChatListItem, text: string, anchorId: string) => {
-      if (!profileId) {
+      // Branch before send, so a read-only session must bail here: sendMessage
+      // no-ops on those and would strand the user in an empty branch.
+      if (!profileId || readOnlySession) {
         return;
       }
 
@@ -1020,6 +1022,7 @@ export function useChatPage() {
       branchSessionMutation,
       messages,
       profileId,
+      readOnlySession,
       sendMessage,
       session,
       sessionModel,

--- a/apps/web/src/pages/chat/use-chat-page.ts
+++ b/apps/web/src/pages/chat/use-chat-page.ts
@@ -956,6 +956,77 @@ export function useChatPage() {
     [executeSend, profileId, readOnlySession]
   );
 
+  /**
+   * Branch the session at the checkpoint before `prompt`, then send `text` into
+   * the branch.
+   */
+  const branchAndSendPrompt = useCallback(
+    async (prompt: ChatListItem, text: string, anchorId: string) => {
+      if (!profileId) {
+        return;
+      }
+
+      const checkpoint = findRetryCheckpoint(messages, prompt);
+
+      if (checkpoint && !session) {
+        setError(
+          "Chat session is unavailable. Please send a new message instead."
+        );
+        return;
+      }
+
+      setBranchingMessageId(anchorId);
+      setError(null);
+
+      try {
+        let retrySession: RemoteChatSession;
+        let initialMessages: ChatListItem[] = [];
+
+        if (checkpoint && session) {
+          const result = await branchSessionMutation.mutateAsync({
+            channel: "web",
+            messageIndex: checkpoint.historyIndex!,
+            profileId,
+            sessionId: session.id,
+          });
+          retrySession = client.createChatSession(result.sessionId, "web");
+          initialMessages = messages.filter(
+            (item) =>
+              typeof item.historyIndex === "number" &&
+              item.historyIndex <= checkpoint.historyIndex!
+          );
+        } else {
+          retrySession = await client.createSession("web", {
+            model: sessionModel ?? undefined,
+            profileId,
+          });
+        }
+
+        localStorage.setItem(sessionStorageKey(profileId), retrySession.id);
+        setSession(retrySession);
+        syncChatUrl(profileId, retrySession.id);
+
+        await sendMessage(text, [], {
+          initialMessages,
+          sessionOverride: retrySession,
+        });
+      } catch (err) {
+        setError(formatError(err));
+      } finally {
+        setBranchingMessageId(null);
+      }
+    },
+    [
+      branchSessionMutation,
+      messages,
+      profileId,
+      sendMessage,
+      session,
+      sessionModel,
+      syncChatUrl,
+    ]
+  );
+
   const handleTryAgainMessage = useCallback(
     async (message: ChatListItem) => {
       if (busy || !profileId) {
@@ -1008,66 +1079,9 @@ export function useChatPage() {
         return;
       }
 
-      const checkpoint = findRetryCheckpoint(messages, prompt);
-
-      if (checkpoint && !session) {
-        setError(
-          "Chat session is unavailable. Please send a new message instead."
-        );
-        return;
-      }
-
-      setBranchingMessageId(message.id);
-      setError(null);
-
-      try {
-        let retrySession: RemoteChatSession;
-        let initialMessages: ChatListItem[] = [];
-
-        if (checkpoint && session) {
-          const result = await branchSessionMutation.mutateAsync({
-            channel: "web",
-            messageIndex: checkpoint.historyIndex!,
-            profileId,
-            sessionId: session.id,
-          });
-          retrySession = client.createChatSession(result.sessionId, "web");
-          initialMessages = messages.filter(
-            (item) =>
-              typeof item.historyIndex === "number" &&
-              item.historyIndex <= checkpoint.historyIndex!
-          );
-        } else {
-          retrySession = await client.createSession("web", {
-            model: sessionModel ?? undefined,
-            profileId,
-          });
-        }
-
-        localStorage.setItem(sessionStorageKey(profileId), retrySession.id);
-        setSession(retrySession);
-        syncChatUrl(profileId, retrySession.id);
-
-        await sendMessage(prompt.content, [], {
-          initialMessages,
-          sessionOverride: retrySession,
-        });
-      } catch (err) {
-        setError(formatError(err));
-      } finally {
-        setBranchingMessageId(null);
-      }
+      await branchAndSendPrompt(prompt, prompt.content, message.id);
     },
-    [
-      branchSessionMutation,
-      busy,
-      messages,
-      profileId,
-      sendMessage,
-      session,
-      sessionModel,
-      syncChatUrl,
-    ]
+    [branchAndSendPrompt, busy, messages, profileId, sendMessage, session]
   );
 
   const isEmptyState = messages.length === 0 && !busy;

--- a/apps/web/src/pages/chat/use-chat-page.ts
+++ b/apps/web/src/pages/chat/use-chat-page.ts
@@ -1087,6 +1087,29 @@ export function useChatPage() {
     [branchAndSendPrompt, busy, messages, profileId, sendMessage, session]
   );
 
+  /** Resend an edited user message; the reply is regenerated from it. */
+  const handleEditMessage = useCallback(
+    async (message: ChatListItem, text: string) => {
+      if (busy || !profileId) {
+        return;
+      }
+
+      const nextText = text.trim();
+
+      if (!nextText || nextText === message.content.trim()) {
+        return;
+      }
+
+      if (message.images?.length || message.documents?.length) {
+        setError("Editing is available for text-only messages.");
+        return;
+      }
+
+      await branchAndSendPrompt(message, nextText, message.id);
+    },
+    [branchAndSendPrompt, busy, profileId]
+  );
+
   const isEmptyState = messages.length === 0 && !busy;
   const composerDisabled =
     !profileId || readOnlySession || updateSessionMutation.isPending;
@@ -1107,6 +1130,7 @@ export function useChatPage() {
     currentModelSelection,
     error,
     handleBranchMessage,
+    handleEditMessage,
     handleModelChange,
     handleProfileSwitch,
     handleThinkingEffortChange,


### PR DESCRIPTION
## Summary

Fix a typo in a sent prompt and the assistant answers the corrected one, no retyping.

**Before:** a sent user message had no action at all; correcting it meant copying the text back into the composer, and the wrong turn stayed in the history the model keeps reading.
**After:** hover a sent message, edit it inline, send. `branchAndSendPrompt` branches at the checkpoint before it, so the thread truncates there and the reply is regenerated.

Why safe:
1. Reuses the Try again path end to end. No server change: `agent.branchSession` already slices history inclusively.
2. The original session is never mutated; the edit continues in a branch, so a mistaken edit destroys nothing.
3. Edit is offered only on stored, text-only, non-failed user rows (`isEditableUserMessage`), and the shared helper now refuses to branch a read-only session, which also hardens Try again.

Only reconsider if the extra session per edit makes the chat list unwieldy.

Fixes #883

## Test plan
- [x] `bun test apps/web/src` (359 pass)
- [x] `tsc --noEmit` in `apps/web` (clean)
- [x] `bun run knip` (clean)
- [x] Hover a sent message, edit it, send: the thread truncates to that point, the reply is regenerated, and the original chat is still in the sidebar.
