### PR TITLE
fix(db): apply bootstrap schema once

### DIFF
--- a/packages/db/src/migrate.test.ts
+++ b/packages/db/src/migrate.test.ts
@@ -493,6 +493,43 @@ describe("schema path resolution", () => {
   });
 });
 
+describe("schema bootstrap version", () => {
+  test("applies schema.sql once while compatibility migrations keep running", () => {
+    const db = new Database(":memory:");
+
+    try {
+      migrateDatabase(db);
+      db.exec("DROP TABLE artifact_shares; DROP TABLE attachments;");
+
+      migrateDatabase(db);
+
+      const artifactSharesTable = db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'artifact_shares'"
+        )
+        .get();
+      const attachmentsTable = db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'attachments'"
+        )
+        .get();
+      expect(artifactSharesTable).toBeNull();
+      expect(attachmentsTable).toEqual({ name: "attachments" });
+
+      const schemaVersion = db
+        .prepare("SELECT version FROM schema_version")
+        .get() as { version: number };
+      const foreignKeys = db.prepare("PRAGMA foreign_keys").get() as {
+        foreign_keys: number;
+      };
+      expect(schemaVersion.version).toBe(1);
+      expect(foreignKeys.foreign_keys).toBe(1);
+    } finally {
+      db.close();
+    }
+  });
+});
+
 describe("chat session schema", () => {
   test("adds a model override to legacy sessions", () => {
     const db = new Database(":memory:");

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -3,21 +3,22 @@ import { existsSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { orgIdFromSkillSourcePath } from "@nakama/core";
+
+const BOOTSTRAP_SCHEMA_VERSION = 1;
+
 export function migrateDatabase(db: Database): void {
-  const schemaPath = resolveSchemaPath();
-  const sql = readFileSync(schemaPath, "utf8");
+  applyBootstrapSchema(db);
 
   // Each step runs in its own transaction so a failure cannot leave one half
   // applied. They deliberately do not share a single outer transaction: the
-  // schema sets `PRAGMA foreign_keys`, and migrateLegacyProfileIds toggles it
-  // and opens its own BEGIN, both of which SQLite ignores or rejects inside a
-  // transaction. Stopping between steps is safe because every step is
-  // idempotent and this runs on every open.
+  // bootstrap schema has its own versioned transaction, while
+  // migrateLegacyProfileIds toggles `PRAGMA foreign_keys` and opens its own
+  // BEGIN. Stopping between steps is safe because every compatibility step is
+  // idempotent and runs on every open.
   const atomic = (step: (database: Database) => void): void => {
     db.transaction(() => step(db))();
   };
 
-  db.exec(sql);
   atomic(migrateProfilesTable);
   atomic(migrateAutomationsTable);
   atomic(migrateDropTasksTables);
@@ -53,6 +54,33 @@ export function migrateDatabase(db: Database): void {
   atomic(migrateComposioTables);
   atomic(migrateComposioUserConnections);
   atomic(migrateProfileChangeEventsTable);
+}
+
+function applyBootstrapSchema(db: Database): void {
+  // Foreign-key enforcement is connection-scoped, so it must run even after
+  // the bootstrap schema has already been applied.
+  db.exec("PRAGMA foreign_keys = ON");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS schema_version (
+      version INTEGER PRIMARY KEY NOT NULL
+    );
+  `);
+
+  const current = db
+    .prepare("SELECT MAX(version) AS version FROM schema_version")
+    .get() as { version: number | null };
+  if ((current.version ?? 0) >= BOOTSTRAP_SCHEMA_VERSION) {
+    return;
+  }
+
+  const schemaPath = resolveSchemaPath();
+  const sql = readFileSync(schemaPath, "utf8");
+  db.transaction(() => {
+    db.exec(sql);
+    db.prepare("INSERT INTO schema_version (version) VALUES (?)").run(
+      BOOTSTRAP_SCHEMA_VERSION
+    );
+  })();
 }
 
 export function resolveSchemaPath(


### PR DESCRIPTION
## Summary

Open a SQLite database repeatedly → the bootstrap schema runs once, while compatibility migrations still run on every open.

**Before:** `migrateDatabase` reads and executes the complete `schema.sql` on every database open.
**After:** `schema_version` records bootstrap version 1 transactionally and skips subsequent baseline replays.

Why safe:
1. Foreign-key enforcement remains connection-scoped and runs before the version check
2. The regression test separates a bootstrap-only table from a compatibility-migrated table

Only revisit if an existing database needs a future schema change without a targeted compatibility migration.

Full-suite note: `bun test` reached 2,921 pass with one unrelated local shell PID failure in `apps/server/src/tools/bash.test.ts`, reproducible in isolation.

Closes #607

## Test plan
- [x] `bun test packages/db/src` (101 pass)
- [x] `bun run check && bun run knip && bun run build`
- [ ] Restart the same SQLite-backed server twice and confirm normal startup
