### PR TITLE
fix(web): poll skill-review overlay via total AgentChannel map

### DIFF
--- a/apps/web/src/hooks/use-post-turn-skill-review-overlay.tsx
+++ b/apps/web/src/hooks/use-post-turn-skill-review-overlay.tsx
@@ -17,6 +17,26 @@ import { canAccessSystemPage } from "@/lib/navigation";
 const POST_TURN_POLL_WINDOW_MS = 45_000;
 const POST_TURN_POLL_INTERVAL_MS = 3000;
 
+/**
+ * Which channels the post-turn skill-review overlay polls. Total over
+ * `AgentChannel` so a new channel fails the typecheck here rather than
+ * silently skipping (#474 / #798). Keep aligned with
+ * `HISTORY_SESSION_CHANNEL` ∩ !`READ_ONLY_SESSION_CHANNEL` in chat-history:
+ * only a writable listed session has a web surface that can apply
+ * suggestions. `cli` is false until history lists it (issue option 2);
+ * telegram/whatsapp/discord stay false because they are read-only in web.
+ */
+const POST_TURN_OVERLAY_POLL_CHANNEL = {
+  automation: false,
+  cli: false,
+  discord: false,
+  subagent: false,
+  task: false,
+  telegram: false,
+  web: true,
+  whatsapp: false,
+} as const satisfies Record<AgentChannel, boolean>;
+
 interface UsePostTurnSkillReviewOverlayArgs {
   lastSuccessfulTurnAt: number | null;
   profile: ProfileSummary | undefined;
@@ -42,7 +62,7 @@ function canPollPostTurnReview({
     reviewEnabled &&
     Boolean(activeOrgId) &&
     Boolean(sessionId) &&
-    sessionChannel === "web" &&
+    POST_TURN_OVERLAY_POLL_CHANNEL[sessionChannel] &&
     !readOnlySession
   );
 }

--- a/apps/web/src/hooks/use-post-turn-skill-review-overlay.tsx
+++ b/apps/web/src/hooks/use-post-turn-skill-review-overlay.tsx
@@ -20,15 +20,16 @@ const POST_TURN_POLL_INTERVAL_MS = 3000;
 /**
  * Which channels the post-turn skill-review overlay polls. Total over
  * `AgentChannel` so a new channel fails the typecheck here rather than
- * silently skipping (#474 / #798). Keep aligned with
- * `HISTORY_SESSION_CHANNEL` ∩ !`READ_ONLY_SESSION_CHANNEL` in chat-history:
- * only a writable listed session has a web surface that can apply
- * suggestions. `cli` is false until history lists it (issue option 2);
- * telegram/whatsapp/discord stay false because they are read-only in web.
+ * silently skipping (#474 / #798).
+ *
+ * `web` and `cli`: poll — a cli session opens in the web chat route with
+ * `sessionChannel === "cli"` (history listing is separate; see #910).
+ * telegram/whatsapp/discord: false — read-only in web, so apply is blocked
+ * anyway. automation/task/subagent: false — server does not review them.
  */
 const POST_TURN_OVERLAY_POLL_CHANNEL = {
   automation: false,
-  cli: false,
+  cli: true,
   discord: false,
   subagent: false,
   task: false,


### PR DESCRIPTION
## Summary

Post-turn skill-review overlay poll gate is a total `AgentChannel` map, and it polls `web` + `cli` so CLI suggestion rows are readable when that session is opened in the dashboard.

**Before:** `sessionChannel === "web"` — a ninth channel would not typecheck-fail here; `cli` suggestions were written and never polled.
**After:** `POST_TURN_OVERLAY_POLL_CHANNEL[sessionChannel]` with `web` and `cli` true; telegram/whatsapp/discord stay false (read-only in web).

Why safe:
1. `cli` sessions already open via the chat route / `resumeSession` — history listing is unrelated (#910 correction)
2. Matches the #798 total-map pattern; new channels fail the typecheck here
3. Read-only channel sessions still skip poll via `!readOnlySession`

Only change telegram/whatsapp/discord (or stop server review for them) if product wants suggestion apply from those histories.

Closes #910

## Test plan
- [x] Diff review: map covers every `AgentChannel` via `satisfies Record<AgentChannel, boolean>`; `cli` + `web` true
- [x] CI green on prior head; re-run after `cli: true`
- [ ] Open a web chat with post-turn review on — banner still polls after a complex turn
- [ ] Open a `cli` session URL in the dashboard after a CLI turn with review on — overlay polls / banner can show
