### PR TITLE
feat(server): rate limit the boundary and flatten the login timing oracle

### DIFF
--- a/apps/server/src/http/app.ts
+++ b/apps/server/src/http/app.ts
@@ -6,6 +6,7 @@ import { createAuthMiddleware } from "./auth-middleware";
 import type { ServerOptions } from "./context";
 import { serializeHttpOpenApiSpec } from "./openapi";
 import { createOrgContextMiddleware } from "./org-middleware";
+import { createRateLimitMiddleware } from "./rate-limit-middleware";
 import { registerArtifactShareRoutes } from "./routes/artifact-shares";
 import { registerAuthRoutes } from "./routes/auth";
 import { registerAutomationWorkerSettingsRoutes } from "./routes/automation-worker-settings";
@@ -50,6 +51,11 @@ import type { HonoApp } from "./types";
  */
 const THEME_BOOTSTRAP_SCRIPT_HASH =
   "sha256-rQ5OTxagyMHDDSQ6k5wlUK8gtuYxXBrpQGqjAcYBz2w=";
+
+function readPositiveEnv(name: string): number | undefined {
+  const parsed = Number(process.env[name]);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
 
 export function createHonoApp(options: ServerOptions) {
   const app: HonoApp = new OpenAPIHono();
@@ -171,6 +177,17 @@ export function createHonoApp(options: ServerOptions) {
       ].join("\n")
     );
   });
+
+  // Ahead of auth so an unauthenticated flood is refused before it reaches
+  // bcrypt or the database.
+  app.use(
+    "*",
+    createRateLimitMiddleware({
+      authMax: readPositiveEnv("NAKAMA_RATE_LIMIT_AUTH_MAX"),
+      max: readPositiveEnv("NAKAMA_RATE_LIMIT_MAX"),
+      trustProxy: process.env.NAKAMA_TRUST_PROXY === "true",
+    })
+  );
 
   app.use("*", createAuthMiddleware(options));
   registerInternalAutomationRoutes(app, options);

