### PR TITLE
feat(providers): add direct Mistral integration

### DIFF
--- a/apps/server/src/providers/compatible-models.ts
+++ b/apps/server/src/providers/compatible-models.ts
@@ -131,7 +131,7 @@ export function catalogCustomModelsToCatalog(
     }
     if (entry.supportsThinking !== undefined) {
       model.supportsThinking = entry.supportsThinking;
-    } else if (provider === "deepseek") {
+    } else if (provider === "deepseek" || provider === "mistral") {
       model.supportsThinking = false;
     }
     if (entry.inputPerMillionUsd !== undefined) {

--- a/apps/server/src/providers/compatible-models.ts
+++ b/apps/server/src/providers/compatible-models.ts
@@ -327,6 +327,7 @@ export function getModelsForProviderInstance(
     instance.type === "anthropic" ||
     instance.type === "gemini" ||
     instance.type === "deepseek" ||
+    instance.type === "mistral" ||
     instance.type === "opencode_go"
   ) {
     const entries = instance.customModels ?? [];

--- a/apps/server/src/providers/create.test.ts
+++ b/apps/server/src/providers/create.test.ts
@@ -18,4 +18,19 @@ describe("createProviderForInstance routing", () => {
     expect(client).not.toBeNull();
     expect(client?.name).toBe("xai");
   });
+
+  test("creates a mistral client from a mistral instance", () => {
+    const instance: ProviderInstance = {
+      apiKey: "test-key",
+      createdAt: new Date().toISOString(),
+      id: "inst_mistral",
+      label: "Mistral",
+      type: "mistral",
+    };
+
+    const client = createProviderForInstance(instance, "mistral-small-2603");
+
+    expect(client).not.toBeNull();
+    expect(client?.name).toBe("mistral");
+  });
 });

--- a/apps/server/src/providers/create.test.ts
+++ b/apps/server/src/providers/create.test.ts
@@ -19,18 +19,65 @@ describe("createProviderForInstance routing", () => {
     expect(client?.name).toBe("xai");
   });
 
-  test("creates a mistral client from a mistral instance", () => {
-    const instance: ProviderInstance = {
-      apiKey: "test-key",
-      createdAt: new Date().toISOString(),
-      id: "inst_mistral",
-      label: "Mistral",
-      type: "mistral",
-    };
+  test("routes mistral instances to the configured base URL with auth", async () => {
+    let seenPath = "";
+    let seenAuth = "";
+    let seenModel = "";
 
-    const client = createProviderForInstance(instance, "mistral-small-2603");
+    const mock = Bun.serve({
+      fetch: async (request) => {
+        const url = new URL(request.url);
+        seenPath = url.pathname;
+        seenAuth = request.headers.get("authorization") ?? "";
+        const body = (await request.json()) as { model?: string };
+        seenModel = body.model ?? "";
+        return Response.json({
+          choices: [
+            {
+              finish_reason: "stop",
+              index: 0,
+              message: { content: "ok", role: "assistant" },
+            },
+          ],
+          created: 1,
+          id: "mock",
+          model: seenModel,
+          object: "chat.completion",
+          usage: {
+            completion_tokens: 1,
+            prompt_tokens: 1,
+            total_tokens: 2,
+          },
+        });
+      },
+      port: 0,
+    });
 
-    expect(client).not.toBeNull();
-    expect(client?.name).toBe("mistral");
+    try {
+      const instance: ProviderInstance = {
+        apiKey: "test-key",
+        baseUrl: `http://127.0.0.1:${mock.port}/v1`,
+        createdAt: new Date().toISOString(),
+        id: "inst_mistral",
+        label: "Mistral",
+        type: "mistral",
+      };
+
+      const client = createProviderForInstance(instance, "mistral-small-2603");
+
+      expect(client).not.toBeNull();
+      expect(client?.name).toBe("mistral");
+
+      const result = await client!.generateChat({
+        messages: [{ content: "ping", role: "user" }],
+      });
+
+      expect(result.content).toBe("ok");
+      expect(seenPath).toBe("/v1/chat/completions");
+      expect(seenAuth).toBe("Bearer test-key");
+      expect(seenModel).toBe("mistral-small-2603");
+    } finally {
+      mock.stop(true);
+    }
   });
 });

