### PR TITLE
feat(error-tracking): report a tool that exhausts its retry budget

### DIFF
--- a/apps/server/src/services/custom-tool-handlers.test.ts
+++ b/apps/server/src/services/custom-tool-handlers.test.ts
@@ -39,9 +39,15 @@ function makeRecord(
 
 let reportedErrors: ErrorReport[] = [];
 let firstReport: Promise<ErrorReport>;
+let queueDir = "";
 const realConsoleError = console.error;
 
 beforeEach(async () => {
+  // reportError queues before it sends, and that queue is a read-modify-write on
+  // one file under NAKAMA_CONFIG_DIR. Without a temp dir here the suite trims
+  // the real queue on whatever machine runs it.
+  queueDir = await mkdtemp(path.join(os.tmpdir(), "nakama-tool-report-"));
+  process.env.NAKAMA_CONFIG_DIR = queueDir;
   process.env.NAKAMA_ERROR_TRACKING_DSN = "https://key@errors.example.test/7";
   await refreshErrorTrackingEnabled();
   reportedErrors = [];
@@ -60,9 +66,15 @@ beforeEach(async () => {
 
 afterEach(async () => {
   delete process.env.NAKAMA_ERROR_TRACKING_DSN;
+  if (originalConfigDir === undefined) {
+    delete process.env.NAKAMA_CONFIG_DIR;
+  } else {
+    process.env.NAKAMA_CONFIG_DIR = originalConfigDir;
+  }
   await refreshErrorTrackingEnabled();
   setErrorSink(null);
   console.error = realConsoleError;
+  await rm(queueDir, { force: true, recursive: true });
 });
 
 describe("withToolRetries", () => {
@@ -133,6 +145,7 @@ describe("withToolRetries", () => {
       withToolRetries(run, "flaky")({}, ctx(controller.signal))
     ).rejects.toBe(cancellation);
     expect(attempts).toBe(1);
+    expect(reportedErrors).toEqual([]);
   });
 
   test("an already-aborted signal never starts the run", async () => {
@@ -149,6 +162,7 @@ describe("withToolRetries", () => {
       withToolRetries(run, "flaky")({}, ctx(controller.signal))
     ).rejects.toBe(cancellation);
     expect(attempts).toBe(0);
+    expect(reportedErrors).toEqual([]);
   });
 
   test("aborting during the backoff cancels the retry", async () => {
@@ -169,6 +183,7 @@ describe("withToolRetries", () => {
     await expect(pending).rejects.toBe(cancellation);
     // Never reached the second attempt.
     expect(attempts).toBe(1);
+    expect(reportedErrors).toEqual([]);
   });
 });
 

--- a/apps/server/src/services/custom-tool-handlers.test.ts
+++ b/apps/server/src/services/custom-tool-handlers.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import type { ToolContext } from "@nakama/core";
+import {
+  type ErrorReport,
+  refreshErrorTrackingEnabled,
+  setErrorSink,
+  type ToolContext,
+} from "@nakama/core";
 import type { StoredToolRecord } from "@nakama/db";
 import {
   CUSTOM_TOOL_HANDLERS,
@@ -32,6 +37,34 @@ function makeRecord(
   };
 }
 
+let reportedErrors: ErrorReport[] = [];
+let firstReport: Promise<ErrorReport>;
+const realConsoleError = console.error;
+
+beforeEach(async () => {
+  process.env.NAKAMA_ERROR_TRACKING_DSN = "https://key@errors.example.test/7";
+  await refreshErrorTrackingEnabled();
+  reportedErrors = [];
+  let resolveFirst: (report: ErrorReport) => void = () => undefined;
+  firstReport = new Promise<ErrorReport>((resolve) => {
+    resolveFirst = resolve;
+  });
+  setErrorSink((report) => {
+    reportedErrors.push(report);
+    resolveFirst(report);
+    return true;
+  });
+  // reportError logs the failure locally whatever the sink does.
+  console.error = () => undefined;
+});
+
+afterEach(async () => {
+  delete process.env.NAKAMA_ERROR_TRACKING_DSN;
+  await refreshErrorTrackingEnabled();
+  setErrorSink(null);
+  console.error = realConsoleError;
+});
+
 describe("withToolRetries", () => {
   test("succeeds on the first attempt without extra calls", async () => {
     let attempts = 0;
@@ -40,7 +73,7 @@ describe("withToolRetries", () => {
       return { ok: true };
     };
 
-    const result = await withToolRetries(run)({}, ctx());
+    const result = await withToolRetries(run, "flaky")({}, ctx());
 
     expect(result).toEqual({ ok: true });
     expect(attempts).toBe(1);
@@ -56,10 +89,12 @@ describe("withToolRetries", () => {
       return { ok: true };
     };
 
-    const result = await withToolRetries(run)({}, ctx());
+    const result = await withToolRetries(run, "flaky")({}, ctx());
 
     expect(result).toEqual({ ok: true });
     expect(attempts).toBe(3);
+    // A recovered failure is not the operator's problem, so nothing is sent.
+    expect(reportedErrors).toEqual([]);
   });
 
   test("stops after two retries and re-throws the last error unchanged", async () => {
@@ -71,8 +106,17 @@ describe("withToolRetries", () => {
       throw new Error(message);
     };
 
-    await expect(withToolRetries(run)({}, ctx())).rejects.toThrow(message);
+    await expect(withToolRetries(run, "flaky")({}, ctx())).rejects.toThrow(
+      message
+    );
     expect(attempts).toBe(TOOL_RETRY_LIMIT + 1);
+
+    // Awaiting the sink rather than a timer: reportError is not awaited by the
+    // wrapper, so this is the boundary that says the send actually happened.
+    const report = await firstReport;
+    expect(report.source).toBe("tool:flaky");
+    expect(report.kind).toBe("tool");
+    expect(reportedErrors).toHaveLength(1);
   });
 
   test("an aborted signal during the run stops immediately and is never retried", async () => {
@@ -85,9 +129,9 @@ describe("withToolRetries", () => {
       throw new Error("boom");
     };
 
-    await expect(withToolRetries(run)({}, ctx(controller.signal))).rejects.toBe(
-      cancellation
-    );
+    await expect(
+      withToolRetries(run, "flaky")({}, ctx(controller.signal))
+    ).rejects.toBe(cancellation);
     expect(attempts).toBe(1);
   });
 
@@ -101,9 +145,9 @@ describe("withToolRetries", () => {
       return { ok: true };
     };
 
-    await expect(withToolRetries(run)({}, ctx(controller.signal))).rejects.toBe(
-      cancellation
-    );
+    await expect(
+      withToolRetries(run, "flaky")({}, ctx(controller.signal))
+    ).rejects.toBe(cancellation);
     expect(attempts).toBe(0);
   });
 
@@ -119,7 +163,7 @@ describe("withToolRetries", () => {
       return { ok: true };
     };
 
-    const pending = withToolRetries(run)({}, ctx(controller.signal));
+    const pending = withToolRetries(run, "flaky")({}, ctx(controller.signal));
     setTimeout(() => controller.abort(cancellation), 25);
 
     await expect(pending).rejects.toBe(cancellation);
@@ -192,6 +236,47 @@ if __name__ == "__main__":
       // policy reaches the python loader, not just the seam wrapper.
       expect(result.ok).toBe(true);
       expect(result.attempts).toBe(3);
+    } finally {
+      if (originalConfigDir === undefined) {
+        delete process.env.NAKAMA_CONFIG_DIR;
+      } else {
+        process.env.NAKAMA_CONFIG_DIR = originalConfigDir;
+      }
+      await rm(configDir, { force: true, recursive: true });
+    }
+  });
+
+  test("an exhausted tool reports under the record's own name", async () => {
+    const configDir = await mkdtemp(path.join(os.tmpdir(), "nakama-config-"));
+    process.env.NAKAMA_CONFIG_DIR = configDir;
+    const toolsDir = path.join(configDir, "tools");
+    const wsDir = path.join(configDir, "ws");
+    await mkdir(toolsDir, { recursive: true });
+    await mkdir(wsDir, { recursive: true });
+
+    await writeFile(
+      path.join(toolsDir, "doomed.js"),
+      `export async function run() {
+  process.exit(3);
+}
+`,
+      "utf8"
+    );
+
+    try {
+      const tool = await getCustomToolHandler("javascript")!.load(
+        makeRecord({
+          handlerConfig: { modulePath: "doomed.js" },
+          handlerType: "javascript",
+          name: "doomed_tool",
+        })
+      );
+
+      await expect(tool!.run({}, { workspaceRoot: wsDir })).rejects.toThrow();
+
+      // The seam passes definition.name, not the module path or the record id,
+      // and only running it end to end says which one arrived.
+      expect((await firstReport).source).toBe("tool:doomed_tool");
     } finally {
       if (originalConfigDir === undefined) {
         delete process.env.NAKAMA_CONFIG_DIR;

--- a/apps/server/src/services/custom-tool-handlers.ts
+++ b/apps/server/src/services/custom-tool-handlers.ts
@@ -4,6 +4,7 @@ import type {
   ToolDefinition,
   ToolSourceResponse,
 } from "@nakama/core";
+import { reportError } from "@nakama/core";
 import type { StoredToolRecord } from "@nakama/db";
 import { resolveCustomToolModulePath } from "./custom-tool-shared";
 import {
@@ -61,9 +62,14 @@ const TOOL_RETRY_BASE_DELAY_MS = 500;
  * retried; an aborted `context.signal` stops immediately and is never
  * retried, including mid-backoff. Cancellation preserves the signal's reason;
  * other final failures are re-thrown unchanged.
+ *
+ * A failure that uses up the budget is also mirrored to the operator's error
+ * tracker, tagged `tool:<name>`. That is the only place that can tell an
+ * exhausted tool from a single failed attempt.
  */
 export function withToolRetries(
-  run: (input: unknown, context: ToolContext) => Promise<unknown>
+  run: (input: unknown, context: ToolContext) => Promise<unknown>,
+  toolName: string
 ): (input: unknown, context: ToolContext) => Promise<unknown> {
   return async (input, context) => {
     let attempts = 0;
@@ -75,6 +81,10 @@ export function withToolRetries(
         attempts += 1;
         context.signal?.throwIfAborted();
         if (attempts > TOOL_RETRY_LIMIT) {
+          // Not awaited: reportError queues synchronously and never throws, and
+          // the model should not wait out the tracker's HTTP timeout on a turn
+          // that has already failed.
+          void reportError(error, { kind: "tool", source: `tool:${toolName}` });
           throw error;
         }
         // Rejects immediately if the signal aborts mid-backoff (including an
@@ -112,7 +122,10 @@ export function getCustomToolHandler(
       if (!definition) {
         return null;
       }
-      return { ...definition, run: withToolRetries(definition.run) };
+      return {
+        ...definition,
+        run: withToolRetries(definition.run, definition.name),
+      };
     },
   };
 }

--- a/packages/core/src/error-tracking.ts
+++ b/packages/core/src/error-tracking.ts
@@ -12,8 +12,11 @@ import { scrubText } from "./error-tracking-scrub";
  * "test" is the event the Integrations tab sends to prove a DSN works. It rides the
  * same pipeline so the operator is checking the real path, and carries a lower level
  * at the ingest so it never sits in a triage queue next to real crashes.
+ *
+ * "tool" is a custom tool that failed every attempt in its retry budget. The process
+ * survives it, so it is tagged apart from a crash and the operator can filter on it.
  */
-export type ErrorReportKind = "crash" | "test";
+export type ErrorReportKind = "crash" | "test" | "tool";
 
 export interface ErrorReport {
   at: string;


### PR DESCRIPTION
## Summary

A custom tool that fails every attempt in its retry budget now reaches the operator's error tracker, tagged by tool. This is phase 4 of #441, the last one with no code behind it.

**Before:** the sink shipped in #444 and nothing outside the four crash handlers called it. A grep for `reportError` callers found the four `installErrorHandlers` sites and the Integrations test-event path, nothing else. An exhausted tool returned `{ error: message }` to the model and vanished.

**After:** one event per exhausted tool, `kind: "tool"` and `source: "tool:<name>"`, so it filters apart from a crash and still lands at Sentry level `error`.

Why safe:
1. `withToolRetries` is the only place that can tell an exhausted tool from one failed attempt, and it wraps both the javascript and python loaders through one seam.
2. Not awaited. `reportError` queues synchronously and never throws, and the model should not wait out the tracker's HTTP timeout on a turn that has already failed. The error is re-thrown unchanged.
3. An aborted signal throws before the budget check, so a cancelled turn reports nothing.
4. `toolName` is a required parameter, so a call site that forgets it fails the typecheck rather than sending `tool:undefined`.

The event carries only what `buildErrorReport` reads from the error, so no tool arguments. "No DSN means no event and no queue write" is `reportError`'s own contract, already covered in `error-tracking.test.ts`, so it is not re-tested here.

## Test plan
- [x] `bun test apps/server/src/services/custom-tool-handlers.test.ts`: 11 pass, 0 fail
- [x] `bun run test`: every workspace 0 fail
- [x] Mutation 1, delete the `reportError` call: 2 tests fail
- [x] Mutation 2, pass `record.id` instead of `definition.name` at the seam: the wiring test fails with `Expected: "tool:doomed_tool"  Received: "tool:tool_flaky"`

Closes #891
