### PR TITLE
fix(web): match composio input and save button size

### DIFF
--- a/apps/web/src/components/ComposioSettingsCard.tsx
+++ b/apps/web/src/components/ComposioSettingsCard.tsx
@@ -270,7 +270,7 @@ function ComposioApiKeySection({
           className="min-w-[4.5rem] shrink-0"
           disabled={!canSave || savePending}
           onClick={onSave}
-          size="sm"
+          size="lg"
           type="button"
         >
           {savePending ? <Spinner className="size-4" /> : "Save"}


### PR DESCRIPTION
## Summary

Composio’s API key input and Save button now line up at the same height.

**Before:** Save was shorter than the input.
**After:** Both controls are 36px tall, using the existing large button size.

Why safe:
1. Only the button size changes.
2. Saving, validation, and key visibility behavior stay unchanged.

## Test plan
- [x] `bun x ultracite check apps/web/src/components/ComposioSettingsCard.tsx` — passed; commit hook also checked 1,303 files.
- [x] `npx react-doctor@latest --verbose --scope changed` — 100/100, no issues.
- [x] Browser check: both controls measure 36px with identical top positions.

## Screenshot

Isolated demo with an unsaved dummy key.

![Composio input and Save button at equal heights](https://github.com/user-attachments/assets/fb255bf1-d8c2-4014-8ac6-b166888592bf)