--- a/apps/server/src/providers/create.ts
+++ b/apps/server/src/providers/create.ts
@@ -28,6 +28,7 @@ import { createOpenCodeGoProvider } from "./opencode-go";
 import { createOpenRouterProvider } from "./openrouter";
 
 const DEFAULT_DEEPSEEK_BASE_URL = "https://api.deepseek.com";
+const DEFAULT_MISTRAL_BASE_URL = "https://api.mistral.ai/v1";
 const DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1";
 
 export interface CreateProviderOptions {
@@ -80,6 +81,13 @@ function createProvider(options: CreateProviderOptions): ProviderClient {
         baseUrl: baseUrlOverride ?? DEFAULT_DEEPSEEK_BASE_URL,
         model,
         providerName: "deepseek",
+      });
+    case "mistral":
+      return createOpenAIProvider({
+        apiKey: options.apiKey,
+        baseUrl: baseUrlOverride ?? DEFAULT_MISTRAL_BASE_URL,
+        model,
+        providerName: "mistral",
       });
     case "minimax":
     case "minimax_cn":

--- a/apps/server/src/providers/models.test.ts
+++ b/apps/server/src/providers/models.test.ts
@@ -87,6 +87,13 @@ describe("resolveModel", () => {
     expect(getDefaultModel("deepseek")).toBe("deepseek-v4-flash");
   });
 
