### PR TITLE
fix(cli): stop printing rotated local auth token to stdout

### DIFF
--- a/apps/cli/src/rotate-token.test.ts
+++ b/apps/cli/src/rotate-token.test.ts
@@ -34,7 +34,11 @@ describe("rotate-token command", () => {
       await expect(verifyLocalAuthToken(rotated!)).resolves.toEqual({
         email: "local-client@nakama.internal",
       });
-      expect(logs.some((line) => line.includes(rotated!))).toBe(true);
+      expect(
+        logs.some((line) => line.includes("Local auth token rotated."))
+      ).toBe(true);
+      expect(logs.some((line) => line.includes("Token file:"))).toBe(true);
+      expect(logs.some((line) => line.includes(rotated!))).toBe(false);
     } finally {
       delete process.env.NAKAMA_CONFIG_DIR;
       await rm(configDir, { force: true, recursive: true });

--- a/apps/cli/src/rotate-token.test.ts
+++ b/apps/cli/src/rotate-token.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  getLocalAuthTokenPath,
   loadLocalAuthToken,
   verifyLocalAuthToken,
 } from "@nakama/core/local-auth";
@@ -28,6 +29,7 @@ describe("rotate-token command", () => {
       }
 
       const rotated = await loadLocalAuthToken();
+      const tokenPath = getLocalAuthTokenPath();
       expect(rotated).toStartWith("tc_local_");
       expect(rotated).not.toBe(original);
       await expect(verifyLocalAuthToken(original!)).resolves.toBeNull();
@@ -37,7 +39,9 @@ describe("rotate-token command", () => {
       expect(
         logs.some((line) => line.includes("Local auth token rotated."))
       ).toBe(true);
-      expect(logs.some((line) => line.includes("Token file:"))).toBe(true);
+      expect(
+        logs.some((line) => line.includes(`Token file: ${tokenPath}`))
+      ).toBe(true);
       expect(logs.some((line) => line.includes(rotated!))).toBe(false);
     } finally {
       delete process.env.NAKAMA_CONFIG_DIR;

--- a/apps/cli/src/rotate-token.ts
+++ b/apps/cli/src/rotate-token.ts
@@ -1,4 +1,5 @@
 import {
+  getLocalAuthTokenPath,
   LocalAuthTokenManagedExternallyError,
   rotateLocalAuthToken,
 } from "@nakama/core/local-auth";
@@ -8,10 +9,10 @@ export function isRotateTokenCommand(argv = process.argv.slice(2)): boolean {
 }
 
 export async function runRotateToken(): Promise<void> {
-  const token = await rotateLocalAuthToken();
+  await rotateLocalAuthToken();
 
   console.log("Local auth token rotated.");
-  console.log(token);
+  console.log(`Token file: ${getLocalAuthTokenPath()}`);
   console.log("");
   console.log(
     "Workers reload from disk on the next request. Restart them if anything stays disconnected."

--- a/packages/core/src/local-auth.ts
+++ b/packages/core/src/local-auth.ts
@@ -31,7 +31,7 @@ function hashLocalAuthToken(token: string): string {
   return createHash("sha256").update(token).digest("hex");
 }
 
-function getLocalAuthTokenPath(): string {
+export function getLocalAuthTokenPath(): string {
   return join(getUserConfigDir(), LOCAL_AUTH_TOKEN_FILENAME);
 }
 


### PR DESCRIPTION
## Summary

`nakama rotate-token` rotates the local auth token and prints only the on-disk path — never the secret.

**Before:** `runRotateToken` logged the fresh bearer token to stdout (shell scrollback / `tee` / pipes could leak full API access).
**After:** success message + `Token file: ~/.nakama/local-auth-token` (via `getLocalAuthTokenPath`); read the file yourself.

Why safe:
1. Token still written by `rotateLocalAuthToken` exactly as before
2. CLI test asserts rotated value is absent from logs and the printed path matches `getLocalAuthTokenPath()`
3. Env-managed tokens (`NAKAMA_LOCAL_AUTH_TOKEN`) still refuse rotate as before

Only re-add a stdout print if an operator workflow truly cannot read the token file.

## Test plan
- [x] `bun test apps/cli/src/rotate-token.test.ts packages/core/src/local-auth.test.ts` (7 pass)
- [ ] Run `nakama rotate-token` locally — confirm stdout has no `tc_local_…` string and the path file contains the new token

Closes #482
