### PR TITLE
fix(server): allowlist NAKAMA_PYTHON_BIN for python tools

### DIFF
--- a/apps/server/src/services/python-tool-loader.test.ts
+++ b/apps/server/src/services/python-tool-loader.test.ts
@@ -51,6 +51,18 @@ describe("resolvePythonBin", () => {
   test("rejects absolute paths outside the allowlist", () => {
     expect(() => resolvePythonBin("/tmp/python3")).toThrow(/allowlist/i);
     expect(() => resolvePythonBin("/bin/bash")).toThrow(/basename/i);
+    expect(() =>
+      resolvePythonBin("/opt/homebrew/Cellar/pythonfoo/bin/python3")
+    ).toThrow(/allowlist/i);
+  });
+
+  test("accepts Homebrew Cellar python and python@ paths by prefix", () => {
+    expect(
+      resolvePythonBin("/opt/homebrew/Cellar/python@3.12/3.12.0/bin/python3")
+    ).toBe("/opt/homebrew/Cellar/python@3.12/3.12.0/bin/python3");
+    expect(
+      resolvePythonBin("/opt/homebrew/Cellar/python/3.12.0/bin/python3")
+    ).toBe("/opt/homebrew/Cellar/python/3.12.0/bin/python3");
   });
 
   test("accepts /usr/bin/python3 when present", () => {

--- a/apps/server/src/services/python-tool-loader.test.ts
+++ b/apps/server/src/services/python-tool-loader.test.ts
@@ -7,9 +7,10 @@ import {
   makeCustomToolRecord,
   setupCustomToolsDir,
 } from "./custom-tool-test-helpers";
-import { loadPythonTool } from "./python-tool-loader";
+import { loadPythonTool, resolvePythonBin } from "./python-tool-loader";
 
 const originalConfigDir = process.env.NAKAMA_CONFIG_DIR;
+const originalPythonBin = process.env.NAKAMA_PYTHON_BIN;
 const setupToolsDir = setupCustomToolsDir;
 const makeRecord = (overrides = {}) =>
   makeCustomToolRecord({
@@ -17,6 +18,45 @@ const makeRecord = (overrides = {}) =>
     handlerType: "python",
     ...overrides,
   });
+
+describe("resolvePythonBin", () => {
+  afterEach(() => {
+    if (originalPythonBin === undefined) {
+      delete process.env.NAKAMA_PYTHON_BIN;
+    } else {
+      process.env.NAKAMA_PYTHON_BIN = originalPythonBin;
+    }
+  });
+
+  test("defaults to python3", () => {
+    delete process.env.NAKAMA_PYTHON_BIN;
+    expect(resolvePythonBin()).toBe("python3");
+  });
+
+  test("accepts bare python3 and python", () => {
+    expect(resolvePythonBin("python3")).toBe("python3");
+    expect(resolvePythonBin("python")).toBe("python");
+    expect(resolvePythonBin("python3.12")).toBe("python3.12");
+  });
+
+  test("rejects bare names that are not python", () => {
+    expect(() => resolvePythonBin("bash")).toThrow(/bare name/i);
+    expect(() => resolvePythonBin("node")).toThrow(/bare name/i);
+  });
+
+  test("rejects relative paths", () => {
+    expect(() => resolvePythonBin("./python3")).toThrow(/absolute path/i);
+  });
+
+  test("rejects absolute paths outside the allowlist", () => {
+    expect(() => resolvePythonBin("/tmp/python3")).toThrow(/allowlist/i);
+    expect(() => resolvePythonBin("/bin/bash")).toThrow(/basename/i);
+  });
+
+  test("accepts /usr/bin/python3 when present", () => {
+    expect(resolvePythonBin("/usr/bin/python3")).toBe("/usr/bin/python3");
+  });
+});
 
 describe("python tool loader", () => {
   let configDir = "";
@@ -26,6 +66,11 @@ describe("python tool loader", () => {
       delete process.env.NAKAMA_CONFIG_DIR;
     } else {
       process.env.NAKAMA_CONFIG_DIR = originalConfigDir;
+    }
+    if (originalPythonBin === undefined) {
+      delete process.env.NAKAMA_PYTHON_BIN;
+    } else {
+      process.env.NAKAMA_PYTHON_BIN = originalPythonBin;
     }
 
     if (configDir) {
@@ -66,6 +111,26 @@ if __name__ == "__main__":
     // The loader must forward context.workspaceRoot to the child process as
     // NAKAMA_WORKSPACE_ROOT.
     expect(result.root).toBe("/tmp/nakama-ws");
+  });
+
+  test("rejects a disallowed NAKAMA_PYTHON_BIN before spawn", async () => {
+    const { configDir: dir, toolsDir } = await setupToolsDir();
+    configDir = dir;
+
+    await writeFile(
+      path.join(toolsDir, "echo.py"),
+      `import json, sys
+def run(input, context):
+    return input
+if __name__ == "__main__":
+    sys.stdout.write(json.dumps(run(json.loads(sys.stdin.read() or "{}"), {})))
+`,
+      "utf8"
+    );
+
+    process.env.NAKAMA_PYTHON_BIN = "/tmp/not-an-allowlisted-python";
+    const tool = await loadPythonTool(makeRecord());
+    await expect(tool!.run({}, {})).rejects.toThrow(/allowlist/i);
   });
 
   test("returns an error tool when the module file is missing", async () => {

--- a/apps/server/src/services/python-tool-loader.ts
+++ b/apps/server/src/services/python-tool-loader.ts
@@ -1,3 +1,4 @@
+import { realpathSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import type { ToolContext, ToolDefinition } from "@nakama/core";
@@ -10,7 +11,78 @@ import {
 } from "./custom-tool-shared";
 import { spawnJsonTool } from "./custom-tool-subprocess";
 
-const PYTHON_BIN = process.env.NAKAMA_PYTHON_BIN ?? "python3";
+/** Bare interpreter names allowed when NAKAMA_PYTHON_BIN has no path. */
+const ALLOWED_PYTHON_BASENAME = /^python(\d+(\.\d+)*)?$/;
+
+/**
+ * Absolute interpreter paths must resolve under one of these prefixes after
+ * realpath (covers Homebrew Cellar symlinks). Anything else is rejected so an
+ * operator cannot point NAKAMA_PYTHON_BIN at an arbitrary host binary (#593).
+ */
+const ALLOWED_PYTHON_PATH_PREFIXES = [
+  "/usr/bin/",
+  "/usr/local/bin/",
+  "/opt/homebrew/bin/",
+  "/opt/homebrew/Cellar/python",
+  "/home/linuxbrew/.linuxbrew/bin/",
+  "/home/linuxbrew/.linuxbrew/Cellar/python",
+] as const;
+
+/**
+ * Resolve NAKAMA_PYTHON_BIN (or the default `python3`) against the allowlist.
+ * Called at spawn time so tests can change the env without reloading the module.
+ */
+export function resolvePythonBin(
+  raw: string | undefined = process.env.NAKAMA_PYTHON_BIN
+): string {
+  const value = raw?.trim() || "python3";
+
+  if (value.includes("\0")) {
+    throw new Error("NAKAMA_PYTHON_BIN contains a null byte.");
+  }
+
+  if (!(value.includes("/") || value.includes("\\"))) {
+    if (!ALLOWED_PYTHON_BASENAME.test(value)) {
+      throw new Error(
+        `NAKAMA_PYTHON_BIN bare name must match python or python3…; got "${value}".`
+      );
+    }
+    return value;
+  }
+
+  if (!path.isAbsolute(value)) {
+    throw new Error(
+      `NAKAMA_PYTHON_BIN must be an absolute path or a bare name (python3); got "${value}".`
+    );
+  }
+
+  let resolved = value;
+  try {
+    resolved = realpathSync(value);
+  } catch {
+    // Missing binary fails later at spawn; still enforce basename + prefix.
+  }
+
+  const basename = path.basename(resolved);
+  if (!ALLOWED_PYTHON_BASENAME.test(basename)) {
+    throw new Error(
+      `NAKAMA_PYTHON_BIN basename must match python or python3…; got "${basename}".`
+    );
+  }
+
+  if (
+    !ALLOWED_PYTHON_PATH_PREFIXES.some(
+      (prefix) =>
+        resolved === prefix.slice(0, -1) || resolved.startsWith(prefix)
+    )
+  ) {
+    throw new Error(
+      `NAKAMA_PYTHON_BIN path is not on the server allowlist: "${value}".`
+    );
+  }
+
+  return value;
+}
 
 export async function loadPythonTool(
   record: StoredToolRecord
@@ -61,7 +133,7 @@ async function runPythonTool(
   // converts the throw into `{ error: message }`.
   return spawnJsonTool({
     args: [modulePath],
-    bin: PYTHON_BIN,
+    bin: resolvePythonBin(),
     context,
     cwd: path.dirname(modulePath),
     input,

--- a/apps/server/src/services/python-tool-loader.ts
+++ b/apps/server/src/services/python-tool-loader.ts
@@ -71,10 +71,18 @@ export function resolvePythonBin(
   }
 
   if (
-    !ALLOWED_PYTHON_PATH_PREFIXES.some(
-      (prefix) =>
-        resolved === prefix.slice(0, -1) || resolved.startsWith(prefix)
-    )
+    !ALLOWED_PYTHON_PATH_PREFIXES.some((prefix) => {
+      if (prefix.endsWith("/")) {
+        return resolved === prefix.slice(0, -1) || resolved.startsWith(prefix);
+      }
+      // Homebrew Cellar formula dirs are `python` or `python@3.x` — require a
+      // path boundary so `…/Cellar/pythonfoo` cannot sneak through.
+      return (
+        resolved === prefix ||
+        resolved.startsWith(`${prefix}/`) ||
+        resolved.startsWith(`${prefix}@`)
+      );
+    })
   ) {
     throw new Error(
       `NAKAMA_PYTHON_BIN path is not on the server allowlist: "${value}".`


### PR DESCRIPTION
## Summary

`NAKAMA_PYTHON_BIN` must be a bare `python`/`python3…` name or an absolute interpreter under known system prefixes before a custom Python tool spawns.

**Before:** any env value was passed straight to `spawnJsonTool` as `bin`.
**After:** `resolvePythonBin()` allowlists bare names and paths under `/usr/bin`, `/usr/local/bin`, Homebrew bin/Cellar python trees (and linuxbrew equivalents), with a path boundary so `…/Cellar/pythonfoo` cannot sneak through.

Why safe:
1. Default `python3` unchanged — existing installs keep working
2. Reject happens before spawn, so a bad env fails closed with a clear error
3. Homebrew Cellar realpaths are covered so `/opt/homebrew/bin/python3` symlinks still resolve

Only extend the prefix list if a supported distro ships Python elsewhere (e.g. pyenv) and operators need it.

Closes #593

## Test plan
- [x] `bun test apps/server/src/services/python-tool-loader.test.ts` (21 pass)
- [ ] With default env, playground/custom Python tool still runs; with `NAKAMA_PYTHON_BIN=/tmp/python3`, tool run fails with allowlist error