+  test("resolves catalog models for Mistral", () => {
+    expect(resolveModel("mistral", "mistral-large-2512")).toBe(
+      "mistral-large-2512"
+    );
+    expect(getDefaultModel("mistral")).toBe("mistral-small-2603");
+  });
+
   test("resolves catalog models for Cerebras", () => {
     expect(resolveModel("cerebras", "gpt-oss-120b")).toBe("gpt-oss-120b");
     expect(getDefaultModel("cerebras")).toBe("gpt-oss-120b");

--- a/apps/server/src/providers/models.test.ts
+++ b/apps/server/src/providers/models.test.ts
@@ -92,6 +92,21 @@ describe("resolveModel", () => {
       "mistral-large-2512"
     );
     expect(getDefaultModel("mistral")).toBe("mistral-small-2603");
+    expect(getModelById("mistral-small-2603")?.supportsThinking).toBe(true);
+    expect(getModelById("mistral-small-2603")?.supportsVision).toBe(true);
+    expect(getModelById("ministral-3b-2512")?.supportsVision).toBe(true);
+  });
+
+  test("uses mistral custom model shortlist when provided", () => {
+    const customModels = [
+      { default: true, id: "mistral-small-2603", name: "Mistral Small 4" },
+    ];
+    expect(resolveModel("mistral", "mistral-small-2603", customModels)).toBe(
+      "mistral-small-2603"
+    );
+    expect(resolveModel("mistral", "unknown-model", customModels)).toBe(
+      "mistral-small-2603"
+    );
   });
 
   test("resolves catalog models for Cerebras", () => {
@@ -230,5 +245,11 @@ describe("modelSupportsVision", () => {
     expect(
       modelSupportsVision("opencode-go/kimi-k2.7-code", "opencode_go")
     ).toBe(false);
+  });
+
+  test("reads Mistral vision flags from the curated catalog", () => {
+    expect(modelSupportsVision("mistral-small-2603", "mistral")).toBe(true);
+    expect(modelSupportsVision("mistral-large-2512", "mistral")).toBe(true);
+    expect(modelSupportsVision("ministral-14b-2512", "mistral")).toBe(true);
   });
 });

--- a/apps/server/src/providers/models.ts
+++ b/apps/server/src/providers/models.ts
@@ -204,7 +204,7 @@ const BASE_MODELS: ProviderModelOption[] = withVisionDefaults([
   },
   {
     contextWindow: 262_144,
-    id: "mistral-medium-2604",
+    id: "mistral-medium-latest",
     inputPerMillionUsd: 1.5,
     maxOutputTokens: 65_536,
     name: "Mistral Medium 3.5",

--- a/apps/server/src/providers/models.ts
+++ b/apps/server/src/providers/models.ts
@@ -191,6 +191,68 @@ const BASE_MODELS: ProviderModelOption[] = withVisionDefaults([
     supportsThinking: true,
   },
   {
+    contextWindow: 262_144,
+    default: true,
+    id: "mistral-small-2603",
+    inputPerMillionUsd: 0.15,
+    maxOutputTokens: 65_536,
+    name: "Mistral Small 4",
+    outputPerMillionUsd: 0.6,
+    provider: "mistral",
+    supportsThinking: true,
+    supportsVision: true,
+  },
+  {
+    contextWindow: 262_144,
+    id: "mistral-medium-2604",
+    inputPerMillionUsd: 1.5,
+    maxOutputTokens: 65_536,
+    name: "Mistral Medium 3.5",
+    outputPerMillionUsd: 7.5,
+    provider: "mistral",
+    supportsVision: true,
+  },
+  {
+    contextWindow: 262_144,
+    id: "mistral-large-2512",
+    inputPerMillionUsd: 0.5,
+    maxOutputTokens: 65_536,
+    name: "Mistral Large 3",
+    outputPerMillionUsd: 1.5,
+    provider: "mistral",
+    supportsVision: true,
+  },
+  {
+    contextWindow: 131_072,
+    id: "ministral-3b-2512",
+    inputPerMillionUsd: 0.1,
+    maxOutputTokens: 65_536,
+    name: "Ministral 3 3B",
+    outputPerMillionUsd: 0.1,
+    provider: "mistral",
+    supportsVision: true,
+  },
+  {
+    contextWindow: 262_144,
+    id: "ministral-8b-2512",
+    inputPerMillionUsd: 0.15,
+    maxOutputTokens: 65_536,
+    name: "Ministral 3 8B",
+    outputPerMillionUsd: 0.15,
+    provider: "mistral",
+    supportsVision: true,
+  },
+  {
+    contextWindow: 262_144,
+    id: "ministral-14b-2512",
+    inputPerMillionUsd: 0.2,
+    maxOutputTokens: 65_536,
+    name: "Ministral 3 14B",
+    outputPerMillionUsd: 0.2,
+    provider: "mistral",
+    supportsVision: true,
+  },
+  {
     contextWindow: 131_072,
     default: true,
     id: "gpt-oss-120b",
@@ -611,6 +673,7 @@ export function getDefaultModel(
       provider === "anthropic" ||
       provider === "gemini" ||
       provider === "deepseek" ||
+      provider === "mistral" ||
       provider === "opencode_go") &&
     customModels?.length
   ) {
@@ -627,15 +690,17 @@ export function getDefaultModel(
           ? "gemini-2.5-flash"
           : provider === "deepseek"
             ? "deepseek-v4-flash"
-            : provider === "cerebras"
-              ? "gpt-oss-120b"
-              : provider === "fireworks"
-                ? "accounts/fireworks/models/kimi-k2p6"
-                : provider === "opencode_go"
-                  ? "opencode-go/kimi-k2.7-code"
-                  : provider === "cloudflare"
-                    ? "@cf/meta/llama-3.3-70b-instruct-fp8-fast"
-                    : "gpt-5.4";
+            : provider === "mistral"
+              ? "mistral-small-2603"
+              : provider === "cerebras"
+                ? "gpt-oss-120b"
+                : provider === "fireworks"
+                  ? "accounts/fireworks/models/kimi-k2p6"
+                  : provider === "opencode_go"
+                    ? "opencode-go/kimi-k2.7-code"
+                    : provider === "cloudflare"
+                      ? "@cf/meta/llama-3.3-70b-instruct-fp8-fast"
+                      : "gpt-5.4";
   return models.find((model) => model.default)?.id ?? models[0]?.id ?? fallback;
 }
 
@@ -699,6 +764,7 @@ export function resolveModel(
       provider === "anthropic" ||
       provider === "gemini" ||
       provider === "deepseek" ||
+      provider === "mistral" ||
       provider === "cerebras" ||
       provider === "fireworks" ||
       provider === "opencode_go") &&

--- a/apps/server/src/providers/openai/index.ts
+++ b/apps/server/src/providers/openai/index.ts
@@ -148,6 +148,10 @@ function providerLabel(providerName: ProviderName): string {
     return "DeepSeek";
   }
 
+  if (providerName === "mistral") {
+    return "Mistral";
+  }
+
   return "OpenAI";
 }
 

--- a/apps/server/src/services/provider-instance-helpers.ts
+++ b/apps/server/src/services/provider-instance-helpers.ts
@@ -151,7 +151,8 @@ export function modelExistsOnInstance(
     instance.type === "openai" ||
     instance.type === "anthropic" ||
     instance.type === "gemini" ||
-    instance.type === "deepseek"
+    instance.type === "deepseek" ||
+    instance.type === "mistral"
   ) {
     if (instance.customModels?.length) {
       return findCustomModel(instance.customModels, trimmed) !== undefined;
@@ -312,7 +313,8 @@ export function applyProviderInstanceUpdate(
       instance.type === "chatgpt" ||
       instance.type === "anthropic" ||
       instance.type === "gemini" ||
-      instance.type === "deepseek"
+      instance.type === "deepseek" ||
+      instance.type === "mistral"
     ) {
       next.customModels = validateCustomModels(request.customModels);
     }

--- a/apps/web/src/components/catalog-provider-model-fields.shared.ts
+++ b/apps/web/src/components/catalog-provider-model-fields.shared.ts
@@ -6,6 +6,7 @@ export const CATALOG_SHORTLIST_PROVIDERS = [
   "anthropic",
   "gemini",
   "deepseek",
+  "mistral",
   "opencode_go",
 ] as const;
 

--- a/apps/web/src/hooks/use-models-dev.ts
+++ b/apps/web/src/hooks/use-models-dev.ts
@@ -29,6 +29,7 @@ const OFFICIAL_PROVIDER_IDS = new Set([
   "openrouter",
   "opencode",
   "deepseek",
+  "mistral",
 ]);
 
 const NPM_MAP: Record<string, SelectedProvider> = {
@@ -39,6 +40,7 @@ const NPM_MAP: Record<string, SelectedProvider> = {
 
 const PROVIDER_ID_OVERRIDES: Record<string, SelectedProvider> = {
   deepseek: "deepseek",
+  mistral: "mistral",
   opencode: "openai_compatible",
   openrouter: "openrouter",
 };

--- a/apps/web/src/lib/models.test.ts
+++ b/apps/web/src/lib/models.test.ts
@@ -22,6 +22,7 @@ function group(
     | "opencode_go"
     | "openrouter"
     | "deepseek"
+    | "mistral"
     | "cerebras"
     | "fireworks",
   flags?: {
@@ -115,6 +116,22 @@ describe("resolveModelThinkingSupport", () => {
       resolveModelThinkingSupport(
         encodeModelSelection("ds-1", "model-1"),
         group("ds-1", "deepseek", { supportsThinking: true })
+      )
+    ).toBe(true);
+  });
+
+  test("treats mistral models as opt-in only", () => {
+    expect(
+      resolveModelThinkingSupport(
+        encodeModelSelection("mi-1", "model-1"),
+        group("mi-1", "mistral")
+      )
+    ).toBe(false);
+
+    expect(
+      resolveModelThinkingSupport(
+        encodeModelSelection("mi-1", "model-1"),
+        group("mi-1", "mistral", { supportsThinking: true })
       )
     ).toBe(true);
   });
@@ -310,6 +327,7 @@ describe("firstAvailableProviderOption", () => {
           "openrouter",
           "gemini",
           "deepseek",
+          "mistral",
           "cerebras",
           "cloudflare",
           "fireworks",

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -49,6 +49,7 @@ export function formatProviderLabel(
     provider === "openrouter" ||
     provider === "gemini" ||
     provider === "deepseek" ||
+    provider === "mistral" ||
     provider === "cerebras" ||
     provider === "cloudflare" ||
     provider === "fireworks" ||
@@ -76,6 +77,7 @@ export const PROVIDER_OPTIONS: Array<{ id: SelectedProvider; label: string }> =
     { id: "openrouter", label: "OpenRouter" },
     { id: "gemini", label: "Gemini" },
     { id: "deepseek", label: "DeepSeek" },
+    { id: "mistral", label: "Mistral" },
     { id: "cerebras", label: "Cerebras" },
     { id: "cloudflare", label: "Cloudflare Worker AI" },
     { id: "fireworks", label: "Fireworks" },
@@ -889,6 +891,7 @@ export function resolveModelThinkingSupport(
     model.provider === "openai_compatible" ||
     model.provider === "openrouter" ||
     model.provider === "deepseek" ||
+    model.provider === "mistral" ||
     model.provider === "cerebras" ||
     model.provider === "fireworks" ||
     model.provider === "ollama"
@@ -938,6 +941,7 @@ export function resolveModelVisionSupport(
     model.provider === "openai_compatible" ||
     model.provider === "opencode_go" ||
     model.provider === "deepseek" ||
+    model.provider === "mistral" ||
     model.provider === "cerebras" ||
     model.provider === "fireworks" ||
     model.provider === "ollama" ||

--- a/docs/website/content/docs/providers.mdx
+++ b/docs/website/content/docs/providers.mdx
@@ -31,6 +31,7 @@ Nakama supports these built-in provider types:
 | OpenRouter | Route to many models through one API key |
 | Gemini | Google Gemini models |
 | DeepSeek | DeepSeek models |
+| Mistral | Mistral models (Small 4, Medium 3.5, Large 3, Ministral 3) |
 | Cerebras | Cerebras models |
 | Cloudflare Worker AI | Workers AI models; add an API key and account ID in Settings (saved to `config.ini`). Llama 3.1 8B is the cheaper catalog option. `CLOUDFLARE_ACCOUNT_ID` is a fallback only |
 | Fireworks | Fireworks AI models |

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -2209,6 +2209,7 @@ export type ProviderName =
   | "openrouter"
   | "gemini"
   | "deepseek"
+  | "mistral"
   | "cerebras"
   | "fireworks"
   | "ollama"

--- a/packages/core/src/document-content.ts
+++ b/packages/core/src/document-content.ts
@@ -79,6 +79,7 @@ const NATIVE_DOCUMENT_MEDIA_TYPES: Record<ProviderName, ReadonlySet<string>> = {
   ]),
   minimax: new Set<string>(),
   minimax_cn: new Set<string>(),
+  mistral: new Set<string>(),
   ollama: new Set<string>(),
   openai: new Set([
     "application/pdf",

--- a/packages/core/src/provider-label.ts
+++ b/packages/core/src/provider-label.ts
@@ -13,6 +13,7 @@ const BUILTIN_LABELS: Record<
   gemini: "Gemini",
   minimax: "MiniMax",
   minimax_cn: "MiniMax (CN)",
+  mistral: "Mistral",
   ollama: "Ollama",
   openai: "OpenAI",
   opencode_go: "OpenCode Go",

--- a/packages/core/src/provider-resolution.test.ts
+++ b/packages/core/src/provider-resolution.test.ts
@@ -16,6 +16,7 @@ describe("parseProviderName", () => {
     expect(parseProviderName("openai_compatible")).toBe("openai_compatible");
     expect(parseProviderName("opencode_go")).toBe("opencode_go");
     expect(parseProviderName("deepseek")).toBe("deepseek");
+    expect(parseProviderName("mistral")).toBe("mistral");
     expect(parseProviderName("cerebras")).toBe("cerebras");
     expect(parseProviderName("fireworks")).toBe("fireworks");
     expect(parseProviderName("minimax")).toBe("minimax");
@@ -34,6 +35,10 @@ describe("parseProviderName", () => {
 describe("apiKeyEnvVarForProvider", () => {
   test("chatgpt uses OAuth, not an API key env var", () => {
     expect(apiKeyEnvVarForProvider("chatgpt")).toBeNull();
+  });
+
+  test("mistral uses MISTRAL_API_KEY", () => {
+    expect(apiKeyEnvVarForProvider("mistral")).toBe("MISTRAL_API_KEY");
   });
 });
 

--- a/packages/core/src/provider-resolution.test.ts
+++ b/packages/core/src/provider-resolution.test.ts
@@ -102,6 +102,18 @@ describe("resolveProvider deepseek", () => {
   });
 });
 
+describe("resolveProvider mistral", () => {
+  test("auto-resolves Mistral when it is the only env API key", () => {
+    const provider = resolveProvider({
+      env: {
+        MISTRAL_API_KEY: "ms-test",
+      },
+    });
+
+    expect(provider).toBe("mistral");
+  });
+});
+
 describe("resolveProvider cerebras", () => {
   test("auto-resolves Cerebras when it is the only env API key", () => {
     const provider = resolveProvider({

--- a/packages/core/src/provider-resolution.ts
+++ b/packages/core/src/provider-resolution.ts
@@ -9,6 +9,7 @@ export const USER_PROVIDER_NAMES: readonly UserProviderName[] = [
   "openrouter",
   "gemini",
   "deepseek",
+  "mistral",
   "cerebras",
   "fireworks",
   "ollama",
@@ -40,6 +41,7 @@ export function parseProviderName(
     normalized === "openrouter" ||
     normalized === "gemini" ||
     normalized === "deepseek" ||
+    normalized === "mistral" ||
     normalized === "cerebras" ||
     normalized === "fireworks" ||
     normalized === "ollama" ||
@@ -71,6 +73,8 @@ export function apiKeyEnvVarForProvider(
       return "GEMINI_API_KEY";
     case "deepseek":
       return null;
+    case "mistral":
+      return "MISTRAL_API_KEY";
     case "cerebras":
       return "CEREBRAS_API_KEY";
     case "fireworks":

--- a/packages/core/src/provider-setup-prompt.ts
+++ b/packages/core/src/provider-setup-prompt.ts
@@ -35,6 +35,7 @@ const PROVIDER_CHOICES: Array<{ id: UserProviderName; label: string }> = [
   { id: "openrouter", label: "OpenRouter" },
   { id: "gemini", label: "Gemini" },
   { id: "deepseek", label: "DeepSeek" },
+  { id: "mistral", label: "Mistral" },
   { id: "xai", label: "xAI Grok" },
   { id: "cerebras", label: "Cerebras" },
   { id: "cloudflare", label: "Cloudflare Worker AI" },
@@ -180,6 +181,7 @@ function resolveProviderChoice(input: string): UserProviderName | null {
     normalized === "openrouter" ||
     normalized === "gemini" ||
     normalized === "deepseek" ||
+    normalized === "mistral" ||
     normalized === "cerebras" ||
     normalized === "cloudflare" ||
     normalized === "fireworks" ||

--- a/packages/core/src/user-config.ts
+++ b/packages/core/src/user-config.ts
@@ -86,6 +86,7 @@ const PROVIDER_TYPE_LABELS: Record<UserProviderName, string> = {
   gemini: "Gemini",
   minimax: "MiniMax",
   minimax_cn: "MiniMax (CN)",
+  mistral: "Mistral",
   ollama: "Ollama",
   openai: "OpenAI",
   openai_compatible: "Custom",


### PR DESCRIPTION
## Summary

Settings → LLM providers can add **Mistral** with its own API key; chat uses `https://api.mistral.ai/v1` like DeepSeek/xAI.

**Before:** Mistral models only via OpenRouter / custom OpenAI-compatible endpoints.
**After:** first-party `mistral` provider (`MISTRAL_API_KEY`), curated catalog (Small 4 default, Medium 3.5, Large 3, Ministral 3), web card + CLI setup + docs row.

Why safe:
1. Same `createOpenAIProvider` path as DeepSeek/xAI — HTTP mock asserts `/v1/chat/completions` + bearer auth
2. Catalog marks vision/thinking per model; custom shortlist thinking stays opt-in
3. No discovery/browse surface — fixed shortlist only

Only re-record / adjust model IDs if La Plateforme renames aliases (Medium uses `mistral-medium-latest`; Small/Large/Ministral use dated ids). Coding-agent harness routing still excludes Mistral (same as xAI) — chat Settings only. Live cassette still needs a real `MISTRAL_API_KEY`.

## Test plan
- [x] `bun test packages/core/src/provider-resolution.test.ts packages/core/src/provider-setup-prompt.test.ts apps/server/src/providers/create.test.ts apps/server/src/providers/models.test.ts apps/web/src/lib/models.test.ts` (77 pass)
- [ ] Add a Mistral provider in Settings with a live key → send one chat on `mistral-small-2603`

Closes #388
