### PR TITLE
fix(server): enforce request boundary limits

### DIFF
--- a/apps/server/src/http/app.test.ts
+++ b/apps/server/src/http/app.test.ts
@@ -11,7 +11,11 @@ import {
 import { AuthService } from "../services/auth-service";
 import { OrgService } from "../services/org-service";
 import { setupTestConfigDir } from "../test-config-dir";
-import { createHonoApp } from "./app";
+import {
+  createHonoApp,
+  DEFAULT_HTTP_REQUEST_BODY_LIMIT_BYTES,
+  MAX_HTTP_REQUEST_BODY_LIMIT_BYTES,
+} from "./app";
 import { createMinimalHonoApp } from "./test-app-helpers";
 import {
   buildSetupAuthBody,
@@ -96,6 +100,46 @@ function createServerOptions() {
 }
 
 describe("createHonoApp", () => {
+  test("rejects oversized request bodies before public route handlers", async () => {
+    const app = createHonoApp(createServerOptions());
+
+    const defaultLimitResponse = await app.fetch(
+      new Request("http://localhost:4310/v1/auth/login", {
+        body: "{}",
+        headers: {
+          "Content-Length": String(DEFAULT_HTTP_REQUEST_BODY_LIMIT_BYTES + 1),
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      })
+    );
+    expect(defaultLimitResponse.status).toBe(413);
+
+    const importWithinLimitResponse = await app.fetch(
+      new Request("http://localhost:4310/v1/auth/setup/import/preview", {
+        body: "{}",
+        headers: {
+          "Content-Length": String(DEFAULT_HTTP_REQUEST_BODY_LIMIT_BYTES + 1),
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      })
+    );
+    expect(importWithinLimitResponse.status).toBe(400);
+
+    const importLimitResponse = await app.fetch(
+      new Request("http://localhost:4310/v1/auth/setup/import/preview", {
+        body: "{}",
+        headers: {
+          "Content-Length": String(MAX_HTTP_REQUEST_BODY_LIMIT_BYTES + 1),
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      })
+    );
+    expect(importLimitResponse.status).toBe(413);
+  });
+
   test("liveness stays up while readiness tracks a closed and reopened database", async () => {
     const database = await createSqliteDatabase(":memory:");
     const { app } = createMinimalHonoApp({

--- a/apps/server/src/http/app.ts
+++ b/apps/server/src/http/app.ts
@@ -1,5 +1,6 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
 import { formatServerError, log, NakamaApiError } from "@nakama/core";
+import { bodyLimit } from "hono/body-limit";
 import { requestId } from "hono/request-id";
 import { tryServeStaticWeb } from "../static-web";
 import { createAuthMiddleware } from "./auth-middleware";
@@ -50,6 +51,18 @@ import type { HonoApp } from "./types";
  */
 const THEME_BOOTSTRAP_SCRIPT_HASH =
   "sha256-rQ5OTxagyMHDDSQ6k5wlUK8gtuYxXBrpQGqjAcYBz2w=";
+// Regular JSON can carry a 5 MiB attachment after base64 expansion. Full-data
+// imports accept a 100 MiB archive, which expands to roughly 134 MiB as base64.
+export const DEFAULT_HTTP_REQUEST_BODY_LIMIT_BYTES = 10 * 1024 * 1024;
+export const MAX_HTTP_REQUEST_BODY_LIMIT_BYTES = 140 * 1024 * 1024;
+const LARGE_BODY_ROUTES = new Set([
+  "/v1/auth/setup/import/preview",
+  "/v1/auth/setup/import/restore",
+  "/v1/platform/data/import/preview",
+  "/v1/platform/data/import/restore",
+  "/v1/profiles/pack/import",
+  "/v1/profiles/pack/import/preview",
+]);
 
 export function createHonoApp(options: ServerOptions) {
   const app: HonoApp = new OpenAPIHono();
@@ -136,6 +149,23 @@ export function createHonoApp(options: ServerOptions) {
     // Apply security headers to the final response
     const finalResponse = c.res;
     c.res = applySecurityHeaders(finalResponse);
+  });
+
+  const rejectOversizedBody = () =>
+    errorResponse("Request body is too large.", 413);
+  const defaultBodyLimit = bodyLimit({
+    maxSize: DEFAULT_HTTP_REQUEST_BODY_LIMIT_BYTES,
+    onError: rejectOversizedBody,
+  });
+  const importBodyLimit = bodyLimit({
+    maxSize: MAX_HTTP_REQUEST_BODY_LIMIT_BYTES,
+    onError: rejectOversizedBody,
+  });
+  app.use("*", (c, next) => {
+    const limit = LARGE_BODY_ROUTES.has(c.req.path)
+      ? importBodyLimit
+      : defaultBodyLimit;
+    return limit(c, next);
   });
 
   // Probes must work before setup/login; they reveal no tenant or config data.

--- a/apps/server/src/http/routes/data-portability.ts
+++ b/apps/server/src/http/routes/data-portability.ts
@@ -160,7 +160,10 @@ export function registerDataPortabilityRoutes(
 
   app.post("/v1/platform/data/import/preview", async (c) => {
     requirePlatformAdminFromContext(c);
-    const body = await readJson<PreviewDataImportRequest>(c.req.raw);
+    const body = await readJson<PreviewDataImportRequest>(
+      c.req.raw,
+      importRequestSchema
+    );
     // Decoded outside the catch so an oversized archive keeps its 413.
     const archive = decodeArchiveRequestData(body.data);
 
@@ -174,7 +177,10 @@ export function registerDataPortabilityRoutes(
 
   app.post("/v1/platform/data/import/restore", async (c) => {
     requirePlatformAdminFromContext(c);
-    const body = await readJson<RestoreDataImportRequest>(c.req.raw);
+    const body = await readJson<RestoreDataImportRequest>(
+      c.req.raw,
+      restoreRequestSchema
+    );
     const archive = decodeArchiveRequestData(body.data);
 
     let restore;

--- a/apps/server/src/http/routes/org-memory.test.ts
+++ b/apps/server/src/http/routes/org-memory.test.ts
@@ -22,6 +22,24 @@ function createApp() {
 const BASE = "http://localhost:4310";
 
 describe("org memory routes (v1)", () => {
+  test("rejects an unknown proposal status filter", async () => {
+    const { app, databaseAdapter } = createApp();
+    const adminSession = await setupFreshInstallSession(
+      app,
+      databaseAdapter,
+      "status-admin@org.com"
+    );
+    const orgId = adminSession.orgId!;
+
+    const response = await app.fetch(
+      new Request(`${BASE}/v1/orgs/${orgId}/memory/proposals?status=unknown`, {
+        headers: adminSession.headers({}, orgId),
+      })
+    );
+
+    expect(response.status).toBe(400);
+  });
+
   test("admin can add a fact, get memory, search, pin, unpin, archive", async () => {
     const { app, authService, databaseAdapter } = createApp();
     const adminSession = await setupFreshInstallSession(

--- a/apps/server/src/http/routes/org-memory.ts
+++ b/apps/server/src/http/routes/org-memory.ts
@@ -16,7 +16,12 @@ import {
   requireNotViewerFromContext,
   requireOrgAdminFromContext,
 } from "../org-guards";
-import { json, readJson, readOptionalJson } from "../shared";
+import {
+  json,
+  parseOptionalQueryEnum,
+  readJson,
+  readOptionalJson,
+} from "../shared";
 import type { HonoApp } from "../types";
 
 export function registerOrgMemoryRoutes(
@@ -693,11 +698,11 @@ export function registerOrgMemoryRoutes(
     const auth = requireOrgAdminFromContext(c);
     const orgId = resolveOrgId(c, auth.activeOrgId ?? "");
     const service = requireService();
-    const status = c.req.query("status") as
-      | "pending"
-      | "approved"
-      | "rejected"
-      | undefined;
+    const status = parseOptionalQueryEnum(c.req.query("status"), [
+      "pending",
+      "approved",
+      "rejected",
+    ]);
     const proposals = await service.listProposals(orgId, status);
     const pendingCount = await service.countPendingProposals(orgId);
     return json({ pendingCount, proposals });

--- a/apps/server/src/http/routes/profile-portability.ts
+++ b/apps/server/src/http/routes/profile-portability.ts
@@ -182,7 +182,10 @@ export function registerProfilePortabilityRoutes(
     const auth = requireOrgAdminOrPlatformAdminFromContext(c);
     const orgId = requireActiveOrgIdFromContext(c);
     const db = requireDatabase(options);
-    const body = await readJson<{ data: string; name?: string }>(c.req.raw);
+    const body = await readJson<{ data: string; name?: string }>(
+      c.req.raw,
+      importRequestSchema
+    );
 
     try {
       const preview = await previewProfilePackImport(
@@ -205,7 +208,10 @@ export function registerProfilePortabilityRoutes(
     const auth = requireOrgAdminOrPlatformAdminFromContext(c);
     const orgId = requireActiveOrgIdFromContext(c);
     const db = requireDatabase(options);
-    const body = await readJson<ProfilePackImportRequest>(c.req.raw);
+    const body = await readJson<ProfilePackImportRequest>(
+      c.req.raw,
+      restoreRequestSchema
+    );
 
     try {
       const imported = await importProfilePack(

--- a/apps/server/src/http/routes/setup-import.test.ts
+++ b/apps/server/src/http/routes/setup-import.test.ts
@@ -188,6 +188,28 @@ describe("setup import routes", () => {
     ).resolves.toBe("keep");
   });
 
+  test("wrong-typed setup import body is rejected before decoding", async () => {
+    const { app } = createApp();
+
+    const previewResponse = await app.fetch(
+      new Request("http://localhost:4310/v1/auth/setup/import/preview", {
+        body: JSON.stringify({ data: 42 }),
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+      })
+    );
+    expect(previewResponse.status).toBe(400);
+
+    const restoreResponse = await app.fetch(
+      new Request("http://localhost:4310/v1/auth/setup/import/restore", {
+        body: JSON.stringify({ confirm: "yes", data: "archive" }),
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+      })
+    );
+    expect(restoreResponse.status).toBe(400);
+  });
+
   test("setup import preview does not leak an unexpected error's message", async () => {
     const { app } = createApp();
     await writeFile(join(getUserConfigDir(), "config.ini"), "keep");

--- a/apps/server/src/http/routes/setup-import.ts
+++ b/apps/server/src/http/routes/setup-import.ts
@@ -128,7 +128,10 @@ export function registerSetupImportRoutes(
 
     await assertSetupImportAllowed(databaseAdapter);
 
-    const body = await readJson<PreviewDataImportRequest>(c.req.raw);
+    const body = await readJson<PreviewDataImportRequest>(
+      c.req.raw,
+      importRequestSchema
+    );
     // Decoded outside the catch so an oversized archive keeps its 413.
     const archive = decodeArchiveRequestData(body.data);
 
@@ -147,7 +150,10 @@ export function registerSetupImportRoutes(
 
     await assertSetupImportAllowed(databaseAdapter);
 
-    const body = await readJson<RestoreDataImportRequest>(c.req.raw);
+    const body = await readJson<RestoreDataImportRequest>(
+      c.req.raw,
+      restoreRequestSchema
+    );
     const archive = decodeArchiveRequestData(body.data);
 
     let restore;

--- a/apps/server/src/http/routes/skill-proposals.test.ts
+++ b/apps/server/src/http/routes/skill-proposals.test.ts
@@ -36,6 +36,24 @@ function createApp() {
 const BASE = "http://localhost:4310";
 
 describe("skill proposal routes (v1)", () => {
+  test("rejects an unknown status filter", async () => {
+    const { app, databaseAdapter } = createApp();
+    const adminSession = await setupFreshInstallSession(
+      app,
+      databaseAdapter,
+      "status-admin@org.com"
+    );
+    const orgId = adminSession.orgId!;
+
+    const response = await app.fetch(
+      new Request(`${BASE}/v1/orgs/${orgId}/skill-proposals?status=unknown`, {
+        headers: adminSession.headers({}, orgId),
+      })
+    );
+
+    expect(response.status).toBe(400);
+  });
+
   test("admin can list, approve, and reject proposals; member needs sessionId to list", async () => {
     const { app, authService, databaseAdapter, skillProposalService } =
       createApp();

--- a/apps/server/src/http/routes/skill-proposals.ts
+++ b/apps/server/src/http/routes/skill-proposals.ts
@@ -13,7 +13,7 @@ import {
   requireNotViewerFromContext,
   requireOrgAdminFromContext,
 } from "../org-guards";
-import { json } from "../shared";
+import { json, parseOptionalQueryEnum } from "../shared";
 import type { HonoApp } from "../types";
 
 export function registerSkillProposalRoutes(
@@ -96,11 +96,11 @@ export function registerSkillProposalRoutes(
     const auth = requireNotViewerFromContext(c);
     const orgId = resolveOrgId(c, auth.activeOrgId ?? "");
     const service = requireService();
-    const status = c.req.query("status") as
-      | "pending"
-      | "approved"
-      | "rejected"
-      | undefined;
+    const status = parseOptionalQueryEnum(c.req.query("status"), [
+      "pending",
+      "approved",
+      "rejected",
+    ]);
     const profileId = c.req.query("profileId");
     const sessionId = c.req.query("sessionId");
     const isOrgAdmin = auth.orgRole === "admin" || auth.isPlatformAdmin;

--- a/apps/server/src/http/routes/skill-suggestions.test.ts
+++ b/apps/server/src/http/routes/skill-suggestions.test.ts
@@ -47,6 +47,24 @@ function createApp() {
 const BASE = "http://localhost:4310";
 
 describe("skill suggestion routes (v1)", () => {
+  test("rejects an unknown status filter", async () => {
+    const { app, databaseAdapter } = createApp();
+    const adminSession = await setupFreshInstallSession(
+      app,
+      databaseAdapter,
+      "status-admin@org.com"
+    );
+    const orgId = adminSession.orgId!;
+
+    const response = await app.fetch(
+      new Request(`${BASE}/v1/orgs/${orgId}/skill-suggestions?status=unknown`, {
+        headers: adminSession.headers({}, orgId),
+      })
+    );
+
+    expect(response.status).toBe(400);
+  });
+
   test("admin can list and apply suggestions; member can too; viewer is forbidden", async () => {
     const { app, databaseAdapter, skillSuggestionService } = createApp();
     const adminSession = await setupFreshInstallSession(

--- a/apps/server/src/http/routes/skill-suggestions.ts
+++ b/apps/server/src/http/routes/skill-suggestions.ts
@@ -10,7 +10,7 @@ import {
 } from "../../services/skill-suggestion-service";
 import type { ServerOptions } from "../context";
 import { requireNotViewerFromContext } from "../org-guards";
-import { json } from "../shared";
+import { json, parseOptionalQueryEnum } from "../shared";
 import type { HonoApp } from "../types";
 
 export function registerSkillSuggestionRoutes(
@@ -94,7 +94,10 @@ export function registerSkillSuggestionRoutes(
     const orgId = resolveOrgId(c, auth.activeOrgId ?? "");
     const service = requireService();
     const sessionId = c.req.query("sessionId");
-    const status = c.req.query("status") as "pending" | "applied" | undefined;
+    const status = parseOptionalQueryEnum(c.req.query("status"), [
+      "pending",
+      "applied",
+    ]);
     const profileId = c.req.query("profileId");
     const suggestions = await service.listSuggestions(orgId, {
       profileId: profileId || undefined,

--- a/apps/server/src/http/shared.test.ts
+++ b/apps/server/src/http/shared.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { readOptionalJson } from "./shared";
+import { z } from "zod";
+import { parseOptionalQueryEnum, readJson, readOptionalJson } from "./shared";
 
 const URL = "http://localhost:4310/test";
 
@@ -18,5 +19,54 @@ describe("readOptionalJson", () => {
     await expect(readOptionalJson(request, {})).rejects.toMatchObject({
       status: 400,
     });
+  });
+});
+
+describe("readJson", () => {
+  const schema = z.object({ enabled: z.boolean() });
+
+  test("returns schema-validated JSON", async () => {
+    const request = new Request(URL, {
+      body: JSON.stringify({ enabled: true }),
+      method: "POST",
+    });
+
+    await expect(readJson(request, schema)).resolves.toEqual({ enabled: true });
+  });
+
+  test("rejects a wrong-typed body", async () => {
+    const request = new Request(URL, {
+      body: JSON.stringify({ enabled: "yes" }),
+      method: "POST",
+    });
+
+    await expect(readJson(request, schema)).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+
+  test("preserves malformed JSON rejection", async () => {
+    const request = new Request(URL, { body: "{", method: "POST" });
+
+    await expect(readJson(request, schema)).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+});
+
+describe("parseOptionalQueryEnum", () => {
+  test("accepts known and absent values", () => {
+    expect(parseOptionalQueryEnum("pending", ["pending", "applied"])).toBe(
+      "pending"
+    );
+    expect(parseOptionalQueryEnum(undefined, ["pending", "applied"])).toBe(
+      undefined
+    );
+  });
+
+  test("rejects unknown values", () => {
+    expect(() =>
+      parseOptionalQueryEnum("unknown", ["pending", "applied"])
+    ).toThrow();
   });
 });

--- a/apps/server/src/http/shared.ts
+++ b/apps/server/src/http/shared.ts
@@ -23,6 +23,7 @@ import type {
 } from "@nakama/db";
 import { ensureLocalClientAccess } from "@nakama/db";
 import type { Context } from "hono";
+import type { ZodType } from "zod";
 import type { AuthService } from "../services/auth-service";
 import { sessionTurnRegistry } from "../services/session-turn-registry";
 import type { AppEnv } from "./types";
@@ -371,15 +372,40 @@ export function assertJsonRequest(request: Request): void {
   }
 }
 
-export async function readJson<T>(request: Request): Promise<T> {
+export async function readJson<T>(
+  request: Request,
+  schema?: ZodType<T>
+): Promise<T> {
   try {
-    return (await request.json()) as T;
+    const body = (await request.json()) as unknown;
+    if (!schema) {
+      return body as T;
+    }
+
+    const parsed = schema.safeParse(body);
+    if (!parsed.success) {
+      throw new NakamaApiError("Invalid request body.", 400);
+    }
+    return parsed.data;
   } catch (err) {
     if (err instanceof SyntaxError) {
       throw new NakamaApiError("Invalid JSON in request body.", 400);
     }
     throw err;
   }
+}
+
+export function parseOptionalQueryEnum<const T extends string>(
+  value: string | undefined,
+  allowed: readonly T[]
+): T | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (allowed.includes(value as T)) {
+    return value as T;
+  }
+  throw new NakamaApiError("Invalid query parameter.", 400);
 }
 
 export async function readOptionalJson<T>(

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -39,7 +39,7 @@ import {
   ensureBundledSkillsAssigned,
   seedDatabase,
 } from "@nakama/db";
-import { createHonoApp } from "./http/app";
+import { createHonoApp, MAX_HTTP_REQUEST_BODY_LIMIT_BYTES } from "./http/app";
 import {
   disableBunIdleTimeoutForLongHeldRequest,
   disableBunIdleTimeoutForSse,
@@ -388,6 +388,7 @@ function startServer(options: {
         },
         hostname: options.host,
         idleTimeout: 255,
+        maxRequestBodySize: MAX_HTTP_REQUEST_BODY_LIMIT_BYTES,
         port,
       });
     } catch (error) {


### PR DESCRIPTION
## Summary

Reject oversized API bodies and invalid import/filter input before services run.

**Before:** every route accepted unbounded bodies, import schemas were documentation-only, and unknown `status` values reached services.
**After:** normal bodies cap at 10 MiB, known imports cap at 140 MiB, six import handlers validate their schemas, and three status filters reject unknown values.

Why safe:
1. Hono rejects oversized bodies before JSON parsing, while Bun enforces the same hard ceiling at the server boundary.
2. The import allowance preserves the documented 100 MiB archive flow after base64 expansion and reuses existing request schemas.

Only extend schema-aware parsing to remaining mutating routes once each route has a real request schema.

## Test plan
- [x] `bun test apps/server/src/http` (284 pass)
- [x] `bun run check`, `bun run knip`, `bun run build`
- [ ] Send an 11 MiB JSON body to a normal route and confirm HTTP 413

Progresses #357
