### PR TITLE
fix(web): confirm before removing a Telegram allowed user

### DIFF
--- a/apps/web/src/components/TelegramAllowedUsersDialog.tsx
+++ b/apps/web/src/components/TelegramAllowedUsersDialog.tsx
@@ -49,6 +49,9 @@ export function TelegramAllowedUsersDialog({
   const [importDraft, setImportDraft] = useState("");
   const [importError, setImportError] = useState<string | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
+  const [removeTarget, setRemoveTarget] = useState<AllowedTelegramUser | null>(
+    null
+  );
 
   function saveAllowedUsers(
     nextUsers: AllowedTelegramUser[],
@@ -134,8 +137,16 @@ export function TelegramAllowedUsersDialog({
     });
   }
 
-  function removeAllowedUserId(id: string) {
-    saveAllowedUsers(allowedUsers.filter((entry) => entry.id !== id));
+  function confirmRemoveAllowedUser() {
+    if (!removeTarget) {
+      return;
+    }
+
+    const id = removeTarget.id;
+    saveAllowedUsers(
+      allowedUsers.filter((entry) => entry.id !== id),
+      () => setRemoveTarget(null)
+    );
   }
 
   return (
@@ -223,7 +234,7 @@ export function TelegramAllowedUsersDialog({
                     <Button
                       aria-label={`Remove Telegram user ID ${user.id}`}
                       disabled={saveMutation.isPending}
-                      onClick={() => removeAllowedUserId(user.id)}
+                      onClick={() => setRemoveTarget(user)}
                       size="icon-sm"
                       type="button"
                       variant="ghost"
@@ -307,6 +318,41 @@ export function TelegramAllowedUsersDialog({
               type="button"
             >
               Add user
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        onOpenChange={(next) => !next && setRemoveTarget(null)}
+        open={removeTarget !== null}
+      >
+        <DialogContent className="gap-5 p-6 sm:max-w-lg">
+          <DialogHeader className="gap-2">
+            <DialogTitle>Remove Telegram user</DialogTitle>
+            <DialogDescription>
+              {removeTarget?.username
+                ? `@${removeTarget.username} (${removeTarget.id})`
+                : removeTarget?.id}{" "}
+              loses access to this profile as soon as this is saved.
+            </DialogDescription>
+          </DialogHeader>
+
+          <DialogFooter className="gap-3 border-t-0 bg-transparent p-0 sm:justify-end">
+            <Button
+              onClick={() => setRemoveTarget(null)}
+              type="button"
+              variant="outline"
+            >
+              Cancel
+            </Button>
+            <Button
+              disabled={saveMutation.isPending}
+              onClick={confirmRemoveAllowedUser}
+              type="button"
+              variant="destructive"
+            >
+              Remove
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/web/src/components/TelegramAllowedUsersDialog.tsx
+++ b/apps/web/src/components/TelegramAllowedUsersDialog.tsx
@@ -57,6 +57,10 @@ export function TelegramAllowedUsersDialog({
     nextUsers: AllowedTelegramUser[],
     afterSuccess?: () => void
   ) {
+    // Optimistic, so a failed save has to put the old list back. Otherwise the
+    // dialog shows a user as removed while the bot still answers them, which is
+    // the wrong direction to be wrong in for an access list.
+    const previousUsers = allowedUsers;
     onAllowedUsersChange(nextUsers);
     setFormError(null);
 
@@ -67,6 +71,7 @@ export function TelegramAllowedUsersDialog({
       },
       {
         onError: (err) => {
+          onAllowedUsersChange(previousUsers);
           const message = formatError(err);
           setFormError(message);
           onError?.(message);
@@ -143,10 +148,11 @@ export function TelegramAllowedUsersDialog({
     }
 
     const id = removeTarget.id;
-    saveAllowedUsers(
-      allowedUsers.filter((entry) => entry.id !== id),
-      () => setRemoveTarget(null)
-    );
+    // Closed before the save resolves on purpose: a failed save rolls the list
+    // back and renders its error in the dialog underneath, which nobody can
+    // read through an open confirm.
+    setRemoveTarget(null);
+    saveAllowedUsers(allowedUsers.filter((entry) => entry.id !== id));
   }
 
   return (


### PR DESCRIPTION
## Summary

Removing a Telegram allowed user now asks first.

**Before:** the remove icon called `removeAllowedUserId`, which called `saveAllowedUsers`, which ran `saveMutation.mutate` on the click. One misclick revoked a user's access with no dialog and nothing to undo it.

**After:** the click sets a `removeTarget` and a confirm dialog decides. Cancel leaves the list untouched, in the UI and on the server.

Why safe:
1. The confirm is shaped like the import dialog already in this file, so no shared ConfirmDialog is added. #781 asked for exactly that restraint.
2. Add and import still save on the action. They are additive and undoable by removing the entry; this is about the destructive one.
3. `DiscordAllowedUsersDialog` stages and saves on Save, so the two dialogs now agree that a remove is not a one-click server write.

Not done: the cancel-path test the issue asked for. `apps/web` has no component test runner, no `.test.tsx` anywhere and no testing-library dependency, and this file's own `TelegramAllowedUsersDialog.test.ts` tests the parser rather than the component. Adding a rendering stack for one dialog is out of proportion; say the word if you want it and I will open that separately.

## Test plan
- [x] `bun run test`: every workspace 0 fail
- [x] `bun x ultracite check` on the changed file: clean
- [ ] Manual: Settings, Telegram, remove a user, cancel, confirm

Closes #890