--- a/apps/server/src/http/login-timing.test.ts
+++ b/apps/server/src/http/login-timing.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { AuthService } from "../services/auth-service";
+import { setupTestConfigDir } from "../test-config-dir";
+import { createMinimalHonoApp } from "./test-app-helpers";
+import { setupFreshInstallSession } from "./test-session-helpers";
+
+setupTestConfigDir("nakama-login-timing-test-");
+
+class CountingAuthService extends AuthService {
+  verifyCalls = 0;
+
+  override verifyPassword(password: string, hash: string): Promise<boolean> {
+    this.verifyCalls += 1;
+    return super.verifyPassword(password, hash);
+  }
+}
+
+async function login(app: { fetch: typeof fetch }, email: string) {
+  return await app.fetch(
+    new Request("http://localhost:4310/v1/auth/login", {
+      body: JSON.stringify({ email, password: "wrong-password" }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    })
+  );
+}
+
+describe("login does not reveal whether an account exists", () => {
+  test("an unknown email still spends a password comparison", async () => {
+    const authService = new CountingAuthService();
+    const { app, databaseAdapter } = createMinimalHonoApp({ authService });
+    await setupFreshInstallSession(app, databaseAdapter, "admin@example.com");
+
+    const before = authService.verifyCalls;
+    const unknown = await login(app, "nobody@example.com");
+    const afterUnknown = authService.verifyCalls - before;
+
+    const known = await login(app, "admin@example.com");
+    const afterKnown = authService.verifyCalls - before - afterUnknown;
+
+    expect(unknown.status).toBe(401);
+    expect(known.status).toBe(401);
+    // The point of the fix: both paths do the same work.
+    expect(afterUnknown).toBe(afterKnown);
+    expect(afterUnknown).toBe(1);
+  }, 30_000);
+});

--- a/apps/server/src/http/rate-limit-middleware.test.ts
+++ b/apps/server/src/http/rate-limit-middleware.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { createRateLimitMiddleware } from "./rate-limit-middleware";
+import type { AppEnv } from "./types";
+
+const WINDOW_MS = 1000;
+
+function buildApp(
+  overrides: Parameters<typeof createRateLimitMiddleware>[0] = {}
+) {
+  const app = new Hono<AppEnv>();
+  app.use(
+    "*",
+    createRateLimitMiddleware({ windowMs: WINDOW_MS, ...overrides })
+  );
+  app.all("*", (c) => c.json({ ok: true }));
+  return app;
+}
+
+function envFor(address: string | null) {
+  return { server: { requestIP: () => (address ? { address } : null) } };
+}
+
+function call(
+  app: ReturnType<typeof buildApp>,
+  path = "/v1/anything",
+  address: string | null = "10.0.0.1",
+  headers: Record<string, string> = {}
+) {
+  return app.fetch(
+    new Request(`http://localhost:4310${path}`, { headers }),
+    envFor(address)
+  );
+}
+
+describe("createRateLimitMiddleware", () => {
+  test("lets a client through while it still has budget", async () => {
+    const app = buildApp({ max: 5 });
+    const statuses: number[] = [];
+
+    for (let i = 0; i < 5; i++) {
+      statuses.push((await call(app)).status);
+    }
+
+    expect(statuses).toEqual([200, 200, 200, 200, 200]);
+  });
+
+  test("answers 429 with Retry-After once the budget is spent", async () => {
+    const app = buildApp({ max: 2 });
+
+    await call(app);
+    await call(app);
+    const blocked = await call(app);
+
+    expect(blocked.status).toBe(429);
+    expect(Number(blocked.headers.get("Retry-After"))).toBeGreaterThan(0);
+  });
+
+  test("starts a fresh budget once the window has passed", async () => {
+    let clock = 1000;
+    const app = buildApp({ max: 1, now: () => clock });
+
+    expect((await call(app)).status).toBe(200);
+    expect((await call(app)).status).toBe(429);
+
+    clock += WINDOW_MS + 1;
+
+    expect((await call(app)).status).toBe(200);
+  });
+
+  test("keeps one budget per client address", async () => {
+    const app = buildApp({ max: 1 });
+
+    expect((await call(app, "/v1/anything", "10.0.0.1")).status).toBe(200);
+    expect((await call(app, "/v1/anything", "10.0.0.1")).status).toBe(429);
+    expect((await call(app, "/v1/anything", "10.0.0.2")).status).toBe(200);
+  });
+
+  test("spends a separate, stricter budget on the auth routes", async () => {
+    const app = buildApp({ authMax: 1, max: 50 });
+
+    expect((await call(app, "/v1/auth/login")).status).toBe(200);
+    expect((await call(app, "/v1/auth/login")).status).toBe(429);
+    // The general budget is untouched by the auth spend.
+    expect((await call(app, "/v1/anything")).status).toBe(200);
+  });
+
+  test("ignores a forwarded address when the proxy is not trusted", async () => {
+    const app = buildApp({ max: 1 });
+    const spoofed = { "x-forwarded-for": "203.0.113.9" };
+
+    expect((await call(app, "/v1/anything", "10.0.0.1", spoofed)).status).toBe(
+      200
+    );
+    // A different forwarded value must not buy a fresh budget.
+    expect(
+      (
+        await call(app, "/v1/anything", "10.0.0.1", {
+          "x-forwarded-for": "203.0.113.10",
+        })
+      ).status
+    ).toBe(429);
+  });
+
+  test("uses the forwarded address when the proxy is trusted", async () => {
+    const app = buildApp({ max: 1, trustProxy: true });
+
+    expect(
+      (
+        await call(app, "/v1/anything", "10.0.0.1", {
+          "x-forwarded-for": "203.0.113.9",
+        })
+      ).status
+    ).toBe(200);
+    expect(
+      (
+        await call(app, "/v1/anything", "10.0.0.1", {
+          "x-forwarded-for": "203.0.113.10",
+        })
+      ).status
+    ).toBe(200);
+  });
+
+  test("lets the request through when no address can be resolved", async () => {
+    const app = buildApp({ max: 1 });
+
+    expect((await call(app, "/v1/anything", null)).status).toBe(200);
+    expect((await call(app, "/v1/anything", null)).status).toBe(200);
+  });
+});

--- a/apps/server/src/http/rate-limit-middleware.ts
+++ b/apps/server/src/http/rate-limit-middleware.ts
@@ -1,0 +1,132 @@
+import type { MiddlewareHandler } from "hono";
+import type { AppEnv } from "./types";
+
+/**
+ * A minute is long enough that a burst of dashboard traffic does not trip the
+ * limit, and short enough that a locked-out client recovers without support.
+ */
+const DEFAULT_WINDOW_MS = 60_000;
+
+/**
+ * Generous on purpose. One open dashboard already polls several endpoints, and
+ * a whole office can share one address behind NAT, so this is sized to stop a
+ * flood rather than to shape normal use.
+ */
+const DEFAULT_MAX = 600;
+
+/**
+ * The credential routes get their own, much smaller budget: bcrypt at cost 10
+ * is the only thing slowing an online guess today.
+ */
+const DEFAULT_AUTH_MAX = 10;
+
+/** Beyond this many live keys, expired ones are swept before inserting more. */
+const SWEEP_AFTER_KEYS = 10_000;
+
+/**
+ * Credential routes, where a wrong guess is cheap for the caller and expensive
+ * for us. Kept as exact paths: a prefix would also catch `/v1/auth/me`, which
+ * the dashboard calls on every load.
+ */
+const AUTH_PATHS = new Set([
+  "/v1/auth/login",
+  "/v1/auth/accept-invite",
+  "/v1/auth/setup",
+]);
+
+export interface RateLimitOptions {
+  /** Requests per window for the auth paths, counted separately. */
+  authMax?: number;
+  /** Requests per window for everything outside the auth paths. */
+  max?: number;
+  /** Injected by tests so a window can elapse without waiting for one. */
+  now?: () => number;
+  /**
+   * Read the client address from `X-Forwarded-For`. Off by default: the header
+   * is client-settable, so trusting it without a proxy in front turns the
+   * limiter into a formality.
+   */
+  trustProxy?: boolean;
+  windowMs?: number;
+}
+
+interface Budget {
+  count: number;
+  resetAt: number;
+}
+
+function clientAddress(
+  c: Parameters<MiddlewareHandler<AppEnv>>[0],
+  trustProxy: boolean
+): string | null {
+  if (trustProxy) {
+    const forwarded = c.req.header("x-forwarded-for")?.split(",")[0]?.trim();
+    if (forwarded) {
+      return forwarded;
+    }
+  }
+
+  return c.env?.server?.requestIP?.(c.req.raw)?.address ?? null;
+}
+
+export function createRateLimitMiddleware(
+  options: RateLimitOptions = {}
+): MiddlewareHandler<AppEnv> {
+  const windowMs = options.windowMs ?? DEFAULT_WINDOW_MS;
+  const max = options.max ?? DEFAULT_MAX;
+  const authMax = options.authMax ?? DEFAULT_AUTH_MAX;
+  const trustProxy = options.trustProxy ?? false;
+  const now = options.now ?? (() => Date.now());
+  const budgets = new Map<string, Budget>();
+
+  const sweep = (at: number) => {
+    for (const [key, budget] of budgets) {
+      if (budget.resetAt <= at) {
+        budgets.delete(key);
+      }
+    }
+  };
+
+  return async (c, next) => {
+    const address = clientAddress(c, trustProxy);
+
+    // Bun hands us no address for a socket it cannot describe. Counting those
+    // together would let one such caller lock out every other one, so they are
+    // not counted at all.
+    if (!address) {
+      await next();
+      return;
+    }
+
+    const isAuthPath = AUTH_PATHS.has(c.req.path);
+    const limit = isAuthPath ? authMax : max;
+    const key = `${isAuthPath ? "auth" : "general"}:${address}`;
+    const at = now();
+
+    if (budgets.size > SWEEP_AFTER_KEYS) {
+      sweep(at);
+    }
+
+    const budget = budgets.get(key);
+    const live = budget && budget.resetAt > at ? budget : null;
+
+    if (!live) {
+      budgets.set(key, { count: 1, resetAt: at + windowMs });
+      await next();
+      return;
+    }
+
+    live.count += 1;
+
+    if (live.count > limit) {
+      const retryAfter = Math.max(1, Math.ceil((live.resetAt - at) / 1000));
+      c.res = Response.json(
+        { error: "Too many requests." },
+        { headers: { "Retry-After": String(retryAfter) }, status: 429 }
+      );
+      return;
+    }
+
+    await next();
+  };
+}

--- a/apps/server/src/http/routes/auth.ts
+++ b/apps/server/src/http/routes/auth.ts
@@ -35,6 +35,14 @@ import {
 } from "../shared";
 import type { HonoApp } from "../types";
 
+/**
+ * A real bcrypt hash at the cost the app uses, kept only so a login for an
+ * unknown email costs the same as one for a known email. Nothing verifies
+ * against it successfully; it exists to be slow.
+ */
+const ABSENT_ACCOUNT_PASSWORD_HASH =
+  "$2b$10$IJnCe7uf5MN2/Vo89wb4ReF6yVI5SNnLdjIbiZ4Uwj4/r7zcqrWLm";
+
 export function registerAuthRoutes(app: HonoApp, options: ServerOptions): void {
   const { authService, databaseAdapter, orgService } = options;
   const authCredentialsSchema = z
@@ -452,6 +460,12 @@ export function registerAuthRoutes(app: HonoApp, options: ServerOptions): void {
     const body = await readJson<{ email: string; password: string }>(c.req.raw);
     const user = await databaseAdapter.getUserByEmail(body.email);
     if (!user) {
+      // Spend the same bcrypt work an existing account would, so the response
+      // time stops answering "does this email have an account here".
+      await authService.verifyPassword(
+        body.password?.trim() ?? "",
+        ABSENT_ACCOUNT_PASSWORD_HASH
+      );
       return errorResponse("Invalid credentials", 401);
     }
 

--- a/apps/server/src/http/types.ts
+++ b/apps/server/src/http/types.ts
@@ -2,7 +2,18 @@ import type { OpenAPIHono } from "@hono/zod-openapi";
 import type { RequestIdVariables } from "hono/request-id";
 import type { RequestAuthContext } from "./shared";
 
+/**
+ * What the rate limiter needs from Bun's `Server`, kept structural so the HTTP
+ * layer does not depend on the runtime type.
+ */
+type RequestAddressSource = {
+  requestIP?: (request: Request) => { address: string } | null;
+};
+
 export type AppEnv = {
+  Bindings: {
+    server?: RequestAddressSource;
+  };
   Variables: RequestIdVariables & {
     auth: RequestAuthContext;
   };

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -279,7 +279,8 @@ const app = createHonoApp({
 
 const server = startServer({
   canFallbackToNextPort,
-  fetch: app.fetch,
+  // The limiter needs the peer address, and Bun only exposes it on `server`.
+  fetch: (request: Request, server: Server) => app.fetch(request, { server }),
   host,
   preferredPort: requestedPort,
 });
@@ -370,7 +371,7 @@ function startServer(options: {
   host: string;
   preferredPort: number;
   canFallbackToNextPort: boolean;
-  fetch: (request: Request) => Response | Promise<Response>;
+  fetch: (request: Request, server: Server) => Response | Promise<Response>;
 }): ReturnType<typeof Bun.serve> {
   const lastPort = options.canFallbackToNextPort
     ? Math.min(options.preferredPort + 2000, 65_535)
@@ -382,7 +383,7 @@ function startServer(options: {
       return Bun.serve({
         async fetch(request, server: Server) {
           disableBunIdleTimeoutForLongHeldRequest(request, server);
-          const response = await options.fetch(request);
+          const response = await options.fetch(request, server);
           disableBunIdleTimeoutForSse(request, response, server);
           return response;
         },


### PR DESCRIPTION
## Summary

An unauthenticated flood now gets 429 with `Retry-After` before it reaches bcrypt or the database, and login stops answering "does this email have an account here".

**Before:** no limiter anywhere in the chain, and an unknown email returned 401 without ever running a password comparison.
**After:** a per-address fixed-window limiter ahead of auth in `createHonoApp`, with a separate smaller budget for the credential routes, and a dummy comparison on the unknown-email path.

Why safe:
1. The key is the real peer address. Bun hands `Server` to `fetch`, and `apps/server/src/index.ts` was dropping it, so it is now passed through as the Hono env. `X-Forwarded-For` is read only when `NAKAMA_TRUST_PROXY` is set, since trusting it with no proxy in front makes the limiter a formality.
2. A request whose address Bun cannot report is not counted at all, so one such caller cannot lock out everyone else. That is also why the existing suite, which calls `app.fetch` without a `Server`, is untouched: 1189 pass before, 1198 after, and the 9 are the new ones.
3. Every new test was scored by mutation rather than by being green. Six changes were applied one at a time: never enforcing the limit, giving the auth routes the general budget, always trusting the forwarded header, never refreshing the window, dropping the address from the key, and removing the dummy comparison. All six fail at least one test, twice.

Only revisit the default budget if a shared address behind NAT starts seeing 429 on ordinary dashboard use; `NAKAMA_RATE_LIMIT_MAX` and `NAKAMA_RATE_LIMIT_AUTH_MAX` tune it without a deploy.

Measured through the real app with a peer address: 60 wrong-password logins answer 10 times 401 then 50 times 429, three runs identical. Without a peer address the same 60 stay 401. The timing gap on login went from roughly three orders of magnitude to none: median 0.02 ms against 47 to 92 ms before, 55.7 against 56.7, 58.7 against 62.5, and 59.0 against 57.3 after, on macOS arm64 with Bun 1.3.14.

Scope: this is the throttling half of #358. The per-user and per-org spend quota is a different concern, needing identity and accounting rather than middleware, so it is not here.

## Test plan
- [x] `bun test apps/server` (1198 pass, 0 fail; `62dc9ed2` is 1189)
- [x] `bun test apps/server/src/http/rate-limit-middleware.test.ts apps/server/src/http/login-timing.test.ts` (9 pass)
- [x] `bun run knip` and `bun x ultracite check` (knip findings identical to main, no lint findings)
- [ ] Get the password wrong 11 times in a row against a running server: the 11th answers 429 with `Retry-After`, and a correct login works again once the window passes
