### PR TITLE
feat(providers): direct Moonshot Kimi integration (intl + CN) (#384)

### DIFF
--- a/apps/server/src/providers/create.ts
+++ b/apps/server/src/providers/create.ts
@@ -96,6 +96,8 @@ function createProvider(options: CreateProviderOptions): ProviderClient {
       });
     case "minimax":
     case "minimax_cn":
+    case "moonshot":
+    case "moonshot_cn":
     case "zhipu":
     case "zhipu_cn":
       return createOpenAIProvider({

--- a/apps/server/src/providers/models.test.ts
+++ b/apps/server/src/providers/models.test.ts
@@ -206,6 +206,37 @@ describe("resolveModel", () => {
       "glm-5.2"
     );
   });
+
+  test("resolves Moonshot models from discovered custom models", () => {
+    const customModels = [
+      { default: true, id: "kimi-k2.5-turbo-preview" },
+      { id: "kimi-k2.5" },
+      { id: "moonshot-v1-128k" },
+    ];
+
+    expect(resolveModel("moonshot", "kimi-k2.5", customModels)).toBe(
+      "kimi-k2.5"
+    );
+    expect(getDefaultModel("moonshot", customModels)).toBe(
+      "kimi-k2.5-turbo-preview"
+    );
+    expect(getDefaultModel("moonshot_cn", customModels)).toBe(
+      "kimi-k2.5-turbo-preview"
+    );
+  });
+
+  test("keeps Moonshot region catalogs independent", () => {
+    // Both platforms expose overlapping ids, so an id discovered on one
+    // instance still resolves against that instance's own list.
+    const cnModels = [{ default: true, id: "moonshot-v1-8k-vision-preview" }];
+
+    expect(
+      resolveModel("moonshot_cn", "moonshot-v1-8k-vision-preview", cnModels)
+    ).toBe("moonshot-v1-8k-vision-preview");
+    expect(resolveModel("moonshot", "not-a-real-model", cnModels)).toBe(
+      "moonshot-v1-8k-vision-preview"
+    );
+  });
 });
 
 describe("modelSupportsVision", () => {
@@ -229,6 +260,22 @@ describe("modelSupportsVision", () => {
     ).toBe(true);
   });
 
+  test("keeps Moonshot models opt-in only (discovered lists)", () => {
+    // Intl K2.x is text-only; the CN platform exposes vision variants, so
+    // vision comes from discovered metadata, never from the id.
+    expect(modelSupportsVision("kimi-k2.5", "moonshot")).toBe(false);
+    expect(
+      modelSupportsVision("moonshot-v1-8k-vision-preview", "moonshot_cn", [
+        { id: "moonshot-v1-8k-vision-preview" },
+      ])
+    ).toBe(false);
+
+    expect(
+      modelSupportsVision("moonshot-v1-8k-vision-preview", "moonshot_cn", [
+        { id: "moonshot-v1-8k-vision-preview", supportsVision: true },
+      ])
+    ).toBe(true);
+  });
   test("treats openai-compatible models as opt-in only", () => {
     expect(
       modelSupportsVision("qwen-vl", "openai_compatible", [{ id: "qwen-vl" }])

--- a/apps/server/src/providers/pricing.test.ts
+++ b/apps/server/src/providers/pricing.test.ts
@@ -39,6 +39,14 @@ const fireworksInstance = {
   type: "fireworks" as const,
 };
 
+const moonshotInstance = {
+  apiKey: "sk-moonshot-test",
+  baseUrl: "https://api.moonshot.ai/v1",
+  createdAt: "2026-09-08T10:00:00.000Z",
+  id: "ms-1",
+  label: "Moonshot Kimi",
+  type: "moonshot" as const,
+};
 describe("estimateUsageCostUsd", () => {
   test("computes cost from catalog pricing", () => {
     const cost = estimateUsageCostUsd(
@@ -148,6 +156,40 @@ describe("estimateUsageCostUsd", () => {
     );
 
     expect(cost).toBeCloseTo(2.5, 5);
+  });
+
+  test("uses saved pricing for moonshot discovered models", () => {
+    const cost = estimateUsageCostUsd("kimi-k2.5", 1_000_000, 1_000_000, {
+      provider: "moonshot",
+      providerInstance: {
+        ...moonshotInstance,
+        customModels: [
+          {
+            id: "kimi-k2.5",
+            inputPerMillionUsd: 0.6,
+            outputPerMillionUsd: 2.5,
+          },
+        ],
+      },
+    });
+
+    expect(cost).toBeCloseTo(3.1, 5);
+  });
+
+  test("does not estimate discovery-provider models without saved pricing", () => {
+    // Discovery catalogs are fetched at runtime, so there is no bundled entry
+    // to price against: report unknown instead of DEFAULT_PRICING.
+    expect(
+      getModelPricing("kimi-k2.5", {
+        provider: "moonshot",
+        providerInstance: {
+          ...moonshotInstance,
+          customModels: [{ id: "kimi-k2.5" }],
+        },
+      })
+    ).toBeNull();
+    expect(getModelPricing("MiniMax-M3", { provider: "minimax" })).toBeNull();
+    expect(getModelPricing("glm-5.2", { provider: "zhipu_cn" })).toBeNull();
   });
 
   test("does not estimate compatible models without user pricing", () => {

--- a/apps/server/src/providers/pricing.ts
+++ b/apps/server/src/providers/pricing.ts
@@ -3,6 +3,7 @@ import {
   type ProviderInstance,
   type ProviderName,
 } from "@nakama/core";
+import { DISCOVERY_MODEL_PROVIDERS } from "@nakama/core/discovery-providers";
 import { getModelById, IMAGE_GENERATION_MODEL_ID } from "./models";
 
 export interface ModelPricing {
@@ -56,12 +57,17 @@ function getCustomModelPricing(
   return null;
 }
 
-/** Providers whose rates only ever come from what the user typed in. */
+/**
+ * Providers whose rates only ever come from what the user typed in. Discovery
+ * providers belong here by construction: their catalogs are fetched from the
+ * platform at runtime, so there is never a bundled entry to price against and
+ * DEFAULT_PRICING would be a guess presented as a rate.
+ */
 const USER_PRICED_PROVIDERS = new Set<ProviderName>([
+  ...DISCOVERY_MODEL_PROVIDERS,
   "cerebras",
   "fireworks",
   "ollama",
-  "openai_compatible",
   "openrouter",
 ]);
 

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -60,6 +60,8 @@ export function formatProviderLabel(
     provider === "xai_oauth" ||
     provider === "minimax" ||
     provider === "minimax_cn" ||
+    provider === "moonshot" ||
+    provider === "moonshot_cn" ||
     provider === "zhipu" ||
     provider === "zhipu_cn" ||
     provider === "xai"
@@ -88,6 +90,8 @@ export const PROVIDER_OPTIONS: Array<{ id: SelectedProvider; label: string }> =
     { id: "minimax", label: "MiniMax" },
     { id: "xai", label: "xAI Grok" },
     { id: "minimax_cn", label: "MiniMax (CN)" },
+    { id: "moonshot", label: "Moonshot Kimi" },
+    { id: "moonshot_cn", label: "Moonshot Kimi (CN)" },
     { id: "zhipu", label: "GLM (Z.ai)" },
     { id: "zhipu_cn", label: "GLM (CN)" },
     { id: "openai_compatible", label: "Custom (OpenAI-compatible)" },

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -2234,6 +2234,8 @@ export type ProviderName =
   | "xai_oauth"
   | "minimax"
   | "minimax_cn"
+  | "moonshot"
+  | "moonshot_cn"
   | "zhipu"
   | "zhipu_cn"
   | "xai";

--- a/packages/core/src/discovery-providers.ts
+++ b/packages/core/src/discovery-providers.ts
@@ -12,6 +12,8 @@ export const DISCOVERY_MODEL_PROVIDERS: ReadonlySet<ProviderName> =
     "openai_compatible",
     "minimax",
     "minimax_cn",
+    "moonshot",
+    "moonshot_cn",
     "xai",
     "zhipu",
     "zhipu_cn",
@@ -25,6 +27,8 @@ export const DISCOVERY_PROVIDER_BASE_URLS: Readonly<
 > = {
   minimax: "https://api.minimax.io/v1",
   minimax_cn: "https://api.minimaxi.com/v1",
+  moonshot: "https://api.moonshot.ai/v1",
+  moonshot_cn: "https://api.moonshot.cn/v1",
   zhipu: "https://api.z.ai/api/paas/v4",
   zhipu_cn: "https://open.bigmodel.cn/api/paas/v4",
 };

--- a/packages/core/src/document-content.ts
+++ b/packages/core/src/document-content.ts
@@ -80,6 +80,8 @@ const NATIVE_DOCUMENT_MEDIA_TYPES: Record<ProviderName, ReadonlySet<string>> = {
   minimax: new Set<string>(),
   minimax_cn: new Set<string>(),
   mistral: new Set<string>(),
+  moonshot: new Set<string>(),
+  moonshot_cn: new Set<string>(),
   ollama: new Set<string>(),
   openai: new Set([
     "application/pdf",

--- a/packages/core/src/provider-label.ts
+++ b/packages/core/src/provider-label.ts
@@ -14,6 +14,8 @@ const BUILTIN_LABELS: Record<
   minimax: "MiniMax",
   minimax_cn: "MiniMax (CN)",
   mistral: "Mistral",
+  moonshot: "Moonshot Kimi",
+  moonshot_cn: "Moonshot Kimi (CN)",
   ollama: "Ollama",
   openai: "OpenAI",
   opencode_go: "OpenCode Go",

--- a/packages/core/src/provider-resolution.test.ts
+++ b/packages/core/src/provider-resolution.test.ts
@@ -23,6 +23,8 @@ describe("parseProviderName", () => {
     expect(parseProviderName("minimax_cn")).toBe("minimax_cn");
     expect(parseProviderName("zhipu")).toBe("zhipu");
     expect(parseProviderName("zhipu_cn")).toBe("zhipu_cn");
+    expect(parseProviderName("moonshot")).toBe("moonshot");
+    expect(parseProviderName("moonshot_cn")).toBe("moonshot_cn");
     expect(parseProviderName("xai")).toBe("xai");
   });
 
@@ -39,6 +41,11 @@ describe("apiKeyEnvVarForProvider", () => {
 
   test("mistral uses MISTRAL_API_KEY", () => {
     expect(apiKeyEnvVarForProvider("mistral")).toBe("MISTRAL_API_KEY");
+  });
+
+  test("maps Moonshot regions to distinct env keys", () => {
+    expect(apiKeyEnvVarForProvider("moonshot")).toBe("MOONSHOT_API_KEY");
+    expect(apiKeyEnvVarForProvider("moonshot_cn")).toBe("MOONSHOT_CN_API_KEY");
   });
 });
 
@@ -146,6 +153,8 @@ describe("isDiscoveryModelProvider", () => {
     expect(isDiscoveryModelProvider("zhipu")).toBe(true);
     expect(isDiscoveryModelProvider("zhipu_cn")).toBe(true);
     expect(isDiscoveryModelProvider("xai")).toBe(true);
+    expect(isDiscoveryModelProvider("moonshot")).toBe(true);
+    expect(isDiscoveryModelProvider("moonshot_cn")).toBe(true);
   });
 
   test("excludes catalog providers", () => {
@@ -168,6 +177,12 @@ describe("defaultDiscoveryBaseUrl", () => {
     );
     expect(defaultDiscoveryBaseUrl("zhipu_cn")).toBe(
       "https://open.bigmodel.cn/api/paas/v4"
+    );
+    expect(defaultDiscoveryBaseUrl("moonshot")).toBe(
+      "https://api.moonshot.ai/v1"
+    );
+    expect(defaultDiscoveryBaseUrl("moonshot_cn")).toBe(
+      "https://api.moonshot.cn/v1"
     );
   });
 

--- a/packages/core/src/provider-resolution.ts
+++ b/packages/core/src/provider-resolution.ts
@@ -20,6 +20,8 @@ export const USER_PROVIDER_NAMES: readonly UserProviderName[] = [
   "xai_oauth",
   "minimax",
   "minimax_cn",
+  "moonshot",
+  "moonshot_cn",
   "zhipu",
   "zhipu_cn",
   "xai",
@@ -53,6 +55,8 @@ export function parseProviderName(
     normalized === "xai_oauth" ||
     normalized === "minimax" ||
     normalized === "minimax_cn" ||
+    normalized === "moonshot" ||
+    normalized === "moonshot_cn" ||
     normalized === "zhipu" ||
     normalized === "zhipu_cn" ||
     normalized === "xai"
@@ -98,6 +102,10 @@ export function apiKeyEnvVarForProvider(
       return "MINIMAX_API_KEY";
     case "minimax_cn":
       return "MINIMAX_CN_API_KEY";
+    case "moonshot":
+      return "MOONSHOT_API_KEY";
+    case "moonshot_cn":
+      return "MOONSHOT_CN_API_KEY";
     case "zhipu":
       return "ZHIPU_API_KEY";
     case "zhipu_cn":

--- a/packages/core/src/provider-setup-prompt.ts
+++ b/packages/core/src/provider-setup-prompt.ts
@@ -44,6 +44,8 @@ const PROVIDER_CHOICES: Array<{ id: UserProviderName; label: string }> = [
   { id: "opencode_go", label: "OpenCode Go" },
   { id: "minimax", label: "MiniMax" },
   { id: "minimax_cn", label: "MiniMax (CN)" },
+  { id: "moonshot", label: "Moonshot Kimi" },
+  { id: "moonshot_cn", label: "Moonshot Kimi (CN)" },
   { id: "zhipu", label: "GLM (Z.ai)" },
   { id: "zhipu_cn", label: "GLM (CN)" },
   { id: "openai_compatible", label: "Custom (OpenAI-compatible)" },
@@ -190,6 +192,8 @@ function resolveProviderChoice(input: string): UserProviderName | null {
     normalized === "opencode_go" ||
     normalized === "minimax" ||
     normalized === "minimax_cn" ||
+    normalized === "moonshot" ||
+    normalized === "moonshot_cn" ||
     normalized === "zhipu" ||
     normalized === "zhipu_cn" ||
     normalized === "xai"

--- a/packages/core/src/user-config.test.ts
+++ b/packages/core/src/user-config.test.ts
@@ -275,6 +275,56 @@ describe("user config multi-provider", () => {
     );
   });
 
+  test("round-trips discovered models_json for discovery providers", async () => {
+    // The writer persists customModels for every provider type, so the reader
+    // must parse them back for discovery providers too — otherwise a fetched
+    // catalog is written to disk and dropped on the next load.
+    configDir = await mkdtemp(join(tmpdir(), "nakama-config-"));
+    process.env.NAKAMA_CONFIG_DIR = configDir;
+
+    const moonshotId = createProviderInstanceId();
+    const zhipuId = createProviderInstanceId();
+
+    await saveUserConfig({
+      defaultProviderId: moonshotId,
+      providers: [
+        {
+          apiKey: "sk-moonshot-test",
+          baseUrl: "https://api.moonshot.ai/v1",
+          createdAt: "2026-09-08T10:00:00.000Z",
+          customModels: [
+            {
+              default: true,
+              id: "kimi-k2.5",
+              inputPerMillionUsd: 0.6,
+              name: "Kimi K2.5",
+              outputPerMillionUsd: 2.5,
+              supportsVision: false,
+            },
+          ],
+          id: moonshotId,
+          label: "Moonshot Kimi",
+          type: "moonshot",
+        },
+        {
+          apiKey: "zp-test",
+          createdAt: "2026-09-08T10:00:00.000Z",
+          customModels: [{ default: true, id: "glm-5.2" }],
+          id: zhipuId,
+          label: "GLM (Z.ai)",
+          type: "zhipu",
+        },
+      ],
+    });
+
+    const loaded = await loadUserConfig();
+    expect(loaded?.providers[0]?.customModels?.[0]?.id).toBe("kimi-k2.5");
+    expect(loaded?.providers[0]?.customModels?.[0]?.inputPerMillionUsd).toBe(
+      0.6
+    );
+    expect(loaded?.providers[1]?.customModels?.[0]?.id).toBe("glm-5.2");
+  });
+
   test("repairs literal undefined label on load", async () => {
     configDir = await mkdtemp(join(tmpdir(), "nakama-config-"));
     process.env.NAKAMA_CONFIG_DIR = configDir;

--- a/packages/core/src/user-config.ts
+++ b/packages/core/src/user-config.ts
@@ -30,6 +30,7 @@ import {
 } from "./ollama-provider-config";
 import {
   apiKeyEnvVarForProvider,
+  isDiscoveryModelProvider,
   parseProviderName,
   type UserProviderName,
 } from "./provider-resolution";
@@ -91,6 +92,8 @@ const PROVIDER_TYPE_LABELS: Record<UserProviderName, string> = {
   minimax: "MiniMax",
   minimax_cn: "MiniMax (CN)",
   mistral: "Mistral",
+  moonshot: "Moonshot Kimi",
+  moonshot_cn: "Moonshot Kimi (CN)",
   ollama: "Ollama",
   openai: "OpenAI",
   openai_compatible: "Custom",
@@ -634,7 +637,7 @@ function loadProvidersFromSections(
       ? normalizeBaseUrl(values.base_url)
       : undefined;
     const customModels =
-      type === "openai_compatible" ||
+      isDiscoveryModelProvider(type) ||
       type === "openrouter" ||
       type === "cerebras" ||
       type === "fireworks" ||


### PR DESCRIPTION
Add Moonshot as a direct first-party provider. Like MiniMax (#380), Moonshot runs split platforms with separate keys and catalogs:

- moonshot     -> https://api.moonshot.ai/v1  (MOONSHOT_API_KEY)
- moonshot_cn  -> https://api.moonshot.cn/v1  (MOONSHOT_CN_API_KEY)

Both endpoints are OpenAI-compatible, so each follows the DeepSeek template (createOpenAIProvider with a region base URL), and both join DISCOVERY_MODEL_PROVIDERS rather than shipping a hardcoded catalog: Browse hits {baseUrl}/models and the fetched entries are stored as instance customModels. Resolution, defaults, vision flags and pricing all derive from that list, so new K-series releases appear without code changes — and the intl/CN catalogs stay independent even where the two platforms expose overlapping model ids.

That matters for capabilities here: intl K2.x is text-only while the CN platform exposes *vision-preview variants, so supportsVision is opt-in from discovered metadata instead of being inferred from the id. No Transcription entry and document-content sets empty, like deepseek.

Two fixes the registry surfaced, both of which Moonshot would otherwise have inherited:

- config.ini round-trip: the writer persists customModels for every provider type, but the reader only parsed models_json for a hardcoded whitelist that excluded discovery providers. A discovered catalog was written and then silently dropped on the next load, leaving the instance with no models after a restart. The reader now routes the whole registry through parseCustomModelsJson.
- pricing: discovery providers have no catalog to price against, so getModelPricing fell through to DEFAULT_PRICING ($1/$3) and reported a confident-but-wrong cost estimate. They now resolve saved per-model pricing like openai_compatible/cerebras/fireworks, and report unknown when the user has not entered rates.

Endpoints and the /v1/models capability were re-verified against the Moonshot platform docs, as the issue asks.

Tests: env-key mapping per region, parseProviderName acceptance, discovery-registry membership, discovered-model resolution with fallback to the instance default, region-independent catalogs, vision opt-in, the models_json round-trip regression (fails without the reader fix), and pricing with and without saved rates.

Closes #384
