### PR TITLE
fix(server): remove profile files on delete

### DIFF
--- a/apps/server/src/services/profile-service.test.ts
+++ b/apps/server/src/services/profile-service.test.ts
@@ -1,8 +1,16 @@
 import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { getProfileSoulDir } from "@nakama/core";
 import {
   createInMemoryDatabaseAdapter,
   createSqliteDatabase,
@@ -941,6 +949,25 @@ describe("profile service deleteProfile", () => {
     ).rejects.toThrow(/at least 3 profiles/);
 
     expect((await db.getProfile(first.profile.id))?.isDefault).toBe(true);
+  });
+
+  test("removes the deleted profile workspace without touching another profile", async () => {
+    const { db, service } = await setup();
+    const removed = await service.createProfile(ORG_ID, { name: "Removed" });
+    const kept = await service.createProfile(ORG_ID, { name: "Kept" });
+    const removedDir = getProfileSoulDir(ORG_ID, removed.profile.id);
+    const keptDir = getProfileSoulDir(ORG_ID, kept.profile.id);
+    const artifactDir = path.join(removedDir, "artifacts");
+    await mkdir(artifactDir, { recursive: true });
+    await writeFile(path.join(artifactDir, "report.md"), "private data");
+
+    await service.deleteProfile(ORG_ID, removed.profile.id);
+
+    expect(await db.getProfile(removed.profile.id)).toBeNull();
+    await expect(access(removedDir)).rejects.toThrow();
+    expect(
+      (await readFile(path.join(keptDir, "SOUL.md"), "utf8")).length
+    ).toBeGreaterThan(0);
   });
 
   test("deletes the default when the org has 3 profiles and promotes a successor", async () => {

--- a/apps/server/src/services/profile-service.test.ts
+++ b/apps/server/src/services/profile-service.test.ts
@@ -10,7 +10,7 @@ import {
 } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { getProfileSoulDir } from "@nakama/core";
+import { getProfileSoulDir, writeArtifactShareSnapshot } from "@nakama/core";
 import {
   createInMemoryDatabaseAdapter,
   createSqliteDatabase,
@@ -968,6 +968,36 @@ describe("profile service deleteProfile", () => {
     expect(
       (await readFile(path.join(keptDir, "SOUL.md"), "utf8")).length
     ).toBeGreaterThan(0);
+  });
+
+  test("removes artifact share snapshots before their rows cascade", async () => {
+    const { db, service } = await setup();
+    const removed = await service.createProfile(ORG_ID, { name: "Removed" });
+    const shareId = "share_delete_test";
+    const storagePath = await writeArtifactShareSnapshot({
+      bytes: Buffer.from("shared private data"),
+      filename: "report.md",
+      orgId: ORG_ID,
+      shareId,
+    });
+    await db.createArtifactShare({
+      createdAt: new Date().toISOString(),
+      createdByUserId: "user_test",
+      filename: "report.md",
+      id: shareId,
+      mimeType: "text/markdown",
+      orgId: ORG_ID,
+      profileId: removed.profile.id,
+      revokedAt: null,
+      sizeBytes: 19,
+      sourcePath: "artifacts/report.md",
+      storagePath,
+      tokenHash: "share_token_hash",
+    });
+
+    await service.deleteProfile(ORG_ID, removed.profile.id);
+
+    await expect(access(storagePath)).rejects.toThrow();
   });
 
   test("deletes the default when the org has 3 profiles and promotes a successor", async () => {

--- a/apps/server/src/services/session-persistence.ts
+++ b/apps/server/src/services/session-persistence.ts
@@ -2,7 +2,12 @@ import { copyFile, mkdir, open, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type { AgentChatSession } from "@nakama/agent";
 import type { ChatMessage, ToolDefinition } from "@nakama/core";
-import { createId, getUserConfigDir, jsonSchemaFromZod } from "@nakama/core";
+import {
+  createId,
+  getProfileSoulDir,
+  getUserConfigDir,
+  jsonSchemaFromZod,
+} from "@nakama/core";
 import type { DatabaseAdapter } from "@nakama/db";
 import { z } from "zod";
 
@@ -93,7 +98,12 @@ export function deleteProfileWithHistoryArchives(
           });
         }
       }
-      // Keep session IDs available for retry if filesystem cleanup fails.
+      // Keep the profile and session IDs available for retry when filesystem
+      // cleanup fails instead of leaving unreachable files after the cascade.
+      await rm(getProfileSoulDir(orgId, profileId), {
+        force: true,
+        recursive: true,
+      });
       return db.deleteProfile(profileId);
     }
   );

--- a/apps/server/src/services/session-persistence.ts
+++ b/apps/server/src/services/session-persistence.ts
@@ -4,6 +4,7 @@ import type { AgentChatSession } from "@nakama/agent";
 import type { ChatMessage, ToolDefinition } from "@nakama/core";
 import {
   createId,
+  deleteArtifactShareSnapshot,
   getProfileSoulDir,
   getUserConfigDir,
   jsonSchemaFromZod,
@@ -90,6 +91,14 @@ export function deleteProfileWithHistoryArchives(
   return withArchiveLock(
     dirname(sessionHistoryArchivePath(orgId, "")),
     async () => {
+      const artifactShares = await db.listArtifactSharesForProfile(
+        orgId,
+        profileId
+      );
+      for (const share of artifactShares) {
+        await deleteArtifactShareSnapshot(orgId, share.storagePath);
+      }
+
       const sessions = await db.listSessions();
       for (const session of sessions) {
         if (session.profileId === profileId) {

--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -1862,6 +1862,13 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
     WHERE org_id = ? AND profile_id = ? AND id = ?
     LIMIT 1
   `);
+  const listArtifactSharesForProfileStmt = db.prepare(`
+    SELECT
+      id, org_id, profile_id, source_path, filename, mime_type, size_bytes,
+      token_hash, storage_path, created_by_user_id, created_at, revoked_at
+    FROM artifact_shares
+    WHERE org_id = ? AND profile_id = ?
+  `);
   const revokeArtifactShareStmt = db.prepare(`
     UPDATE artifact_shares
     SET revoked_at = ?
@@ -2724,6 +2731,12 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
         record.completedAt,
         record.position
       );
+    },
+
+    async listArtifactSharesForProfile(orgId, profileId) {
+      return listArtifactSharesForProfileStmt
+        .all(orgId, profileId)
+        .map((row) => toArtifactShareRecord(row as ArtifactShareRow));
     },
 
     async listAutomationRuns(automationId, limit = 20) {

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -800,6 +800,11 @@ export interface DatabaseAdapter {
   insertWorkflowRun(record: StoredWorkflowRunRecord): Promise<void>;
   insertWorkflowRunStep(record: StoredWorkflowRunStepRecord): Promise<void>;
 
+  listArtifactSharesForProfile(
+    orgId: string,
+    profileId: string
+  ): Promise<StoredArtifactShareRecord[]>;
+
   listAutomationRuns(
     automationId: string,
     limit?: number


### PR DESCRIPTION
## Summary

Delete a profile → remove its soul, artifacts, attachments, skills, knowledge-base files, and public share snapshots from disk.

**Before:** profile deletion removed database rows and session archives but left the profile workspace and external share snapshots behind.
**After:** `deleteProfileWithHistoryArchives` enumerates and deletes validated share snapshots, then removes the validated profile directory before the database cascade.

Why safe:
1. Both cleanup paths validate their organization/profile boundaries before touching disk.
2. Files are removed before database deletion, so a filesystem error keeps profile, session, and share IDs available for retry.

Organization and user erasure remain separate follow-ups in #368.

## Test plan
- [x] `bun test apps/server/src/services` (551 pass); `bun test packages/db` (101 pass)
- [x] Targeted Ultracite check and `bun run build`
- [ ] Share an artifact, delete its profile, and confirm both workspace and share snapshot are gone

Progresses #368