### PR TITLE
feat(telegram): per-org bot credentials and one bot per identity

### DIFF
--- a/apps/platform/telegram/src/auth-store.ts
+++ b/apps/platform/telegram/src/auth-store.ts
@@ -1,4 +1,7 @@
-import type { TelegramConfigFile } from "@nakama/core/telegram-config";
+import type {
+  TelegramConfigFile,
+  TelegramConfigScope,
+} from "@nakama/core/telegram-config";
 import {
   isTelegramUserAuthorized,
   loadTelegramConfigFile,
@@ -8,8 +11,10 @@ import {
 export class TelegramAuthStore {
   private config: TelegramConfigFile | null = null;
 
+  constructor(private readonly orgId: TelegramConfigScope) {}
+
   async reload(): Promise<TelegramConfigFile | null> {
-    this.config = await loadTelegramConfigFile();
+    this.config = await loadTelegramConfigFile(this.orgId);
     return this.config;
   }
 
@@ -29,7 +34,11 @@ export class TelegramAuthStore {
     handshakeInput: string,
     userId: number
   ): Promise<{ ok: boolean; message: string }> {
-    const result = await verifyAndPairTelegramUser(handshakeInput, userId);
+    const result = await verifyAndPairTelegramUser(
+      this.orgId,
+      handshakeInput,
+      userId
+    );
     await this.reload();
     return result;
   }

--- a/apps/platform/telegram/src/chat-handler.test.ts
+++ b/apps/platform/telegram/src/chat-handler.test.ts
@@ -33,6 +33,12 @@ import {
   writeTelegramConfigIni,
 } from "./test-helpers";
 
+const TEST_CONFIG = {
+  botToken: "1234567890:TEST",
+  orgId: null,
+  profileId: "default",
+};
+
 // These handler tests run in ~0.2s locally but occasionally exceed the 5000ms
 // default under CI's concurrent all-workspace load. Give them more headroom.
 setDefaultTimeout(10_000);
@@ -78,7 +84,7 @@ describe("createChatHandler group chats", () => {
           pairedUserIds: [42],
         });
 
-        const authStore = new TelegramAuthStore();
+        const authStore = new TelegramAuthStore(null);
         await authStore.reload();
         const { client, calls } = createMockClient();
         const sessionStore = new SessionStore(
@@ -89,7 +95,7 @@ describe("createChatHandler group chats", () => {
         const handleMessage = createChatHandler({
           authStore,
           client,
-          config: { botToken: "1234567890:TEST", profileId: "default" },
+          config: TEST_CONFIG,
           getBotInfo: () => TEST_BOT_INFO,
           orgStore,
           sessionStore,
@@ -135,7 +141,7 @@ describe("createChatHandler group chats", () => {
         pairedUserIds: [42],
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, calls } = createMockClient();
       const sessionStore = new SessionStore(
@@ -146,7 +152,7 @@ describe("createChatHandler group chats", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         getBotInfo: () => TEST_BOT_INFO,
         orgStore,
         sessionStore,
@@ -177,7 +183,7 @@ describe("createChatHandler group chats", () => {
         profileId: "research",
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, calls, getLastCreateSessionProfileId } = createMockClient(
         {
@@ -195,7 +201,7 @@ describe("createChatHandler group chats", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "research" },
+        config: { ...TEST_CONFIG, profileId: "research" },
         getBotInfo: () => TEST_BOT_INFO,
         orgStore,
         sessionStore,
@@ -236,7 +242,7 @@ describe("createChatHandler group chats", () => {
         pairedUserIds: [42],
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, getLastCreateSessionProfileId } = createMockClient({
         profiles: [
@@ -252,7 +258,7 @@ describe("createChatHandler group chats", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         getBotInfo: () => TEST_BOT_INFO,
         orgStore,
         sessionStore,
@@ -294,7 +300,7 @@ describe("createChatHandler group chats", () => {
         pairedUserIds: [42],
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client } = createMockClient({
         profiles: [
@@ -310,7 +316,7 @@ describe("createChatHandler group chats", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         getBotInfo: () => TEST_BOT_INFO,
         orgStore,
         sessionStore,
@@ -345,7 +351,7 @@ describe("createChatHandler group chats", () => {
         pairedUserIds: [42],
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client } = createMockClient({
         profiles: [
@@ -367,7 +373,7 @@ describe("createChatHandler group chats", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         getBotInfo: () => TEST_BOT_INFO,
         orgStore,
         sessionStore,
@@ -404,7 +410,7 @@ describe("createChatHandler group chats", () => {
         pairedUserIds: [42],
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, getLastCreateSessionProfileId } = createMockClient({
         profiles: [
@@ -420,7 +426,7 @@ describe("createChatHandler group chats", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         getBotInfo: () => TEST_BOT_INFO,
         orgStore,
         sessionStore,
@@ -447,7 +453,7 @@ describe("createChatHandler group chats", () => {
         pairedUserIds: [42],
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, calls } = createMockClient({
         orgs: createMultiTestOrgs(),
@@ -466,7 +472,7 @@ describe("createChatHandler group chats", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         getBotInfo: () => TEST_BOT_INFO,
         orgStore,
         sessionStore,
@@ -497,7 +503,7 @@ describe("createChatHandler group chats", () => {
         pairedUserIds: [42],
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, getStreamControls } = createMockClient({
         autoComplete: false,
@@ -511,7 +517,7 @@ describe("createChatHandler group chats", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         getBotInfo: () => TEST_BOT_INFO,
         orgStore,
         sessionStore,
@@ -575,7 +581,7 @@ describe("createChatHandler group chats", () => {
         handshakeCode: "ABCD1234",
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, calls } = createMockClient();
       const sessionStore = new SessionStore(
@@ -586,7 +592,7 @@ describe("createChatHandler group chats", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         getBotInfo: () => TEST_BOT_INFO,
         orgStore,
         sessionStore,
@@ -617,7 +623,7 @@ describe("createChatHandler group chats", () => {
         pairedUserIds: [42],
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client } = createMockClient({ orgs: createMultiTestOrgs() });
       const sessionStore = new SessionStore(
@@ -628,7 +634,7 @@ describe("createChatHandler group chats", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         getBotInfo: () => TEST_BOT_INFO,
         orgStore,
         sessionStore,
@@ -656,7 +662,7 @@ describe("createChatHandler security", () => {
         handshakeCode: "ABCD1234",
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, calls } = createMockClient();
       const sessionStore = new SessionStore(
@@ -667,7 +673,7 @@ describe("createChatHandler security", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -689,7 +695,7 @@ describe("createChatHandler security", () => {
         handshakeCode: "ABCD1234",
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, calls } = createMockClient();
       const sessionStore = new SessionStore(
@@ -700,7 +706,7 @@ describe("createChatHandler security", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -726,7 +732,7 @@ describe("createChatHandler security", () => {
         handshakeCode: "ABCD1234",
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, calls } = createMockClient();
       const sessionStore = new SessionStore(
@@ -737,7 +743,7 @@ describe("createChatHandler security", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -764,7 +770,7 @@ describe("createChatHandler security", () => {
         handshakeCode: "ABCD1234",
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, calls } = createMockClient();
       const sessionStore = new SessionStore(
@@ -775,7 +781,7 @@ describe("createChatHandler security", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -814,7 +820,7 @@ describe("createChatHandler security", () => {
         profileId: "missing_profile",
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, calls, getLastCreateSessionProfileId } = createMockClient(
         {
@@ -829,7 +835,7 @@ describe("createChatHandler security", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "missing_profile" },
+        config: { ...TEST_CONFIG, profileId: "missing_profile" },
         orgStore,
         sessionStore,
       });
@@ -859,7 +865,7 @@ describe("createChatHandler security", () => {
         handshakeCode: "ABCD1234",
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client } = createMockClient();
       const sessionStore = new SessionStore(
@@ -870,7 +876,7 @@ describe("createChatHandler security", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -900,7 +906,7 @@ describe("createChatHandler security", () => {
         botToken: "1234567890:TEST",
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, calls } = createMockClient();
       const sessionStore = new SessionStore(
@@ -911,7 +917,7 @@ describe("createChatHandler security", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -936,7 +942,7 @@ describe("createChatHandler security", () => {
         botToken: "1234567890:TEST",
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, calls } = createMockClient();
       const sessionStore = new SessionStore(
@@ -947,7 +953,7 @@ describe("createChatHandler security", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -972,7 +978,7 @@ describe("createChatHandler security", () => {
         botToken: "1234567890:TEST",
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, calls, getStreamControl } = createMockClient({
         autoComplete: false,
@@ -986,7 +992,7 @@ describe("createChatHandler security", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -1028,7 +1034,7 @@ describe("createChatHandler security", () => {
         botToken: "1234567890:TEST",
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client } = createMockClient();
       const sessionStore = new SessionStore(
@@ -1039,7 +1045,7 @@ describe("createChatHandler security", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -1062,7 +1068,7 @@ describe("createChatHandler security", () => {
         botToken: "1234567890:TEST",
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client } = createMockClient({
         steps: [
@@ -1093,7 +1099,7 @@ describe("createChatHandler security", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -1131,7 +1137,7 @@ describe("createChatHandler security", () => {
         botToken: "1234567890:TEST",
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client } = createMockClient({
         steps: [
@@ -1149,7 +1155,7 @@ describe("createChatHandler security", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -1173,7 +1179,7 @@ describe("createChatHandler security", () => {
         botToken: "1234567890:TEST",
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, getStreamControl } = createMockClient({
         autoComplete: false,
@@ -1196,7 +1202,7 @@ describe("createChatHandler security", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -1246,7 +1252,7 @@ describe("createChatHandler security", () => {
         botToken: "1234567890:TEST",
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client } = createMockClient({
         steps: [
@@ -1269,7 +1275,7 @@ describe("createChatHandler security", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -1302,7 +1308,7 @@ describe("createChatHandler security", () => {
         botToken: "1234567890:TEST",
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client } = createMockClient({
         steps: [
@@ -1332,7 +1338,7 @@ describe("createChatHandler security", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -1365,7 +1371,7 @@ describe("createChatHandler security", () => {
         handshakeCode: "ABCD1234",
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, calls } = createMockClient();
       const sessionStore = new SessionStore(
@@ -1376,7 +1382,7 @@ describe("createChatHandler security", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -1401,7 +1407,7 @@ describe("createChatHandler security", () => {
         botToken: "1234567890:TEST",
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, calls } = createMockClient();
       const sessionStore = new SessionStore(
@@ -1412,7 +1418,7 @@ describe("createChatHandler security", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -1436,7 +1442,7 @@ describe("createChatHandler security", () => {
         botToken: "1234567890:TEST",
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, calls } = createMockClient();
       const sessionStore = new SessionStore(
@@ -1447,7 +1453,7 @@ describe("createChatHandler security", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -1473,7 +1479,7 @@ describe("bridge API integration", () => {
         pairedUserIds: [1001],
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, calls, orgIds } = createMockClient();
       const sessionStore = new SessionStore(
@@ -1484,7 +1490,7 @@ describe("bridge API integration", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -1508,7 +1514,7 @@ describe("bridge API integration", () => {
         pairedUserIds: [1001],
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client } = createMockClient();
       const sessionStore = new SessionStore(
@@ -1519,7 +1525,7 @@ describe("bridge API integration", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -1544,7 +1550,7 @@ describe("bridge API integration", () => {
         pairedUserIds: [1001],
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, calls } = createMockClient({
         orgs: createMultiTestOrgs(),
@@ -1557,7 +1563,7 @@ describe("bridge API integration", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -1581,7 +1587,7 @@ describe("bridge API integration", () => {
         pairedUserIds: [1001],
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, calls, orgIds } = createMockClient({
         orgs: createMultiTestOrgs(),
@@ -1594,7 +1600,7 @@ describe("bridge API integration", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -1620,7 +1626,7 @@ describe("bridge API integration", () => {
         pairedUserIds: [1001],
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client } = createMockClient({
         profiles: [
@@ -1636,7 +1642,7 @@ describe("bridge API integration", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -1660,7 +1666,7 @@ describe("bridge API integration", () => {
         pairedUserIds: [1001],
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client } = createMockClient({
         profiles: [
@@ -1676,7 +1682,7 @@ describe("bridge API integration", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -1700,7 +1706,7 @@ describe("bridge API integration", () => {
         pairedUserIds: [1001],
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, calls, getLastCreateSessionProfileId } = createMockClient(
         {
@@ -1718,7 +1724,7 @@ describe("bridge API integration", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -1749,7 +1755,7 @@ describe("bridge API integration", () => {
         pairedUserIds: [1001],
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, getLastCreateSessionProfileId } = createMockClient({
         orgs: createMultiTestOrgs(),
@@ -1768,7 +1774,7 @@ describe("bridge API integration", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -1794,7 +1800,7 @@ describe("bridge API integration", () => {
         pairedUserIds: [1001],
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, listProfilesOrgIds } = createMockClient({
         orgs: createMultiTestOrgs(),
@@ -1813,7 +1819,7 @@ describe("bridge API integration", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -1840,7 +1846,7 @@ describe("bridge API integration", () => {
         pairedUserIds: [1001],
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, getLastCreateSessionProfileId } = createMockClient({
         orgs: createMultiTestOrgs(),
@@ -1865,7 +1871,7 @@ describe("bridge API integration", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -1929,7 +1935,7 @@ describe("createChatHandler document attachments", () => {
         })
       );
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, calls, getLastStreamInput } = createMockClient();
       const sessionStore = new SessionStore(
@@ -1940,7 +1946,7 @@ describe("createChatHandler document attachments", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -1977,7 +1983,7 @@ describe("createChatHandler document attachments", () => {
 
       fetchSpy = spyOn(globalThis, "fetch");
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, calls } = createMockClient();
       const sessionStore = new SessionStore(
@@ -1988,7 +1994,7 @@ describe("createChatHandler document attachments", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -2015,7 +2021,7 @@ describe("createChatHandler document attachments", () => {
         botToken: "1234567890:TEST",
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
         new Response(Buffer.from("voice-bytes"), {
@@ -2032,7 +2038,7 @@ describe("createChatHandler document attachments", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -2066,7 +2072,7 @@ describe("createChatHandler document attachments", () => {
         botToken: "1234567890:TEST",
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, calls } = createMockClient();
       const sessionStore = new SessionStore(
@@ -2077,7 +2083,7 @@ describe("createChatHandler document attachments", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -2151,7 +2157,7 @@ describe("createChatHandler artifact delivery", () => {
         pairedUserIds: [4242],
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, calls } = createMockClient({
         messages: artifactMessages,
@@ -2171,7 +2177,7 @@ describe("createChatHandler artifact delivery", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -2198,7 +2204,7 @@ describe("createChatHandler artifact delivery", () => {
         pairedUserIds: [4242],
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, calls } = createMockClient({
         messages: [
@@ -2240,7 +2246,7 @@ describe("createChatHandler artifact delivery", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -2263,7 +2269,7 @@ describe("createChatHandler artifact delivery", () => {
         pairedUserIds: [4242],
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, calls } = createMockClient();
       const sessionStore = new SessionStore(
@@ -2292,7 +2298,7 @@ describe("createChatHandler artifact delivery", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -2324,7 +2330,7 @@ describe("stream cleanup", () => {
         botToken: "1234567890:TEST",
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, getStreamControl } = createMockClient({
         autoComplete: false,
@@ -2338,7 +2344,7 @@ describe("stream cleanup", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });
@@ -2403,7 +2409,7 @@ describe("createChatHandler session hot cache", () => {
         pairedUserIds: [4242],
       });
 
-      const authStore = new TelegramAuthStore();
+      const authStore = new TelegramAuthStore(null);
       await authStore.reload();
       const { client, calls } = createMockClient();
       const sessionStore = new SessionStore(
@@ -2421,7 +2427,7 @@ describe("createChatHandler session hot cache", () => {
       const handleMessage = createChatHandler({
         authStore,
         client,
-        config: { botToken: "1234567890:TEST", profileId: "default" },
+        config: TEST_CONFIG,
         orgStore,
         sessionStore,
       });

--- a/apps/platform/telegram/src/chat-handler.ts
+++ b/apps/platform/telegram/src/chat-handler.ts
@@ -538,6 +538,13 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     channelOrgKey: string,
     messageText: string | undefined
   ): Promise<boolean> {
+    // A bot owned by an org answers only for that org, so neither the picker
+    // nor a stored per-user selection may move the chat to another tenant.
+    if (config.orgId) {
+      client.setOrgId(config.orgId);
+      return true;
+    }
+
     const orgContext = await prepareChannelOrgContext({
       getSelectedOrgId: () => getOrgSelection(orgStore, channelOrgKey)?.orgId,
       listOrgs: () => client.listUserOrgs(),
@@ -574,6 +581,11 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     conversationKey: string,
     telegram: TelegramRichMessenger
   ): Promise<void> {
+    if (config.orgId) {
+      await telegram.send("This bot serves a single organization.");
+      return;
+    }
+
     const { orgs } = await client.listUserOrgs();
 
     if (orgs.length === 0) {

--- a/apps/platform/telegram/src/config.ts
+++ b/apps/platform/telegram/src/config.ts
@@ -1,33 +1,66 @@
 import {
   DEFAULT_TELEGRAM_PROFILE_ID,
   getTelegramConfigPath,
+  listTelegramConfigOrgIds,
   loadTelegramConfigFile,
   resolveTelegramConfigFromSources,
+  type TelegramConfigScope,
 } from "@nakama/core/telegram-config";
 
 export interface TelegramBridgeConfig {
   botToken: string;
+  /** Org that owns this bot, or null for the install-wide config. */
+  orgId: TelegramConfigScope;
   profileId: string;
 }
 
-export async function loadConfig(
+/**
+ * Every identity this install should run: the install-wide config plus one per
+ * org that saved its own. Ordered so the install-wide bot keeps its place.
+ */
+export async function loadTelegramIdentities(
   env: Record<string, string | undefined> = process.env
-): Promise<TelegramBridgeConfig> {
-  const file = await loadTelegramConfigFile();
-  const resolved = resolveTelegramConfigFromSources({ env, file });
+): Promise<TelegramBridgeConfig[]> {
+  const scopes: TelegramConfigScope[] = [
+    null,
+    ...(await listTelegramConfigOrgIds()),
+  ];
+  const identities: TelegramBridgeConfig[] = [];
+
+  for (const scope of scopes) {
+    const config = await loadConfigOrNull(scope, env);
+
+    if (config) {
+      identities.push(config);
+    }
+  }
+
+  if (identities.length === 0) {
+    throw new Error(formatNotConfiguredMessage());
+  }
+
+  return identities;
+}
+
+async function loadConfigOrNull(
+  orgId: TelegramConfigScope,
+  env: Record<string, string | undefined>
+): Promise<TelegramBridgeConfig | null> {
+  const file = await loadTelegramConfigFile(orgId);
+  // TELEGRAM_BOT_TOKEN is an install-wide override, so it must not leak into an
+  // org's identity and give two scopes the same token.
+  const resolved = resolveTelegramConfigFromSources({
+    env: orgId === null ? env : {},
+    file,
+  });
 
   if (!resolved) {
-    const hasEnvToken = Boolean(env.TELEGRAM_BOT_TOKEN?.trim());
-
-    if (!(hasEnvToken || file)) {
-      throw new Error(formatNotConfiguredMessage());
-    }
-
-    throw new Error(`${formatNotConfiguredMessage()}\n\nMissing: bot token.`);
+    return null;
   }
 
   return {
     botToken: resolved.botToken,
+    orgId,
     profileId: resolved.profileId || DEFAULT_TELEGRAM_PROFILE_ID,
   };
 }
@@ -44,6 +77,6 @@ function formatNotConfiguredMessage(): string {
     "  5. Message your bot and paste the pairing code once",
     "",
     "Or set env var: TELEGRAM_BOT_TOKEN",
-    `Config file: ${getTelegramConfigPath()}`,
+    `Config file: ${getTelegramConfigPath(null)}`,
   ].join("\n");
 }

--- a/apps/platform/telegram/src/index.ts
+++ b/apps/platform/telegram/src/index.ts
@@ -6,10 +6,7 @@ import {
   log,
 } from "@nakama/core";
 import { hasActiveStreams } from "@nakama/core/channel-active-stream";
-import {
-  ChannelOrgStore,
-  getChannelOrgSelectionPath,
-} from "@nakama/core/channel-org";
+import { ChannelOrgStore } from "@nakama/core/channel-org";
 import { ChannelSessionStore } from "@nakama/core/channel-session-store";
 import {
   ensureServerRunning,
@@ -19,28 +16,28 @@ import { loadLocalAuthToken } from "@nakama/core/local-auth";
 import { resolveWebPublicUrl } from "@nakama/core/runtime";
 import { getTelegramConfigDir } from "@nakama/core/telegram-config";
 import {
-  clearTelegramWorkerHeartbeat,
+  createTelegramWorkerHeartbeat,
   isHeartbeatAlive,
-  readTelegramWorkerHeartbeat,
-  writeTelegramWorkerHeartbeat,
 } from "@nakama/core/telegram-worker";
 import { TelegramAuthStore } from "./auth-store";
 import { createBot } from "./bot";
-import { loadConfig } from "./config";
+import { loadTelegramIdentities, type TelegramBridgeConfig } from "./config";
 
 installErrorHandlers("worker:telegram");
 void installErrorTrackingSink();
 
+type StartedIdentity = {
+  clearHeartbeat: () => Promise<void>;
+  stop: () => void;
+  writeHeartbeat: () => Promise<void>;
+};
+
 let spawnedChild: Bun.Subprocess | null = null;
-let botStop: (() => void) | null = null;
 let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+const started: StartedIdentity[] = [];
 
 registerCleanupHandlers(() => {
-  botStop?.();
-  if (heartbeatTimer) {
-    clearInterval(heartbeatTimer);
-  }
-  void clearTelegramWorkerHeartbeat();
+  stopAll();
   if (hasActiveStreams()) {
     console.warn(
       "Leaving the spawned Nakama server running so in-flight agent turns can finish; the next worker start will reuse it."
@@ -51,40 +48,21 @@ registerCleanupHandlers(() => {
 });
 
 try {
-  const existingHeartbeat = await readTelegramWorkerHeartbeat();
-
-  if (
-    existingHeartbeat &&
-    existingHeartbeat.pid !== process.pid &&
-    isHeartbeatAlive(existingHeartbeat)
-  ) {
-    console.error(
-      `Another Nakama Telegram bridge is already running (pid ${existingHeartbeat.pid}). ` +
-        "Stop the existing bridge worker or disable it in the dashboard before starting a new one."
-    );
-    process.exit(1);
-  }
-
-  const config = await loadConfig();
+  const identities = await loadTelegramIdentities();
   const { serverUrl, spawnedChild: child } = await ensureServerRunning();
   spawnedChild = child;
 
-  const client = new NakamaClient({
-    authToken:
-      (await loadLocalAuthToken("telegram@nakama.internal")) ?? undefined,
+  const authToken =
+    (await loadLocalAuthToken("telegram@nakama.internal")) ?? undefined;
+  const probe = new NakamaClient({
+    authToken,
     baseUrl: serverUrl,
     clientOrigin: resolveWebPublicUrl(),
   });
-  const health = await client.health();
-
-  if (!health.providerConfigured) {
-    console.warn(
-      "Server has no provider configured. Chat runs in offline mode until an API key is set."
-    );
-  }
+  const health = await probe.health();
 
   try {
-    await client.listUserOrgs();
+    await probe.listUserOrgs();
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error(
@@ -95,15 +73,91 @@ try {
     process.exit(1);
   }
 
+  if (!health.providerConfigured) {
+    console.warn(
+      "Server has no provider configured. Chat runs in offline mode until an API key is set."
+    );
+  }
+
+  const running: Promise<void>[] = [];
+
+  for (const config of identities) {
+    const bot = await startIdentity(config, serverUrl, authToken);
+
+    if (bot) {
+      running.push(bot);
+    }
+  }
+
+  if (running.length === 0) {
+    console.error(
+      "Every configured Telegram bot is already claimed by a running bridge."
+    );
+    process.exit(1);
+  }
+
+  log("info", "worker.started", {
+    count: running.length,
+    worker: "telegram",
+  });
+  console.log(`Server: ${serverUrl}`);
+
+  heartbeatTimer = setInterval(() => {
+    for (const identity of started) {
+      void identity.writeHeartbeat();
+    }
+  }, 15_000);
+
+  await Promise.all(running);
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  stopAll();
+  // Await before exit: void + process.exit can leave a stale heartbeat file.
+  await Promise.all(started.map((identity) => identity.clearHeartbeat()));
+  stopSpawnedServer(spawnedChild);
+  process.exit(1);
+} finally {
+  stopSpawnedServer(spawnedChild);
+}
+
+/**
+ * Starts one bot for one config scope, or returns null when another process
+ * already holds that identity. Telegram drops updates for whichever poller is
+ * not last, so a second claim has to be refused rather than raced.
+ */
+async function startIdentity(
+  config: TelegramBridgeConfig,
+  serverUrl: string,
+  authToken: string | undefined
+): Promise<Promise<void> | null> {
+  const label = config.orgId ? `org ${config.orgId}` : "install-wide config";
+  const heartbeat = createTelegramWorkerHeartbeat(config.orgId);
+  const existing = await heartbeat.read();
+
+  if (existing && existing.pid !== process.pid && isHeartbeatAlive(existing)) {
+    console.error(
+      `Another Nakama Telegram bridge already runs the ${label} bot (pid ${existing.pid}). Skipping it.`
+    );
+    return null;
+  }
+
+  const configDir = getTelegramConfigDir(config.orgId);
+  const client = new NakamaClient({
+    authToken,
+    baseUrl: serverUrl,
+    clientOrigin: resolveWebPublicUrl(),
+  });
+
   const sessionStore = new ChannelSessionStore(
-    join(getTelegramConfigDir(), "chat-sessions.json")
+    join(configDir, "chat-sessions.json")
   );
   await sessionStore.load();
 
-  const orgStore = new ChannelOrgStore(getChannelOrgSelectionPath("telegram"));
+  const orgStore = new ChannelOrgStore(join(configDir, "org-selection.json"));
   await orgStore.load();
 
-  const authStore = new TelegramAuthStore();
+  const authStore = new TelegramAuthStore(config.orgId);
   await authStore.reload();
 
   const bot = await createBot(config, {
@@ -113,43 +167,39 @@ try {
     sessionStore,
   });
 
-  log("info", "worker.started", { worker: "telegram" });
-  console.log(`Server: ${serverUrl}`);
-  console.log(`Profile: ${config.profileId}`);
+  const writeHeartbeat = () =>
+    heartbeat.write({ pid: process.pid, updatedAt: new Date().toISOString() });
+
+  started.push({
+    clearHeartbeat: heartbeat.clear,
+    stop: () => bot.stop(),
+    writeHeartbeat,
+  });
+
+  await writeHeartbeat();
+
   const authConfig = authStore.getConfig();
-  const paired = authConfig?.pairedUserIds.length ?? 0;
-  const pendingHandshake = authConfig?.handshakeCode ? "yes" : "no";
   console.log(
-    `Paired users: ${paired} · Pending handshake: ${pendingHandshake}`
+    `${label}: profile ${config.profileId} · paired ${authConfig?.pairedUserIds.length ?? 0} · pending handshake ${authConfig?.handshakeCode ? "yes" : "no"}`
   );
 
-  // Assign before start/heartbeat so failure paths can always stop the bot.
-  botStop = () => bot.stop();
-
-  await writeTelegramWorkerHeartbeat();
-  heartbeatTimer = setInterval(() => {
-    void writeTelegramWorkerHeartbeat();
-  }, 15_000);
-
-  await bot.start({
+  return bot.start({
     onStart: (info) => {
-      console.log(`Bot @${info.username} is listening.`);
+      console.log(`Bot @${info.username} is listening for ${label}.`);
     },
   });
-} catch (error) {
-  const message = error instanceof Error ? error.message : String(error);
-  console.error(message);
+}
+
+function stopAll(): void {
   if (heartbeatTimer) {
     clearInterval(heartbeatTimer);
     heartbeatTimer = null;
   }
-  botStop?.();
-  // Await before exit — void + process.exit can leave a stale heartbeat file.
-  await clearTelegramWorkerHeartbeat();
-  stopSpawnedServer(spawnedChild);
-  process.exit(1);
-} finally {
-  stopSpawnedServer(spawnedChild);
+
+  for (const identity of started) {
+    identity.stop();
+    void identity.clearHeartbeat();
+  }
 }
 
 function registerCleanupHandlers(cleanup: () => void): void {

--- a/apps/platform/telegram/src/index.ts
+++ b/apps/platform/telegram/src/index.ts
@@ -37,7 +37,7 @@ let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
 const started: StartedIdentity[] = [];
 
 registerCleanupHandlers(() => {
-  stopAll();
+  void stopAll();
   if (hasActiveStreams()) {
     console.warn(
       "Leaving the spawned Nakama server running so in-flight agent turns can finish; the next worker start will reuse it."
@@ -112,9 +112,8 @@ try {
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error);
   console.error(message);
-  stopAll();
   // Await before exit: void + process.exit can leave a stale heartbeat file.
-  await Promise.all(started.map((identity) => identity.clearHeartbeat()));
+  await stopAll();
   stopSpawnedServer(spawnedChild);
   process.exit(1);
 } finally {
@@ -190,16 +189,18 @@ async function startIdentity(
   });
 }
 
-function stopAll(): void {
+async function stopAll(): Promise<void> {
   if (heartbeatTimer) {
     clearInterval(heartbeatTimer);
     heartbeatTimer = null;
   }
 
-  for (const identity of started) {
-    identity.stop();
-    void identity.clearHeartbeat();
-  }
+  await Promise.all(
+    started.map((identity) => {
+      identity.stop();
+      return identity.clearHeartbeat();
+    })
+  );
 }
 
 function registerCleanupHandlers(cleanup: () => void): void {

--- a/apps/server/src/http/routes/models.ts
+++ b/apps/server/src/http/routes/models.ts
@@ -63,6 +63,7 @@ import { getTimezoneCatalog } from "../../services/timezone-catalog-service";
 import { streamAgentBrowserInstall } from "../coding-harness-install-stream";
 import type { ServerOptions } from "../context";
 import {
+  requireActiveOrgIdFromContext,
   requireNotViewerFromContext,
   requireOrgAdminFromContext,
   requireOrgAdminOrPlatformAdminFromContext,
@@ -1721,18 +1722,20 @@ export function registerModelRoutes(
     );
   });
 
-  app.get("/v1/settings/telegram", async (c) => {
-    getRequestAuth(c);
-    return json<TelegramSettingsResponse>(await agent.getTelegramSettings());
-  });
+  app.get("/v1/settings/telegram", async (c) =>
+    json<TelegramSettingsResponse>(
+      await agent.getTelegramSettings(requireActiveOrgIdFromContext(c))
+    )
+  );
 
   app.put("/v1/settings/telegram", async (c) => {
     requireOrgAdminOrPlatformAdminFromContext(c);
+    const orgId = requireActiveOrgIdFromContext(c);
     const body = await readJson<UpdateTelegramSettingsRequest>(c.req.raw);
 
     try {
       return json<TelegramSettingsResponse>(
-        await agent.setTelegramSettings(body)
+        await agent.setTelegramSettings(orgId, body)
       );
     } catch (error) {
       if (error instanceof NakamaApiError) {
@@ -1745,9 +1748,10 @@ export function registerModelRoutes(
 
   app.post("/v1/settings/telegram/handshake", async (c) => {
     requireOrgAdminOrPlatformAdminFromContext(c);
+    const orgId = requireActiveOrgIdFromContext(c);
     try {
       return json<TelegramSettingsResponse>(
-        await agent.regenerateTelegramHandshake()
+        await agent.regenerateTelegramHandshake(orgId)
       );
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/apps/server/src/http/routes/notification-webhooks.test.ts
+++ b/apps/server/src/http/routes/notification-webhooks.test.ts
@@ -22,7 +22,7 @@ describe("notification webhook routes", () => {
   async function createApp() {
     tempHome = await mkdtemp(path.join(os.tmpdir(), "nakama-notify-webhook-"));
     homedirSpy = spyOn(os, "homedir").mockReturnValue(tempHome);
-    await saveTelegramConfig({ botToken: "1234567890:TEST" });
+    await saveTelegramConfig(null, { botToken: "1234567890:TEST" });
 
     return createMinimalHonoApp({
       agent: {},

--- a/apps/server/src/http/routes/system.ts
+++ b/apps/server/src/http/routes/system.ts
@@ -12,7 +12,7 @@ import {
 } from "../../services/composio-callback-url";
 import type { ServerOptions } from "../context";
 import { requireOrgAdminFromContext } from "../org-guards";
-import { errorResponse, readJson } from "../shared";
+import { errorResponse, getRequestAuth, readJson } from "../shared";
 import type { HonoApp } from "../types";
 
 const DOCS_HTML = `<!doctype html>
@@ -199,7 +199,10 @@ export function registerSystemRoutes(
   });
 
   app.openapi(systemStatusRoute, async (c) =>
-    c.json(await systemStatus.getStatus(), 200)
+    c.json(
+      await systemStatus.getStatus(getRequestAuth(c).activeOrgId ?? null),
+      200
+    )
   );
 
   app.openapi(getWebPublicUrlRoute, async (c) => {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -33,6 +33,7 @@ import {
   NAKAMA_API_VERSION,
   writeRuntimeServerUrl,
 } from "@nakama/core";
+import { claimLegacyTelegramConfig } from "@nakama/core/telegram-config";
 import {
   createDatabase,
   type Database,
@@ -114,6 +115,21 @@ await seedDatabase(database.adapter);
 const interruptedRuns = await database.adapter.failInterruptedRuns();
 if (interruptedRuns > 0) {
   console.log(`Settled ${interruptedRuns} run(s) interrupted by a restart`);
+}
+
+// Channel credentials used to be install-wide. On a single-org install that
+// config can only belong to that org, so claim it once before any scope-exact
+// read reports the org as unconfigured.
+const [soleOrganization, ...otherOrganizations] =
+  await database.adapter.listOrganizations();
+if (soleOrganization && otherOrganizations.length === 0) {
+  const claimed = await claimLegacyTelegramConfig(soleOrganization.id);
+
+  if (claimed) {
+    console.log(
+      `Moved the Telegram config into organization ${soleOrganization.id}; restart the Telegram worker.`
+    );
+  }
 }
 
 const authService = new AuthService();

--- a/apps/server/src/services/agent-service.test.ts
+++ b/apps/server/src/services/agent-service.test.ts
@@ -22,6 +22,9 @@ import { setupFreshInstallSession } from "../http/test-session-helpers";
 import { setupTestConfigDir } from "../test-config-dir";
 import { AgentService } from "./agent-service";
 import { sessionTurnRegistry } from "./session-turn-registry";
+
+const TEST_ORG_ID = "org_test";
+
 import { SkillsService } from "./skills-service";
 
 const ORG_ID = "org_test";
@@ -914,9 +917,10 @@ describe("AgentService bot token validation", () => {
     );
 
     const error = await captureError(() =>
-      service.setTelegramSettings({ botToken })
+      service.setTelegramSettings(TEST_ORG_ID, { botToken })
     );
-    const configured = (await service.getTelegramSettings()).configured;
+    const configured = (await service.getTelegramSettings(TEST_ORG_ID))
+      .configured;
 
     expect({ configured, rejected: error !== null, requestCount }).toEqual({
       configured: false,
@@ -924,7 +928,7 @@ describe("AgentService bot token validation", () => {
       requestCount: 1,
     });
     expect(error?.message).not.toContain(botToken);
-    expect(await loadTelegramConfigFile()).toBeNull();
+    expect(await loadTelegramConfigFile(TEST_ORG_ID)).toBeNull();
   });
 
   test("persists a Telegram token accepted by Telegram", async () => {
@@ -942,13 +946,15 @@ describe("AgentService bot token validation", () => {
       createInMemoryDatabaseAdapter()
     );
 
-    const saved = await service.setTelegramSettings({
+    const saved = await service.setTelegramSettings(TEST_ORG_ID, {
       botToken: "123456:valid-token",
     });
 
     expect(saved.configured).toBe(true);
     expect(new URL(requestUrl).pathname).toBe("/bot123456%3Avalid-token/getMe");
-    expect((await service.getTelegramSettings()).configured).toBe(true);
+    expect((await service.getTelegramSettings(TEST_ORG_ID)).configured).toBe(
+      true
+    );
   });
 
   test("rejects and does not persist a Discord token rejected by Discord", async () => {
@@ -1016,32 +1022,34 @@ describe("AgentService bot token validation", () => {
       null,
       createInMemoryDatabaseAdapter()
     );
-    await service.setTelegramSettings({
+    await service.setTelegramSettings(TEST_ORG_ID, {
       allowedUserIds: "42",
       botToken: "123456:original-token",
       profileId: "original",
     });
-    const beforeReplacement = await loadTelegramConfigFile();
+    const beforeReplacement = await loadTelegramConfigFile(TEST_ORG_ID);
 
     globalThis.fetch = (async () =>
       new Response(null, { status: 401 })) as typeof fetch;
     await expect(
-      service.setTelegramSettings({
+      service.setTelegramSettings(TEST_ORG_ID, {
         allowedUserIds: "43",
         botToken: "123456:rejected-token",
         profileId: "replacement",
       })
     ).rejects.toBeInstanceOf(Error);
-    expect(await loadTelegramConfigFile()).toEqual(beforeReplacement);
+    expect(await loadTelegramConfigFile(TEST_ORG_ID)).toEqual(
+      beforeReplacement
+    );
 
     globalThis.fetch = (async () => {
       throw new Error("Token-less Telegram edits must not call the provider.");
     }) as typeof fetch;
-    await service.setTelegramSettings({
+    await service.setTelegramSettings(TEST_ORG_ID, {
       allowedUserIds: "43",
       profileId: "edited",
     });
-    expect(await loadTelegramConfigFile()).toMatchObject({
+    expect(await loadTelegramConfigFile(TEST_ORG_ID)).toMatchObject({
       allowedUserIds: [43],
       botToken: "123456:original-token",
       profileId: "edited",
@@ -1117,7 +1125,7 @@ describe("AgentService bot token validation", () => {
       expect(body.error).not.toContain(botToken);
     }
 
-    expect(await loadTelegramConfigFile()).toBeNull();
+    expect(await loadTelegramConfigFile(TEST_ORG_ID)).toBeNull();
     expect(await loadDiscordConfigFile()).toBeNull();
   });
 });

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -1091,14 +1091,15 @@ export class AgentService {
     };
   }
 
-  async getTelegramSettings(): Promise<TelegramSettingsResponse> {
-    return loadTelegramSettingsPublic();
+  async getTelegramSettings(orgId: string): Promise<TelegramSettingsResponse> {
+    return loadTelegramSettingsPublic(orgId);
   }
 
   async setTelegramSettings(
+    orgId: string,
     input: UpdateTelegramSettingsRequest
   ): Promise<TelegramSettingsResponse> {
-    const existing = await loadTelegramSettingsPublic();
+    const existing = await loadTelegramSettingsPublic(orgId);
     const botToken =
       input.botToken !== undefined && input.botToken.trim()
         ? input.botToken.trim()
@@ -1131,7 +1132,7 @@ export class AgentService {
       }
     }
 
-    return saveTelegramConfig({
+    return saveTelegramConfig(orgId, {
       ...(botToken ? { botToken } : {}),
       ...(input.allowedUserIds === undefined
         ? existing.allowedUserIds.length > 0
@@ -1142,8 +1143,10 @@ export class AgentService {
     });
   }
 
-  async regenerateTelegramHandshake(): Promise<TelegramSettingsResponse> {
-    return regenerateTelegramHandshake();
+  async regenerateTelegramHandshake(
+    orgId: string
+  ): Promise<TelegramSettingsResponse> {
+    return regenerateTelegramHandshake(orgId);
   }
 
   async getDiscordSettings(): Promise<DiscordSettingsResponse> {

--- a/apps/server/src/services/automation-service.ts
+++ b/apps/server/src/services/automation-service.ts
@@ -114,6 +114,7 @@ export class AutomationService {
       isEmailConfigured: this.canSendEmail
         ? () => this.canSendEmail!(profileId, orgId)
         : undefined,
+      orgId,
     });
 
     const now = new Date().toISOString();
@@ -182,6 +183,7 @@ export class AutomationService {
       isEmailConfigured: this.canSendEmail
         ? () => this.canSendEmail!(profileId, orgId)
         : undefined,
+      orgId,
     });
 
     const updated: StoredAutomation = {

--- a/apps/server/src/services/system-status-service.test.ts
+++ b/apps/server/src/services/system-status-service.test.ts
@@ -79,7 +79,7 @@ describe("SystemStatusService", () => {
       uptimeSeconds: 30,
     });
 
-    const status = await service.getStatus();
+    const status = await service.getStatus(null);
 
     expect(status.automationWorker).toEqual({
       activeRuns: 2,
@@ -114,7 +114,7 @@ describe("SystemStatusService", () => {
       uptimeSeconds: 30,
     });
 
-    const status = await service.getStatus();
+    const status = await service.getStatus(null);
 
     expect(status.automationWorker.ok).toBe(false);
     expect(status.automationWorker.running).toBe(false);
@@ -132,7 +132,7 @@ describe("SystemStatusService", () => {
       uptimeSeconds: null,
     });
 
-    const status = await service.getStatus();
+    const status = await service.getStatus(null);
 
     expect(status.automationWorker.ok).toBe(false);
     expect(status.automationWorker.process?.managed).toBe(false);
@@ -152,7 +152,7 @@ describe("SystemStatusService", () => {
       },
     });
 
-    const status = await service.getStatus();
+    const status = await service.getStatus(null);
 
     expect(reachabilityCalls).toBe(1);
     expect(status.server).toMatchObject({

--- a/apps/server/src/services/system-status-service.ts
+++ b/apps/server/src/services/system-status-service.ts
@@ -30,7 +30,7 @@ export class SystemStatusService {
     private readonly databaseAdapter: DatabaseAdapter | null = null
   ) {}
 
-  async getStatus(): Promise<SystemStatusResponse> {
+  async getStatus(orgId: string | null): Promise<SystemStatusResponse> {
     const providerConfigured = this.agent.providerConfigured;
     const models = await this.agent.getModels();
     const usageFields = this.agent.getUsageStatusFields();
@@ -44,9 +44,9 @@ export class SystemStatusService {
       automationProcess.status === "online";
 
     const [telegramStatus, whatsappStatus, discordStatus] = await Promise.all([
-      this.resolveWorkerStatus("telegram", statuses.telegram),
-      this.resolveWorkerStatus("whatsapp", statuses.whatsapp),
-      this.resolveWorkerStatus("discord", statuses.discord),
+      this.resolveWorkerStatus("telegram", statuses.telegram, orgId),
+      this.resolveWorkerStatus("whatsapp", statuses.whatsapp, orgId),
+      this.resolveWorkerStatus("discord", statuses.discord, orgId),
     ]);
 
     return {
@@ -80,13 +80,14 @@ export class SystemStatusService {
 
   private async resolveWorkerStatus(
     name: "telegram" | "whatsapp" | "discord",
-    pm2Status: WorkerProcessInfo | null
+    pm2Status: WorkerProcessInfo | null,
+    orgId: string | null
   ) {
     if (pm2Status?.managed) {
       const running = pm2Status.status === "online";
 
       if (name === "telegram") {
-        const heartbeat = await getTelegramWorkerStatus();
+        const heartbeat = await getTelegramWorkerStatus(orgId);
         return {
           ...heartbeat,
           process: pm2Status,
@@ -112,7 +113,7 @@ export class SystemStatusService {
     }
 
     if (name === "telegram") {
-      return getTelegramWorkerStatus();
+      return getTelegramWorkerStatus(orgId);
     }
 
     if (name === "discord") {

--- a/docs/website/content/docs/telegram/chat.mdx
+++ b/docs/website/content/docs/telegram/chat.mdx
@@ -50,7 +50,7 @@ These commands are available in Telegram:
 | `/clear` | Clear chat history |
 | `/compact` | Compact conversation history |
 | `/new` | Start a new conversation |
-| `/org` | Choose or switch organization |
+| `/org` | Choose or switch organization, on the shared install-wide bot only |
 | `/profile` | Choose or switch profile |
 | `/status` | Show server and model status |
 

--- a/docs/website/content/docs/telegram/index.mdx
+++ b/docs/website/content/docs/telegram/index.mdx
@@ -46,6 +46,24 @@ Open **Integrations → Telegram** in the Nakama web app, then:
 
 When you save for the first time, Nakama can generate a pairing code for linking your Telegram account.
 
+## One bot per organization
+
+Each organization saves its own bot token under **Integrations → Telegram**, and a
+bot answers for exactly one organization. Org A's token is never readable from Org
+B, and a save is refused when another organization already runs that token, because
+Telegram delivers each update to one poller only.
+
+The bridge starts one bot per configured organization, so a single
+`bun run dev:telegram` covers all of them. Credentials live in
+`~/.nakama/orgs/<org id>/telegram/config.ini`.
+
+Installs configured before this existed keep one config at
+`~/.nakama/telegram/config.ini`. With a single organization the server moves it into
+that org on the next start and logs a line asking you to restart the bridge. With
+several organizations it keeps serving every org as the shared bot until an admin
+saves a token of their own, and `/org` still picks which organization a chat
+belongs to.
+
 ## Step 3: Enable audio transcription for voice chat
 
 Telegram voice notes and audio files are turned into text before they are sent to the agent.

--- a/packages/core/src/automation-delivery.ts
+++ b/packages/core/src/automation-delivery.ts
@@ -5,7 +5,10 @@ import type {
 } from "./contract";
 import { isDiscordSnowflake, loadDiscordConfigFile } from "./discord-config";
 import { isEmailConfigComplete, loadEmailConfig } from "./email-config";
-import { loadTelegramConfigFile } from "./telegram-config";
+import {
+  loadTelegramConfigFile,
+  resolveTelegramScopeForOrg,
+} from "./telegram-config";
 import { loadWhatsAppConfigFile } from "./whatsapp-config";
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -140,18 +143,21 @@ export function shouldDeliverForRun(
 
 export interface ValidateAutomationDeliveryOptions {
   isEmailConfigured?: () => Promise<boolean> | boolean;
+  orgId: string;
 }
 
 export async function validateAutomationDelivery(
   delivery: AutomationDelivery | undefined,
-  options: ValidateAutomationDeliveryOptions = {}
+  options: ValidateAutomationDeliveryOptions
 ): Promise<void> {
   if (!delivery) {
     return;
   }
 
   if (delivery.channel === "telegram") {
-    const config = await loadTelegramConfigFile();
+    const config = await loadTelegramConfigFile(
+      await resolveTelegramScopeForOrg(options.orgId)
+    );
 
     if (!config?.botToken.trim()) {
       throw new Error(

--- a/packages/core/src/channels/telegram-outbound.test.ts
+++ b/packages/core/src/channels/telegram-outbound.test.ts
@@ -22,7 +22,7 @@ describe("createTelegramOutboundAdapter", () => {
   async function useTempHome(run: () => Promise<void>): Promise<void> {
     tempHome = await mkdtemp(path.join(os.tmpdir(), "nakama-tg-outbound-"));
     homedirSpy = spyOn(os, "homedir").mockReturnValue(tempHome);
-    await saveTelegramConfig({ botToken: "1234567890:TEST" });
+    await saveTelegramConfig(null, { botToken: "1234567890:TEST" });
     await run();
   }
 

--- a/packages/core/src/channels/telegram-outbound.ts
+++ b/packages/core/src/channels/telegram-outbound.ts
@@ -19,7 +19,7 @@ export function createTelegramOutboundAdapter(
     async send(input): Promise<ChannelSendResult> {
       try {
         const config = await loadTelegramConfigFile(
-          input.orgId ? await resolveTelegramScopeForOrg(input.orgId) : null
+          await resolveTelegramScopeForOrg(input.orgId ?? null)
         );
         const token = config?.botToken.trim();
 

--- a/packages/core/src/channels/telegram-outbound.ts
+++ b/packages/core/src/channels/telegram-outbound.ts
@@ -1,4 +1,7 @@
-import { loadTelegramConfigFile } from "../telegram-config";
+import {
+  loadTelegramConfigFile,
+  resolveTelegramScopeForOrg,
+} from "../telegram-config";
 import { splitTelegramChunks } from "./message-format";
 import { renderTelegramRichText } from "./telegram-rich-text";
 import type { ChannelSendResult, TelegramOutboundAdapter } from "./types";
@@ -15,7 +18,9 @@ export function createTelegramOutboundAdapter(
   return {
     async send(input): Promise<ChannelSendResult> {
       try {
-        const config = await loadTelegramConfigFile();
+        const config = await loadTelegramConfigFile(
+          input.orgId ? await resolveTelegramScopeForOrg(input.orgId) : null
+        );
         const token = config?.botToken.trim();
 
         if (!token) {

--- a/packages/core/src/telegram-config.test.ts
+++ b/packages/core/src/telegram-config.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
+  claimLegacyTelegramConfig,
   generateHandshakeCode,
+  getTelegramConfigDir,
   isTelegramUserAuthorized,
+  listTelegramConfigOrgIds,
   loadTelegramConfigFile,
   maskBotToken,
   normalizeHandshakeInput,
@@ -10,7 +13,10 @@ import {
   saveTelegramConfig,
   verifyAndPairTelegramUser,
 } from "./telegram-config";
-import { describeSharedChannelConfigTests } from "./testing/channel-config-fixtures";
+import {
+  describeSharedChannelConfigTests,
+  withTempHomedir,
+} from "./testing/channel-config-fixtures";
 
 describe("parseAllowedUserIds", () => {
   test("parses comma-separated ids", () => {
@@ -43,7 +49,7 @@ describeSharedChannelConfigTests({
   },
   generateHandshakeCode,
   isUserAuthorized: isTelegramUserAuthorized,
-  loadConfigFile: loadTelegramConfigFile,
+  loadConfigFile: () => loadTelegramConfigFile(null),
   mask: maskBotToken,
   name: "telegram",
   normalize: normalizeHandshakeInput,
@@ -53,6 +59,47 @@ describeSharedChannelConfigTests({
     pairedUserIds: [1],
   },
   sampleId: 9001,
-  saveConfig: saveTelegramConfig,
-  verifyAndPair: verifyAndPairTelegramUser,
+  saveConfig: (input) => saveTelegramConfig(null, input),
+  verifyAndPair: (handshakeInput, userId) =>
+    verifyAndPairTelegramUser(null, handshakeInput, userId),
+});
+
+describe("per-org telegram config", () => {
+  test("keeps each org's credentials out of the other scopes", async () => {
+    await withTempHomedir("nakama-telegram-org-", async () => {
+      await saveTelegramConfig("org_a", { botToken: "111:AAA" });
+
+      expect(await loadTelegramConfigFile("org_b")).toBeNull();
+      expect(await loadTelegramConfigFile(null)).toBeNull();
+      expect((await loadTelegramConfigFile("org_a"))?.botToken).toBe("111:AAA");
+      expect(await listTelegramConfigOrgIds()).toEqual(["org_a"]);
+    });
+  });
+
+  test("refuses a bot token another scope already runs", async () => {
+    await withTempHomedir("nakama-telegram-dup-", async () => {
+      await saveTelegramConfig(null, { botToken: "111:AAA" });
+
+      await expect(
+        saveTelegramConfig("org_b", { botToken: "111:AAA" })
+      ).rejects.toThrow("already in use by another organization");
+    });
+  });
+
+  test("claims the install-wide config for a sole org, once", async () => {
+    await withTempHomedir("nakama-telegram-claim-", async () => {
+      await saveTelegramConfig(null, { botToken: "111:AAA" });
+
+      expect(await claimLegacyTelegramConfig("org_a")).toBe(true);
+      expect((await loadTelegramConfigFile("org_a"))?.botToken).toBe("111:AAA");
+      expect(await loadTelegramConfigFile(null)).toBeNull();
+      expect(await claimLegacyTelegramConfig("org_a")).toBe(false);
+    });
+  });
+
+  test("rejects an org id that would escape the config dir", () => {
+    expect(() => getTelegramConfigDir("../../etc")).toThrow(
+      "Invalid organization id"
+    );
+  });
 });

--- a/packages/core/src/telegram-config.ts
+++ b/packages/core/src/telegram-config.ts
@@ -70,7 +70,7 @@ export async function listTelegramConfigOrgIds(): Promise<string[]> {
     }
   }
 
-  return configured.sort();
+  return configured;
 }
 
 export function parseAllowedUserIds(raw: string): number[] {
@@ -118,8 +118,12 @@ export async function loadTelegramConfigFile(
  * along.
  */
 export async function resolveTelegramScopeForOrg(
-  orgId: string
+  orgId: TelegramConfigScope
 ): Promise<TelegramConfigScope> {
+  if (orgId === null) {
+    return null;
+  }
+
   return (await pathExists(getTelegramConfigPath(orgId))) ? orgId : null;
 }
 

--- a/packages/core/src/telegram-config.ts
+++ b/packages/core/src/telegram-config.ts
@@ -1,4 +1,5 @@
-import { join } from "node:path";
+import { rename } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import {
   generateHandshakeCode,
   isBotChannelUserAuthorized,
@@ -8,7 +9,8 @@ import {
   verifyAndPairBotChannelUser,
   writeBotChannelIniConfig,
 } from "./channel-config-shared";
-import { getUserConfigDir } from "./user-config";
+import { ensureDir, pathExists, readDirectoryOrEmpty } from "./fs";
+import { getOrgConfigDir, getUserConfigDir } from "./user-config";
 
 export {
   generateHandshakeCode,
@@ -41,12 +43,34 @@ export interface UpdateTelegramSettingsInput {
   profileId?: string;
 }
 
-export function getTelegramConfigDir(): string {
-  return join(getUserConfigDir(), "telegram");
+/**
+ * Config scope. An org id reads that org's own credentials; `null` reads the
+ * install-wide config that predates per-org channels and still serves every
+ * org that has not saved its own.
+ */
+export type TelegramConfigScope = string | null;
+
+export function getTelegramConfigDir(orgId: TelegramConfigScope): string {
+  const base = orgId === null ? getUserConfigDir() : getOrgConfigDir(orgId);
+  return join(base, "telegram");
 }
 
-export function getTelegramConfigPath(): string {
-  return join(getTelegramConfigDir(), "config.ini");
+export function getTelegramConfigPath(orgId: TelegramConfigScope): string {
+  return join(getTelegramConfigDir(orgId), "config.ini");
+}
+
+/** Org ids that have saved their own Telegram credentials. */
+export async function listTelegramConfigOrgIds(): Promise<string[]> {
+  const orgIds = await readDirectoryOrEmpty(join(getUserConfigDir(), "orgs"));
+  const configured: string[] = [];
+
+  for (const orgId of orgIds) {
+    if (await pathExists(getTelegramConfigPath(orgId))) {
+      configured.push(orgId);
+    }
+  }
+
+  return configured.sort();
 }
 
 export function parseAllowedUserIds(raw: string): number[] {
@@ -78,12 +102,50 @@ export function isTelegramUserAuthorized(
   return isBotChannelUserAuthorized(userId, config);
 }
 
-export async function loadTelegramConfigFile(): Promise<TelegramConfigFile | null> {
+export async function loadTelegramConfigFile(
+  orgId: TelegramConfigScope
+): Promise<TelegramConfigFile | null> {
   return loadBotChannelIniConfig({
-    configPath: getTelegramConfigPath(),
+    configPath: getTelegramConfigPath(orgId),
     defaultProfileId: DEFAULT_TELEGRAM_PROFILE_ID,
     parseUserIds: parseAllowedUserIds,
   });
+}
+
+/**
+ * Which config actually serves this org: its own when it has one, otherwise the
+ * install-wide config, which is the bot that has been answering its users all
+ * along.
+ */
+export async function resolveTelegramScopeForOrg(
+  orgId: string
+): Promise<TelegramConfigScope> {
+  return (await pathExists(getTelegramConfigPath(orgId))) ? orgId : null;
+}
+
+/**
+ * Pre-org installs keep one Telegram config at the config-dir root. On a
+ * single-org install it can only belong to that org, so move the directory
+ * once and take the chat sessions and pairings with it. Multi-org installs
+ * keep the shared bot until an admin saves credentials of their own.
+ */
+export async function claimLegacyTelegramConfig(
+  orgId: string
+): Promise<boolean> {
+  const legacyDir = getTelegramConfigDir(null);
+  const targetDir = getTelegramConfigDir(orgId);
+
+  if (!(await pathExists(join(legacyDir, "config.ini")))) {
+    return false;
+  }
+
+  if (await pathExists(targetDir)) {
+    return false;
+  }
+
+  await ensureDir(dirname(targetDir));
+  await rename(legacyDir, targetDir);
+  return true;
 }
 
 export function toTelegramSettingsPublic(
@@ -110,17 +172,20 @@ export function toTelegramSettingsPublic(
   };
 }
 
-export async function loadTelegramSettingsPublic(): Promise<TelegramSettingsPublic> {
-  return toTelegramSettingsPublic(await loadTelegramConfigFile());
+export async function loadTelegramSettingsPublic(
+  orgId: TelegramConfigScope
+): Promise<TelegramSettingsPublic> {
+  return toTelegramSettingsPublic(await loadTelegramConfigFile(orgId));
 }
 
 async function writeTelegramConfigFile(
+  orgId: TelegramConfigScope,
   config: TelegramConfigFile
 ): Promise<void> {
   await writeBotChannelIniConfig({
     config,
-    configDir: getTelegramConfigDir(),
-    configPath: getTelegramConfigPath(),
+    configDir: getTelegramConfigDir(orgId),
+    configPath: getTelegramConfigPath(orgId),
     label: "Telegram",
   });
 }
@@ -179,16 +244,48 @@ function buildSavedTelegramConfig(
 }
 
 export async function saveTelegramConfig(
+  orgId: TelegramConfigScope,
   input: UpdateTelegramSettingsInput
 ): Promise<TelegramSettingsPublic> {
-  const existing = await loadTelegramConfigFile();
+  const existing = await loadTelegramConfigFile(orgId);
   const next = buildSavedTelegramConfig(input, existing);
-  await writeTelegramConfigFile(next);
+  await assertTelegramTokenUnclaimed(orgId, next.botToken);
+  await writeTelegramConfigFile(orgId, next);
   return toTelegramSettingsPublic(next);
 }
 
-export async function regenerateTelegramHandshake(): Promise<TelegramSettingsPublic> {
-  const existing = await loadTelegramConfigFile();
+/**
+ * Telegram drops updates for whichever poller is not last, so two scopes on one
+ * token silently lose messages instead of failing. Reject it at save time.
+ */
+async function assertTelegramTokenUnclaimed(
+  orgId: TelegramConfigScope,
+  botToken: string
+): Promise<void> {
+  const scopes: TelegramConfigScope[] = [
+    null,
+    ...(await listTelegramConfigOrgIds()),
+  ];
+
+  for (const scope of scopes) {
+    if (scope === orgId) {
+      continue;
+    }
+
+    const config = await loadTelegramConfigFile(scope);
+
+    if (config?.botToken === botToken) {
+      throw new Error(
+        "This bot token is already in use by another organization. Create a separate bot with @BotFather."
+      );
+    }
+  }
+}
+
+export async function regenerateTelegramHandshake(
+  orgId: TelegramConfigScope
+): Promise<TelegramSettingsPublic> {
+  const existing = await loadTelegramConfigFile(orgId);
 
   if (!existing?.botToken.trim()) {
     throw new Error("Save a bot token before generating a pairing code.");
@@ -199,11 +296,12 @@ export async function regenerateTelegramHandshake(): Promise<TelegramSettingsPub
     handshakeCode: generateHandshakeCode(),
   };
 
-  await writeTelegramConfigFile(next);
+  await writeTelegramConfigFile(orgId, next);
   return toTelegramSettingsPublic(next);
 }
 
 export async function verifyAndPairTelegramUser(
+  orgId: TelegramConfigScope,
   handshakeInput: string,
   userId: number
 ): Promise<{ ok: true; message: string } | { ok: false; message: string }> {
@@ -211,9 +309,9 @@ export async function verifyAndPairTelegramUser(
     handshakeInput,
     isAuthorized: isTelegramUserAuthorized,
     label: "Telegram",
-    load: loadTelegramConfigFile,
+    load: () => loadTelegramConfigFile(orgId),
     userId,
-    write: writeTelegramConfigFile,
+    write: (config) => writeTelegramConfigFile(orgId, config),
   });
 }
 

--- a/packages/core/src/telegram-worker.test.ts
+++ b/packages/core/src/telegram-worker.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
-  parseTelegramWorkerHeartbeat,
+  createTelegramWorkerHeartbeat,
   resolveTelegramWorkerStatus,
 } from "./telegram-worker";
+import { withTempHomedir } from "./testing/channel-config-fixtures";
 
 describe("resolveTelegramWorkerStatus", () => {
   test("is ok when telegram is not configured", () => {
@@ -67,17 +68,19 @@ describe("resolveTelegramWorkerStatus", () => {
   });
 });
 
-describe("parseTelegramWorkerHeartbeat", () => {
-  test("parses valid JSON", () => {
-    expect(
-      parseTelegramWorkerHeartbeat(
-        JSON.stringify({ pid: 12, updatedAt: "2026-01-01T00:00:00.000Z" })
-      )
-    ).toEqual({ pid: 12, updatedAt: "2026-01-01T00:00:00.000Z" });
-  });
+describe("createTelegramWorkerHeartbeat", () => {
+  test("claims each identity separately", async () => {
+    await withTempHomedir("nakama-telegram-hb-", async () => {
+      const legacy = createTelegramWorkerHeartbeat(null);
+      const orgA = createTelegramWorkerHeartbeat("org_a");
 
-  test("returns null for invalid payloads", () => {
-    expect(parseTelegramWorkerHeartbeat("not json")).toBeNull();
-    expect(parseTelegramWorkerHeartbeat("{}")).toBeNull();
+      await legacy.write({
+        pid: process.pid,
+        updatedAt: new Date().toISOString(),
+      });
+
+      expect(await legacy.isRunning()).toBe(true);
+      expect(await orgA.isRunning()).toBe(false);
+    });
   });
 });

--- a/packages/core/src/telegram-worker.ts
+++ b/packages/core/src/telegram-worker.ts
@@ -2,6 +2,8 @@ import type { TelegramWorkerStatus } from "./contract";
 import {
   getTelegramConfigDir,
   loadTelegramSettingsPublic,
+  resolveTelegramScopeForOrg,
+  type TelegramConfigScope,
   type TelegramSettingsPublic,
 } from "./telegram-config";
 import {
@@ -13,15 +15,12 @@ import {
 export type { WorkerHeartbeatBase as TelegramWorkerHeartbeat } from "./worker-heartbeat";
 export { isHeartbeatAlive, isProcessAlive };
 
-const store = createWorkerHeartbeatStore({
-  getDir: getTelegramConfigDir,
-});
-
-export const getTelegramWorkerHeartbeatPath = store.getPath;
-export const parseTelegramWorkerHeartbeat = store.parse;
-export const readTelegramWorkerHeartbeat = store.read;
-export const clearTelegramWorkerHeartbeat = store.clear;
-export const isTelegramWorkerRunning = store.isRunning;
+/** One heartbeat per identity: the file lives beside the config it belongs to. */
+export function createTelegramWorkerHeartbeat(orgId: TelegramConfigScope) {
+  return createWorkerHeartbeatStore({
+    getDir: () => getTelegramConfigDir(orgId),
+  });
+}
 
 export function resolveTelegramWorkerStatus(
   settings: TelegramSettingsPublic,
@@ -34,16 +33,12 @@ export function resolveTelegramWorkerStatus(
   return { configured, ok, paired, running };
 }
 
-export async function writeTelegramWorkerHeartbeat(
-  pid = process.pid,
-  updatedAt = new Date().toISOString()
-): Promise<void> {
-  await store.write({ pid, updatedAt });
-}
-
-export async function getTelegramWorkerStatus(): Promise<TelegramWorkerStatus> {
-  const settings = await loadTelegramSettingsPublic();
-  const running = await isTelegramWorkerRunning();
+export async function getTelegramWorkerStatus(
+  orgId: string | null
+): Promise<TelegramWorkerStatus> {
+  const scope = orgId === null ? null : await resolveTelegramScopeForOrg(orgId);
+  const settings = await loadTelegramSettingsPublic(scope);
+  const running = await createTelegramWorkerHeartbeat(scope).isRunning();
 
   return resolveTelegramWorkerStatus(settings, running);
 }

--- a/packages/core/src/telegram-worker.ts
+++ b/packages/core/src/telegram-worker.ts
@@ -34,9 +34,9 @@ export function resolveTelegramWorkerStatus(
 }
 
 export async function getTelegramWorkerStatus(
-  orgId: string | null
+  orgId: TelegramConfigScope
 ): Promise<TelegramWorkerStatus> {
-  const scope = orgId === null ? null : await resolveTelegramScopeForOrg(orgId);
+  const scope = await resolveTelegramScopeForOrg(orgId);
   const settings = await loadTelegramSettingsPublic(scope);
   const running = await createTelegramWorkerHeartbeat(scope).isRunning();
 

--- a/packages/core/src/user-config.ts
+++ b/packages/core/src/user-config.ts
@@ -236,6 +236,18 @@ export function validateTimezone(
   return value;
 }
 
+// Org id reaches this as a path segment, so anything that could climb out of
+// the config dir is rejected here rather than at each caller.
+const ORG_ID_SEGMENT = /^[A-Za-z0-9][\w.-]{0,63}$/;
+
+export function getOrgConfigDir(orgId: string): string {
+  if (!ORG_ID_SEGMENT.test(orgId)) {
+    throw new Error(`Invalid organization id: ${orgId}`);
+  }
+
+  return join(getUserConfigDir(), "orgs", orgId);
+}
+
 export function getUserConfigDir(): string {
   const override = process.env.NAKAMA_CONFIG_DIR?.trim();
 


### PR DESCRIPTION
## Summary

Each org configures its own Telegram bot, and the bridge runs one bot per identity. First channel of #780; Discord, WhatsApp and Instagram are separate PRs on the same layout.

**Before:** one install-wide `~/.nakama/telegram/config.ini`. `setTelegramSettings` took no org id, so any org admin could overwrite another org's bot token, and one bot served every org.
**After:** config resolves per scope (`~/.nakama/orgs/<orgId>/telegram/config.ini`, or the old path for installs that predate this). The settings API reads and writes only the caller's active org, a save is refused when another scope already runs that token, and the bridge starts one bot per configured identity, each with its own heartbeat file. A bot owned by an org binds every chat to that org, so `/org` cannot move a conversation to another tenant.

Why safe:
1. The four new tests were watched failing: with the scope dropped from `getTelegramConfigDir` and the duplicate-token guard removed, all four go red, and green again with them back.
2. Existing installs keep working. A single-org install has its config moved into that org at startup (log line asks for a bridge restart); a multi-org install keeps the shared bot until an admin saves their own, `/org` included.
3. `TELEGRAM_BOT_TOKEN` stays install-wide only, so the env override cannot hand two scopes the same token.

Design pick 3 from the issue, reasoning in https://github.com/ahmadrosid/nakama/issues/780#issuecomment-5596012385.

## Test plan
- [x] `bun run test`, every workspace green (core 741, server 1189, telegram 103)
- [x] new tests confirmed failing against the unscoped code before the fix
- [ ] Not run live. The per-identity claim is covered by a heartbeat test, not by a bridge started twice against two real bot tokens.
