### PR TITLE
fix(web): attach pending skill review to the composer

### DIFF
--- a/apps/web/src/components/chat/SkillPostTurnReviewBanner.tsx
+++ b/apps/web/src/components/chat/SkillPostTurnReviewBanner.tsx
@@ -1,9 +1,12 @@
 import type { SkillProposal, SkillSuggestion } from "@nakama/core/contract";
+import { Cancel01Icon, QuillWrite02Icon } from "hugeicons-react";
 import { Link } from "react-router-dom";
+import { ChatComposerNotice } from "@/components/chat/chat-tips";
 import { skillSuggestionPreview } from "@/components/chat/skill-post-turn-review.shared";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { orgSkillProposalsPath } from "@/lib/navigation";
+import { cn } from "@/lib/utils";
 
 export type SuggestionApplyState =
   | "idle"
@@ -18,8 +21,85 @@ interface SkillPostTurnReviewBannerProps {
   canApply: boolean;
   isOrgAdmin: boolean;
   onApply: (suggestionId: string) => void;
+  onDismiss: (id: string) => void;
   pendingProposals: SkillProposal[];
   suggestions: SkillSuggestion[];
+}
+
+function DismissButton({
+  className,
+  label,
+  onDismiss,
+}: {
+  className?: string;
+  label: string;
+  onDismiss: () => void;
+}) {
+  return (
+    <Button
+      aria-label={label}
+      className={cn(
+        "relative text-muted-foreground after:absolute after:top-1/2 after:left-1/2 after:size-10 after:-translate-x-1/2 after:-translate-y-1/2 hover:text-foreground active:scale-[0.96]",
+        className
+      )}
+      onClick={onDismiss}
+      size="icon-sm"
+      type="button"
+      variant="ghost"
+    >
+      <Cancel01Icon strokeWidth={1.5} />
+    </Button>
+  );
+}
+
+const PENDING_PROPOSAL_REASON =
+  "Makes the agent smarter for you. Needs admin approval to go live.";
+
+function proposalTitle(proposal: SkillProposal): string {
+  const action = proposal.action.replaceAll("_", " ");
+  return `${action.charAt(0).toUpperCase()}${action.slice(1)} “${proposal.skillName}”`;
+}
+
+function PendingProposalRow({
+  isOrgAdmin,
+  onDismiss,
+  proposal,
+}: {
+  isOrgAdmin: boolean;
+  onDismiss: () => void;
+  proposal: SkillProposal;
+}) {
+  return (
+    <div className="text-sm">
+      <div className="flex items-center gap-2">
+        <QuillWrite02Icon
+          aria-hidden
+          className="size-3.5 shrink-0"
+          strokeWidth={1.5}
+        />
+        <p className="min-w-0 flex-1 truncate font-medium text-foreground">
+          {proposalTitle(proposal)}
+        </p>
+        <div className="flex shrink-0 items-center">
+          {isOrgAdmin ? (
+            <Link
+              className="px-1.5 text-xs underline underline-offset-2 hover:text-foreground"
+              to={orgSkillProposalsPath(proposal.profileId)}
+            >
+              Review
+            </Link>
+          ) : null}
+          <DismissButton
+            label={`Dismiss skill ${proposal.action} ${proposal.skillName}`}
+            onDismiss={onDismiss}
+          />
+        </div>
+      </div>
+      <p className="mt-0.5 text-pretty pl-[1.375rem] text-muted-foreground text-xs leading-tight">
+        {PENDING_PROPOSAL_REASON}
+      </p>
+    </div>
+  );
 }
 
 export function SkillPostTurnReviewBanner({
@@ -30,99 +110,90 @@ export function SkillPostTurnReviewBanner({
   canApply,
   isOrgAdmin,
   onApply,
+  onDismiss,
 }: SkillPostTurnReviewBannerProps) {
   if (suggestions.length === 0 && pendingProposals.length === 0) {
     return null;
   }
 
   return (
-    <div
-      className="mb-3 flex flex-col gap-2"
-      data-testid="skill-post-turn-review-banner"
-    >
-      {pendingProposals.map((proposal) => (
-        <div
-          className="rounded-md border border-border bg-muted/40 px-3 py-2 text-sm"
-          key={proposal.id}
-        >
-          <p className="font-medium text-foreground">
-            Skill {proposal.action} “{proposal.skillName}” pending admin review
-          </p>
-          <p className="mt-1 text-muted-foreground text-xs">
-            Post-turn review staged this change. It will not go live until an
-            org admin approves it.
-          </p>
-          {isOrgAdmin ? (
-            <p className="mt-2 text-xs">
-              <Link
-                className="underline underline-offset-2 hover:text-foreground"
-                to={orgSkillProposalsPath(proposal.profileId)}
-              >
-                Review proposals
-              </Link>
-            </p>
-          ) : null}
-        </div>
-      ))}
+    <ChatComposerNotice className="py-1.5">
+      <div
+        className="flex flex-col divide-y divide-border"
+        data-testid="skill-post-turn-review-banner"
+      >
+        {pendingProposals.map((proposal) => (
+          <PendingProposalRow
+            isOrgAdmin={isOrgAdmin}
+            key={proposal.id}
+            onDismiss={() => onDismiss(`proposal:${proposal.id}`)}
+            proposal={proposal}
+          />
+        ))}
 
-      {suggestions.map((suggestion) => {
-        const preview = skillSuggestionPreview(suggestion);
-        const state = applyStateById[suggestion.id] ?? "idle";
-        const error = applyErrorById[suggestion.id];
-        const applied = state === "applied" || state === "staged";
-        const loading = state === "loading";
+        {suggestions.map((suggestion) => {
+          const preview = skillSuggestionPreview(suggestion);
+          const state = applyStateById[suggestion.id] ?? "idle";
+          const error = applyErrorById[suggestion.id];
+          const applied = state === "applied" || state === "staged";
+          const loading = state === "loading";
 
-        return (
-          <div
-            className="rounded-md border border-border bg-muted/40 px-3 py-2 text-sm"
-            key={suggestion.id}
-          >
-            <p className="font-medium text-foreground">{preview.title}</p>
-            <p className="mt-1 text-muted-foreground text-xs">
-              {preview.description}
-            </p>
-            {preview.excerpt ? (
-              <pre className="mt-2 max-h-32 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border/70 bg-background/70 p-2 font-mono text-2xs text-foreground leading-relaxed">
-                {preview.excerpt}
-              </pre>
-            ) : null}
-            {suggestion.warnings && suggestion.warnings.length > 0 ? (
-              <p className="mt-2 text-amber-600 text-xs dark:text-amber-400">
-                {suggestion.warnings.join(" ")}
+          return (
+            <div className="relative py-2 pr-8 text-sm" key={suggestion.id}>
+              <DismissButton
+                className="absolute top-0.5 right-0"
+                label={`Dismiss ${preview.title}`}
+                onDismiss={() => onDismiss(`suggestion:${suggestion.id}`)}
+              />
+              <p className="text-pretty font-medium text-foreground">
+                {preview.title}
               </p>
-            ) : null}
-            {error ? (
-              <p className="mt-2 text-destructive text-xs">{error}</p>
-            ) : null}
-            {state === "staged" ? (
-              <p className="mt-2 text-muted-foreground text-xs">
-                Write approval is on — staged for admin review instead of
-                writing immediately.
+              <p className="mt-1 text-muted-foreground text-xs">
+                {preview.description}
               </p>
-            ) : null}
-            <div className="mt-2 flex items-center gap-2">
-              <Button
-                disabled={!canApply || applied || loading}
-                onClick={() => onApply(suggestion.id)}
-                size="sm"
-                type="button"
-              >
-                {loading ? <Spinner className="mr-2" /> : null}
-                {applied
-                  ? state === "staged"
-                    ? "Staged"
-                    : "Applied"
-                  : "Apply"}
-              </Button>
-              {canApply ? null : (
-                <span className="text-muted-foreground text-xs">
-                  Viewers cannot apply.
-                </span>
-              )}
+              {preview.excerpt ? (
+                <pre className="mt-2 max-h-32 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border/70 bg-background/70 p-2 font-mono text-2xs text-foreground leading-relaxed">
+                  {preview.excerpt}
+                </pre>
+              ) : null}
+              {suggestion.warnings && suggestion.warnings.length > 0 ? (
+                <p className="mt-2 text-amber-600 text-xs dark:text-amber-400">
+                  {suggestion.warnings.join(" ")}
+                </p>
+              ) : null}
+              {error ? (
+                <p className="mt-2 text-destructive text-xs">{error}</p>
+              ) : null}
+              {state === "staged" ? (
+                <p className="mt-2 text-muted-foreground text-xs">
+                  Write approval is on — staged for admin review instead of
+                  writing immediately.
+                </p>
+              ) : null}
+              <div className="mt-2 flex items-center gap-2">
+                <Button
+                  disabled={!canApply || applied || loading}
+                  onClick={() => onApply(suggestion.id)}
+                  size="sm"
+                  type="button"
+                >
+                  {loading ? <Spinner className="mr-2" /> : null}
+                  {applied
+                    ? state === "staged"
+                      ? "Staged"
+                      : "Applied"
+                    : "Apply"}
+                </Button>
+                {canApply ? null : (
+                  <span className="text-muted-foreground text-xs">
+                    Viewers cannot apply.
+                  </span>
+                )}
+              </div>
             </div>
-          </div>
-        );
-      })}
-    </div>
+          );
+        })}
+      </div>
+    </ChatComposerNotice>
   );
 }

--- a/apps/web/src/components/chat/SkillPostTurnReviewBanner.tsx
+++ b/apps/web/src/components/chat/SkillPostTurnReviewBanner.tsx
@@ -18,8 +18,6 @@ export type SuggestionApplyState =
 interface SkillPostTurnReviewBannerProps {
   applyErrorById: Record<string, string | undefined>;
   applyStateById: Record<string, SuggestionApplyState>;
-  canApply: boolean;
-  isOrgAdmin: boolean;
   onApply: (suggestionId: string) => void;
   onDismiss: (id: string) => void;
   pendingProposals: SkillProposal[];
@@ -55,20 +53,16 @@ function DismissButton({
 const PENDING_PROPOSAL_REASON =
   "Makes the agent smarter for you. Needs admin approval to go live.";
 
-function proposalTitle(proposal: SkillProposal): string {
-  const action = proposal.action.replaceAll("_", " ");
-  return `${action.charAt(0).toUpperCase()}${action.slice(1)} “${proposal.skillName}”`;
-}
-
 function PendingProposalRow({
-  isOrgAdmin,
   onDismiss,
   proposal,
 }: {
-  isOrgAdmin: boolean;
   onDismiss: () => void;
   proposal: SkillProposal;
 }) {
+  const action = proposal.action.replaceAll("_", " ");
+  const title = `${action.charAt(0).toUpperCase()}${action.slice(1)} “${proposal.skillName}”`;
+
   return (
     <div className="text-sm">
       <div className="flex items-center gap-2">
@@ -78,17 +72,15 @@ function PendingProposalRow({
           strokeWidth={1.5}
         />
         <p className="min-w-0 flex-1 truncate font-medium text-foreground">
-          {proposalTitle(proposal)}
+          {title}
         </p>
         <div className="flex shrink-0 items-center">
-          {isOrgAdmin ? (
-            <Link
-              className="px-1.5 text-xs underline underline-offset-2 hover:text-foreground"
-              to={orgSkillProposalsPath(proposal.profileId)}
-            >
-              Review
-            </Link>
-          ) : null}
+          <Link
+            className="px-1.5 text-xs underline underline-offset-2 hover:text-foreground"
+            to={orgSkillProposalsPath(proposal.profileId)}
+          >
+            Review
+          </Link>
           <DismissButton
             label={`Dismiss skill ${proposal.action} ${proposal.skillName}`}
             onDismiss={onDismiss}
@@ -107,8 +99,6 @@ export function SkillPostTurnReviewBanner({
   pendingProposals,
   applyStateById,
   applyErrorById,
-  canApply,
-  isOrgAdmin,
   onApply,
   onDismiss,
 }: SkillPostTurnReviewBannerProps) {
@@ -124,7 +114,6 @@ export function SkillPostTurnReviewBanner({
       >
         {pendingProposals.map((proposal) => (
           <PendingProposalRow
-            isOrgAdmin={isOrgAdmin}
             key={proposal.id}
             onDismiss={() => onDismiss(`proposal:${proposal.id}`)}
             proposal={proposal}
@@ -172,7 +161,7 @@ export function SkillPostTurnReviewBanner({
               ) : null}
               <div className="mt-2 flex items-center gap-2">
                 <Button
-                  disabled={!canApply || applied || loading}
+                  disabled={applied || loading}
                   onClick={() => onApply(suggestion.id)}
                   size="sm"
                   type="button"
@@ -184,11 +173,6 @@ export function SkillPostTurnReviewBanner({
                       : "Applied"
                     : "Apply"}
                 </Button>
-                {canApply ? null : (
-                  <span className="text-muted-foreground text-xs">
-                    Viewers cannot apply.
-                  </span>
-                )}
               </div>
             </div>
           );

--- a/apps/web/src/components/chat/chat-composer.tsx
+++ b/apps/web/src/components/chat/chat-composer.tsx
@@ -17,7 +17,14 @@ import {
   Image01Icon,
   WifiOff01Icon,
 } from "hugeicons-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   PromptInput,
   PromptInputBody,
@@ -120,6 +127,7 @@ interface ChatComposerFullProps extends ChatComposerBaseProps {
   availableSkills?: SkillSummary[];
   contextUsage?: ChatContextUsage | null;
   currentModelSelection: string | null;
+  headerNotice?: ReactNode;
   onModelChange: (selection: string) => void;
   onNavigateSetup?: () => void;
   onThinkingEffortChange?: (effort: ThinkingEffort) => void;
@@ -150,13 +158,18 @@ const EMPTY_SKILLS: SkillSummary[] = [];
 
 function ChatComposerNotice({
   error,
+  headerNotice,
   showTips,
 }: {
   error: string | null;
+  headerNotice?: ReactNode;
   showTips: boolean;
 }) {
   if (error) {
     return <ChatComposerError message={error} />;
+  }
+  if (headerNotice) {
+    return headerNotice;
   }
   if (showTips) {
     return <ChatTips />;
@@ -246,6 +259,7 @@ function ChatComposerStackedPrompt({
   disabled,
   displayError,
   footerClassName,
+  headerNotice,
   onStop,
   onSubmit,
   placeholder,
@@ -262,6 +276,7 @@ function ChatComposerStackedPrompt({
   disabled: boolean;
   displayError: string | null;
   footerClassName?: string;
+  headerNotice?: ReactNode;
   onStop?: () => void;
   onSubmit: (text: string, files: FileUIPart[]) => void;
   placeholder: string;
@@ -273,7 +288,11 @@ function ChatComposerStackedPrompt({
 }) {
   return (
     <>
-      <ChatComposerNotice error={displayError} showTips={showTips} />
+      <ChatComposerNotice
+        error={displayError}
+        headerNotice={headerNotice}
+        showTips={showTips}
+      />
       <PromptInput
         accept={ALL_ATTACHMENT_ACCEPT}
         className={composerShellClass}
@@ -329,6 +348,7 @@ function ChatComposerBarePrompt({
   disabled,
   displayError,
   footerClassName,
+  headerNotice,
   isMinimal,
   onStop,
   onSubmit,
@@ -346,6 +366,7 @@ function ChatComposerBarePrompt({
   disabled: boolean;
   displayError: string | null;
   footerClassName?: string;
+  headerNotice?: ReactNode;
   isMinimal: boolean;
   onStop?: () => void;
   onSubmit: (text: string, files: FileUIPart[]) => void;
@@ -358,7 +379,11 @@ function ChatComposerBarePrompt({
 }) {
   return (
     <>
-      <ChatComposerNotice error={displayError} showTips={showTips} />
+      <ChatComposerNotice
+        error={displayError}
+        headerNotice={headerNotice}
+        showTips={showTips}
+      />
       <PromptInput
         accept={isMinimal ? undefined : ALL_ATTACHMENT_ACCEPT}
         className={isMinimal ? composerShellCompactClass : composerShellClass}
@@ -491,6 +516,7 @@ function ChatComposerMain({
     disabled: layout.disabled,
     displayError,
     footerClassName: props.footerClassName,
+    headerNotice: isFullComposer(props) ? props.headerNotice : undefined,
     onStop: props.onStop,
     onSubmit: props.onSubmit,
     placeholder: layout.placeholder,

--- a/apps/web/src/components/chat/chat-tips.tsx
+++ b/apps/web/src/components/chat/chat-tips.tsx
@@ -11,7 +11,7 @@ const TIPS = [
 
 const TIP_INTERVAL_MS = 10_000;
 
-function ChatComposerNotice({
+export function ChatComposerNotice({
   children,
   className,
   role,

--- a/apps/web/src/components/profiles/SkillProposalsPanel.tsx
+++ b/apps/web/src/components/profiles/SkillProposalsPanel.tsx
@@ -125,7 +125,7 @@ function ProposalReviewDialog({
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogContent className="gap-4 overflow-hidden p-4 sm:max-w-lg sm:p-6">
+      <DialogContent className="gap-4 overflow-hidden p-4 sm:max-w-2xl sm:p-6">
         <DialogHeader className="pr-8">
           <DialogTitle>
             {actionLabel(proposal.action)} skill &ldquo;{proposal.skillName}

--- a/apps/web/src/hooks/use-post-turn-skill-review-overlay.tsx
+++ b/apps/web/src/hooks/use-post-turn-skill-review-overlay.tsx
@@ -12,6 +12,7 @@ import {
   useSkillSuggestions,
 } from "@/hooks/use-skill-suggestions";
 import { formatError } from "@/lib/client";
+import { canAccessSystemPage } from "@/lib/navigation";
 
 const POST_TURN_POLL_WINDOW_MS = 45_000;
 const POST_TURN_POLL_INTERVAL_MS = 3000;
@@ -26,14 +27,14 @@ interface UsePostTurnSkillReviewOverlayArgs {
 
 function canPollPostTurnReview({
   activeOrgId,
-  activeOrgRole,
+  canReview,
   readOnlySession,
   reviewEnabled,
   sessionChannel,
   sessionId,
 }: {
   activeOrgId?: string;
-  activeOrgRole?: string;
+  canReview: boolean;
   readOnlySession: boolean;
   reviewEnabled: boolean;
   sessionChannel: AgentChannel;
@@ -45,7 +46,7 @@ function canPollPostTurnReview({
     Boolean(sessionId) &&
     sessionChannel === "web" &&
     !readOnlySession &&
-    activeOrgRole !== "viewer"
+    canReview
   );
 }
 
@@ -118,14 +119,18 @@ export function usePostTurnSkillReviewOverlay({
   lastSuccessfulTurnAt,
   readOnlySession,
 }: UsePostTurnSkillReviewOverlayArgs) {
-  const { activeOrg } = useAuth();
+  const { activeOrg, user } = useAuth();
   const reviewEnabled = resolveProfileOrgBooleanOverride(
     profile?.skillsPostTurnReview ?? null,
     activeOrg?.skillsPostTurnReview ?? false
   );
+  const canReview = canAccessSystemPage(
+    user?.isPlatformAdmin === true,
+    activeOrg?.role
+  );
   const canPoll = canPollPostTurnReview({
     activeOrgId: activeOrg?.id,
-    activeOrgRole: activeOrg?.role,
+    canReview,
     readOnlySession,
     reviewEnabled,
     sessionChannel,
@@ -173,8 +178,8 @@ export function usePostTurnSkillReviewOverlay({
     <SkillPostTurnReviewBanner
       applyErrorById={applyErrorById}
       applyStateById={applyStateById}
-      canApply={activeOrg?.role !== "viewer"}
-      isOrgAdmin={activeOrg?.role === "admin"}
+      canApply={canReview}
+      isOrgAdmin={canReview}
       onApply={(id) =>
         void handleApply(id, () => {
           void suggestionsQuery.refetch();

--- a/apps/web/src/hooks/use-post-turn-skill-review-overlay.tsx
+++ b/apps/web/src/hooks/use-post-turn-skill-review-overlay.tsx
@@ -27,14 +27,12 @@ interface UsePostTurnSkillReviewOverlayArgs {
 
 function canPollPostTurnReview({
   activeOrgId,
-  canReview,
   readOnlySession,
   reviewEnabled,
   sessionChannel,
   sessionId,
 }: {
   activeOrgId?: string;
-  canReview: boolean;
   readOnlySession: boolean;
   reviewEnabled: boolean;
   sessionChannel: AgentChannel;
@@ -45,8 +43,7 @@ function canPollPostTurnReview({
     Boolean(activeOrgId) &&
     Boolean(sessionId) &&
     sessionChannel === "web" &&
-    !readOnlySession &&
-    canReview
+    !readOnlySession
   );
 }
 
@@ -128,14 +125,15 @@ export function usePostTurnSkillReviewOverlay({
     user?.isPlatformAdmin === true,
     activeOrg?.role
   );
-  const canPoll = canPollPostTurnReview({
-    activeOrgId: activeOrg?.id,
-    canReview,
-    readOnlySession,
-    reviewEnabled,
-    sessionChannel,
-    sessionId,
-  });
+  const canPoll =
+    canReview &&
+    canPollPostTurnReview({
+      activeOrgId: activeOrg?.id,
+      readOnlySession,
+      reviewEnabled,
+      sessionChannel,
+      sessionId,
+    });
   const polling = usePostTurnPolling(canPoll, lastSuccessfulTurnAt);
   const pollQuery = {
     enabled: canPoll,
@@ -159,17 +157,13 @@ export function usePostTurnSkillReviewOverlay({
       ),
     [proposalsQuery.data?.proposals, sessionId]
   );
-  const [dismissedIdsBySession, setDismissedIdsBySession] = useState<
-    Record<string, readonly string[]>
-  >({});
-  const sessionKey = sessionId ?? "";
-  const dismissedIds = new Set(dismissedIdsBySession[sessionKey] ?? []);
-
+  const [dismissedIds, setDismissedIds] = useState<readonly string[]>([]);
+  const dismissed = new Set(dismissedIds);
   const visibleSuggestions = suggestions.filter(
-    (suggestion) => !dismissedIds.has(`suggestion:${suggestion.id}`)
+    (suggestion) => !dismissed.has(`${sessionId}:suggestion:${suggestion.id}`)
   );
   const visibleProposals = pendingProposals.filter(
-    (proposal) => !dismissedIds.has(`proposal:${proposal.id}`)
+    (proposal) => !dismissed.has(`${sessionId}:proposal:${proposal.id}`)
   );
   const showBanner =
     canPoll && (visibleSuggestions.length > 0 || visibleProposals.length > 0);
@@ -178,8 +172,6 @@ export function usePostTurnSkillReviewOverlay({
     <SkillPostTurnReviewBanner
       applyErrorById={applyErrorById}
       applyStateById={applyStateById}
-      canApply={canReview}
-      isOrgAdmin={canReview}
       onApply={(id) =>
         void handleApply(id, () => {
           void suggestionsQuery.refetch();
@@ -187,14 +179,14 @@ export function usePostTurnSkillReviewOverlay({
         })
       }
       onDismiss={(id) => {
-        if (!sessionKey) {
+        if (!sessionId) {
           return;
         }
-        setDismissedIdsBySession((current) => {
-          const next = new Set(current[sessionKey] ?? []);
-          next.add(id);
-          return { ...current, [sessionKey]: [...next] };
-        });
+        setDismissedIds((current) =>
+          current.includes(`${sessionId}:${id}`)
+            ? current
+            : [...current, `${sessionId}:${id}`]
+        );
       }}
       pendingProposals={visibleProposals}
       suggestions={visibleSuggestions}

--- a/apps/web/src/hooks/use-post-turn-skill-review-overlay.tsx
+++ b/apps/web/src/hooks/use-post-turn-skill-review-overlay.tsx
@@ -154,8 +154,20 @@ export function usePostTurnSkillReviewOverlay({
       ),
     [proposalsQuery.data?.proposals, sessionId]
   );
+  const [dismissedIdsBySession, setDismissedIdsBySession] = useState<
+    Record<string, readonly string[]>
+  >({});
+  const sessionKey = sessionId ?? "";
+  const dismissedIds = new Set(dismissedIdsBySession[sessionKey] ?? []);
+
+  const visibleSuggestions = suggestions.filter(
+    (suggestion) => !dismissedIds.has(`suggestion:${suggestion.id}`)
+  );
+  const visibleProposals = pendingProposals.filter(
+    (proposal) => !dismissedIds.has(`proposal:${proposal.id}`)
+  );
   const showBanner =
-    canPoll && (suggestions.length > 0 || pendingProposals.length > 0);
+    canPoll && (visibleSuggestions.length > 0 || visibleProposals.length > 0);
 
   const banner = showBanner ? (
     <SkillPostTurnReviewBanner
@@ -169,8 +181,18 @@ export function usePostTurnSkillReviewOverlay({
           void proposalsQuery.refetch();
         })
       }
-      pendingProposals={pendingProposals}
-      suggestions={suggestions}
+      onDismiss={(id) => {
+        if (!sessionKey) {
+          return;
+        }
+        setDismissedIdsBySession((current) => {
+          const next = new Set(current[sessionKey] ?? []);
+          next.add(id);
+          return { ...current, [sessionKey]: [...next] };
+        });
+      }}
+      pendingProposals={visibleProposals}
+      suggestions={visibleSuggestions}
     />
   ) : null;
 

--- a/apps/web/src/pages/chat/chat-page-content.tsx
+++ b/apps/web/src/pages/chat/chat-page-content.tsx
@@ -73,7 +73,6 @@ export function ChatPageContent(state: ChatPageState) {
 
   const composer = (
     <>
-      {skillReviewBanner}
       {readOnlyBanner}
       <ChatComposer
         availableSkills={availableSkills}
@@ -90,6 +89,7 @@ export function ChatPageContent(state: ChatPageState) {
         disabled={composerDisabled}
         draftStorageKey={composerDraftKey}
         error={error}
+        headerNotice={skillReviewBanner}
         onModelChange={handleModelChange}
         onNavigateSetup={navigateSetup}
         onStop={stopStreaming}


### PR DESCRIPTION
## Summary

Org admins and platform admins get a dismissible skill-review notice on the composer, like tips. Members and viewers do not.

**Before:** floating card for any non-viewer; no dismiss; proposal dialog capped at 512px.
**After:** attached composer cap for org/platform admin only, session-local dismiss, Review + X, wider proposal dialog (`sm:max-w-2xl`).

Why safe:
1. Dismiss is local UI state keyed by session — it does not approve or reject the proposal
2. Review still uses the existing proposals path
3. Visibility uses `canAccessSystemPage` (org admin or platform admin)

Only follow up if a platform admin without org-admin role cannot open Review.

## Test plan
- [x] `bun x ultracite check` on the touched web files
- [x] As org admin: after a post-turn skill create, notice sits on the composer, X hides it, Review opens proposals
- [x] As member: same turn produces no composer cap

## Screenshots

https://github.com/user-attachments/assets/2e108114-7e6a-46f4-8d83-1e9406951c26
