### PR TITLE
fix(server): preserve split UTF-8 installer output

### DIFF
--- a/apps/server/src/services/cli-package-install.test.ts
+++ b/apps/server/src/services/cli-package-install.test.ts
@@ -43,6 +43,35 @@ const PIPE_HOLDING_PLAN = {
 };
 
 describe("runTimedInstallCommand", () => {
+  test("preserves UTF-8 characters split across stdout and stderr chunks", async () => {
+    const progress: string[] = [];
+    const result = await runTimedInstallCommand(
+      {
+        args: [
+          "-e",
+          `
+          process.stdout.write(Buffer.from([0xf0, 0x9f]));
+          process.stderr.write(Buffer.from([0xe2]));
+          await Bun.sleep(100);
+          process.stdout.write(Buffer.from([0x9a, 0x80, 0x0a]));
+          process.stderr.write(Buffer.from([0x82, 0xac]));
+          `,
+        ],
+        command: process.execPath,
+        displayCommand: "split UTF-8 output",
+      },
+      (message) => progress.push(message)
+    );
+
+    expect(result).toEqual({
+      exitCode: 0,
+      stderr: "\u20ac",
+      stdout: "\ud83d\ude80",
+      timedOut: false,
+    });
+    expect(progress).toEqual(["stdout: \ud83d\ude80", "stderr: \u20ac"]);
+  });
+
   test("gives up on an installer that outlives the timeout", async () => {
     const result = await runTimedInstallCommand(STALLING_PLAN, undefined, {
       timeoutMs: 50,

--- a/apps/server/src/services/cli-package-install.ts
+++ b/apps/server/src/services/cli-package-install.ts
@@ -117,11 +117,11 @@ export async function probeCliVersion(command: string): Promise<{
       resolve({ installed: false, missing: false, version: null });
     }, timeoutMs);
 
-    child.stdout?.on("data", (chunk) => {
-      stdout += chunk.toString();
+    child.stdout?.setEncoding("utf8").on("data", (text: string) => {
+      stdout += text;
     });
-    child.stderr?.on("data", (chunk) => {
-      stderr += chunk.toString();
+    child.stderr?.setEncoding("utf8").on("data", (text: string) => {
+      stderr += text;
     });
     child.once("error", (error) => {
       clearTimeout(timeoutId);

--- a/apps/server/src/services/cli-package-install.ts
+++ b/apps/server/src/services/cli-package-install.ts
@@ -283,14 +283,12 @@ export async function runTimedInstallCommand(
       return nextBuffer;
     };
 
-    child.stdout?.on("data", (chunk) => {
-      const text = chunk.toString();
+    child.stdout?.setEncoding("utf8").on("data", (text: string) => {
       stdout += text;
       stdoutBuffer += text;
       stdoutBuffer = flushBuffer(stdoutBuffer, "stdout");
     });
-    child.stderr?.on("data", (chunk) => {
-      const text = chunk.toString();
+    child.stderr?.setEncoding("utf8").on("data", (text: string) => {
       stderr += text;
       stderrBuffer += text;
       stderrBuffer = flushBuffer(stderrBuffer, "stderr");


### PR DESCRIPTION
## Summary

Agent-browser installation diagnostics and CLI version probes preserve Unicode across pipe reads.

**Before:** decoding individual Buffer chunks turns split UTF-8 characters into replacement characters.
**After:** native `setEncoding('utf8')` buffers incomplete characters independently on stdout and stderr.

Why safe:
1. No custom decoder or dependency; line buffering, final-line delivery, and install lifecycle remain unchanged.
2. One real-child regression checks both pipes and captured/progress output, including a final line without a newline; it failed before the fix on Windows and Linux.

Scope includes installer diagnostics and CLI version probes; installation behavior and the bash tool are unchanged. Fixes #935; assignment requested in the issue before opening the draft.

## Test plan
- [x] `bun test apps/server/src/services/cli-package-install.test.ts` on Linux/Bun 1.3.14 (9 pass); new regression also passes on Windows/Bun 1.4.0.
- [x] Targeted Ultracite check and `bun run knip`; smoke checks preserve Unicode through progress/error SSE and retain replacement behavior for incomplete UTF-8 at EOF.
- [x] CI tests, Knip, and React Doctor pass on [the latest head](https://github.com/ahmadrosid/nakama/commit/443666c6ddc76a04a2adc738cec39436a93fe8fd). Refreshed simplification self-review and independent static correctness review found no blockers. A real-executable version-probe smoke check failed before the follow-up and passed afterward for both pipes; 5 existing status/timeout checks pass.

Broader Linux installer/service/SSE run: 21 pass, 1 fail (`install stream emits progress events`: fixture cannot find `bun`); the same failure reproduces with unchanged upstream production code. Windows shell-fixture checks also fail. A later LF-normalized test copy did not resolve the Linux failure. No live package installation or browser UI check was performed.