### PR TITLE
fix(cli): allowlist @path image reads to cwd and config dir

### DIFF
--- a/apps/cli/src/image-input.test.ts
+++ b/apps/cli/src/image-input.test.ts
@@ -1,30 +1,95 @@
-import { describe, expect, test } from "bun:test";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { afterEach, describe, expect, test } from "bun:test";
+import { realpathSync } from "node:fs";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { mergeSendInput, parseImageLine } from "./image-input";
+import {
+  mergeSendInput,
+  parseImageLine,
+  resolveAllowedImagePath,
+} from "./image-input";
 
 const tinyPng = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
   "base64"
 );
 
+const originalCwd = process.cwd();
+const originalConfigDir = process.env.NAKAMA_CONFIG_DIR;
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  if (originalConfigDir === undefined) {
+    delete process.env.NAKAMA_CONFIG_DIR;
+  } else {
+    process.env.NAKAMA_CONFIG_DIR = originalConfigDir;
+  }
+});
+
+describe("resolveAllowedImagePath", () => {
+  test("allows a relative path under cwd", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "nakama-cli-img-"));
+    process.chdir(dir);
+    await writeFile(join(dir, "shot.png"), tinyPng);
+
+    expect(resolveAllowedImagePath("./shot.png")).toBe(
+      realpathSync(join(dir, "shot.png"))
+    );
+  });
+
+  test("allows a path under NAKAMA_CONFIG_DIR", async () => {
+    const configDir = await mkdtemp(join(tmpdir(), "nakama-cfg-"));
+    process.env.NAKAMA_CONFIG_DIR = configDir;
+    const nested = join(configDir, "uploads");
+    await mkdir(nested);
+    await writeFile(join(nested, "shot.png"), tinyPng);
+
+    expect(resolveAllowedImagePath(join(nested, "shot.png"))).toBe(
+      realpathSync(join(nested, "shot.png"))
+    );
+  });
+
+  test("rejects absolute paths outside cwd and config dir", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "nakama-cli-img-"));
+    process.chdir(dir);
+    process.env.NAKAMA_CONFIG_DIR = await mkdtemp(
+      join(tmpdir(), "nakama-cfg-")
+    );
+
+    expect(() => resolveAllowedImagePath("/etc/passwd")).toThrow(
+      /outside allowed directories/i
+    );
+  });
+});
+
 describe("parseImageLine", () => {
   test("returns null for normal text", async () => {
     expect(await parseImageLine("hello")).toBeNull();
   });
 
-  test("parses image path with message", async () => {
+  test("parses image path with message under cwd", async () => {
     const dir = await mkdtemp(join(tmpdir(), "nakama-cli-"));
-    const path = join(dir, "test.png");
-    await writeFile(path, tinyPng);
+    process.chdir(dir);
+    await writeFile(join(dir, "test.png"), tinyPng);
 
-    const result = await parseImageLine(`@${path} what is this?`);
+    const result = await parseImageLine("@./test.png what is this?");
 
     expect(result).toEqual({
       images: [{ data: tinyPng.toString("base64"), mediaType: "image/png" }],
       message: "what is this?",
     });
+  });
+
+  test("rejects image paths outside the allowlist", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "nakama-cli-"));
+    process.chdir(dir);
+    process.env.NAKAMA_CONFIG_DIR = await mkdtemp(
+      join(tmpdir(), "nakama-cfg-")
+    );
+
+    await expect(parseImageLine("@/etc/hosts look")).rejects.toThrow(
+      /outside allowed directories/i
+    );
   });
 });
 

--- a/apps/cli/src/image-input.test.ts
+++ b/apps/cli/src/image-input.test.ts
@@ -60,6 +60,23 @@ describe("resolveAllowedImagePath", () => {
       /outside allowed directories/i
     );
   });
