### PR TITLE
fix(db): stop reassigning the sqlite tool on every start

### DIFF
--- a/packages/db/src/seed.test.ts
+++ b/packages/db/src/seed.test.ts
@@ -15,6 +15,32 @@ import {
 } from "./seed";
 
 describe("seed cleanup", () => {
+  test("keeps a tool an operator unassigned from a profile", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const now = new Date().toISOString();
+
+    await db.upsertProfile({
+      createdAt: now,
+      id: "profile_stripped",
+      isSuper: false,
+      model: null,
+      name: "Stripped",
+      systemPrompt: "",
+      updatedAt: now,
+    });
+    await ensureBuiltinToolDefinitions(db);
+    await db.assignToolToProfile("profile_stripped", BUILTIN_TOOL_IDS.sqlite);
+    await db.unassignToolFromProfile(
+      "profile_stripped",
+      BUILTIN_TOOL_IDS.sqlite
+    );
+
+    await seedDatabase(db);
+
+    const tools = await db.listToolsForProfile("profile_stripped");
+    expect(tools.map((tool) => tool.id)).not.toContain(BUILTIN_TOOL_IDS.sqlite);
+  });
+
   test("deleteTool unassigns every profile before deleting", async () => {
     const db = createInMemoryDatabaseAdapter();
     const now = new Date().toISOString();

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -46,9 +46,6 @@ export async function seedDatabase(db: DatabaseAdapter): Promise<void> {
   await removeDeprecatedServerTools(db);
   await removeUnsupportedTools(db);
   await ensureBuiltinToolDefinitions(db);
-  for (const profile of await db.listProfiles()) {
-    await db.assignToolToProfile(profile.id, BUILTIN_TOOL_IDS.sqlite);
-  }
   await ensureSubAgentToolDefinition(db);
   await ensureSessionToolDefinitions(db);
   await ensureBashToolDefinition(db);


### PR DESCRIPTION
## Summary

Removing a tool from a profile now survives a restart.

**Before:** `seedDatabase` looped over every profile on every boot and assigned the sqlite tool. An operator who unassigned it got a 200, saw it gone, and had it back after the next restart with nothing logged.
**After:** the loop is gone. New profiles still get sqlite at creation, `DEFAULT_BUILTIN_TOOL_IDS` is every entry of `BUILTIN_TOOL_IDS`, so nothing changes for a fresh install.

Why safe:
1. The loop was a backfill for profiles created before the workflow feature (#826). It has run on every boot since, so any install that has started once already has the assignment; deleting it backfills nothing that is still missing.
2. The new test fails with the loop restored and passes without it.

Part of #940. The larger half of that issue, whether a turn should carry the 16 platform tools when the profile carries none, is a design call I left alone.

## Test plan
- [x] `bun test packages/db/src/seed.test.ts`, 16 pass
- [x] Watched the new test fail with the loop put back: `(fail) keeps a tool an operator unassigned from a profile`
- [x] `bun run test`, all 11 workspaces exit 0
- [ ] Not checked on a Postgres-backed install; the test uses the in-memory adapter
