### PR TITLE
feat(web): show context and reply usage in click popovers

### DIFF
--- a/apps/web/src/components/chat/chat-composer.tsx
+++ b/apps/web/src/components/chat/chat-composer.tsx
@@ -141,7 +141,6 @@ interface ChatComposerFullProps extends ChatComposerBaseProps {
     models: ProviderModelOption[];
   }>;
   renderModelLabel: (selection: string | null) => string | null;
-  /** Tokens and cost of the whole session; hidden by the Settings toggle. */
   sessionUsage?: ChatUsage | null;
   showOfflineHint?: boolean;
   showTips?: boolean;

--- a/apps/web/src/components/chat/chat-context-usage.tsx
+++ b/apps/web/src/components/chat/chat-context-usage.tsx
@@ -13,7 +13,7 @@ import {
   formatContextUsageLabel,
   formatTokenCountDetailed,
 } from "@/lib/chat-context-usage";
-import { formatChatUsage } from "@/lib/chat-usage";
+import { formatChatUsageCost } from "@/lib/chat-usage";
 import { cn } from "@/lib/utils";
 
 /** Match BrainIcon / select chevron visual weight in the composer toolbar. */
@@ -38,7 +38,6 @@ export function ChatContextUsageRing({
   className,
 }: {
   usage: ChatContextUsage;
-  /** Session token total, folded in here rather than shown beside the ring. */
   sessionUsage?: ChatUsage | null;
   className?: string;
 }) {
@@ -48,9 +47,7 @@ export function ChatContextUsageRing({
   const circumference = 2 * Math.PI * radius;
   const dashOffset = circumference * (1 - ratio);
   const label = formatContextUsageLabel(usage);
-  const sessionLabel = sessionUsage
-    ? `Session · ${formatChatUsage(sessionUsage)}`
-    : null;
+  const sessionCost = sessionUsage ? formatChatUsageCost(sessionUsage) : null;
   const segments = contextUsageSegments(usage);
   const segmentTotal = segments.reduce(
     (sum, segment) => sum + segment.tokens,
@@ -67,7 +64,7 @@ export function ChatContextUsageRing({
       <PopoverTrigger
         render={
           <button
-            aria-label={sessionLabel ? `${label} · ${sessionLabel}` : label}
+            aria-label={sessionCost ? `${label} · ${sessionCost}` : label}
             className={cn(
               "inline-flex h-7 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
               className
@@ -163,14 +160,21 @@ export function ChatContextUsageRing({
               </span>
             </li>
           ))}
+          {sessionCost ? (
+            <li className="flex items-center justify-between gap-3">
+              <span>Cost</span>
+              <span className="text-muted-foreground tabular-nums">
+                {sessionCost}
+              </span>
+            </li>
+          ) : null}
         </ul>
 
-        {usage.source === "estimate" || sessionLabel || optimizedNote ? (
+        {usage.source === "estimate" || optimizedNote ? (
           <div className="mt-3 space-y-1 text-muted-foreground text-xs">
             {usage.source === "estimate" ? (
               <p>Estimated from prompt size</p>
             ) : null}
-            {sessionLabel ? <p>{sessionLabel}</p> : null}
             {optimizedNote ? <p>{optimizedNote}</p> : null}
           </div>
         ) : null}

--- a/apps/web/src/components/chat/chat-context-usage.tsx
+++ b/apps/web/src/components/chat/chat-context-usage.tsx
@@ -1,10 +1,8 @@
 import type { ChatUsage } from "@nakama/core/contract";
-import { Cancel01Icon } from "hugeicons-react";
-import { Button } from "@/components/ui/button";
 import {
   Popover,
-  PopoverClose,
   PopoverContent,
+  PopoverHeader,
   PopoverTrigger,
 } from "@/components/ui/popover";
 import {
@@ -115,21 +113,7 @@ export function ChatContextUsageRing({
         side="top"
         sideOffset={8}
       >
-        <div className="mb-2 flex items-start justify-between gap-2">
-          <h2 className="font-medium text-sm leading-none">Context Usage</h2>
-          <PopoverClose
-            render={
-              <Button
-                className="-mt-1 -mr-1 size-7 text-muted-foreground"
-                size="icon-sm"
-                variant="ghost"
-              />
-            }
-          >
-            <Cancel01Icon className="size-3.5" />
-            <span className="sr-only">Close</span>
-          </PopoverClose>
-        </div>
+        <PopoverHeader title="Context Usage" />
 
         <div className="mb-2 flex items-baseline justify-between gap-3 text-muted-foreground text-xs">
           <span>{percent}% Full</span>

--- a/apps/web/src/components/chat/chat-context-usage.tsx
+++ b/apps/web/src/components/chat/chat-context-usage.tsx
@@ -1,13 +1,19 @@
 import type { ChatUsage } from "@nakama/core/contract";
+import { Cancel01Icon } from "hugeicons-react";
+import { Button } from "@/components/ui/button";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+  Popover,
+  PopoverClose,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import {
   type ChatContextUsage,
   contextUsageRatio,
+  contextUsageSegments,
+  formatBytes,
   formatContextUsageLabel,
+  formatTokenCountDetailed,
 } from "@/lib/chat-context-usage";
 import { formatChatUsage } from "@/lib/chat-usage";
 import { cn } from "@/lib/utils";
@@ -39,6 +45,7 @@ export function ChatContextUsageRing({
   className?: string;
 }) {
   const ratio = contextUsageRatio(usage);
+  const percent = Math.round(ratio * 100);
   const radius = (RING_SIZE - STROKE_WIDTH) / 2;
   const circumference = 2 * Math.PI * radius;
   const dashOffset = circumference * (1 - ratio);
@@ -46,10 +53,20 @@ export function ChatContextUsageRing({
   const sessionLabel = sessionUsage
     ? `Session · ${formatChatUsage(sessionUsage)}`
     : null;
+  const segments = contextUsageSegments(usage);
+  const segmentTotal = segments.reduce(
+    (sum, segment) => sum + segment.tokens,
+    0
+  );
+  const fillRatio = ratio;
+  const optimizedNote =
+    usage.bytesKeptOut && usage.bytesProduced
+      ? `${formatBytes(usage.bytesKeptOut)} of tool output saved (${Math.round((100 * usage.bytesKeptOut) / usage.bytesProduced)}%)`
+      : null;
 
   return (
-    <Tooltip>
-      <TooltipTrigger
+    <Popover>
+      <PopoverTrigger
         render={
           <button
             aria-label={sessionLabel ? `${label} · ${sessionLabel}` : label}
@@ -92,15 +109,88 @@ export function ChatContextUsageRing({
           </button>
         }
       />
-      <TooltipContent
-        className="flex-col items-start gap-0.5 text-xs"
+      <PopoverContent
+        align="start"
+        className="w-80 min-w-80 p-3.5"
         side="top"
+        sideOffset={8}
       >
-        <span>{label}</span>
-        {sessionLabel ? (
-          <span className="text-background/70">{sessionLabel}</span>
+        <div className="mb-2 flex items-start justify-between gap-2">
+          <h2 className="font-medium text-sm leading-none">Context Usage</h2>
+          <PopoverClose
+            render={
+              <Button
+                className="-mt-1 -mr-1 size-7 text-muted-foreground"
+                size="icon-sm"
+                variant="ghost"
+              />
+            }
+          >
+            <Cancel01Icon className="size-3.5" />
+            <span className="sr-only">Close</span>
+          </PopoverClose>
+        </div>
+
+        <div className="mb-2 flex items-baseline justify-between gap-3 text-muted-foreground text-xs">
+          <span>{percent}% Full</span>
+          <span>
+            ~{formatTokenCountDetailed(usage.usedTokens)} /{" "}
+            {formatTokenCountDetailed(usage.usableContextTokens)} Tokens
+          </span>
+        </div>
+
+        <div
+          aria-hidden
+          className="mb-3 flex h-1.5 overflow-hidden rounded-full bg-muted"
+        >
+          {segments.map((segment) => (
+            <div
+              className={cn("h-full min-w-px", segment.colorClass)}
+              key={segment.id}
+              style={{
+                width: `${
+                  segmentTotal > 0 && fillRatio > 0
+                    ? (segment.tokens / segmentTotal) * fillRatio * 100
+                    : 0
+                }%`,
+              }}
+            />
+          ))}
+        </div>
+
+        <ul className="flex flex-col gap-2 text-sm">
+          {segments.map((segment) => (
+            <li
+              className="flex items-center justify-between gap-3"
+              key={segment.id}
+            >
+              <span className="flex min-w-0 items-center gap-2">
+                <span
+                  aria-hidden
+                  className={cn(
+                    "size-2.5 shrink-0 rounded-[3px]",
+                    segment.colorClass
+                  )}
+                />
+                <span className="truncate">{segment.label}</span>
+              </span>
+              <span className="text-muted-foreground tabular-nums">
+                {formatTokenCountDetailed(segment.tokens)}
+              </span>
+            </li>
+          ))}
+        </ul>
+
+        {usage.source === "estimate" || sessionLabel || optimizedNote ? (
+          <div className="mt-3 space-y-1 text-muted-foreground text-xs">
+            {usage.source === "estimate" ? (
+              <p>Estimated from prompt size</p>
+            ) : null}
+            {sessionLabel ? <p>{sessionLabel}</p> : null}
+            {optimizedNote ? <p>{optimizedNote}</p> : null}
+          </div>
         ) : null}
-      </TooltipContent>
-    </Tooltip>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/apps/web/src/components/chat/chat-message-list.tsx
+++ b/apps/web/src/components/chat/chat-message-list.tsx
@@ -655,6 +655,7 @@ function AssistantMessageActions({
 
   return (
     <div className="flex items-center gap-1 pt-1 opacity-60 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 group-active:opacity-100">
+      {usage ? <ChatUsageBadge usage={usage} /> : null}
       <button
         aria-label={copied ? "Copied" : "Copy response"}
         className={cn(
@@ -715,7 +716,6 @@ function AssistantMessageActions({
           </DropdownMenuContent>
         </DropdownMenu>
       ) : null}
-      {usage ? <ChatUsageBadge className="ml-1" usage={usage} /> : null}
     </div>
   );
 }

--- a/apps/web/src/components/chat/chat-usage-badge.tsx
+++ b/apps/web/src/components/chat/chat-usage-badge.tsx
@@ -1,5 +1,18 @@
 import type { ChatUsage } from "@nakama/core/contract";
-import { chatUsageTitle, formatChatUsage } from "@/lib/chat-usage";
+import { Cancel01Icon } from "hugeicons-react";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverClose,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  chatUsageTitle,
+  formatChatUsageCost,
+  formatCompactTokens,
+  formatUsd,
+} from "@/lib/chat-usage";
 import { cn } from "@/lib/utils";
 
 /**
@@ -21,7 +34,16 @@ function ChatUsageIcon({ className }: { className?: string }) {
   );
 }
 
-/** Icon + "1,234 in · 56 out · $0.0042" line shown under an assistant reply. */
+function UsageDetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <li className="flex items-center justify-between gap-6">
+      <span>{label}</span>
+      <span className="text-muted-foreground tabular-nums">{value}</span>
+    </li>
+  );
+}
+
+/** Cost chip under an assistant reply. Click for in / out / total. */
 export function ChatUsageBadge({
   usage,
   className,
@@ -29,16 +51,65 @@ export function ChatUsageBadge({
   usage: ChatUsage;
   className?: string;
 }) {
+  const cost = formatChatUsageCost(usage);
+  const label = chatUsageTitle(usage);
+
   return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-1 text-muted-foreground text-xs tabular-nums",
-        className
-      )}
-      title={chatUsageTitle(usage)}
-    >
-      <ChatUsageIcon className="size-3.5 shrink-0" />
-      {formatChatUsage(usage)}
-    </span>
+    <Popover>
+      <PopoverTrigger
+        render={
+          <button
+            aria-label={label}
+            className={cn(
+              "inline-flex h-8 items-center gap-1 rounded-lg px-1.5 text-muted-foreground text-xs tabular-nums transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+              className
+            )}
+            type="button"
+          >
+            <ChatUsageIcon className="size-3.5 shrink-0" />
+            {cost}
+          </button>
+        }
+      />
+      <PopoverContent
+        align="start"
+        className="w-56 min-w-56 p-3.5"
+        side="top"
+        sideOffset={8}
+      >
+        <div className="mb-2 flex items-start justify-between gap-2">
+          <h2 className="font-medium text-sm leading-none">Usage</h2>
+          <PopoverClose
+            render={
+              <Button
+                className="-mt-1 -mr-1 size-7 text-muted-foreground"
+                size="icon-sm"
+                variant="ghost"
+              />
+            }
+          >
+            <Cancel01Icon className="size-3.5" />
+            <span className="sr-only">Close</span>
+          </PopoverClose>
+        </div>
+        <ul className="flex flex-col gap-2 text-sm">
+          <UsageDetailRow
+            label="In"
+            value={formatCompactTokens(usage.inputTokens)}
+          />
+          <UsageDetailRow
+            label="Out"
+            value={formatCompactTokens(usage.outputTokens)}
+          />
+          <UsageDetailRow
+            label="Total"
+            value={usage.totalTokens.toLocaleString()}
+          />
+          {usage.costUsd == null ? null : (
+            <UsageDetailRow label="Cost" value={formatUsd(usage.costUsd)} />
+          )}
+        </ul>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/apps/web/src/components/chat/chat-usage-badge.tsx
+++ b/apps/web/src/components/chat/chat-usage-badge.tsx
@@ -1,10 +1,8 @@
 import type { ChatUsage } from "@nakama/core/contract";
-import { Cancel01Icon } from "hugeicons-react";
-import { Button } from "@/components/ui/button";
 import {
   Popover,
-  PopoverClose,
   PopoverContent,
+  PopoverHeader,
   PopoverTrigger,
 } from "@/components/ui/popover";
 import {
@@ -77,21 +75,7 @@ export function ChatUsageBadge({
         side="top"
         sideOffset={8}
       >
-        <div className="mb-2 flex items-start justify-between gap-2">
-          <h2 className="font-medium text-sm leading-none">Usage</h2>
-          <PopoverClose
-            render={
-              <Button
-                className="-mt-1 -mr-1 size-7 text-muted-foreground"
-                size="icon-sm"
-                variant="ghost"
-              />
-            }
-          >
-            <Cancel01Icon className="size-3.5" />
-            <span className="sr-only">Close</span>
-          </PopoverClose>
-        </div>
+        <PopoverHeader title="Usage" />
         <ul className="flex flex-col gap-2 text-sm">
           <UsageDetailRow
             label="In"

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -1,5 +1,6 @@
 import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
-
+import { Cancel01Icon } from "hugeicons-react";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 function Popover({ ...props }: PopoverPrimitive.Root.Props) {
@@ -48,4 +49,24 @@ function PopoverClose({ ...props }: PopoverPrimitive.Close.Props) {
   return <PopoverPrimitive.Close data-slot="popover-close" {...props} />;
 }
 
-export { Popover, PopoverClose, PopoverContent, PopoverTrigger };
+function PopoverHeader({ title }: { title: string }) {
+  return (
+    <div className="mb-2 flex items-start justify-between gap-2">
+      <h2 className="font-medium text-sm leading-none">{title}</h2>
+      <PopoverClose
+        render={
+          <Button
+            className="-mt-1 -mr-1 size-7 text-muted-foreground"
+            size="icon-sm"
+            variant="ghost"
+          />
+        }
+      >
+        <Cancel01Icon className="size-3.5" />
+        <span className="sr-only">Close</span>
+      </PopoverClose>
+    </div>
+  );
+}
+
+export { Popover, PopoverContent, PopoverHeader, PopoverTrigger };

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -44,4 +44,8 @@ function PopoverContent({
   );
 }
 
-export { Popover, PopoverContent, PopoverTrigger };
+function PopoverClose({ ...props }: PopoverPrimitive.Close.Props) {
+  return <PopoverPrimitive.Close data-slot="popover-close" {...props} />;
+}
+
+export { Popover, PopoverClose, PopoverContent, PopoverTrigger };

--- a/apps/web/src/hooks/use-chat-usage-visible.ts
+++ b/apps/web/src/hooks/use-chat-usage-visible.ts
@@ -4,7 +4,7 @@ import {
   getInitialChatUsageVisible,
 } from "@/lib/chat-usage";
 
-/** Settings toggle: show tokens and cost under each assistant reply. */
+/** Settings toggle: show tokens and cost under each assistant reply. Off by default. */
 export function useChatUsageVisible() {
   const { collapsed: visible, toggle } = useLocalStorageFlag(
     CHAT_USAGE_VISIBLE_KEY,

--- a/apps/web/src/lib/chat-context-usage.test.ts
+++ b/apps/web/src/lib/chat-context-usage.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, test } from "bun:test";
 import type { ChatContextUsage } from "@nakama/core/contract";
 import {
   contextUsageRatio,
+  contextUsageSegments,
   formatContextUsageLabel,
   formatTokenCount,
+  formatTokenCountDetailed,
 } from "./chat-context-usage";
 
 const sample = (partial: Partial<ChatContextUsage> = {}): ChatContextUsage => ({
@@ -43,6 +45,43 @@ describe("formatTokenCount", () => {
     expect(formatTokenCount(1500)).toBe("1.5k");
     expect(formatTokenCount(12_400)).toBe("12k");
     expect(formatTokenCount(1_200_000)).toBe("1.2M");
+  });
+});
+
+describe("formatTokenCountDetailed", () => {
+  test("keeps a decimal for tens of thousands", () => {
+    expect(formatTokenCountDetailed(60_500)).toBe("60.5k");
+    expect(formatTokenCountDetailed(256_000)).toBe("256k");
+  });
+});
+
+describe("contextUsageSegments", () => {
+  test("lists measured buckets and drops empty ones", () => {
+    expect(
+      contextUsageSegments(
+        sample({
+          breakdown: {
+            conversation: 36_700,
+            systemPrompt: 1100,
+            toolDefinitions: 9900,
+          },
+        })
+      ).map((segment) => segment.id)
+    ).toEqual(["systemPrompt", "toolDefinitions", "conversation"]);
+  });
+
+  test("adds other when the provider total is larger than the estimate", () => {
+    const segments = contextUsageSegments(
+      sample({
+        breakdown: {
+          conversation: 10_000,
+          systemPrompt: 1000,
+          toolDefinitions: 2000,
+        },
+        usedTokens: 20_000,
+      })
+    );
+    expect(segments.at(-1)).toMatchObject({ id: "other", tokens: 7000 });
   });
 });
 

--- a/apps/web/src/lib/chat-context-usage.ts
+++ b/apps/web/src/lib/chat-context-usage.ts
@@ -26,6 +26,82 @@ export function formatTokenCount(tokens: number): string {
   return `${(tokens / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
 }
 
+/** One decimal for thousands so the popover header can show ~60.5k, not 61k. */
+export function formatTokenCountDetailed(tokens: number): string {
+  const value = Math.max(0, tokens);
+  if (value < 1000) {
+    return String(Math.round(value));
+  }
+
+  if (value < 1_000_000) {
+    return `${(value / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+  }
+
+  return `${(value / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+}
+
+export type ContextUsageSegment = {
+  colorClass: string;
+  id: string;
+  label: string;
+  tokens: number;
+};
+
+const SEGMENT_META = [
+  {
+    colorClass: "bg-zinc-400 dark:bg-zinc-500",
+    id: "systemPrompt",
+    label: "System prompt",
+  },
+  {
+    colorClass: "bg-violet-500",
+    id: "toolDefinitions",
+    label: "Tool definitions",
+  },
+  {
+    colorClass: "bg-rose-900",
+    id: "conversation",
+    label: "Conversation",
+  },
+] as const;
+
+export function contextUsageSegments(
+  usage: ChatContextUsage
+): ContextUsageSegment[] {
+  const used = Math.max(0, usage.usedTokens);
+  const breakdown = usage.breakdown;
+
+  if (!breakdown) {
+    return used > 0
+      ? [
+          {
+            colorClass: "bg-rose-900",
+            id: "used",
+            label: "Used",
+            tokens: used,
+          },
+        ]
+      : [];
+  }
+
+  const parts: ContextUsageSegment[] = SEGMENT_META.flatMap((meta) => {
+    const tokens = breakdown[meta.id];
+    return tokens > 0 ? [{ ...meta, tokens }] : [];
+  });
+
+  const estimated = parts.reduce((sum, part) => sum + part.tokens, 0);
+  if (used > estimated && used - estimated >= 1) {
+    parts.push({
+      colorClass: "bg-sky-600",
+      id: "other",
+      label: "Other",
+      tokens: used - estimated,
+    });
+  }
+
+  return parts;
+}
+
 export function formatBytes(bytes: number): string {
   if (bytes < 1024) {
     return `${bytes} B`;

--- a/apps/web/src/lib/chat-usage.test.ts
+++ b/apps/web/src/lib/chat-usage.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
   addChatUsage,
+  CHAT_USAGE_VISIBLE_KEY,
   chatUsageTitle,
   formatChatUsage,
+  formatChatUsageCost,
+  getInitialChatUsageVisible,
   sumChatUsage,
 } from "./chat-usage";
 
@@ -51,6 +54,25 @@ describe("chat usage", () => {
     expect(sumChatUsage([{ role: "assistant" }])).toBeUndefined();
   });
 
+  test("shows only the dollar amount on the cost chip", () => {
+    expect(
+      formatChatUsageCost({
+        costUsd: 0.0027,
+        inputTokens: 12_000,
+        outputTokens: 265,
+        totalTokens: 12_265,
+      })
+    ).toBe("$0.0027");
+    expect(
+      formatChatUsageCost({
+        estimated: true,
+        inputTokens: 10,
+        outputTokens: 2,
+        totalTokens: 12,
+      })
+    ).toBeNull();
+  });
+
   test("formats tokens, cost and the estimate marker", () => {
     expect(
       formatChatUsage({
@@ -85,6 +107,31 @@ describe("chat usage", () => {
     expect(compacted(1_234_567)).toBe("1.2m");
     expect(compacted(1_500_000_000)).toBe("1.5b");
     expect(compacted(2_300_000_000_000)).toBe("2.3t");
+  });
+
+  test("hides token usage until the setting is turned on", () => {
+    const previous = globalThis.localStorage;
+    const store = new Map<string, string>();
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: (key: string) => store.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          store.set(key, value);
+        },
+      },
+    });
+
+    try {
+      expect(getInitialChatUsageVisible()).toBe(false);
+      store.set(CHAT_USAGE_VISIBLE_KEY, "true");
+      expect(getInitialChatUsageVisible()).toBe(true);
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", {
+        configurable: true,
+        value: previous,
+      });
+    }
   });
 
   test("keeps the exact count in the hover title", () => {

--- a/apps/web/src/lib/chat-usage.ts
+++ b/apps/web/src/lib/chat-usage.ts
@@ -2,12 +2,12 @@ import type { ChatUsage } from "@nakama/core/contract";
 
 export const CHAT_USAGE_VISIBLE_KEY = "nakama-chat-usage-visible";
 
-/** Defaults to visible; only an explicit "false" hides it. */
+/** Defaults to hidden; only an explicit "true" shows it. */
 export function getInitialChatUsageVisible(): boolean {
   try {
-    return localStorage.getItem(CHAT_USAGE_VISIBLE_KEY) !== "false";
+    return localStorage.getItem(CHAT_USAGE_VISIBLE_KEY) === "true";
   } catch {
-    return true;
+    return false;
   }
 }
 
@@ -75,8 +75,16 @@ export function formatUsd(amount: number): string {
 const compactTokenFormat = new Intl.NumberFormat("en", { notation: "compact" });
 
 /** 945 · 1.2k · 12k · 1.2m · 1.5b · 2.3t */
-function formatCompactTokens(tokens: number): string {
+export function formatCompactTokens(tokens: number): string {
   return compactTokenFormat.format(tokens).toLowerCase();
+}
+
+export function formatChatUsageCost(usage: ChatUsage): string | null {
+  if (usage.costUsd == null) {
+    return null;
+  }
+
+  return `${usage.estimated ? "~" : ""}${formatUsd(usage.costUsd)}`;
 }
 
 export function formatChatUsage(usage: ChatUsage): string {

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -66,16 +66,11 @@ export function SettingsPage() {
             className="flex flex-wrap items-center justify-between gap-3 px-4 py-3"
             id="chat-usage-setting"
           >
-            <div className="min-w-0 space-y-0.5">
-              <p className="font-medium text-foreground text-sm">
-                Token usage in chat
-              </p>
-              <p className="text-muted-foreground text-xs">
-                Show tokens and estimated cost under each reply.
-              </p>
-            </div>
+            <p className="font-medium text-foreground text-sm">
+              Token usage in chat
+            </p>
             <Switch
-              aria-label="Show token usage in chat"
+              aria-label="Token usage in chat"
               checked={chatUsage.visible}
               onCheckedChange={chatUsage.toggle}
             />

--- a/apps/web/src/pages/chat/chat-page-content.tsx
+++ b/apps/web/src/pages/chat/chat-page-content.tsx
@@ -60,10 +60,7 @@ export function ChatPageContent(state: ChatPageState) {
   } = state;
 
   const { visible: showUsage } = useChatUsageVisible();
-  const sessionUsage = useMemo(
-    () => (showUsage ? sumChatUsage(messages) : undefined),
-    [messages, showUsage]
-  );
+  const sessionUsage = useMemo(() => sumChatUsage(messages), [messages]);
   const { banner: skillReviewBanner } = usePostTurnSkillReviewOverlay({
     lastSuccessfulTurnAt,
     profile: activeProfile,

--- a/packages/agent/src/chat-context-usage.test.ts
+++ b/packages/agent/src/chat-context-usage.test.ts
@@ -111,12 +111,13 @@ describe("chat context usage", () => {
 
     await session.send("hi");
 
-    expect(session.getContextUsage()).toEqual({
-      contextWindow: 100_000,
-      source: "provider",
-      usableContextTokens: 92_000,
-      usedTokens: 12_000,
-    });
+    const usage = session.getContextUsage();
+    expect(usage?.contextWindow).toBe(100_000);
+    expect(usage?.source).toBe("provider");
+    expect(usage?.usableContextTokens).toBe(92_000);
+    expect(usage?.usedTokens).toBe(12_000);
+    expect(usage?.breakdown?.conversation).toBeGreaterThan(0);
+    expect(usage?.breakdown?.systemPrompt).toBeGreaterThanOrEqual(0);
   });
 
   test("falls back to an estimate when provider omits usage", async () => {

--- a/packages/agent/src/chat.ts
+++ b/packages/agent/src/chat.ts
@@ -43,7 +43,9 @@ import {
 import {
   type CompactionConfig,
   compactHistory,
+  estimateHistoryTokenBreakdown,
   estimateHistoryTokens,
+  type HistoryTokenBreakdown,
   providerReplaysThinking,
   usableContextTokens,
 } from "./history-compaction";
@@ -213,15 +215,29 @@ export function createAgentChatSession(
       : undefined;
   }
 
+  function currentTokenBreakdown(): HistoryTokenBreakdown {
+    const dateLine = `Today is ${formatCurrentDate()}.`;
+    return estimateHistoryTokenBreakdown(
+      history,
+      `${systemPrompt}\n\n${dateLine}`,
+      llmToolsForEstimate(),
+      dependencies.provider
+        ? providerReplaysThinking(dependencies.provider.name)
+        : true
+    );
+  }
+
   function buildContextUsage(
     usedTokens: number,
-    source: ChatContextUsage["source"]
+    source: ChatContextUsage["source"],
+    breakdown = currentTokenBreakdown()
   ): ChatContextUsage | null {
     if (!options.compaction) {
       return null;
     }
 
     return {
+      breakdown,
       // Reported only once an optimiser has actually removed something in this
       // session, so the chip stays silent rather than announcing a feature.
       bytesKeptOut: bytesKeptOut > 0 ? bytesKeptOut : undefined,
@@ -245,17 +261,14 @@ export function createAgentChatSession(
       return null;
     }
 
-    const dateLine = `Today is ${formatCurrentDate()}.`;
-    const usedTokens = estimateHistoryTokens(
-      history,
-      `${systemPrompt}\n\n${dateLine}`,
-      llmToolsForEstimate(),
-      dependencies.provider
-        ? providerReplaysThinking(dependencies.provider.name)
-        : true
+    const breakdown = currentTokenBreakdown();
+    return buildContextUsage(
+      breakdown.systemPrompt +
+        breakdown.conversation +
+        breakdown.toolDefinitions,
+      "estimate",
+      breakdown
     );
-
-    return buildContextUsage(usedTokens, "estimate");
   }
 
   async function runCompaction(force: boolean): Promise<CompactionResponse> {

--- a/packages/agent/src/history-compaction.test.ts
+++ b/packages/agent/src/history-compaction.test.ts
@@ -8,6 +8,7 @@ import {
   buildCompactionPrompt,
   type CompactionConfig,
   compactHistory,
+  estimateHistoryTokenBreakdown,
   estimateHistoryTokens,
   isOverflow,
   pruneToolOutputs,
@@ -288,6 +289,33 @@ describe("history compaction", () => {
     const estimate = estimateHistoryTokens(messages, "system prompt");
 
     expect(estimate).toBeGreaterThan(100);
+  });
+
+  test("splits the estimate into system, tools, and conversation", () => {
+    const messages: ChatMessage[] = [
+      { content: "x".repeat(400), role: "user" },
+    ];
+    const tools = [
+      {
+        description: "search",
+        name: "search",
+        parameters: { type: "object" },
+      },
+    ];
+    const breakdown = estimateHistoryTokenBreakdown(
+      messages,
+      "system prompt",
+      tools
+    );
+
+    expect(breakdown.systemPrompt).toBeGreaterThan(0);
+    expect(breakdown.conversation).toBeGreaterThan(0);
+    expect(breakdown.toolDefinitions).toBeGreaterThan(0);
+    expect(
+      breakdown.systemPrompt +
+        breakdown.conversation +
+        breakdown.toolDefinitions
+    ).toBe(estimateHistoryTokens(messages, "system prompt", tools));
   });
 
   test("counts providerContent once and keeps thinking (#340)", () => {

--- a/packages/agent/src/history-compaction.ts
+++ b/packages/agent/src/history-compaction.ts
@@ -131,16 +131,39 @@ function estimateMessageTokens(
   return total;
 }
 
+export interface HistoryTokenBreakdown {
+  conversation: number;
+  systemPrompt: number;
+  toolDefinitions: number;
+}
+
+export function estimateHistoryTokenBreakdown(
+  messages: readonly ChatMessage[],
+  systemPrompt: string,
+  tools?: LlmToolDefinition[],
+  replaysThinking = true
+): HistoryTokenBreakdown {
+  return {
+    conversation: estimateMessageTokens(messages, replaysThinking),
+    systemPrompt: estimateTokens(systemPrompt),
+    toolDefinitions: estimateTokens(JSON.stringify(tools ?? [])),
+  };
+}
+
 export function estimateHistoryTokens(
   messages: readonly ChatMessage[],
   systemPrompt: string,
   tools?: LlmToolDefinition[],
   replaysThinking = true
 ): number {
+  const breakdown = estimateHistoryTokenBreakdown(
+    messages,
+    systemPrompt,
+    tools,
+    replaysThinking
+  );
   return (
-    estimateTokens(systemPrompt) +
-    estimateMessageTokens(messages, replaysThinking) +
-    estimateTokens(JSON.stringify(tools ?? []))
+    breakdown.systemPrompt + breakdown.conversation + breakdown.toolDefinitions
   );
 }
 

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -935,7 +935,18 @@ export interface SessionMessageMeta {
 /** How full the model context window is for the current chat session. */
 export type ChatContextUsageSource = "provider" | "estimate";
 
+export interface ChatContextUsageBreakdown {
+  conversation: number;
+  systemPrompt: number;
+  toolDefinitions: number;
+}
+
 export interface ChatContextUsage {
+  /**
+   * Estimated composition of the prompt (system + tools + history). Token
+   * total may differ from `usedTokens` when the provider reports input size.
+   */
+  breakdown?: ChatContextUsageBreakdown;
   /**
    * Bytes an optimiser kept out of this session's context so far. Absent until
    * something is actually removed, so the UI reports a measurement rather than


### PR DESCRIPTION
## Summary

Click the composer context ring or a reply’s `$0.0027` chip → full token breakdown. Reply usage stays off until Settings turns it on.

**Before:** hover tooltip on the ring; `12k in · 265 out · $0.0027` always on under each reply.
**After:** click popovers; cost-only chip on the left of the action row; `getInitialChatUsageVisible` defaults to off.

Why safe:
1. Breakdown is estimated system / tools / conversation — no invented Rules/Skills rows
2. Old sessions without `breakdown` still show a single Used segment
3. Existing `nakama-chat-usage-visible=true` stays on

Only follow up if you need Rules / Skills / MCP as separate buckets.

## Test plan
- [x] `bun test packages/agent/src/history-compaction.test.ts packages/agent/src/chat-context-usage.test.ts apps/web/src/lib/chat-context-usage.test.ts apps/web/src/lib/chat-usage.test.ts` (33 pass)
- [ ] Turn Token usage on, click `$0.0027` then the context ring — popovers match, chip is left of Copy