+
+  test("rejects a sibling path that only shares a string prefix with cwd", async () => {
+    const parent = await mkdtemp(join(tmpdir(), "nakama-cli-pfx-"));
+    const cwdRoot = join(parent, "fo");
+    const sibling = join(parent, "foo");
+    await mkdir(cwdRoot);
+    await mkdir(sibling);
+    process.chdir(cwdRoot);
+    process.env.NAKAMA_CONFIG_DIR = await mkdtemp(
+      join(tmpdir(), "nakama-cfg-")
+    );
+    await writeFile(join(sibling, "shot.png"), tinyPng);
+
+    expect(() =>
+      resolveAllowedImagePath(join(sibling, "shot.png"))
+    ).toThrow(/outside allowed directories/i);
+  });
 });
 
 describe("parseImageLine", () => {

--- a/apps/cli/src/image-input.ts
+++ b/apps/cli/src/image-input.ts
@@ -67,13 +67,14 @@ function resolveAllowedRoots(): string[] {
 }
 
 function isWithinRoots(target: string, roots: string[]): boolean {
-  const normalized = target.endsWith(path.sep) ? target : target + path.sep;
   for (const root of roots) {
-    const rootEnd = root.endsWith(path.sep) ? root : root + path.sep;
-    if (normalized === rootEnd || normalized.startsWith(rootEnd)) {
+    if (target === root) {
       return true;
     }
-    if (target === root) {
+    // Compare target against `root + sep`, not `target + sep` against `root +
+    // sep` — otherwise cwd `/tmp/fo` would falsely allow `/tmp/foo/secret`.
+    const prefix = root.endsWith(path.sep) ? root : root + path.sep;
+    if (target.startsWith(prefix)) {
       return true;
     }
   }

--- a/apps/cli/src/image-input.ts
+++ b/apps/cli/src/image-input.ts
@@ -1,6 +1,8 @@
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
 import type { ImageAttachment, SendMessageInput } from "@nakama/core";
-import { MAX_IMAGE_BYTES } from "@nakama/core";
+import { getUserConfigDir, MAX_IMAGE_BYTES } from "@nakama/core";
 
 const IMAGE_PATH_PATTERN = /^@(\S+)(?:\s+([\s\S]*))?$/;
 
@@ -11,6 +13,72 @@ const EXTENSION_MEDIA_TYPES: Record<string, string> = {
   ".png": "image/png",
   ".webp": "image/webp",
 };
+
+/**
+ * Resolve `@path` image reads to an allowlisted absolute path.
+ * Allowed roots: process.cwd() and the Nakama config dir (`~/.nakama` or
+ * `NAKAMA_CONFIG_DIR`). Blocks clipboard-stuffed absolute paths like
+ * `/etc/passwd` (#545).
+ */
+export function resolveAllowedImagePath(filePath: string): string {
+  if (filePath.includes("\0")) {
+    throw new Error("Image path contains a null byte.");
+  }
+
+  const expanded = expandHome(filePath);
+  const absolute = path.resolve(process.cwd(), expanded);
+  const allowedRoots = resolveAllowedRoots();
+
+  let realPath: string;
+  try {
+    realPath = realpathSync(absolute);
+  } catch {
+    realPath = absolute;
+  }
+
+  if (!isWithinRoots(realPath, allowedRoots)) {
+    throw new Error(
+      `Image path is outside allowed directories (cwd or Nakama config dir): ${filePath}`
+    );
+  }
+
+  return realPath;
+}
+
+function expandHome(filePath: string): string {
+  if (filePath === "~") {
+    return process.env.HOME ?? homedir();
+  }
+  if (filePath.startsWith("~/")) {
+    return path.join(process.env.HOME ?? homedir(), filePath.slice(2));
+  }
+  return filePath;
+}
+
+function resolveAllowedRoots(): string[] {
+  const roots = [process.cwd(), getUserConfigDir()];
+  return roots.map((root) => {
+    try {
+      return realpathSync(root);
+    } catch {
+      return path.resolve(root);
+    }
+  });
+}
+
+function isWithinRoots(target: string, roots: string[]): boolean {
+  const normalized = target.endsWith(path.sep) ? target : target + path.sep;
+  for (const root of roots) {
+    const rootEnd = root.endsWith(path.sep) ? root : root + path.sep;
+    if (normalized === rootEnd || normalized.startsWith(rootEnd)) {
+      return true;
+    }
+    if (target === root) {
+      return true;
+    }
+  }
+  return false;
+}
 
 export async function parseImageLine(
   line: string
@@ -23,12 +91,13 @@ export async function parseImageLine(
 
   const filePath = match[1]!;
   const message = (match[2] ?? "").trim();
+  const resolvedPath = resolveAllowedImagePath(filePath);
 
-  if (!existsSync(filePath)) {
+  if (!existsSync(resolvedPath)) {
     throw new Error(`Image file not found: ${filePath}`);
   }
 
-  const file = Bun.file(filePath);
+  const file = Bun.file(resolvedPath);
   const size = file.size;
 
   if (size > MAX_IMAGE_BYTES) {
@@ -37,7 +106,9 @@ export async function parseImageLine(
     );
   }
 
-  const extension = filePath.slice(filePath.lastIndexOf(".")).toLowerCase();
+  const extension = resolvedPath
+    .slice(resolvedPath.lastIndexOf("."))
+    .toLowerCase();
   const mediaType = EXTENSION_MEDIA_TYPES[extension];
 
   if (!mediaType) {


### PR DESCRIPTION
## Summary

CLI `@path` image attachment only reads files under `process.cwd()` or the Nakama config dir (`~/.nakama` / `NAKAMA_CONFIG_DIR`).

**Before:** any readable path up to 5 MB was base64-encoded into the prompt.
**After:** `resolveAllowedImagePath` realpath-checks against those two roots (true directory containment, not string-prefix) and rejects everything else (e.g. `/etc/passwd`, sibling `/tmp/foo` when cwd is `/tmp/fo`).

Why safe:
1. Relative images under the operator cwd still work (`@./shot.png`)
2. Paths under the config dir still work for stored uploads
3. Symlink escape blocked via `realpathSync` on both the file and the roots

Only widen the allowlist if operators need a deliberate third root (document it then).

Closes #545

## Test plan
- [x] `bun test apps/cli/src/image-input.test.ts` (9 pass)
- [ ] From the CLI, `@./some.png` under cwd still attaches; `@/etc/hosts` errors with outside allowed directories
