### PR TITLE
feat(providers): add Vercel AI Gateway integration

### DIFF
--- a/apps/server/src/providers/compatible-models.ts
+++ b/apps/server/src/providers/compatible-models.ts
@@ -136,6 +136,7 @@ export function catalogCustomModelsToCatalog(
     } else if (
       provider === "deepseek" ||
       provider === "together" ||
+      provider === "vercel_ai_gateway" ||
       provider === "mistral" ||
       provider === "perplexity"
     ) {
@@ -329,6 +330,7 @@ export function getModelsForProviderInstance(
     instance.type === "gemini" ||
     instance.type === "deepseek" ||
     instance.type === "together" ||
+    instance.type === "vercel_ai_gateway" ||
     instance.type === "mistral" ||
     instance.type === "perplexity" ||
     instance.type === "opencode_go"

--- a/apps/server/src/providers/create.test.ts
+++ b/apps/server/src/providers/create.test.ts
@@ -81,6 +81,68 @@ describe("createProviderForInstance routing", () => {
     }
   });
 
+  test("routes vercel_ai_gateway instances to the configured base URL with auth", async () => {
+    let seenPath = "";
+    let seenAuth = "";
+    let seenModel = "";
+
+    const mock = Bun.serve({
+      fetch: async (request) => {
+        const url = new URL(request.url);
+        seenPath = url.pathname;
+        seenAuth = request.headers.get("authorization") ?? "";
+        const body = (await request.json()) as { model?: string };
+        seenModel = body.model ?? "";
+        return Response.json({
+          choices: [
+            {
+              finish_reason: "stop",
+              index: 0,
+              message: { content: "ok", role: "assistant" },
+            },
+          ],
+          created: 1,
+          id: "mock",
+          model: seenModel,
+          object: "chat.completion",
+          usage: {
+            completion_tokens: 1,
+            prompt_tokens: 1,
+            total_tokens: 2,
+          },
+        });
+      },
+      port: 0,
+    });
+
+    try {
+      const instance: ProviderInstance = {
+        apiKey: "test-key",
+        baseUrl: `http://127.0.0.1:${mock.port}/v1`,
+        createdAt: new Date().toISOString(),
+        id: "inst_vercel_ai_gateway",
+        label: "Vercel AI Gateway",
+        type: "vercel_ai_gateway",
+      };
+
+      const client = createProviderForInstance(instance, "openai/gpt-4o-mini");
+
+      expect(client).not.toBeNull();
+      expect(client?.name).toBe("vercel_ai_gateway");
+
+      const result = await client!.generateChat({
+        messages: [{ content: "ping", role: "user" }],
+      });
+
+      expect(result.content).toBe("ok");
+      expect(seenPath).toBe("/v1/chat/completions");
+      expect(seenAuth).toBe("Bearer test-key");
+      expect(seenModel).toBe("openai/gpt-4o-mini");
+    } finally {
+      mock.stop(true);
+    }
+  });
+
   test("routes mistral instances to the configured base URL with auth", async () => {
     let seenPath = "";
     let seenAuth = "";

--- a/apps/server/src/providers/create.test.ts
+++ b/apps/server/src/providers/create.test.ts
@@ -85,20 +85,29 @@ describe("createProviderForInstance routing", () => {
     let seenPath = "";
     let seenAuth = "";
     let seenModel = "";
+    let seenReasoning: unknown;
 
     const mock = Bun.serve({
       fetch: async (request) => {
         const url = new URL(request.url);
         seenPath = url.pathname;
         seenAuth = request.headers.get("authorization") ?? "";
-        const body = (await request.json()) as { model?: string };
+        const body = (await request.json()) as {
+          model?: string;
+          reasoning?: unknown;
+        };
         seenModel = body.model ?? "";
+        seenReasoning = body.reasoning;
         return Response.json({
           choices: [
             {
               finish_reason: "stop",
               index: 0,
-              message: { content: "ok", role: "assistant" },
+              message: {
+                content: "ok",
+                reasoning: "because",
+                role: "assistant",
+              },
             },
           ],
           created: 1,
@@ -132,12 +141,15 @@ describe("createProviderForInstance routing", () => {
 
       const result = await client!.generateChat({
         messages: [{ content: "ping", role: "user" }],
+        providerOptions: { thinking: { effort: "medium", enabled: true } },
       });
 
       expect(result.content).toBe("ok");
+      expect(result.thinking).toBe("because");
       expect(seenPath).toBe("/v1/chat/completions");
       expect(seenAuth).toBe("Bearer test-key");
       expect(seenModel).toBe("openai/gpt-4o-mini");
+      expect(seenReasoning).toEqual({ effort: "medium", enabled: true });
     } finally {
       mock.stop(true);
     }

--- a/apps/server/src/providers/create.test.ts
+++ b/apps/server/src/providers/create.test.ts
@@ -145,7 +145,7 @@ describe("createProviderForInstance routing", () => {
       });
 
       expect(result.content).toBe("ok");
-      expect(result.thinking).toBe("because");
+      expect(result.assistantMessage.thinking).toBe("because");
       expect(seenPath).toBe("/v1/chat/completions");
       expect(seenAuth).toBe("Bearer test-key");
       expect(seenModel).toBe("openai/gpt-4o-mini");

--- a/apps/server/src/providers/create.ts
+++ b/apps/server/src/providers/create.ts
@@ -34,6 +34,7 @@ import { createXaiProvider } from "./xai-oauth";
 
 const DEFAULT_DEEPSEEK_BASE_URL = "https://api.deepseek.com";
 const DEFAULT_TOGETHER_BASE_URL = "https://api.together.xyz/v1";
+const DEFAULT_VERCEL_AI_GATEWAY_BASE_URL = "https://ai-gateway.vercel.sh/v1";
 const DEFAULT_MISTRAL_BASE_URL = "https://api.mistral.ai/v1";
 const DEFAULT_PERPLEXITY_BASE_URL = "https://api.perplexity.ai";
 const DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1";
@@ -95,6 +96,13 @@ function createProvider(options: CreateProviderOptions): ProviderClient {
         baseUrl: baseUrlOverride ?? DEFAULT_TOGETHER_BASE_URL,
         model,
         providerName: "together",
+      });
+    case "vercel_ai_gateway":
+      return createOpenAIProvider({
+        apiKey: options.apiKey,
+        baseUrl: baseUrlOverride ?? DEFAULT_VERCEL_AI_GATEWAY_BASE_URL,
+        model,
+        providerName: "vercel_ai_gateway",
       });
     case "mistral":
       return createOpenAIProvider({

--- a/apps/server/src/providers/models.test.ts
+++ b/apps/server/src/providers/models.test.ts
@@ -115,6 +115,32 @@ describe("resolveModel", () => {
     );
   });
 
+  test("resolves catalog models for Vercel AI Gateway", () => {
+    expect(resolveModel("vercel_ai_gateway", "openai/gpt-4o-mini")).toBe(
+      "openai/gpt-4o-mini"
+    );
+    expect(
+      resolveModel("vercel_ai_gateway", "anthropic/claude-sonnet-4.5")
+    ).toBe("anthropic/claude-sonnet-4.5");
+    expect(getDefaultModel("vercel_ai_gateway")).toBe("openai/gpt-4o-mini");
+    expect(getModelById("openai/gpt-4o-mini")?.supportsVision).toBe(true);
+    expect(getModelById("openai/gpt-5")?.supportsThinking).toBe(true);
+    expect(getModelById("meta/llama-3.3-70b")?.supportsVision).toBe(false);
+    expect(getModelById("deepseek/deepseek-v4-flash")?.supportsThinking).toBe(
+      true
+    );
+  });
+
+  test("uses vercel_ai_gateway custom model shortlist when provided", () => {
+    const customModels = [{ default: true, id: "openai/gpt-5", name: "GPT-5" }];
+    expect(
+      resolveModel("vercel_ai_gateway", "openai/gpt-5", customModels)
+    ).toBe("openai/gpt-5");
+    expect(
+      resolveModel("vercel_ai_gateway", "unknown-model", customModels)
+    ).toBe("openai/gpt-5");
+  });
+
   test("resolves catalog models for Mistral", () => {
     expect(resolveModel("mistral", "mistral-large-2512")).toBe(
       "mistral-large-2512"
@@ -338,6 +364,15 @@ describe("modelSupportsVision", () => {
     expect(modelSupportsVision("openai/gpt-oss-120b", "together")).toBe(false);
     expect(modelSupportsVision("Qwen/Qwen3.5-9B", "together")).toBe(true);
     expect(modelSupportsVision("MiniMaxAI/MiniMax-M3", "together")).toBe(true);
+  });
+
+  test("reads Vercel AI Gateway vision flags from the curated catalog", () => {
+    expect(modelSupportsVision("openai/gpt-4o-mini", "vercel_ai_gateway")).toBe(
+      true
+    );
+    expect(modelSupportsVision("meta/llama-3.3-70b", "vercel_ai_gateway")).toBe(
+      false
+    );
   });
 
   test("reads Mistral vision flags from the curated catalog", () => {

--- a/apps/server/src/providers/models.ts
+++ b/apps/server/src/providers/models.ts
@@ -351,6 +351,71 @@ const BASE_MODELS: ProviderModelOption[] = withVisionDefaults([
     supportsVision: true,
   },
   {
+    contextWindow: 128_000,
+    default: true,
+    id: "openai/gpt-4o-mini",
+    inputPerMillionUsd: 0.15,
+    maxOutputTokens: 16_384,
+    name: "GPT-4o mini",
+    outputPerMillionUsd: 0.6,
+    provider: "vercel_ai_gateway",
+    supportsVision: true,
+  },
+  {
+    contextWindow: 400_000,
+    id: "openai/gpt-5",
+    inputPerMillionUsd: 1.25,
+    maxOutputTokens: 128_000,
+    name: "GPT-5",
+    outputPerMillionUsd: 10,
+    provider: "vercel_ai_gateway",
+    supportsThinking: true,
+    supportsVision: true,
+  },
+  {
+    contextWindow: 1_000_000,
+    id: "anthropic/claude-sonnet-4.5",
+    inputPerMillionUsd: 3,
+    maxOutputTokens: 64_000,
+    name: "Claude Sonnet 4.5",
+    outputPerMillionUsd: 15,
+    provider: "vercel_ai_gateway",
+    supportsThinking: true,
+    supportsVision: true,
+  },
+  {
+    contextWindow: 1_000_000,
+    id: "google/gemini-2.5-flash",
+    inputPerMillionUsd: 0.3,
+    maxOutputTokens: 65_536,
+    name: "Gemini 2.5 Flash",
+    outputPerMillionUsd: 2.5,
+    provider: "vercel_ai_gateway",
+    supportsThinking: true,
+    supportsVision: true,
+  },
+  {
+    contextWindow: 128_000,
+    id: "meta/llama-3.3-70b",
+    inputPerMillionUsd: 0.72,
+    maxOutputTokens: 8192,
+    name: "Llama 3.3 70B",
+    outputPerMillionUsd: 0.72,
+    provider: "vercel_ai_gateway",
+    supportsVision: false,
+  },
+  {
+    contextWindow: 1_000_000,
+    id: "deepseek/deepseek-v4-flash",
+    inputPerMillionUsd: 0.13,
+    maxOutputTokens: 384_000,
+    name: "DeepSeek V4 Flash",
+    outputPerMillionUsd: 0.26,
+    provider: "vercel_ai_gateway",
+    supportsThinking: true,
+    supportsVision: false,
+  },
+  {
     contextWindow: 131_072,
     default: true,
     id: "gpt-oss-120b",
@@ -767,6 +832,7 @@ export function getDefaultModel(
       provider === "gemini" ||
       provider === "deepseek" ||
       provider === "together" ||
+      provider === "vercel_ai_gateway" ||
       provider === "mistral" ||
       provider === "perplexity" ||
       provider === "opencode_go") &&
@@ -787,19 +853,21 @@ export function getDefaultModel(
             ? "deepseek-v4-flash"
             : provider === "together"
               ? "openai/gpt-oss-120b"
-              : provider === "mistral"
-                ? "mistral-small-2603"
-                : provider === "perplexity"
-                  ? "sonar"
-                  : provider === "cerebras"
-                    ? "gpt-oss-120b"
-                    : provider === "fireworks"
-                      ? "accounts/fireworks/models/kimi-k2p6"
-                      : provider === "opencode_go"
-                        ? "opencode-go/kimi-k2.7-code"
-                        : provider === "cloudflare"
-                          ? "@cf/meta/llama-3.3-70b-instruct-fp8-fast"
-                          : "gpt-5.4";
+              : provider === "vercel_ai_gateway"
+                ? "openai/gpt-4o-mini"
+                : provider === "mistral"
+                  ? "mistral-small-2603"
+                  : provider === "perplexity"
+                    ? "sonar"
+                    : provider === "cerebras"
+                      ? "gpt-oss-120b"
+                      : provider === "fireworks"
+                        ? "accounts/fireworks/models/kimi-k2p6"
+                        : provider === "opencode_go"
+                          ? "opencode-go/kimi-k2.7-code"
+                          : provider === "cloudflare"
+                            ? "@cf/meta/llama-3.3-70b-instruct-fp8-fast"
+                            : "gpt-5.4";
   return models.find((model) => model.default)?.id ?? models[0]?.id ?? fallback;
 }
 
@@ -864,6 +932,7 @@ export function resolveModel(
       provider === "gemini" ||
       provider === "deepseek" ||
       provider === "together" ||
+      provider === "vercel_ai_gateway" ||
       provider === "mistral" ||
       provider === "perplexity" ||
       provider === "cerebras" ||

--- a/apps/server/src/providers/openai/index.ts
+++ b/apps/server/src/providers/openai/index.ts
@@ -369,6 +369,9 @@ async function buildChatCompletionRequestBody(options: {
     ...(provider === "deepseek"
       ? buildDeepSeekThinkingBody(options.thinking)
       : {}),
+    ...(provider === "vercel_ai_gateway"
+      ? buildVercelReasoningBody(options.thinking)
+      : {}),
     ...(provider === "perplexity" && options.thinking?.enabled
       ? {
           reasoning_effort: normalizeThinkingEffort(options.thinking.effort),
@@ -444,6 +447,22 @@ function buildDeepSeekThinkingBody(
   };
 }
 
+/** AI Gateway Chat Completions extension: top-level `reasoning` object. */
+function buildVercelReasoningBody(
+  thinking: ProviderChatOptions["thinking"] | undefined
+) {
+  if (!thinking?.enabled) {
+    return {};
+  }
+
+  return {
+    reasoning: {
+      effort: normalizeThinkingEffort(thinking.effort),
+      enabled: true,
+    },
+  };
+}
+
 function readReasoningContent(
   value: unknown,
   options?: { preserveWhitespace?: boolean }
@@ -456,7 +475,9 @@ function readReasoningContent(
   const direct =
     typeof record.reasoning_content === "string"
       ? record.reasoning_content
-      : undefined;
+      : typeof record.reasoning === "string"
+        ? record.reasoning
+        : undefined;
 
   if (direct === undefined) {
     return;

--- a/apps/server/src/providers/openai/index.ts
+++ b/apps/server/src/providers/openai/index.ts
@@ -152,6 +152,10 @@ function providerLabel(providerName: ProviderName): string {
     return "Together AI";
   }
 
+  if (providerName === "vercel_ai_gateway") {
+    return "Vercel AI Gateway";
+  }
+
   if (providerName === "mistral") {
     return "Mistral";
   }

--- a/apps/server/src/providers/openai/index.ts
+++ b/apps/server/src/providers/openai/index.ts
@@ -369,8 +369,13 @@ async function buildChatCompletionRequestBody(options: {
     ...(provider === "deepseek"
       ? buildDeepSeekThinkingBody(options.thinking)
       : {}),
-    ...(provider === "vercel_ai_gateway"
-      ? buildVercelReasoningBody(options.thinking)
+    ...(provider === "vercel_ai_gateway" && options.thinking?.enabled
+      ? {
+          reasoning: {
+            effort: normalizeThinkingEffort(options.thinking.effort),
+            enabled: true,
+          },
+        }
       : {}),
     ...(provider === "perplexity" && options.thinking?.enabled
       ? {
@@ -444,22 +449,6 @@ function buildDeepSeekThinkingBody(
   return {
     reasoning_effort: reasoningEffort,
     thinking: { type: "enabled" as const },
-  };
-}
-
-/** AI Gateway Chat Completions extension: top-level `reasoning` object. */
-function buildVercelReasoningBody(
-  thinking: ProviderChatOptions["thinking"] | undefined
-) {
-  if (!thinking?.enabled) {
-    return {};
-  }
-
-  return {
-    reasoning: {
-      effort: normalizeThinkingEffort(thinking.effort),
-      enabled: true,
-    },
   };
 }
 

--- a/apps/server/src/services/provider-instance-helpers.ts
+++ b/apps/server/src/services/provider-instance-helpers.ts
@@ -156,6 +156,7 @@ export function modelExistsOnInstance(
     instance.type === "gemini" ||
     instance.type === "deepseek" ||
     instance.type === "together" ||
+    instance.type === "vercel_ai_gateway" ||
     instance.type === "mistral" ||
     instance.type === "perplexity"
   ) {
@@ -357,6 +358,7 @@ export function applyProviderInstanceUpdate(
       instance.type === "gemini" ||
       instance.type === "deepseek" ||
       instance.type === "together" ||
+      instance.type === "vercel_ai_gateway" ||
       instance.type === "mistral" ||
       instance.type === "perplexity"
     ) {

--- a/apps/web/src/components/catalog-provider-model-fields.shared.ts
+++ b/apps/web/src/components/catalog-provider-model-fields.shared.ts
@@ -8,6 +8,7 @@ export const CATALOG_SHORTLIST_PROVIDERS = [
   "gemini",
   "deepseek",
   "together",
+  "vercel_ai_gateway",
   "mistral",
   "perplexity",
   "opencode_go",

--- a/apps/web/src/hooks/use-models-dev.ts
+++ b/apps/web/src/hooks/use-models-dev.ts
@@ -36,6 +36,7 @@ const OFFICIAL_PROVIDER_IDS = new Set([
 
 const NPM_MAP: Record<string, SelectedProvider> = {
   "@ai-sdk/anthropic": "anthropic",
+  "@ai-sdk/gateway": "vercel_ai_gateway",
   "@ai-sdk/google": "gemini",
   "@ai-sdk/openai": "openai",
 };
@@ -47,12 +48,12 @@ const PROVIDER_ID_OVERRIDES: Record<string, SelectedProvider> = {
   openrouter: "openrouter",
   perplexity: "perplexity",
   together: "together",
+  vercel: "vercel_ai_gateway",
 };
 
 const UNSUPPORTED_NPM: Record<string, string> = {
   "@ai-sdk/amazon-bedrock": "Requires AWS SigV4 auth",
   "@ai-sdk/azure": "Requires Azure deployment routing",
-  "@ai-sdk/gateway": "Requires Vercel AI Gateway",
   "@ai-sdk/google-vertex": "Requires Google Cloud OAuth",
   "@ai-sdk/google-vertex/anthropic": "Requires Google Cloud OAuth",
   "@jerome-benoit/sap-ai-provider-v2": "Requires SAP-specific auth",

--- a/apps/web/src/lib/models.test.ts
+++ b/apps/web/src/lib/models.test.ts
@@ -24,6 +24,7 @@ function group(
     | "openrouter"
     | "deepseek"
     | "together"
+    | "vercel_ai_gateway"
     | "mistral"
     | "perplexity"
     | "cerebras"
@@ -135,6 +136,22 @@ describe("resolveModelThinkingSupport", () => {
       resolveModelThinkingSupport(
         encodeModelSelection("tg-1", "model-1"),
         group("tg-1", "together", { supportsThinking: true })
+      )
+    ).toBe(true);
+  });
+
+  test("treats vercel_ai_gateway models as opt-in only for thinking", () => {
+    expect(
+      resolveModelThinkingSupport(
+        encodeModelSelection("vag-1", "model-1"),
+        group("vag-1", "vercel_ai_gateway")
+      )
+    ).toBe(false);
+
+    expect(
+      resolveModelThinkingSupport(
+        encodeModelSelection("vag-1", "model-1"),
+        group("vag-1", "vercel_ai_gateway", { supportsThinking: true })
       )
     ).toBe(true);
   });
@@ -276,6 +293,22 @@ describe("resolveModelVisionSupport", () => {
     ).toBe(true);
   });
 
+  test("treats vercel_ai_gateway models as opt-in only for vision", () => {
+    expect(
+      resolveModelVisionSupport(
+        encodeModelSelection("vag-1", "model-1"),
+        group("vag-1", "vercel_ai_gateway")
+      )
+    ).toBe(false);
+
+    expect(
+      resolveModelVisionSupport(
+        encodeModelSelection("vag-1", "model-1"),
+        group("vag-1", "vercel_ai_gateway", { supportsVision: true })
+      )
+    ).toBe(true);
+  });
+
   test("treats fireworks models as opt-in only for vision", () => {
     expect(
       resolveModelVisionSupport(
@@ -380,6 +413,7 @@ describe("firstAvailableProviderOption", () => {
           "gemini",
           "deepseek",
           "together",
+          "vercel_ai_gateway",
           "mistral",
           "perplexity",
           "cerebras",

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -66,7 +66,8 @@ export function formatProviderLabel(
     provider === "zhipu" ||
     provider === "zhipu_cn" ||
     provider === "xai" ||
-    provider === "together"
+    provider === "together" ||
+    provider === "vercel_ai_gateway"
   ) {
     return formatConfiguredProviderLabel(provider, displayName);
   }
@@ -84,6 +85,7 @@ export const PROVIDER_OPTIONS: Array<{ id: SelectedProvider; label: string }> =
     { id: "gemini", label: "Gemini" },
     { id: "deepseek", label: "DeepSeek" },
     { id: "together", label: "Together AI" },
+    { id: "vercel_ai_gateway", label: "Vercel AI Gateway" },
     { id: "mistral", label: "Mistral" },
     { id: "perplexity", label: "Perplexity Sonar" },
     { id: "cerebras", label: "Cerebras" },
@@ -900,6 +902,7 @@ export function resolveModelThinkingSupport(
     model.provider === "openrouter" ||
     model.provider === "deepseek" ||
     model.provider === "together" ||
+    model.provider === "vercel_ai_gateway" ||
     model.provider === "mistral" ||
     model.provider === "perplexity" ||
     model.provider === "cerebras" ||
@@ -952,6 +955,7 @@ export function resolveModelVisionSupport(
     model.provider === "opencode_go" ||
     model.provider === "deepseek" ||
     model.provider === "together" ||
+    model.provider === "vercel_ai_gateway" ||
     model.provider === "mistral" ||
     model.provider === "perplexity" ||
     model.provider === "cerebras" ||

--- a/docs/website/content/docs/providers.mdx
+++ b/docs/website/content/docs/providers.mdx
@@ -33,6 +33,7 @@ Nakama supports these built-in provider types:
 | Gemini | Google Gemini models |
 | DeepSeek | DeepSeek models |
 | Together AI | Open-source and hosted models via Together |
+| Vercel AI Gateway | One Vercel key → many labs' models (`creator/model` ids) |
 | Mistral | Mistral models (Small 4, Medium 3.5, Large 3, Ministral 3) |
 | Perplexity Sonar | Search-grounded Sonar models with citation links |
 | Cerebras | Cerebras models |

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -2244,7 +2244,8 @@ export type ProviderName =
   | "zhipu"
   | "zhipu_cn"
   | "xai"
-  | "together";
+  | "together"
+  | "vercel_ai_gateway";
 
 export interface ChatgptOAuthCredentials {
   accessToken: string;

--- a/packages/core/src/document-content.ts
+++ b/packages/core/src/document-content.ts
@@ -99,6 +99,7 @@ const NATIVE_DOCUMENT_MEDIA_TYPES: Record<ProviderName, ReadonlySet<string>> = {
   ]),
   perplexity: new Set<string>(),
   together: new Set<string>(),
+  vercel_ai_gateway: new Set<string>(),
   xai: new Set<string>(),
   xai_oauth: new Set<string>(),
   zhipu: new Set<string>(),

--- a/packages/core/src/provider-label.ts
+++ b/packages/core/src/provider-label.ts
@@ -22,6 +22,7 @@ const BUILTIN_LABELS: Record<
   openrouter: "OpenRouter",
   perplexity: "Perplexity Sonar",
   together: "Together AI",
+  vercel_ai_gateway: "Vercel AI Gateway",
   xai: "xAI Grok",
   xai_oauth: "Grok (SuperGrok / Premium+)",
   zhipu: "GLM (Z.ai)",

--- a/packages/core/src/provider-resolution.test.ts
+++ b/packages/core/src/provider-resolution.test.ts
@@ -28,6 +28,7 @@ describe("parseProviderName", () => {
     expect(parseProviderName("moonshot_cn")).toBe("moonshot_cn");
     expect(parseProviderName("xai")).toBe("xai");
     expect(parseProviderName("together")).toBe("together");
+    expect(parseProviderName("vercel_ai_gateway")).toBe("vercel_ai_gateway");
   });
 
   test("rejects unknown values", () => {
@@ -43,6 +44,12 @@ describe("apiKeyEnvVarForProvider", () => {
 
   test("maps Together AI to its env key", () => {
     expect(apiKeyEnvVarForProvider("together")).toBe("TOGETHER_API_KEY");
+  });
+
+  test("maps Vercel AI Gateway to its env key", () => {
+    expect(apiKeyEnvVarForProvider("vercel_ai_gateway")).toBe(
+      "VERCEL_AI_GATEWAY_API_KEY"
+    );
   });
 
   test("mistral uses MISTRAL_API_KEY", () => {
@@ -131,6 +138,18 @@ describe("resolveProvider together", () => {
   });
 });
 
+describe("resolveProvider vercel_ai_gateway", () => {
+  test("auto-resolves Vercel AI Gateway when it is the only env API key", () => {
+    const provider = resolveProvider({
+      env: {
+        VERCEL_AI_GATEWAY_API_KEY: "vgw-test",
+      },
+    });
+
+    expect(provider).toBe("vercel_ai_gateway");
+  });
+});
+
 describe("resolveProvider mistral", () => {
   test("auto-resolves Mistral when it is the only env API key", () => {
     const provider = resolveProvider({
@@ -194,6 +213,7 @@ describe("isDiscoveryModelProvider", () => {
   test("excludes catalog providers", () => {
     expect(isDiscoveryModelProvider("deepseek")).toBe(false);
     expect(isDiscoveryModelProvider("together")).toBe(false);
+    expect(isDiscoveryModelProvider("vercel_ai_gateway")).toBe(false);
     expect(isDiscoveryModelProvider("mistral")).toBe(false);
     expect(isDiscoveryModelProvider("openai")).toBe(false);
     expect(isDiscoveryModelProvider("opencode_go")).toBe(false);

--- a/packages/core/src/provider-resolution.ts
+++ b/packages/core/src/provider-resolution.ts
@@ -27,6 +27,7 @@ export const USER_PROVIDER_NAMES: readonly UserProviderName[] = [
   "zhipu_cn",
   "xai",
   "together",
+  "vercel_ai_gateway",
 ] as const;
 
 export {
@@ -63,7 +64,8 @@ export function parseProviderName(
     normalized === "zhipu" ||
     normalized === "zhipu_cn" ||
     normalized === "xai" ||
-    normalized === "together"
+    normalized === "together" ||
+    normalized === "vercel_ai_gateway"
   ) {
     return normalized;
   }
@@ -120,6 +122,8 @@ export function apiKeyEnvVarForProvider(
       return "XAI_API_KEY";
     case "together":
       return "TOGETHER_API_KEY";
+    case "vercel_ai_gateway":
+      return "VERCEL_AI_GATEWAY_API_KEY";
   }
 }
 

--- a/packages/core/src/provider-setup-prompt.ts
+++ b/packages/core/src/provider-setup-prompt.ts
@@ -36,6 +36,7 @@ const PROVIDER_CHOICES: Array<{ id: UserProviderName; label: string }> = [
   { id: "gemini", label: "Gemini" },
   { id: "deepseek", label: "DeepSeek" },
   { id: "together", label: "Together AI" },
+  { id: "vercel_ai_gateway", label: "Vercel AI Gateway" },
   { id: "mistral", label: "Mistral" },
   { id: "perplexity", label: "Perplexity Sonar" },
   { id: "xai", label: "xAI Grok" },
@@ -200,7 +201,8 @@ function resolveProviderChoice(input: string): UserProviderName | null {
     normalized === "zhipu" ||
     normalized === "zhipu_cn" ||
     normalized === "xai" ||
-    normalized === "together"
+    normalized === "together" ||
+    normalized === "vercel_ai_gateway"
   ) {
     return normalized;
   }

--- a/packages/core/src/user-config.ts
+++ b/packages/core/src/user-config.ts
@@ -101,6 +101,7 @@ const PROVIDER_TYPE_LABELS: Record<UserProviderName, string> = {
   openrouter: "OpenRouter",
   perplexity: "Perplexity Sonar",
   together: "Together AI",
+  vercel_ai_gateway: "Vercel AI Gateway",
   xai: "xAI Grok",
   xai_oauth: "Grok (SuperGrok / Premium+)",
   zhipu: "GLM (Z.ai)",

--- a/packages/core/src/user-config.ts
+++ b/packages/core/src/user-config.ts
@@ -30,7 +30,6 @@ import {
 } from "./ollama-provider-config";
 import {
   apiKeyEnvVarForProvider,
-  isDiscoveryModelProvider,
   parseProviderName,
   type UserProviderName,
 } from "./provider-resolution";
@@ -641,9 +640,7 @@ function loadProvidersFromSections(
       : undefined;
     // Writer persists models_json for every type that has a shortlist/catalog
     // override; load any present JSON so restarts keep shortlists.
-    const customModels = values.models_json?.trim()
-      ? parseCustomModelsJson(values.models_json)
-      : undefined;
+    const customModels = parseCustomModelsJson(values.models_json);
     const hostMode =
       type === "ollama"
         ? (parseOllamaHostMode(values.host_mode) ?? undefined)

--- a/packages/core/src/user-config.ts
+++ b/packages/core/src/user-config.ts
@@ -639,15 +639,11 @@ function loadProvidersFromSections(
     const baseUrl = values.base_url?.trim()
       ? normalizeBaseUrl(values.base_url)
       : undefined;
-    const customModels =
-      isDiscoveryModelProvider(type) ||
-      type === "openrouter" ||
-      type === "cerebras" ||
-      type === "fireworks" ||
-      type === "ollama" ||
-      type === "opencode_go"
-        ? parseCustomModelsJson(values.models_json)
-        : undefined;
+    // Writer persists models_json for every type that has a shortlist/catalog
+    // override; load any present JSON so restarts keep shortlists.
+    const customModels = values.models_json?.trim()
+      ? parseCustomModelsJson(values.models_json)
+      : undefined;
     const hostMode =
       type === "ollama"
         ? (parseOllamaHostMode(values.host_mode) ?? undefined)


### PR DESCRIPTION
## Summary

Settings → LLM providers gains **Vercel AI Gateway** — one Vercel key, many labs' `creator/model` ids via `https://ai-gateway.vercel.sh/v1`, with Gateway `reasoning` wired and shortlists that survive restart.

**Before:** gateway only as a hand-rolled Custom OpenAI-compatible endpoint; thinking toggle was a no-op on the wire; shortlists dropped on reload.
**After:** first-party `vercel_ai_gateway` card with `VERCEL_AI_GATEWAY_API_KEY`, curated shortlist, Chat Completions `reasoning` object + `message.reasoning` parse, and `models_json` reload.

Why safe:
1. Same Together/DeepSeek OpenAI-compat factory — Bearer auth matches Vercel docs
2. Capability flags stay opt-in per catalog row; reasoning body only when UI enables thinking
3. Unit coverage for parse/env, routing, reasoning round-trip, catalog, and UI opt-in

Only re-add a live cassette if gateway response quirks show up in production that mocks miss.

Closes #391

## Test plan
- [x] `bun test packages/core/src/provider-resolution.test.ts packages/core/src/user-config.test.ts apps/server/src/providers/create.test.ts apps/server/src/providers/models.test.ts apps/web/src/lib/models.test.ts` (120 pass)
- [ ] Add Vercel AI Gateway in Settings with a real key → chat with `openai/gpt-4o-mini`; enable thinking on `openai/gpt-5` and confirm reasoning text appears

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/composer-000000)
