### PR TITLE
fix(server): preserve event order when replacing replay snapshots

### DIFF
--- a/apps/server/src/services/session-turn-registry.test.ts
+++ b/apps/server/src/services/session-turn-registry.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { AgentTodo, StreamEvent } from "@nakama/core";
 import { SessionTurnRegistry } from "./session-turn-registry";
 
 describe("SessionTurnRegistry", () => {
@@ -34,6 +35,94 @@ describe("SessionTurnRegistry", () => {
 
     registry.endTurn("session_1", { reply: "hello world!", type: "done" });
     expect(registry.getStatus("session_1")).toEqual({ active: false });
+  });
+
+  test("replacing a todo snapshot preserves tool lifecycle order on replay", () => {
+    const registry = new SessionTurnRegistry();
+    registry.beginTurn("session_1");
+
+    const live: StreamEvent[] = [];
+    registry.subscribe("session_1", (event) => live.push(event));
+
+    const todos: AgentTodo[] = [
+      { content: "Read files", id: "todo_1", status: "in_progress" },
+    ];
+    const events: StreamEvent[] = [
+      { todos: [], type: "todos_updated" },
+      {
+        input: { todos },
+        tool: "todo_write",
+        toolCallId: "call_1",
+        type: "tool_start",
+      },
+      {
+        result: { todos },
+        tool: "todo_write",
+        toolCallId: "call_1",
+        type: "tool_end",
+      },
+      { todos, type: "todos_updated" },
+    ];
+    for (const event of events) {
+      registry.publish("session_1", event);
+    }
+
+    const replay: StreamEvent[] = [];
+    registry.subscribe("session_1", (event) => replay.push(event));
+
+    expect(live).toEqual(events);
+    expect(replay).toEqual(events.slice(1));
+
+    const chunk: StreamEvent = { delta: "Done", type: "chunk" };
+    registry.publish("session_1", chunk);
+    expect(live).toEqual([...events, chunk]);
+    expect(replay).toEqual([...events.slice(1), chunk]);
+  });
+
+  test("replays the latest interleaved tool inputs in publication order", () => {
+    const registry = new SessionTurnRegistry();
+    registry.beginTurn("session_1");
+
+    const first: StreamEvent = {
+      accumulatedArguments: "{",
+      delta: "{",
+      tool: "read_file",
+      toolCallId: "call_1",
+      type: "tool_input_delta",
+    };
+    const second: StreamEvent = { ...first, toolCallId: "call_2" };
+    const chunk: StreamEvent = { delta: "Reading files", type: "chunk" };
+    const firstUpdated: StreamEvent = {
+      ...first,
+      accumulatedArguments: '{"path":"a.txt"}',
+      delta: '"path":"a.txt"}',
+    };
+    const secondUpdated: StreamEvent = {
+      ...second,
+      accumulatedArguments: '{"path":',
+      delta: '"path":',
+    };
+    const secondComplete: StreamEvent = {
+      ...second,
+      accumulatedArguments: '{"path":"b.txt"}',
+      delta: '"b.txt"}',
+    };
+
+    for (const event of [
+      first,
+      second,
+      chunk,
+      firstUpdated,
+      secondUpdated,
+      secondComplete,
+    ]) {
+      registry.publish("session_1", event);
+    }
+
+    const replay: StreamEvent[] = [];
+    registry.subscribe("session_1", (event) => replay.push(event));
+
+    expect(replay).toEqual([chunk, firstUpdated, secondComplete]);
   });
 
   test("multiple subscribers each receive replay and live events", () => {

--- a/apps/server/src/services/session-turn-registry.ts
+++ b/apps/server/src/services/session-turn-registry.ts
@@ -70,22 +70,17 @@ function removeEventAt(turn: ActiveTurn, index: number): StreamEvent {
     throw new Error("Snapshot index must reference a buffered event.");
   }
 
-  const lastIndex = turn.events.length - 1;
-
-  if (index !== lastIndex) {
-    const lastEvent = turn.events[lastIndex]!;
-    turn.events[index] = lastEvent;
-    const movedKey = snapshotKey(lastEvent);
-    if (movedKey) {
-      turn.snapshotIndexes.set(movedKey, index);
-    }
-  }
-
-  turn.events.pop();
+  turn.events.splice(index, 1);
 
   const removedKey = snapshotKey(removed);
   if (removedKey) {
     turn.snapshotIndexes.delete(removedKey);
+  }
+
+  for (const [key, snapshotIndex] of turn.snapshotIndexes) {
+    if (snapshotIndex > index) {
+      turn.snapshotIndexes.set(key, snapshotIndex - 1);
+    }
   }
 
   return removed;


### PR DESCRIPTION
## Summary

Reconnect to an active chat and receive buffered tool events in their original order.

**Before:** Replacing a todo snapshot could replay `tool_end` before `tool_start`, so the web client dropped the result and showed a completed tool as running.
**After:** `removeEventAt` removes the obsolete snapshot in place and adjusts subsequent snapshot indexes, preserving the order of retained events.

Why safe:
1. Live delivery and the policy of retaining the latest snapshot are unchanged.
2. Regression tests cover replay versus live ordering and repeated updates to interleaved tool-input snapshots.

## Test plan
- [x] `bun test apps/server/src/services/session-turn-registry.test.ts apps/server/src/http/routes/sessions.stream.test.ts` (17 pass; the new ordering regression fails on unmodified `main`).
- [x] `bun run check` (1,295 files, LF validation checkout), `bun run knip`, and `bun run --filter @nakama/server build`.
- [ ] Reload an active chat after two todo updates; the completed tool should retain its result and completed status.

The full server suite on Windows had 1,102 passes and 46 failures: 45 reproduced on unmodified `main`; the remaining theme-hash failure disappears with LF checkout. The other workspace suites also encountered Windows file-permission/locking failures in core and db. Linux CI is still pending.