### PR TITLE
fix(chatgpt): recover model discovery from rejected tokens

### DIFF
--- a/apps/server/src/providers/chatgpt/oauth.test.ts
+++ b/apps/server/src/providers/chatgpt/oauth.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
   CHATGPT_JWT_CLAIM_PATH,
+  fetchChatgptCodexModels,
   parseChatgptCodexModelsPayload,
   readChatgptAccountIdFromAccessToken,
 } from "./oauth";
@@ -20,6 +21,55 @@ describe("fetchChatgptCodexModels", () => {
     globalThis.fetch = originalFetch;
   });
 
+  test("refreshes a rejected token despite a future expiry and saves it before retrying", async () => {
+    const accessToken = buildJwt({
+      [CHATGPT_JWT_CLAIM_PATH]: { chatgpt_account_id: "acct_1" },
+    });
+    let saved = false;
+    let modelRequests = 0;
+    let refreshRequests = 0;
+    globalThis.fetch = (async (input, init) => {
+      if (String(input).includes("/oauth/token")) {
+        refreshRequests++;
+        expect(
+          new URLSearchParams(String(init?.body)).get("refresh_token")
+        ).toBe("refresh");
+        return Response.json({
+          access_token: accessToken,
+          expires_in: 3600,
+          refresh_token: "replacement",
+        });
+      }
+      modelRequests++;
+      if (modelRequests === 1) {
+        return new Response(null, { status: 401 });
+      }
+      expect(saved).toBe(true);
+      expect(new Headers(init?.headers).get("Authorization")).toBe(
+        `Bearer ${accessToken}`
+      );
+      return Response.json({ models: [{ slug: "gpt-5.4" }] });
+    }) as typeof fetch;
+
+    const models = await fetchChatgptCodexModels(
+      {
+        accessToken: "rejected-token",
+        accountId: "acct_1",
+        expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+        refreshToken: "refresh",
+      },
+      (oauth) => {
+        expect(oauth.accessToken).toBe(accessToken);
+        expect(oauth.refreshToken).toBe("replacement");
+        saved = true;
+        return Promise.resolve();
+      }
+    );
+    expect(models.map((model) => model.id)).toEqual(["gpt-5.4"]);
+    expect(modelRequests).toBe(2);
+    expect(refreshRequests).toBe(1);
+  });
+
   test("throws when Codex returns an error status", async () => {
     globalThis.fetch = (async () =>
       new Response("nope", { status: 403 })) as typeof fetch;
@@ -35,6 +85,49 @@ describe("fetchChatgptCodexModels", () => {
       })
     ).rejects.toThrow("ChatGPT models failed (403)");
   });
+
+  test.each(["refresh rejected", "retry rejected"])(
+    "stops when %s and asks for reconnection",
+    async (failure) => {
+      let modelRequests = 0;
+      let refreshRequests = 0;
+      let saved = 0;
+      globalThis.fetch = (async (input) => {
+        if (String(input).includes("/oauth/token")) {
+          refreshRequests++;
+          if (failure === "refresh rejected") {
+            return new Response(null, { status: 400 });
+          }
+          return Response.json({
+            access_token: buildJwt({
+              [CHATGPT_JWT_CLAIM_PATH]: { chatgpt_account_id: "acct_1" },
+            }),
+            expires_in: 3600,
+            refresh_token: "replacement",
+          });
+        }
+        modelRequests++;
+        return new Response(null, { status: 401 });
+      }) as typeof fetch;
+      await expect(
+        fetchChatgptCodexModels(
+          {
+            accessToken: "rejected",
+            accountId: "acct_1",
+            expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+            refreshToken: "refresh",
+          },
+          () => {
+            saved++;
+            return Promise.resolve();
+          }
+        )
+      ).rejects.toMatchObject({ status: 400 });
+      expect(refreshRequests).toBe(1);
+      expect(modelRequests).toBe(failure === "refresh rejected" ? 1 : 2);
+      expect(saved).toBe(failure === "refresh rejected" ? 0 : 1);
+    }
+  );
 });
 
 describe("parseChatgptCodexModelsPayload", () => {

--- a/apps/server/src/providers/chatgpt/oauth.ts
+++ b/apps/server/src/providers/chatgpt/oauth.ts
@@ -292,20 +292,45 @@ export function parseChatgptCodexModelsPayload(
 }
 
 export async function fetchChatgptCodexModels(
-  oauth: ChatgptOAuthCredentials
+  oauth: ChatgptOAuthCredentials,
+  onTokenRefresh?: (oauth: ChatgptOAuthCredentials) => Promise<void>
 ): Promise<CustomModelEntry[]> {
-  const response = await fetch(
-    `${CHATGPT_CODEX_BASE_URL}/models?client_version=1.0.0`,
-    {
+  const fetchModels = (credentials: ChatgptOAuthCredentials) =>
+    fetch(`${CHATGPT_CODEX_BASE_URL}/models?client_version=1.0.0`, {
       headers: {
         Accept: "application/json",
-        Authorization: `Bearer ${oauth.accessToken}`,
-        "ChatGPT-Account-ID": oauth.accountId,
+        Authorization: `Bearer ${credentials.accessToken}`,
+        "ChatGPT-Account-ID": credentials.accountId,
         "OpenAI-Beta": "responses=v1",
         originator: "codex_cli_rs",
       },
+    });
+  let response = await fetchModels(oauth);
+
+  // The upstream can reject a token before its stored expiry. Refresh once,
+  // and persist rotated credentials before making another request.
+  if (response.status === 401 && onTokenRefresh) {
+    await response.body?.cancel();
+    let refreshed: ChatgptOAuthCredentials;
+    try {
+      refreshed = await refreshChatgptOAuthToken(oauth.refreshToken);
+    } catch {
+      throw new NakamaApiError(
+        "ChatGPT sign-in expired. Reconnect in Settings → LLM providers.",
+        400
+      );
     }
-  );
+    await onTokenRefresh(refreshed);
+    response = await fetchModels(refreshed);
+  }
+
+  if (response.status === 401) {
+    await response.body?.cancel();
+    throw new NakamaApiError(
+      "ChatGPT sign-in expired. Reconnect in Settings → LLM providers.",
+      400
+    );
+  }
 
   if (!response.ok) {
     const text = await response.text().catch(() => "");

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -2289,7 +2289,9 @@ export class AgentService {
         await this.persistChatgptOAuth(providerId, oauth);
       }
 
-      const entries = await fetchChatgptCodexModels(oauth);
+      const entries = await fetchChatgptCodexModels(oauth, (refreshed) =>
+        this.persistChatgptOAuth(providerId, refreshed)
+      );
       const models = catalogCustomModelsToCatalog(entries, [], "chatgpt");
 
       return {


### PR DESCRIPTION
## Summary

ChatGPT users can load their models when a saved token is rejected before its recorded expiry.

**Before:** Manage models returned HTTP 500 and an empty list.
**After:** Refresh the token, save the replacement credentials, and retry once; failed recovery asks the user to reconnect.

Why safe:
1. Recovery only runs after HTTP 401 and retries once.
2. Replacement credentials are saved before retrying.

## Test plan

- [x] `bun test apps/server/src/providers/chatgpt apps/server/src/services/agent-service.test.ts` (38 pass)
- [x] `bun x ultracite fix` in the commit hook (1,295 files checked, no changes)
- [x] Live local discovery: HTTP 500 before → HTTP 200 with 8 models after
