### PR TITLE
fix(server): make the install deadline cancel the install

### DIFF
--- a/apps/server/src/http/coding-harness-install-stream.test.ts
+++ b/apps/server/src/http/coding-harness-install-stream.test.ts
@@ -117,4 +117,26 @@ describe("streamInstallEvents", () => {
 
     expect(thrown).toEqual([]);
   });
+
+  test("the deadline aborts the signal the executor was handed", async () => {
+    const seen: string[] = [];
+    let abortedDuringRun = false;
+
+    const response = streamInstallEvents<TestEvent>(
+      async (send, signal) => {
+        seen.push(`aborted-at-start:${signal.aborted}`);
+        await Bun.sleep(OUTLIVES_TIMEOUT_MS);
+        abortedDuringRun = signal.aborted;
+        send({ message: "late", type: "progress" });
+      },
+      { timeoutMs: TIMEOUT_MS }
+    );
+
+    const events = await readEvents(response);
+    await Bun.sleep(OUTLIVES_TIMEOUT_MS);
+
+    expect(seen[0]).toBe("aborted-at-start:false");
+    expect(abortedDuringRun).toBe(true);
+    expect(events.at(-1)?.type).toBe("error");
+  });
 });

--- a/apps/server/src/http/coding-harness-install-stream.ts
+++ b/apps/server/src/http/coding-harness-install-stream.ts
@@ -10,7 +10,10 @@ type InstallStreamOptions = {
 };
 
 export function streamInstallEvents<TEvent extends { type: string }>(
-  executor: (send: (event: TEvent) => void) => Promise<void>,
+  executor: (
+    send: (event: TEvent) => void,
+    signal: AbortSignal
+  ) => Promise<void>,
   options: InstallStreamOptions = {}
 ): Response {
   const encoder = new TextEncoder();
@@ -23,6 +26,12 @@ export function streamInstallEvents<TEvent extends { type: string }>(
   let terminated = false;
   let keepalive: ReturnType<typeof setInterval> | undefined;
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  /**
+   * Closing the stream used to leave the installer running: the deadline ended
+   * the response and nothing told the work to stop. This is what the executor
+   * watches so a timeout, or a client that hangs up, actually reaches it.
+   */
+  const abortController = new AbortController();
 
   const clearTimers = () => {
     clearInterval(keepalive);
@@ -33,6 +42,7 @@ export function streamInstallEvents<TEvent extends { type: string }>(
     cancel() {
       terminated = true;
       clearTimers();
+      abortController.abort();
     },
     async start(controller) {
       const send = (event: TEvent) => {
@@ -68,11 +78,12 @@ export function streamInstallEvents<TEvent extends { type: string }>(
           error: timeoutMessage,
           type: "error",
         } as Extract<TEvent, InstallStreamErrorEvent>);
+        abortController.abort();
         finish();
       }, timeoutMs);
 
       try {
-        await executor(send);
+        await executor(send, abortController.signal);
       } catch (error) {
         send({
           error: formatServerError(error),
@@ -94,7 +105,10 @@ export function streamInstallEvents<TEvent extends { type: string }>(
 }
 
 export function streamAgentBrowserInstall(
-  executor: (send: (event: AgentBrowserInstallEvent) => void) => Promise<void>,
+  executor: (
+    send: (event: AgentBrowserInstallEvent) => void,
+    signal: AbortSignal
+  ) => Promise<void>,
   options: InstallStreamOptions = {}
 ): Response {
   return streamInstallEvents<AgentBrowserInstallEvent>(executor, options);

--- a/apps/server/src/http/routes/models.ts
+++ b/apps/server/src/http/routes/models.ts
@@ -1575,13 +1575,16 @@ export function registerModelRoutes(
     requireOrgAdminFromContext(c);
 
     return streamAgentBrowserInstall(
-      async (send) => {
-        const status = await installAgentBrowser((progress) => {
-          send({
-            message: progress.message,
-            type: "progress",
-          });
-        });
+      async (send, signal) => {
+        const status = await installAgentBrowser(
+          (progress) => {
+            send({
+              message: progress.message,
+              type: "progress",
+            });
+          },
+          { signal }
+        );
 
         send({
           status,

--- a/apps/server/src/services/agent-browser-service.ts
+++ b/apps/server/src/services/agent-browser-service.ts
@@ -70,7 +70,8 @@ export interface AgentBrowserInstallProgress {
 }
 
 export async function installAgentBrowser(
-  onProgress?: (progress: AgentBrowserInstallProgress) => void
+  onProgress?: (progress: AgentBrowserInstallProgress) => void,
+  options: { signal?: AbortSignal } = {}
 ): Promise<AgentBrowserStatusResponse> {
   const emitProgress = (message: string) => {
     onProgress?.({ message });
@@ -84,7 +85,9 @@ export async function installAgentBrowser(
   emitProgress("Starting agent-browser install.");
   emitProgress(cliPlan.displayCommand);
 
-  const cliResult = await runTimedInstallCommand(cliPlan, emitProgress);
+  const cliResult = await runTimedInstallCommand(cliPlan, emitProgress, {
+    signal: options.signal,
+  });
   const cliOutput = [cliResult.stdout, cliResult.stderr]
     .filter(Boolean)
     .join("\n")
@@ -106,6 +109,16 @@ export async function installAgentBrowser(
     );
   }
 
+  // The browser download is the long half, so starting it after the caller has
+  // gone is the case this guards. The abort is checked between the two commands
+  // as well as inside each one.
+  if (options.signal?.aborted) {
+    throw new NakamaApiError(
+      "Install cancelled before the agent-browser download started.",
+      502
+    );
+  }
+
   ensureProcessPath();
   emitProgress(`${AGENT_BROWSER_COMMAND} install`);
 
@@ -115,7 +128,8 @@ export async function installAgentBrowser(
       command: AGENT_BROWSER_COMMAND,
       displayCommand: `${AGENT_BROWSER_COMMAND} install`,
     },
-    emitProgress
+    emitProgress,
+    { signal: options.signal }
   );
   const browserOutput = [browserResult.stdout, browserResult.stderr]
     .filter(Boolean)

--- a/apps/server/src/services/cli-package-install.test.ts
+++ b/apps/server/src/services/cli-package-install.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { runTimedInstallCommand } from "./cli-package-install";
 
 const STALLING_PLAN = {
@@ -155,4 +158,53 @@ describe("runTimedInstallCommand", () => {
       timedOut: true,
     });
   });
+
+  /**
+   * The installer shells out and the grandchild outlives its parent. A kill
+   * aimed at the direct child leaves that grandchild running, which is what
+   * "the timeout does not cancel the install" meant in practice.
+   */
+  test("a timed-out install stops the processes it started, not just the one it spawned", async () => {
+    const marker = join(tmpdir(), `nakama-install-grandchild-${Date.now()}`);
+    rmSync(marker, { force: true });
+
+    const result = await runTimedInstallCommand(
+      {
+        args: [
+          "-c",
+          `sh -c 'sleep 1.2; echo alive > ${marker}' & echo started; wait`,
+        ],
+        command: "sh",
+        displayCommand: "sh -c 'grandchild'",
+      },
+      undefined,
+      { settleTimeoutMs: 1000, sigtermGraceMs: 100, timeoutMs: 200 }
+    );
+
+    expect(result.timedOut).toBe(true);
+
+    // Past the grandchild's own sleep: if the group was signalled it never
+    // wrote, and if only the direct child was signalled it has by now.
+    await Bun.sleep(1600);
+    const survived = existsSync(marker);
+    rmSync(marker, { force: true });
+    expect(survived).toBe(false);
+  }, 15_000);
+
+  test("an aborted signal ends the install without waiting for the deadline", async () => {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 100);
+
+    const startedAt = Date.now();
+    const result = await runTimedInstallCommand(STALLING_PLAN, undefined, {
+      settleTimeoutMs: 1000,
+      signal: controller.signal,
+      sigtermGraceMs: 100,
+      timeoutMs: 60_000,
+    });
+
+    // The 60s deadline never fired, so finishing at all is the abort working.
+    expect(result.timedOut).toBe(true);
+    expect(Date.now() - startedAt).toBeLessThan(10_000);
+  }, 15_000);
 });

--- a/apps/server/src/services/cli-package-install.ts
+++ b/apps/server/src/services/cli-package-install.ts
@@ -146,6 +146,7 @@ export async function runTimedInstallCommand(
   options: {
     settleTimeoutMs?: number;
     sigtermGraceMs?: number;
+    signal?: AbortSignal;
     timeoutMs?: number;
   } = {}
 ): Promise<{
@@ -158,9 +159,13 @@ export async function runTimedInstallCommand(
   const timeoutMs = options.timeoutMs ?? CLI_INSTALL_TIMEOUT_MS;
   const sigtermGraceMs = options.sigtermGraceMs ?? CLI_SIGTERM_GRACE_MS;
   const settleTimeoutMs = options.settleTimeoutMs ?? CLI_SETTLE_TIMEOUT_MS;
+  const signal = options.signal;
 
   return new Promise((resolve) => {
     const child = spawn(plan.command, plan.args, {
+      // Its own process group, so a deadline can signal the whole install
+      // rather than only the command we spawned. Installers shell out, and
+      // those grandchildren outlive a kill aimed at the direct child.
       env: getToolExecutionEnv(),
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -177,6 +182,7 @@ export async function runTimedInstallCommand(
       clearTimeout(timeoutId);
       clearTimeout(killTimeoutId);
       clearTimeout(settleTimeoutId);
+      signal?.removeEventListener("abort", onAbort);
     };
 
     /**
@@ -195,9 +201,29 @@ export async function runTimedInstallCommand(
       });
     };
 
-    const timeoutId = setTimeout(() => {
-      timedOut = true;
+    /**
+     * Signals the whole process group. The `detached` above is what makes the
+     * negative pid mean the group rather than the one child; the fallback
+     * covers a group that is already gone while the child is not.
+     */
+    const killTree = (killSignal: "SIGTERM" | "SIGKILL") => {
+      if (child.pid) {
+        try {
+          process.kill(-child.pid, killSignal);
+          return;
+        } catch {
+          // Group already reaped, fall through to the direct child.
+        }
+      }
 
+      try {
+        child.kill(killSignal);
+      } catch {
+        // Already gone.
+      }
+    };
+
+    const terminate = () => {
       // The process can already be gone with `close` still outstanding, held by
       // whatever the installer left running. There is nothing left to wait for.
       if (exited) {
@@ -205,10 +231,28 @@ export async function runTimedInstallCommand(
         return;
       }
 
-      child.kill("SIGTERM");
-      killTimeoutId = setTimeout(() => child.kill("SIGKILL"), sigtermGraceMs);
+      killTree("SIGTERM");
+      killTimeoutId = setTimeout(() => killTree("SIGKILL"), sigtermGraceMs);
       settleTimeoutId = setTimeout(settleAsTimedOut, settleTimeoutMs);
+    };
+
+    const onAbort = () => {
+      timedOut = true;
+      terminate();
+    };
+
+    const timeoutId = setTimeout(() => {
+      timedOut = true;
+      terminate();
     }, timeoutMs);
+
+    if (signal) {
+      if (signal.aborted) {
+        onAbort();
+      } else {
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+    }
 
     const emitLine = (prefix: "stdout" | "stderr", line: string) => {
       if (timedOut) {

--- a/apps/server/src/services/cli-package-install.ts
+++ b/apps/server/src/services/cli-package-install.ts
@@ -183,7 +183,7 @@ export async function runTimedInstallCommand(
       clearTimeout(timeoutId);
       clearTimeout(killTimeoutId);
       clearTimeout(settleTimeoutId);
-      signal?.removeEventListener("abort", onAbort);
+      signal?.removeEventListener("abort", terminate);
     };
 
     /**
@@ -225,6 +225,8 @@ export async function runTimedInstallCommand(
     };
 
     const terminate = () => {
+      timedOut = true;
+
       // The process can already be gone with `close` still outstanding, held by
       // whatever the installer left running. There is nothing left to wait for.
       if (exited) {
@@ -237,21 +239,13 @@ export async function runTimedInstallCommand(
       settleTimeoutId = setTimeout(settleAsTimedOut, settleTimeoutMs);
     };
 
-    const onAbort = () => {
-      timedOut = true;
-      terminate();
-    };
-
-    const timeoutId = setTimeout(() => {
-      timedOut = true;
-      terminate();
-    }, timeoutMs);
+    const timeoutId = setTimeout(terminate, timeoutMs);
 
     if (signal) {
       if (signal.aborted) {
-        onAbort();
+        terminate();
       } else {
-        signal.addEventListener("abort", onAbort, { once: true });
+        signal.addEventListener("abort", terminate, { once: true });
       }
     }
 

--- a/apps/server/src/services/cli-package-install.ts
+++ b/apps/server/src/services/cli-package-install.ts
@@ -166,6 +166,7 @@ export async function runTimedInstallCommand(
       // Its own process group, so a deadline can signal the whole install
       // rather than only the command we spawned. Installers shell out, and
       // those grandchildren outlive a kill aimed at the direct child.
+      detached: true,
       env: getToolExecutionEnv(),
       stdio: ["ignore", "pipe", "pipe"],
     });


### PR DESCRIPTION
## Summary

The install deadline now stops the install, instead of only ending the response.

**Before:** the timeout closed the stream and the work carried on. `installAgentBrowser` went on to start the browser download, and the per-command kill reached only the process it spawned.
**After:** `streamInstallEvents` aborts a signal the executor watches, and `runTimedInstallCommand` signals the whole process group.

Why safe:
1. The `signal` option is additive, so the six existing `runTimedInstallCommand` tests pass untouched, and the other caller in `coding-agent-harness-service` needs no change
2. The group signal falls back to the direct child when the group is already gone, which is also the path on Windows where a negative pid is unsupported
3. Mutation-checked: removing `detached`, downgrading the group kill to a child kill, dropping the abort listener, not aborting on the deadline, and not passing the signal each fail a test

Only follow up if an install needs to survive a server stop: the detached child no longer receives the terminal signal that used to reach it through the shared process group.

## Test plan
- [x] `bun test apps/server/src` (1138 pass, 1135 on base)
- [x] `bun test apps/server/src/services/cli-package-install.test.ts` (8 pass)
- [x] `bun test apps/server/src/http/coding-harness-install-stream.test.ts` (7 pass)
- [ ] Start an agent-browser install, close the tab before it finishes, and confirm no install process is left behind

Refs #439
