### PR TITLE
chore: remove unused helpers and duplicate dependencies

### DIFF
--- a/apps/server/src/providers/compatible-models.ts
+++ b/apps/server/src/providers/compatible-models.ts
@@ -147,13 +147,6 @@ export function catalogCustomModelsToCatalog(
   });
 }
 
-export function openCodeGoCustomModelsToCatalog(
-  entries: CustomModelEntry[],
-  staticModels: ProviderModelOption[]
-): ProviderModelOption[] {
-  return catalogCustomModelsToCatalog(entries, staticModels, "opencode_go");
-}
-
 export function mergeOpenRouterCatalog(
   staticModels: ProviderModelOption[],
   customEntries: CustomModelEntry[]
@@ -351,20 +344,6 @@ export function getModelsForProviderInstance(
   return annotate(
     AVAILABLE_MODELS.filter((model) => model.provider === instance.type)
   );
-}
-
-export function getModelsForConfiguredProvider(
-  provider: ProviderName | null,
-  instance: ProviderInstance | null | undefined,
-  currentModel?: string | null
-): ProviderModelOption[] {
-  if (!instance) {
-    return provider
-      ? AVAILABLE_MODELS.filter((model) => model.provider === provider)
-      : AVAILABLE_MODELS;
-  }
-
-  return getModelsForProviderInstance(instance, currentModel);
 }
 
 export function resolveOpenRouterDefaultModel(
@@ -638,11 +617,4 @@ export function compatibleModelSupportsThinking(
   customModels: CustomModelEntry[] | undefined
 ): boolean {
   return findCustomModel(customModels, modelId)?.supportsThinking === true;
-}
-
-export function compatibleModelSupportsVision(
-  modelId: string,
-  customModels: CustomModelEntry[] | undefined
-): boolean {
-  return findCustomModel(customModels, modelId)?.supportsVision === true;
 }

--- a/apps/server/src/providers/models.ts
+++ b/apps/server/src/providers/models.ts
@@ -627,10 +627,6 @@ export function validateOpenCodeGoCustomModels(
   return models;
 }
 
-export function getAvailableModels(): ProviderModelOption[] {
-  return AVAILABLE_MODELS;
-}
-
 export function getModelById(modelId: string): ProviderModelOption | undefined {
   return AVAILABLE_MODELS.find((model) => model.id === modelId);
 }

--- a/apps/server/src/providers/shared.ts
+++ b/apps/server/src/providers/shared.ts
@@ -63,16 +63,6 @@ export function extractOpenAITokenUsage(
   });
 }
 
