### PR TITLE
fix(whatsapp): recover linked sessions and deliver report files

### DIFF
--- a/apps/platform/discord/src/chat-handler.test.ts
+++ b/apps/platform/discord/src/chat-handler.test.ts
@@ -493,7 +493,7 @@ describe("createChatHandler artifact delivery", () => {
     });
   });
 
-  test("does not publish when the turn has no sidecar pair", async () => {
+  test("publishes successful artifact writes without a sidecar", async () => {
     await withTempHome(async (homeDir) => {
       const { handleMessage, calls, sessionStore } = await createPairedHandler(
         homeDir,
@@ -536,8 +536,8 @@ describe("createChatHandler artifact delivery", () => {
       });
       await handleMessage(message);
 
-      expect(calls.publishProfileArtifactShare).toBe(0);
-      expect(sentMessages.some((reply) => reply.includes("/s/"))).toBe(false);
+      expect(calls.publishProfileArtifactShare).toBe(1);
+      expect(sentMessages.some((reply) => reply.includes("/s/"))).toBe(true);
     });
   });
 

--- a/apps/platform/telegram/src/chat-handler.test.ts
+++ b/apps/platform/telegram/src/chat-handler.test.ts
@@ -2191,7 +2191,7 @@ describe("createChatHandler artifact delivery", () => {
     });
   });
 
-  test("does not publish when the turn has no sidecar pair", async () => {
+  test("publishes successful artifact writes without a sidecar", async () => {
     await withTempHome(async (homeDir) => {
       await writeTelegramConfigIni(homeDir, {
         botToken: "1234567890:TEST",
@@ -2251,8 +2251,8 @@ describe("createChatHandler artifact delivery", () => {
       });
       await handleMessage(ctx);
 
-      expect(calls.publishProfileArtifactShare).toBe(0);
-      expect(replies.some((reply) => reply.includes("/s/"))).toBe(false);
+      expect(calls.publishProfileArtifactShare).toBe(1);
+      expect(replies.some((reply) => reply.includes("/s/"))).toBe(true);
     });
   });
 

--- a/apps/platform/whatsapp/src/channel-artifact-flow.ts
+++ b/apps/platform/whatsapp/src/channel-artifact-flow.ts
@@ -76,7 +76,7 @@ export async function maybeSendWhatsAppAttachOnlyCommand(input: {
   });
 }
 
-async function sendArtifactDocumentForPath(input: {
+export async function sendArtifactDocumentForPath(input: {
   client: NakamaClient;
   profileId: string;
   path: string;

--- a/apps/platform/whatsapp/src/chat-handler.test.ts
+++ b/apps/platform/whatsapp/src/chat-handler.test.ts
@@ -1627,7 +1627,7 @@ describe("createChatHandler artifact delivery", () => {
     });
   });
 
-  test("does not publish when the turn has no sidecar pair", async () => {
+  test("publishes and attaches a successful write without a sidecar", async () => {
     await withArtifactChat(
       {
         messages: [
@@ -1655,11 +1655,15 @@ describe("createChatHandler artifact delivery", () => {
         ],
       },
       async (ctx) => {
-        await ctx.handleMessage({ jid: PAIRED_JID, text: "thanks" });
+        await ctx.handleMessage({
+          jid: PAIRED_JID,
+          text: "tolong kirim csv file kesini please",
+        });
 
-        expect(ctx.calls.publishProfileArtifactShare).toBe(0);
+        expect(ctx.calls.publishProfileArtifactShare).toBe(1);
+        expect(documentSendCount(ctx.sent)).toBe(1);
         expect(ctx.sent.some((message) => message.text.includes("/s/"))).toBe(
-          false
+          true
         );
       }
     );
@@ -1669,7 +1673,10 @@ describe("createChatHandler artifact delivery", () => {
     await withArtifactChat(
       { deliverableArtifacts: [SAMPLE_ARTIFACT] },
       async (ctx) => {
-        await ctx.handleMessage({ jid: PAIRED_JID, text: "send me the file" });
+        await ctx.handleMessage({
+          jid: PAIRED_JID,
+          text: "kirim file rekap-well-test.csv",
+        });
 
         expect(ctx.calls.readProfileArtifactContent).toBe(1);
         expect(documentSendCount(ctx.sent)).toBe(1);
@@ -1707,6 +1714,35 @@ describe("createChatHandler artifact delivery", () => {
       expect(documentSendCount(ctx.sent)).toBe(1);
       expect(ctx.calls.sendStream).toBe(1);
     });
+  });
+
+  test("creates the requested report before sending even with an older artifact", async () => {
+    await withArtifactChat(
+      { deliverableArtifacts: [SAMPLE_ARTIFACT], messages: artifactMessages },
+      async (ctx) => {
+        await ctx.handleMessage({
+          jid: PAIRED_JID,
+          text: "collect the report from 01-09-2026 to 06-09-2026 in csv file then send it to this group",
+        });
+        expect(ctx.calls.sendStream).toBe(1);
+        expect(ctx.calls.publishProfileArtifactShare).toBe(1);
+        expect(documentSendCount(ctx.sent)).toBe(1);
+      }
+    );
+  });
+
+  test("does not send an older artifact when report creation produces no file", async () => {
+    await withArtifactChat(
+      { deliverableArtifacts: [SAMPLE_ARTIFACT], messages: [] },
+      async (ctx) => {
+        await ctx.handleMessage({
+          jid: PAIRED_JID,
+          text: "collect the report then send it to this group",
+        });
+        expect(ctx.calls.sendStream).toBe(1);
+        expect(documentSendCount(ctx.sent)).toBe(0);
+      }
+    );
   });
 
   test("attaches in a group when the user asks to send the file", async () => {

--- a/apps/platform/whatsapp/src/chat-handler.test.ts
+++ b/apps/platform/whatsapp/src/chat-handler.test.ts
@@ -1614,20 +1614,25 @@ describe("createChatHandler artifact delivery", () => {
     });
   }
 
-  test("posts a publish share link after a paired save-artifact turn", async () => {
+  test("sends a new artifact as a document on a conversational retry", async () => {
     await withArtifactChat({ messages: artifactMessages }, async (ctx) => {
-      await ctx.handleMessage({ jid: PAIRED_JID, text: "thanks" });
+      await ctx.handleMessage({
+        jid: PAIRED_JID,
+        text: "tolong coba lagi tadi masih belum berhasil",
+      });
 
-      expect(ctx.calls.publishProfileArtifactShare).toBe(1);
+      expect(ctx.calls.publishProfileArtifactShare).toBe(0);
+      expect(documentSendCount(ctx.sent)).toBe(1);
+      expect(ctx.sent.some((message) => message.text.includes("/s/"))).toBe(
+        false
+      );
       expect(
-        ctx.sent.some((message) =>
-          message.text.includes("https://app.example/s/tok_test")
-        )
-      ).toBe(true);
+        ctx.sessionStore.getDeliverableArtifacts(PAIRED_JID).at(-1)?.path
+      ).toBe("report.md");
     });
   });
 
-  test("publishes and attaches a successful write without a sidecar", async () => {
+  test("attaches a successful write without a sidecar", async () => {
     await withArtifactChat(
       {
         messages: [
@@ -1660,10 +1665,10 @@ describe("createChatHandler artifact delivery", () => {
           text: "tolong kirim csv file kesini please",
         });
 
-        expect(ctx.calls.publishProfileArtifactShare).toBe(1);
+        expect(ctx.calls.publishProfileArtifactShare).toBe(0);
         expect(documentSendCount(ctx.sent)).toBe(1);
         expect(ctx.sent.some((message) => message.text.includes("/s/"))).toBe(
-          true
+          false
         );
       }
     );
@@ -1709,7 +1714,7 @@ describe("createChatHandler artifact delivery", () => {
         text: "save it and send me the file",
       });
 
-      expect(ctx.calls.publishProfileArtifactShare).toBe(1);
+      expect(ctx.calls.publishProfileArtifactShare).toBe(0);
       expect(ctx.calls.readProfileArtifactContent).toBe(1);
       expect(documentSendCount(ctx.sent)).toBe(1);
       expect(ctx.calls.sendStream).toBe(1);
@@ -1725,7 +1730,7 @@ describe("createChatHandler artifact delivery", () => {
           text: "collect the report from 01-09-2026 to 06-09-2026 in csv file then send it to this group",
         });
         expect(ctx.calls.sendStream).toBe(1);
-        expect(ctx.calls.publishProfileArtifactShare).toBe(1);
+        expect(ctx.calls.publishProfileArtifactShare).toBe(0);
         expect(documentSendCount(ctx.sent)).toBe(1);
       }
     );
@@ -1745,52 +1750,65 @@ describe("createChatHandler artifact delivery", () => {
     );
   });
 
-  test("attaches in a group when the user asks to send the file", async () => {
-    await withTempHome(async (homeDir) => {
-      await writeWhatsAppConfigIni(homeDir, {
-        pairedJid: PAIRED_JID,
-        phoneNumber: "1234567890",
-      });
+  test.each([false, true])(
+    "attaches in a group (new artifact on retry: %s)",
+    async (retry) => {
+      await withTempHome(async (homeDir) => {
+        await writeWhatsAppConfigIni(homeDir, {
+          pairedJid: PAIRED_JID,
+          phoneNumber: "1234567890",
+        });
 
-      const authStore = new WhatsAppAuthStore();
-      await authStore.reload();
-      const { client, calls } = createMockClient();
-      const sessionStore = new SessionStore(
-        path.join(homeDir, ".nakama", "whatsapp", "chat-sessions.json")
-      );
-      await sessionStore.load();
-      sessionStore.set(GROUP_JID, {
-        deliverableArtifacts: [SAMPLE_ARTIFACT],
-        profileId: "default",
-        sessionId: "session_test",
-        updatedAt: new Date().toISOString(),
-      });
-      await sessionStore.save();
-      const orgStore = createTestOrgStore(homeDir);
-      await orgStore.load();
-      const { sent, socket } = createMockSocket();
-      const handleMessage = createChatHandler({
-        authStore,
-        client,
-        config: { phoneNumber: "1234567890", profileId: "default" },
-        getSocket: () => socket as never,
-        orgStore,
-        sessionStore,
-      });
+        const authStore = new WhatsAppAuthStore();
+        await authStore.reload();
+        const { client, calls } = createMockClient({
+          messages: retry ? artifactMessages : [],
+        });
+        const sessionStore = new SessionStore(
+          path.join(homeDir, ".nakama", "whatsapp", "chat-sessions.json")
+        );
+        await sessionStore.load();
+        sessionStore.set(GROUP_JID, {
+          deliverableArtifacts: [SAMPLE_ARTIFACT],
+          profileId: "default",
+          sessionId: "session_test",
+          updatedAt: new Date().toISOString(),
+        });
+        await sessionStore.save();
+        const orgStore = createTestOrgStore(homeDir);
+        await orgStore.load();
+        const { sent, socket } = createMockSocket();
+        const handleMessage = createChatHandler({
+          authStore,
+          client,
+          config: { phoneNumber: "1234567890", profileId: "default" },
+          getSocket: () => socket as never,
+          orgStore,
+          sessionStore,
+        });
 
-      await handleMessage(
-        groupInbound({
-          mentionedJids: [BOT_ME.id],
-          text: "@Nakama send me the file",
-        })
-      );
+        await handleMessage(
+          groupInbound({
+            mentionedJids: [BOT_ME.id],
+            text: retry
+              ? "@Nakama tolong coba lagi tadi masih belum berhasil"
+              : "@Nakama send me the file",
+          })
+        );
 
-      expect(calls.readProfileArtifactContent).toBe(1);
-      expect(documentSendCount(sent)).toBe(1);
-      expect(calls.sendStream).toBe(0);
-      expect(sent.some((message) => message.jid === GROUP_JID)).toBe(true);
-    });
-  });
+        expect(calls.readProfileArtifactContent).toBe(1);
+        expect(documentSendCount(sent)).toBe(1);
+        expect(calls.sendStream).toBe(retry ? 1 : 0);
+        expect(calls.publishProfileArtifactShare).toBe(0);
+        const document = sent.find(
+          (message) => message.content.document !== undefined
+        );
+        expect(document?.jid).toBe(GROUP_JID);
+        expect(document?.content.fileName).toBe("report.md");
+        expect(Buffer.isBuffer(document?.content.document)).toBe(true);
+      });
+    }
+  );
 
   test("sends a document for /attach without an agent turn", async () => {
     await withArtifactChat(

--- a/apps/platform/whatsapp/src/chat-handler.ts
+++ b/apps/platform/whatsapp/src/chat-handler.ts
@@ -1,5 +1,9 @@
 import type { NakamaClient, RemoteChatSession } from "@nakama/client";
-import { deliverTurnArtifactShares, isAttachOnlyCommand } from "@nakama/core";
+import {
+  extractPairedTurnArtifacts,
+  isAttachOnlyCommand,
+  pushDeliverableArtifact,
+} from "@nakama/core";
 import { formatClientError } from "@nakama/core/api-error";
 import {
   clearActiveStream,
@@ -28,6 +32,7 @@ import type { WhatsAppAuthStore } from "./auth-store";
 import {
   maybeSendRequestedWhatsAppArtifactAttachment,
   maybeSendWhatsAppAttachOnlyCommand,
+  sendArtifactDocumentForPath,
 } from "./channel-artifact-flow";
 import { isChannelDebugEnabled } from "./channel-log";
 import type { WhatsAppBridgeConfig } from "./config";
@@ -523,25 +528,34 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     }
 
     if (profileId) {
-      const artifacts = await deliverTurnArtifactShares({
-        conversationKey,
-        publish: (path) => client.publishProfileArtifactShare(profileId, path),
-        sendFooter: (footer) => sendText(jid, footer, { raw: true }),
-        session,
-        sessionStore,
+      const artifacts = extractPairedTurnArtifacts(await session.getMessages());
+      if (artifacts.length === 0) {
+        return;
+      }
+      let registry = sessionStore.getDeliverableArtifacts(conversationKey);
+      for (const artifact of artifacts) {
+        registry = pushDeliverableArtifact(registry, {
+          ...artifact,
+          sharePath: null,
+          shareUrl: null,
+        });
+      }
+      sessionStore.updateArtifactState(conversationKey, {
+        deliverableArtifacts: registry,
       });
+      await sessionStore.save();
 
-      // Creation requests attach only if this turn actually produced an artifact.
       const postTurnSocket = getSocket();
-      if (postTurnSocket && (!createsArtifact || artifacts.length > 0)) {
-        await maybeSendRequestedWhatsAppArtifactAttachment({
-          attachUserText,
+      if (!postTurnSocket) {
+        return;
+      }
+      for (const artifact of artifacts) {
+        await sendArtifactDocumentForPath({
+          ...artifact,
           client,
-          conversationKey,
           jid,
           profileId,
           sendPlain: (text) => sendText(jid, text),
-          sessionStore,
           socket: postTurnSocket,
         });
       }

--- a/apps/platform/whatsapp/src/chat-handler.ts
+++ b/apps/platform/whatsapp/src/chat-handler.ts
@@ -429,7 +429,12 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     const profileId = sessionStore.get(conversationKey)?.profileId;
     const socket = getSocket();
 
-    if (profileId && socket) {
+    // ponytail: imperative phrases only; use an explicit send tool for richer requests.
+    const createsArtifact =
+      /^\s*(?:(?:please|tolong)\s+)?(?:collect|create|generate|save|buat(?:kan)?|rekap(?:kan)?)\b/i.test(
+        attachUserText
+      );
+    if (profileId && socket && !createsArtifact) {
       const attached = await maybeSendRequestedWhatsAppArtifactAttachment({
         attachUserText,
         client,
@@ -518,7 +523,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     }
 
     if (profileId) {
-      await deliverTurnArtifactShares({
+      const artifacts = await deliverTurnArtifactShares({
         conversationKey,
         publish: (path) => client.publishProfileArtifactShare(profileId, path),
         sendFooter: (footer) => sendText(jid, footer, { raw: true }),
@@ -526,10 +531,9 @@ export function createChatHandler(deps: ChatHandlerDeps) {
         sessionStore,
       });
 
-      // Same-turn "save and send me the file": registry is empty before the
-      // agent runs, so attach after shares are minted.
+      // Creation requests attach only if this turn actually produced an artifact.
       const postTurnSocket = getSocket();
-      if (postTurnSocket) {
+      if (postTurnSocket && (!createsArtifact || artifacts.length > 0)) {
         await maybeSendRequestedWhatsAppArtifactAttachment({
           attachUserText,
           client,

--- a/apps/platform/whatsapp/src/send-artifact-document.test.ts
+++ b/apps/platform/whatsapp/src/send-artifact-document.test.ts
@@ -73,8 +73,7 @@ describe("sendWhatsAppArtifactDocument", () => {
     );
 
     expect(result.ok).toBe(false);
-    expect(result.error).toContain("too large");
-    expect(result.error).toContain("share link");
+    expect(result.error).toBeTruthy();
     expect(calls).toHaveLength(0);
   });
 

--- a/apps/platform/whatsapp/src/send-artifact-document.ts
+++ b/apps/platform/whatsapp/src/send-artifact-document.ts
@@ -2,7 +2,7 @@ import type { WASocket } from "@whiskeysockets/baileys";
 
 /**
  * Memory/Buffer safety budget for in-process Baileys document uploads.
- * Not a claim about WhatsApp's absolute document ceiling — share link remains the fallback.
+ * Not a claim about WhatsApp's absolute document ceiling.
  */
 export const WHATSAPP_ARTIFACT_DOCUMENT_MAX_BYTES = 16 * 1024 * 1024;
 
@@ -18,7 +18,7 @@ export interface SendWhatsAppArtifactDocumentResult {
 }
 
 export function formatWhatsAppArtifactOversizeError(bytes: number): string {
-  return `File is too large for WhatsApp attach (${formatMegabytes(bytes)}; max ${formatMegabytes(WHATSAPP_ARTIFACT_DOCUMENT_MAX_BYTES)}). Use the share link instead.`;
+  return `File is too large for WhatsApp attach (${formatMegabytes(bytes)}; max ${formatMegabytes(WHATSAPP_ARTIFACT_DOCUMENT_MAX_BYTES)}). Download it from Artifacts in Nakama.`;
 }
 
 export async function sendWhatsAppArtifactDocument(

--- a/apps/platform/whatsapp/src/socket.test.ts
+++ b/apps/platform/whatsapp/src/socket.test.ts
@@ -12,6 +12,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import * as baileys from "@whiskeysockets/baileys";
+import { usePrivateMultiFileAuthState } from "./auth-state";
 
 const sockets: Array<{
   end: ReturnType<typeof mock>;
@@ -21,7 +22,7 @@ const delays: number[] = [];
 const endOrder: string[] = [];
 let endResolvers: Array<() => void> = [];
 
-const createSocket = mock(() => {
+const createSocket = mock((_config: baileys.UserFacingSocketConfig) => {
   const ev = new EventEmitter();
   let endResolve: (() => void) | null = null;
   const endPromise = new Promise<void>((resolve) => {
@@ -168,6 +169,117 @@ describe("WhatsApp socket reconnect", () => {
     expect(createSocket).toHaveBeenCalledTimes(1);
     expect(delays).toEqual([]);
   });
+
+  test.each([
+    ["123:2@s.whatsapp.net", "456:2@lid"],
+    ["456:2@lid", "123:2@s.whatsapp.net"],
+  ])(
+    "decrypts linked-device messages after %s switches to %s",
+    async (originalJid, migratedJid) => {
+      const handle = await createWhatsAppSocket({ onMessage: async () => {} });
+      await handle.start();
+      const config = createSocket.mock.calls[0]![0];
+      const receiver = config.auth!;
+      receiver.creds.me = { id: "123:9@s.whatsapp.net", lid: "456:9@lid" };
+      const { state: sender } = await usePrivateMultiFileAuthState(
+        join(tempConfigDir, "sender")
+      );
+      const makeRepository =
+        baileys.DEFAULT_CONNECTION_CONFIG.makeSignalRepository;
+      const sending = makeRepository(sender);
+      const receiving = config.makeSignalRepository!(receiver);
+      const destination = "123:9@s.whatsapp.net";
+      const { creds } = receiver;
+      const preKey = baileys.Curve.generateKeyPair();
+      await receiver.keys.set({ "pre-key": { "1": preKey } });
+      await sending.injectE2ESession({
+        jid: destination,
+        session: {
+          identityKey: baileys.generateSignalPubKey(
+            creds.signedIdentityKey.public
+          ),
+          preKey: {
+            keyId: 1,
+            publicKey: baileys.generateSignalPubKey(preKey.public),
+          },
+          registrationId: creds.registrationId,
+          signedPreKey: {
+            keyId: creds.signedPreKey.keyId,
+            publicKey: baileys.generateSignalPubKey(
+              creds.signedPreKey.keyPair.public
+            ),
+            signature: creds.signedPreKey.signature,
+          },
+        },
+      });
+      const first = await sending.encryptMessage({
+        data: Buffer.from("first"),
+        jid: destination,
+      });
+      await receiving.decryptMessage({ jid: originalJid, ...first });
+      const ack = await receiving.encryptMessage({
+        data: Buffer.from("ack"),
+        jid: originalJid,
+      });
+      await sending.decryptMessage({ jid: destination, ...ack });
+
+      // A stale session at the new address fails MAC verification; the original still works.
+      const stale = await sender.keys.get("session", [
+        sending.jidToSignalProtocolAddress(destination),
+      ]);
+      await receiver.keys.set({
+        session: {
+          [receiving.jidToSignalProtocolAddress(migratedJid)]:
+            stale[sending.jidToSignalProtocolAddress(destination)],
+        },
+      });
+      const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+      try {
+        const message = await sending.encryptMessage({
+          data: Buffer.from("after migration"),
+          jid: destination,
+        });
+        expect(message.type).toBe("msg");
+        await expect(
+          receiving.decryptMessage({ jid: "456:3@lid", ...message })
+        ).rejects.toThrow();
+        await expect(
+          receiving.decryptMessage({ jid: "789:2@lid", ...message })
+        ).rejects.toThrow();
+        const corrupted = Buffer.from(message.ciphertext);
+        corrupted[corrupted.length - 1] += 1;
+        await expect(
+          receiving.decryptMessage({
+            ...message,
+            ciphertext: corrupted,
+            jid: migratedJid,
+          })
+        ).rejects.toThrow();
+        const plaintext = await receiving.decryptMessage({
+          jid: migratedJid,
+          ...message,
+        });
+        expect(Buffer.from(plaintext).toString()).toBe("after migration");
+        const errorsAfterRecovery = errorSpy.mock.calls.length;
+        const next = await sending.encryptMessage({
+          data: Buffer.from("next"),
+          jid: destination,
+        });
+        expect(
+          Buffer.from(
+            await receiving.decryptMessage({ jid: migratedJid, ...next })
+          ).toString()
+        ).toBe("next");
+        expect(errorSpy.mock.calls.length).toBe(errorsAfterRecovery);
+        // The alternate session must retain replay protection and device isolation.
+        await expect(
+          receiving.decryptMessage({ jid: migratedJid, ...next })
+        ).rejects.toThrow();
+      } finally {
+        errorSpy.mockRestore();
+      }
+    }
+  );
 
   test("clears old-socket listeners on reconnect so upserts cannot leak", async () => {
     const received: string[] = [];

--- a/apps/platform/whatsapp/src/socket.ts
+++ b/apps/platform/whatsapp/src/socket.ts
@@ -1,9 +1,12 @@
 import { getWhatsAppConfigDir } from "@nakama/core/whatsapp-config";
 import {
+  DEFAULT_CONNECTION_CONFIG,
   DisconnectReason,
   extractMessageContent,
   fetchLatestBaileysVersion,
   getContentType,
+  jidDecode,
+  jidEncode,
   makeWASocket,
   type WASocket,
 } from "@whiskeysockets/baileys";
@@ -66,6 +69,55 @@ export async function createWhatsAppSocket(
         browser: ["Nakama", "Chrome", "4.0.0"] as [string, string, string],
         connectTimeoutMs: 30_000,
         logger: baileysLogger,
+        makeSignalRepository(auth) {
+          const repository =
+            DEFAULT_CONNECTION_CONFIG.makeSignalRepository(auth);
+          const decrypt = repository.decryptMessage.bind(repository);
+          const recovered = new Map<string, string>();
+          // Baileys 6 looks up PN and LID sessions separately. Only our own
+          // credentials provide a trusted identity pair without stanza metadata.
+          repository.decryptMessage = async (message) => {
+            const sender = jidDecode(message.jid);
+            const pn = jidDecode(state.creds.me?.id);
+            const lid = jidDecode(state.creds.me?.lid);
+            const alternate =
+              sender?.server === "lid" && sender.user === lid?.user
+                ? pn
+                : sender?.server === "s.whatsapp.net" &&
+                    sender.user === pn?.user
+                  ? lid
+                  : undefined;
+            if (!(sender && alternate)) {
+              return decrypt(message);
+            }
+            const alternateJid = jidEncode(
+              alternate.user,
+              alternate.server,
+              sender.device
+            );
+            const primary = recovered.get(message.jid) ?? message.jid;
+            try {
+              return await decrypt({ ...message, jid: primary });
+            } catch (error) {
+              if (
+                !(error instanceof Error) ||
+                (error.name !== "SessionError" && error.message !== "Bad MAC")
+              ) {
+                throw error;
+              }
+              const fallback =
+                primary === message.jid ? alternateJid : message.jid;
+              try {
+                const plaintext = await decrypt({ ...message, jid: fallback });
+                recovered.set(message.jid, fallback);
+                return plaintext;
+              } catch {
+                throw error;
+              }
+            }
+          };
+          return repository;
+        },
         markOnlineOnConnect: false,
         printQRInTerminal: false,
         retryRequestDelayMs: 2000,

--- a/packages/core/src/channel-artifact-delivery.test.ts
+++ b/packages/core/src/channel-artifact-delivery.test.ts
@@ -20,11 +20,19 @@ describe("isAttachIntent", () => {
     expect(isAttachIntent("send me the csv")).toBe(true);
     expect(isAttachIntent("attach the image")).toBe(true);
     expect(isAttachIntent("send nakama-pitch-deck.pdf")).toBe(true);
+    expect(isAttachIntent("tolong kirim csv file kesini please")).toBe(true);
+    expect(
+      isAttachIntent(
+        "collect the report from 01-09-2026 to 06-09-2026 in csv file then send it to this group"
+      )
+    ).toBe(true);
   });
 
   test("does not match unrelated text", () => {
     expect(isAttachIntent("thanks")).toBe(false);
     expect(isAttachIntent("save a report")).toBe(false);
+    expect(isAttachIntent("jangan kirim csv ke grup")).toBe(false);
+    expect(isAttachIntent("tidak usah kirimkan file")).toBe(false);
   });
 });
 

--- a/packages/core/src/channel-artifact-delivery.ts
+++ b/packages/core/src/channel-artifact-delivery.ts
@@ -17,7 +17,7 @@ export interface PublishArtifactShareResult {
 }
 
 const ATTACH_NOUN =
-  "file|document|attachment|artifact|pdf|csv|zip|image|photo|screenshot|report|deck";
+  "file|document|attachment|artifact|pdf|csv|zip|image|photo|screenshot|report|deck|dokumen|lampiran|laporan";
 
 /** Phrase matching for Telegram (and legacy callers). Discord natural-language
  * sends use the send_discord_artifact tool instead. */
@@ -32,6 +32,8 @@ const ATTACH_INTENT_PATTERNS = [
   ),
   /\bsend\s+(?:me\s+)?(?:the\s+)?\S+\.(?:pdf|csv|png|jpe?g|gif|webp|zip|txt|md)\b/i,
   /\battach\s+it\b/i,
+  /\bsend\s+it\s+(?:to\s+(?:this|the)\s+(?:group|chat)|here)\b/i,
+  new RegExp(String.raw`\bkirim(?:kan)?\s+(?:${ATTACH_NOUN})(?:nya)?\b`, "i"),
   /^\/attach(?:@\w+)?(?:\s|$)/i,
 ];
 
@@ -46,6 +48,10 @@ export interface ListedArtifactCandidate {
 export function isAttachIntent(text: string): boolean {
   const normalized = text.trim();
   if (!normalized) {
+    return false;
+  }
+
+  if (/\b(?:jangan|tidak\s+usah)\s+kirim(?:kan)?\b/i.test(normalized)) {
     return false;
   }
 

--- a/packages/core/src/channel-artifacts.test.ts
+++ b/packages/core/src/channel-artifacts.test.ts
@@ -93,7 +93,7 @@ describe("extractPairedTurnArtifacts", () => {
     ]);
   });
 
-  test("returns empty when content write has no sidecar", () => {
+  test("derives metadata from a successful artifact write without a sidecar", () => {
     const contentPath = `${ARTIFACTS_ROOT}/draft.md`;
 
     expect(
@@ -113,7 +113,68 @@ describe("extractPairedTurnArtifacts", () => {
           result: { bytesWritten: 5, path: contentPath },
         }),
       ])
-    ).toEqual([]);
+    ).toEqual([
+      {
+        filename: "draft.md",
+        mimeType: "text/markdown",
+        path: "draft.md",
+        savedAt: "",
+        sizeBytes: 5,
+      },
+    ]);
+  });
+
+  test("delivers CSV with incomplete metadata and the resolved filename", () => {
+    const contentPath = `${ARTIFACTS_ROOT}/report-2026-09-08.csv`;
+    const messages: ChatMessage[] = [
+      { content: "tolong kirim csv file kesini please", role: "user" },
+      assistantWithToolCalls([
+        {
+          arguments: {
+            content: '{"mimeType":"text/csv"}',
+            path: "artifacts/report.csv.nakama-meta.json",
+          },
+          id: "meta",
+          name: "write_file",
+        },
+      ]),
+      toolMessage({
+        id: "content",
+        input: {},
+        name: "write_file",
+        result: { bytesWritten: 934, path: contentPath },
+      }),
+      toolMessage({
+        id: "meta",
+        input: {},
+        name: "write_file",
+        result: { bytesWritten: 23, path: `${contentPath}.nakama-meta.json` },
+      }),
+    ];
+    expect(extractPairedTurnArtifacts(messages)).toEqual([
+      {
+        filename: "report-2026-09-08.csv",
+        mimeType: "text/csv",
+        path: "report-2026-09-08.csv",
+        savedAt: "",
+        sizeBytes: 934,
+      },
+    ]);
+  });
+
+  test("does not infer artifacts without a valid byte count", () => {
+    for (const bytesWritten of [undefined, -1, 1.5, "934"]) {
+      expect(
+        extractPairedTurnArtifacts([
+          toolMessage({
+            id: "content",
+            input: {},
+            name: "write_file",
+            result: { bytesWritten, path: `${ARTIFACTS_ROOT}/report.csv` },
+          }),
+        ])
+      ).toEqual([]);
+    }
   });
 
   test("ignores failed writes", () => {

--- a/packages/core/src/channel-artifacts.ts
+++ b/packages/core/src/channel-artifacts.ts
@@ -1,3 +1,4 @@
+import { inferArtifactMimeType } from "./artifact-mime";
 import type { ChatMessage } from "./contract";
 
 const ARTIFACT_META_SUFFIX = ".nakama-meta.json";
@@ -309,8 +310,8 @@ export function extractLatestTurnMessages(
 }
 
 /**
- * Extract save-artifact pairs (content + `.nakama-meta.json` sidecar) from chat history.
- * Strict pairing only — no content-only or assistant-text fallbacks.
+ * Extract successful artifact writes from chat history. Complete sidecars override
+ * metadata inferred from the write result; assistant text never counts as a write.
  */
 export function extractPairedTurnArtifacts(
   messages: ChatMessage[]
@@ -340,6 +341,21 @@ export function extractPairedTurnArtifacts(
     }
 
     contentWrites.set(resolvedPath, { relativePath });
+    const sizeBytes = getWriteFileResult(message)?.bytesWritten;
+    if (
+      typeof sizeBytes === "number" &&
+      Number.isInteger(sizeBytes) &&
+      sizeBytes >= 0
+    ) {
+      artifactsByPath.set(
+        relativePath,
+        buildArtifactRef(relativePath, {
+          mimeType: inferArtifactMimeType(relativePath),
+          savedAt: "",
+          sizeBytes,
+        })
+      );
+    }
   }
 
   for (const message of turnMessages) {


### PR DESCRIPTION
## Summary

WhatsApp can recover linked-device messages and deliver requested report files.

**Before:** PN/LID session mismatches could block decryption, and successful CSV writes were skipped or delivered only as links.
**After:** Trusted linked-device sessions retry the alternate address; new artifacts are sent directly as WhatsApp documents, including conversational retries, without public share links or a send-phrase requirement.

Why safe:
1. Session recovery is restricted to the linked account's trusted identity pair; artifact discovery still requires a successful tool write under artifacts/.
2. Report creation runs before sending, and a failed creation cannot resend an older artifact.

Files over 16 MiB remain available in Artifacts. Live WhatsApp delivery still needs the manual check below.

## Test plan

- [x] `bun test packages/core/src/channel-artifacts.test.ts packages/core/src/channel-artifact-delivery.test.ts apps/platform/whatsapp/src apps/platform/telegram/src/chat-handler.test.ts apps/platform/discord/src/chat-handler.test.ts` — 234 pass, including the reported retry in a group and assertions that document bytes are sent without publishing links.
- [x] `bun run check`, `bun run knip`, and `bun run --cwd apps/platform/whatsapp build`.
- [ ] Ask the validator to create a CSV and send it to the WhatsApp group; confirm a document arrives.
