### PR TITLE
fix(dev): restrict pre-commit formatting to staged files

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -9,7 +9,7 @@ fi
 
 # Run formatter, capturing the exit code so we can still re-stage and report
 FORMAT_EXIT_CODE=0
-bun x ultracite fix || FORMAT_EXIT_CODE=$?
+bun x ultracite fix --staged || FORMAT_EXIT_CODE=$?
 
 # Re-stage files that were already staged
 echo "$STAGED_FILES" | while IFS= read -r file; do

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prepare": "husky",
     "preview:docs": "bun run --cwd docs/website preview",
     "start": "bun run apps/server/dist/index.js",
-    "test": "bun run --workspaces --if-present test",
+    "test": "bun test scripts/pre-commit.test.ts && bun run --workspaces --if-present test",
     "view:cassettes": "bun run apps/server/src/testing/cassettes/serve.ts"
   },
   "overrides": {

--- a/scripts/pre-commit.test.ts
+++ b/scripts/pre-commit.test.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "bun:test";
+import { chmod, mkdtemp, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const root = resolve(import.meta.dir, "..");
+
+test.each(["staged file.ts", "notes.mdx"])(
+  "pre-commit formats only staged files when committing %s",
+  async (stagedFile) => {
+    const cwd = await mkdtemp(join(tmpdir(), "nakama-hook-"));
+    const git = (...args: string[]) => {
+      const result = Bun.spawnSync(["git", ...args], { cwd });
+      expect(result.exitCode, result.stderr.toString()).toBe(0);
+      return result.stdout.toString();
+    };
+    try {
+      git("init");
+      git("config", "core.autocrlf", "false");
+      git("config", "core.hooksPath", ".git/hooks");
+      git("config", "commit.gpgSign", "false");
+      git("config", "user.name", "Hook Test");
+      git("config", "user.email", "hook@example.invalid");
+      await Bun.write(
+        join(cwd, "untouched.ts"),
+        "export const untouched = 1;\n"
+      );
+      git("add", "untouched.ts");
+      git("commit", "-m", "baseline");
+
+      await symlink(
+        join(root, "node_modules"),
+        join(cwd, "node_modules"),
+        "junction"
+      );
+      await Bun.write(
+        join(cwd, "biome.jsonc"),
+        Bun.file(join(root, "biome.jsonc"))
+      );
+      const hook = join(cwd, ".git/hooks/pre-commit");
+      await Bun.write(
+        hook,
+        // Husky supplies the shell entry point in the real checkout.
+        "#!/bin/sh\n" +
+          (await Bun.file(join(root, ".husky/pre-commit")).text()).replaceAll(
+            "\r\n",
+            "\n"
+          )
+      );
+      await chmod(hook, 0o755);
+
+      const unformatted = "export const untouched={value:2}\n";
+      await Bun.write(join(cwd, "untouched.ts"), unformatted);
+      await Bun.write(join(cwd, "untracked.ts"), unformatted);
+      const staged = stagedFile.endsWith(".ts")
+        ? "export const staged={value:1}\n"
+        : "# Notes\n";
+      await Bun.write(join(cwd, stagedFile), staged);
+      git("add", "--", stagedFile);
+      git("commit", "-m", "exercise hook");
+
+      expect(await Bun.file(join(cwd, "untouched.ts")).text()).toBe(
+        unformatted
+      );
+      expect(await Bun.file(join(cwd, "untracked.ts")).text()).toBe(
+        unformatted
+      );
+      const committed = git("show", `HEAD:${stagedFile}`);
+      expect(committed).toBe(await Bun.file(join(cwd, stagedFile)).text());
+      if (stagedFile.endsWith(".ts")) {
+        expect(committed).not.toBe(staged);
+      }
+      expect(
+        git("diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD").trim()
+      ).toBe(stagedFile);
+    } finally {
+      await rm(cwd, { force: true, recursive: true });
+    }
+  },
+  30_000
+);


### PR DESCRIPTION
## Summary

Contributors can commit without the formatter rewriting unrelated working-tree files.

Closes #929. Assignment requested in the issue; not yet granted.

**Before:** any staged change, including docs, triggers repository-wide `ultracite fix`.
**After:** the existing hook uses `--staged`; only staged files are formatted and re-staged.

Why safe:
1. Uses Biome's native staged-file selection through Ultracite; no new dependencies or file-list parser.
2. Existing failure propagation and re-staging remain unchanged; docs-only commits succeed without touching TypeScript files.
3. Real-Git regression tests are included in the existing CI test command.

Residual: unstaged hunks inside a partially staged file retain the existing re-staging behavior; this change only limits which files are formatted.

## Test plan
- [x] `bun test scripts/pre-commit.test.ts` (2 pass on Windows/Bun 1.4.0 and Linux/Bun 1.3.14 in Podman; both failed before the fix). Covers a staged filename with spaces, docs-only commits, committed formatting, and unchanged unstaged/untracked files.
- [x] `bun x ultracite check package.json scripts/pre-commit.test.ts`, `bun run knip`, and the real commit hook passed. Latest-head CI passed. Post-CI ponytail/lean review followed by fresh correctness/spec review passed with no findings. Published for maintainer review; these agent reviews do not imply maintainer approval.