-export function extractAnthropicTokenUsage(
-  value: unknown
-): ChatCompletionResult["usage"] | undefined {
-  const record = readRecord(value);
-  return buildTokenUsage({
-    inputTokens: record.input_tokens,
-    outputTokens: record.output_tokens,
-  });
-}
-
 export function extractGeminiTokenUsage(
   value: unknown
 ): ChatCompletionResult["usage"] | undefined {

--- a/apps/server/src/services/coding-agent-harness-service.ts
+++ b/apps/server/src/services/coding-agent-harness-service.ts
@@ -13,7 +13,6 @@ import {
   mergeWorkspaceSettings,
 } from "@nakama/db";
 import {
-  ensureBunGlobalInstallDirs,
   ensureProcessPath,
   getToolExecutionEnv,
 } from "../lib/ensure-process-path";
@@ -22,8 +21,6 @@ import {
   CLI_SIGTERM_GRACE_MS,
   detectNpmOrBun,
   probeCliVersion,
-  runTimedInstallCommand,
-  summarizeInstallOutput,
 } from "./cli-package-install";
 import { buildHarnessNonInteractiveArgs } from "./coding-agent-command";
 import {
@@ -91,12 +88,6 @@ export interface ListCodingAgentHarnessStatusesOptions {
   /** When true, run live readiness probes for installed harnesses. Default false (use cache). */
   probe?: boolean;
   probeContext?: CodingAgentHarnessProbeContext;
-}
-
-export interface CodingAgentHarnessInstallProgress {
-  harnessId: string;
-  message: string;
-  name: string;
 }
 
 const DEFAULT_HARNESSES: StoredCodingAgentHarnessRecord[] = [
@@ -475,86 +466,6 @@ export async function resolveCodingAgentHarness(
   );
 }
 
-export async function verifyCodingAgentHarness(
-  db: DatabaseAdapter,
-  harnessId?: string | null,
-  probeContext?: CodingAgentHarnessProbeContext
-): Promise<{
-  ok: boolean;
-  harnessId: string | null;
-  name: string | null;
-  version: string | null;
-  installed: boolean;
-  authenticated: boolean | null;
-  ready: boolean;
-  nextStep: "install" | "retry" | null;
-  statusMessage: string | null;
-  error: string | null;
-}> {
-  const settings = await loadCodingAgentWorkspaceSettings(db);
-  const targetHarnessId =
-    harnessId ??
-    settings.selectedHarnessId ??
-    settings.harnesses.find((entry) => entry.enabled)?.id ??
-    null;
-
-  if (!targetHarnessId) {
-    return {
-      authenticated: null,
-      error: "No supported coding agent is installed yet.",
-      harnessId: harnessId ?? null,
-      installed: false,
-      name: null,
-      nextStep: "install",
-      ok: false,
-      ready: false,
-      statusMessage: "Install a supported coding agent first.",
-      version: null,
-    };
-  }
-
-  let harness: CodingAgentHarnessStatus;
-
-  try {
-    harness = await refreshCodingAgentHarnessProbe(
-      db,
-      targetHarnessId,
-      probeContext
-    );
-  } catch {
-    return {
-      authenticated: null,
-      error: "No supported coding agent is installed yet.",
-      harnessId: targetHarnessId,
-      installed: false,
-      name: null,
-      nextStep: "install",
-      ok: false,
-      ready: false,
-      statusMessage: "Install a supported coding agent first.",
-      version: null,
-    };
-  }
-
-  return {
-    authenticated: harness.authenticated,
-    error: harness.installed
-      ? harness.ready
-        ? null
-        : (harness.statusMessage ??
-          `Nakama could not verify ${harness.name} yet.`)
-      : `${harness.name} is not installed or could not be started with \`${harness.command} --version\`.`,
-    harnessId: harness.id,
-    installed: harness.installed,
-    name: harness.name,
-    nextStep: harness.nextStep,
-    ok: harness.ready,
-    ready: harness.ready,
-    statusMessage: harness.statusMessage,
-    version: harness.version,
-  };
-}
-
 function mergeHarnesses(
   storedHarnesses: StoredCodingAgentHarnessRecord[]
 ): StoredCodingAgentHarnessRecord[] {
@@ -743,80 +654,6 @@ export function getCodingHarnessInstallCommand(
   kind: StoredCodingAgentHarnessKind
 ): string {
   return buildCodingHarnessInstallPlan(kind).displayCommand;
-}
-
-export function getCodingHarnessInstallHint(
-  kind: StoredCodingAgentHarnessKind
-): string {
-  if (kind === "cursor_agent") {
-    return "Install and authenticate Cursor Agent CLI on this machine yourself (verify with `agent --version`), then check again.";
-  }
-
-  if (kind === "codex") {
-    return "Install the Codex CLI on this machine, then check again.";
-  }
-
-  if (kind === "claude_code") {
-    return "Install Claude Code on this machine, then check again.";
-  }
-
-  if (kind === "pi") {
-    return "Install pi CLI (@earendil-works/pi-coding-agent) on this machine, then check again.";
-  }
-
-  return "Install OpenCode on this machine, then check again.";
-}
-
-export async function installCodingAgentHarness(
-  db: DatabaseAdapter,
-  harnessId: string,
-  onProgress?: (progress: CodingAgentHarnessInstallProgress) => void
-): Promise<CodingAgentHarnessStatus> {
-  const settings = await loadCodingAgentWorkspaceSettings(db);
-  const harness = settings.harnesses.find((entry) => entry.id === harnessId);
-
-  if (!harness) {
-    throw new Error("Unknown coding harness.");
-  }
-
-  const installPlan = buildCodingHarnessInstallPlan(harness.kind);
-  if (installPlan.command === "bun") {
-    ensureBunGlobalInstallDirs();
-  }
-  const emitProgress = (message: string) => {
-    onProgress?.({
-      harnessId: harness.id,
-      message,
-      name: harness.name,
-    });
-  };
-
-  emitProgress(`Starting ${harness.name} install.`);
-  emitProgress(installPlan.displayCommand);
-
-  const result = await runTimedInstallCommand(installPlan, emitProgress);
-  const combinedOutput = [result.stdout, result.stderr]
-    .filter(Boolean)
-    .join("\n")
-    .trim();
-
-  if (result.timedOut) {
-    throw new Error(`Install timed out while running ${harness.name}.`);
-  }
-
-  if (result.exitCode !== 0) {
-    throw new Error(
-      combinedOutput
-        ? `${harness.name} install failed: ${summarizeInstallOutput(combinedOutput)}`
-        : `${harness.name} install failed.`
-    );
-  }
-
-  emitProgress(`${harness.name} install finished. Refreshing readiness.`);
-
-  const updated = await refreshCodingAgentHarnessProbe(db, harness.id);
-
-  return updated;
 }
 
 async function probeHarnessLight(

--- a/apps/server/src/services/coding-agent-spawn-env.ts
+++ b/apps/server/src/services/coding-agent-spawn-env.ts
@@ -380,14 +380,3 @@ export function redactSpawnEnvForPrompt(
 
   return redacted;
 }
-
-export function redactSpawnEnvForApi(
-  env: Record<string, string>,
-  options: { includeSecrets: boolean }
-): Record<string, string> {
-  if (options.includeSecrets) {
-    return { ...env };
-  }
-
-  return redactSpawnEnvForPrompt(env);
-}

--- a/apps/server/src/tools/send-discord-artifact-tool.ts
+++ b/apps/server/src/tools/send-discord-artifact-tool.ts
@@ -163,33 +163,3 @@ export const sendDiscordArtifactTool: ToolDefinition<
 export function createSendDiscordArtifactTools(): ToolDefinition[] {
   return [sendDiscordArtifactTool];
 }
-
-export function parseSendDiscordArtifactToolResult(
-  result: unknown
-): SendDiscordArtifactSuccess | null {
-  if (typeof result !== "object" || result === null) {
-    return null;
-  }
-
-  const record = result as Record<string, unknown>;
-  if (record.ok !== true) {
-    return null;
-  }
-
-  if (
-    typeof record.path !== "string" ||
-    typeof record.filename !== "string" ||
-    typeof record.mimeType !== "string" ||
-    typeof record.sizeBytes !== "number"
-  ) {
-    return null;
-  }
-
-  return {
-    filename: record.filename,
-    mimeType: record.mimeType,
-    ok: true,
-    path: record.path,
-    sizeBytes: record.sizeBytes,
-  };
-}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,8 +13,6 @@
     "@base-ui/react": "^1.5.0",
     "@fontsource-variable/inter": "^5.3.0",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
-    "@hugeicons/core-free-icons": "^4.3.0",
-    "@hugeicons/react": "^1.1.10",
     "@nakama/client": "workspace:*",
     "@nakama/core": "workspace:*",
     "@streamdown/cjk": "^1.0.3",

--- a/apps/web/src/components/chat/WorkflowRunToolRow.tsx
+++ b/apps/web/src/components/chat/WorkflowRunToolRow.tsx
@@ -1,10 +1,9 @@
+import { useQuery } from "@tanstack/react-query";
 import {
+  CancelCircleIcon,
   CheckmarkCircle02Icon,
   DashedLineCircleIcon,
-} from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
-import { useQuery } from "@tanstack/react-query";
-import { CancelCircleIcon } from "hugeicons-react";
+} from "hugeicons-react";
 import type { ChatListItem } from "@/lib/chat-history";
 import {
   buildWorkflowRunCard,
@@ -140,8 +139,9 @@ function renderStepMark(
   }
 
   const completed = status === "completed";
+  const Icon = completed ? CheckmarkCircle02Icon : DashedLineCircleIcon;
   return (
-    <HugeiconsIcon
+    <Icon
       aria-hidden
       className={cn(
         "size-4 shrink-0",
@@ -150,7 +150,6 @@ function renderStepMark(
         className
       )}
       color="currentColor"
-      icon={completed ? CheckmarkCircle02Icon : DashedLineCircleIcon}
       size={16}
       strokeWidth={1.5}
     />

--- a/apps/web/src/lib/knowledge-base-files.ts
+++ b/apps/web/src/lib/knowledge-base-files.ts
@@ -5,6 +5,8 @@ import {
   parseDocumentDataUrl,
 } from "@nakama/core/message-content";
 
+import { readFileAsDataUrl } from "./read-file-as-data-url";
+
 export const KNOWLEDGE_BASE_ACCEPT = `.pdf,.docx,.txt,.md,.csv,application/pdf,${DOCX_MEDIA_TYPE},text/plain,text/csv,text/markdown`;
 
 const KB_EXTENSIONS = new Set([".pdf", ".docx", ".txt", ".md", ".csv"]);
@@ -27,21 +29,10 @@ export function isKnowledgeBaseFile(file: File): boolean {
 export function fileToDocumentAttachment(
   file: File
 ): Promise<DocumentAttachment | null> {
-  return new Promise((resolve) => {
-    const reader = new FileReader();
-    reader.onloadend = () => {
-      const result = typeof reader.result === "string" ? reader.result : null;
-      if (!result) {
-        resolve(null);
-        return;
-      }
-
-      const filename = file.name.trim() || "document";
-      resolve(parseDocumentDataUrl(result, filename));
-    };
-    reader.onerror = () => resolve(null);
-    reader.readAsDataURL(file);
-  });
+  return readFileAsDataUrl(file).then(
+    (data) => parseDocumentDataUrl(data, file.name.trim() || "document"),
+    () => null
+  );
 }
 
 export function formatBytes(bytes: number): string {

--- a/apps/web/src/lib/profile-images.ts
+++ b/apps/web/src/lib/profile-images.ts
@@ -1,16 +1,10 @@
 import type { ImageAttachment } from "@nakama/core/contract";
 import { parseDataUrl } from "@nakama/core/message-content";
 
+import { readFileAsDataUrl } from "./read-file-as-data-url";
+
 export function fileToImageAttachment(
   file: File
 ): Promise<ImageAttachment | null> {
-  return new Promise((resolve) => {
-    const reader = new FileReader();
-    reader.onloadend = () => {
-      const result = typeof reader.result === "string" ? reader.result : null;
-      resolve(result ? parseDataUrl(result) : null);
-    };
-    reader.onerror = () => resolve(null);
-    reader.readAsDataURL(file);
-  });
+  return readFileAsDataUrl(file).then(parseDataUrl, () => null);
 }

--- a/bun.lock
+++ b/bun.lock
@@ -85,8 +85,6 @@
         "@base-ui/react": "^1.5.0",
         "@fontsource-variable/inter": "^5.3.0",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
-        "@hugeicons/core-free-icons": "^4.3.0",
-        "@hugeicons/react": "^1.1.10",
         "@nakama/client": "workspace:*",
         "@nakama/core": "workspace:*",
         "@streamdown/cjk": "^1.0.3",
@@ -374,7 +372,7 @@
 
     "@hono/zod-validator": ["@hono/zod-validator@0.9.0", "", { "peerDependencies": { "hono": ">=4.11.2", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-n0ZSXmCiHVIp4Y5wlOOyZCeTd/rsawA/qW1cipB8QOYKZ9N8Tk0nZUZCXho9cu374AN4JpDNKioNKBJ/W+LBug=="],
 
-    "@hugeicons/core-free-icons": ["@hugeicons/core-free-icons@4.3.0", "", {}, "sha512-5DC5gq2psNDKBQThOjpuFCtMco8nl2FkrBzZgG15cFGM0kSwUoych/pw0DmjBygF9qRDITdBPtmzJqLsOeImMg=="],
+    "@hugeicons/core-free-icons": ["@hugeicons/core-free-icons@3.3.0", "", {}, "sha512-qYyr4JQ2eQIHTSTbITvnJvs6ERNK64D9gpwZnf2IyuG0exzqfyABLO/oTB71FB3RZPfu1GbwycdiGSo46apjMQ=="],
 
     "@hugeicons/react": ["@hugeicons/react@1.1.10", "", { "peerDependencies": { "react": ">=16.0.0" } }, "sha512-9tAsd92yMVVGP+E+d8cM+wc0VnXuYZHNbWQi7TOe8k2neawmhiaFmVFbzyruejhOMa197/LbgvSED32ayUo3ZA=="],
 
@@ -2287,8 +2285,6 @@
     "get-uri/data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
-
-    "hugeicons-react/@hugeicons/core-free-icons": ["@hugeicons/core-free-icons@3.3.0", "", {}, "sha512-qYyr4JQ2eQIHTSTbITvnJvs6ERNK64D9gpwZnf2IyuG0exzqfyABLO/oTB71FB3RZPfu1GbwycdiGSo46apjMQ=="],
 
     "imapflow/iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
 

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -26,16 +26,12 @@
     "apps/server/src/providers/compatible-models.ts": ["exports"],
     "apps/server/src/providers/anthropic/index.ts": ["exports"],
     "apps/server/src/providers/models.ts": ["exports"],
-    "apps/server/src/providers/shared.ts": ["exports"],
     "apps/server/src/providers/usage-tracking.ts": ["exports", "types"],
     "apps/server/src/http/org-guards.ts": ["exports"],
     "apps/server/src/http/public-routes.ts": ["exports"],
     "apps/server/src/services/skills-service.ts": ["exports"],
     "apps/server/src/services/coding-agent-bash-env.ts": ["exports"],
-    "apps/server/src/services/coding-agent-harness-service.ts": [
-      "exports",
-      "types"
-    ],
+    "apps/server/src/services/coding-agent-harness-service.ts": ["exports"],
     "apps/server/src/services/coding-agent-spawn-env.ts": ["exports"],
     "apps/server/src/services/composio-api-client.ts": ["exports", "types"],
     "apps/server/src/services/data-portability.ts": ["exports"],


### PR DESCRIPTION
## Summary

Keep the same chat and attachment behavior with fewer unused helpers and direct dependencies.

**Before:** Uncalled helpers, duplicate FileReader implementations, and two direct icon packages added maintenance work.
**After:** Dead helpers are gone; attachments share the existing reader and workflow icons use `hugeicons-react`.

Why safe:
1. Removed helpers have no callers; active provider, probe, and Discord tool paths remain covered by tests.
2. Sixteen before/after checks preserve attachment results and null-on-read-error handling. Icon size, stroke, colors, and animation are preserved.

The icon packages remain transitive dependencies of `hugeicons-react`. Independent code review is pending.

Fixes #915

## Test plan

- [x] Focused provider, harness, spawn-env, Discord artifact, and workflow tests: `bun test apps/server/src/providers/compatible-models.test.ts apps/server/src/providers/shared.test.ts apps/server/src/services/coding-agent-harness-service.test.ts apps/server/src/tools/send-discord-artifact-tool.test.ts apps/server/src/services/coding-agent-spawn-env.test.ts apps/web/src/lib/chat-stream-workflow.test.ts` — 68 pass.
- [x] `bun run --cwd apps/web build`, `bun run --cwd apps/server build`, `bun run knip`, changed-file Ultracite check, and `npx react-doctor@latest --verbose --scope changed` — pass; React Doctor 100/100.
- [ ] Open a workflow run in chat and check its pending, completed, and failed icons.
