### PR TITLE
fix(tools): align file edit matching with pi

### DIFF
--- a/packages/core/src/tools/builtin.test.ts
+++ b/packages/core/src/tools/builtin.test.ts
@@ -336,6 +336,129 @@ describe("file builtin tools", () => {
     expect(result.toString("utf8")).toBe("\uFEFFhello new");
   });
 
+  test.each([
+    {
+      content: "  old\nold\n",
+      edits: [{ newText: "new\n", oldText: "  old\n" }],
+      expected: "new\nold\n",
+      name: "keeps indentation and boundary newlines in oldText",
+    },
+    {
+      content: "😀 Ａ ﬁ \u201Bhi\u201F \u2212 \u2009x\n",
+      edits: [{ newText: "done", oldText: "A fi 'hi\" -  x" }],
+      expected: "😀 done\n",
+      name: "matches compatibility Unicode and emoji offsets",
+    },
+    {
+      content: "keep “this”  \nleft “quote” old  \nnext Ａ  \nkeep ‘that’\t\n",
+      edits: [
+        { newText: "new", oldText: "old" },
+        { newText: "B", oldText: "A" },
+      ],
+      expected: 'keep “this”  \nleft "quote" new\nnext B\nkeep ‘that’\t\n',
+      name: "normalizes only touched lines in mixed exact and fuzzy edits",
+    },
+    {
+      content: "keep  \nＡ and Ｂ  \ntail\t\n",
+      edits: [
+        { newText: "one", oldText: "A" },
+        { newText: "two", oldText: "B" },
+      ],
+      expected: "keep  \none and two\ntail\t\n",
+      name: "merges two replacements touching the same normalized line",
+    },
+    {
+      content: 'same “text”  \nsame "text"\t\nＡ\n',
+      edits: [{ newText: "B", oldText: "A" }],
+      expected: 'same “text”  \nsame "text"\t\nB\n',
+      name: "preserves the right duplicate normalized line",
+    },
+    {
+      content: "before\rold\rafter\r",
+      edits: [{ newText: "new", oldText: "before\nold" }],
+      expected: "new\nafter\n",
+      name: "normalizes lone CR to LF",
+    },
+    {
+      content: "first\r\nold\nlast\n",
+      edits: [{ newText: "new", oldText: "old" }],
+      expected: "first\r\nnew\r\nlast\r\n",
+      name: "uses the first newline style for a mixed-ending file",
+    },
+    {
+      content: "one two",
+      edits: [
+        { newText: "one", oldText: "one" },
+        { newText: "three", oldText: "two" },
+      ],
+      expected: "one three",
+      name: "permits unchanged entries when the batch changes content",
+    },
+    {
+      content: "\t",
+      edits: [{ newText: " ", oldText: "\t" }],
+      expected: " ",
+      name: "matches whitespace-only oldText exactly",
+    },
+  ])("edit_file $name", async ({ content, edits, expected }) => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "nakama-edit-"));
+    const targetPath = path.join(tempDir, "note.txt");
+    await writeFile(targetPath, content);
+    await runEditFile({ edits, path: targetPath }, PROFILE_CONTEXT, {
+      workspaceRoot: tempDir,
+    });
+    expect(await readFile(targetPath, "utf8")).toBe(expected);
+  });
+
+  test.each([
+    {
+      content: "one two three",
+      edits: [{ newText: "-", oldText: " " }],
+      name: "rejects ambiguous whitespace-only searches",
+    },
+    {
+      content: "Ａ A",
+      edits: [{ newText: "B", oldText: "A" }],
+      name: "rejects normalized duplicates even with one exact match",
+    },
+    {
+      content: "ＡＢＣ",
+      edits: [
+        { newText: "x", oldText: "AB" },
+        { newText: "y", oldText: "BC" },
+      ],
+      name: "rejects overlapping fuzzy matches",
+    },
+    {
+      content: "old\r\nline",
+      edits: [{ newText: "old\r\nline", oldText: "old\nline" }],
+      name: "rejects a no-op after newline normalization",
+    },
+    {
+      content: "Ａ present",
+      edits: [
+        { newText: "B", oldText: "A" },
+        { newText: "new", oldText: "missing" },
+      ],
+      name: "rejects a missing edit without applying valid siblings",
+    },
+    {
+      content: "old",
+      edits: [{ newText: "new", oldText: "" }],
+      name: "rejects empty oldText",
+    },
+  ])("edit_file $name without writing", async ({ content, edits }) => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "nakama-edit-"));
+    const targetPath = path.join(tempDir, "note.txt");
+    await writeFile(targetPath, content);
+    await expect(
+      runEditFile({ edits, path: targetPath }, PROFILE_CONTEXT, {
+        workspaceRoot: tempDir,
+      })
+    ).rejects.toThrow();
+    expect(await readFile(targetPath, "utf8")).toBe(content);
+  });
+
   test("edit_file rejects missing oldText", async () => {
     tempDir = await mkdtemp(path.join(os.tmpdir(), "nakama-edit-"));
     const targetPath = path.join(tempDir, "note.txt");

--- a/packages/core/src/tools/builtin.ts
+++ b/packages/core/src/tools/builtin.ts
@@ -61,7 +61,7 @@ export const editFileInputSchema = z
         z
           .object({
             newText: z.string({ error: "newText is required." }),
-            oldText: requiredTrimmedString("oldText"),
+            oldText: z.string({ error: "oldText is required." }).min(1),
           })
           .strict()
       )
@@ -486,13 +486,39 @@ export async function runEditFile(
     rawBuffer.subarray(0, 3).equals(Buffer.from([0xef, 0xbb, 0xbf]));
   const content = rawBuffer.toString("utf8", hasBom ? 3 : 0);
   const lineEnding = detectLineEnding(content);
-  const plans = parsed.edits
-    .map((edit, index) => planEdit(content, edit, index, lineEnding))
+  const normalizedContent = normalizeToLF(content);
+  const edits = parsed.edits.map((edit) => ({
+    newText: normalizeToLF(edit.newText),
+    oldText: normalizeToLF(edit.oldText),
+  }));
+  const fuzzyMatches = edits.filter(
+    (edit) =>
+      !normalizedContent.includes(edit.oldText) &&
+      normalizeForEditMatch(normalizedContent).includes(
+        normalizeForEditMatch(edit.oldText)
+      )
+  ).length;
+  const base =
+    fuzzyMatches > 0
+      ? normalizeForEditMatch(normalizedContent)
+      : normalizedContent;
+  const plans = edits
+    .map((edit, index) => planEdit(base, edit, index))
     .sort((a, b) => a.start - b.start);
   assertNoOverlappingEdits(plans);
 
-  const nextContent = applyEditPlans(content, plans);
-  const outputContent = hasBom ? `\uFEFF${nextContent}` : nextContent;
+  const nextContent =
+    fuzzyMatches > 0
+      ? applyEditsPreservingLines(normalizedContent, base, plans)
+      : applyEditPlans(base, plans);
+  if (nextContent === normalizedContent) {
+    throw new Error(
+      "No changes made: replacements produced identical content."
+    );
+  }
+  const restored =
+    lineEnding === "\r\n" ? nextContent.replace(/\n/g, "\r\n") : nextContent;
+  const outputContent = hasBom ? `\uFEFF${restored}` : restored;
   const bytesWritten = Buffer.byteLength(outputContent, "utf8");
 
   await guardFilePath(
@@ -505,15 +531,15 @@ export async function runEditFile(
 
   return {
     bytesWritten,
-    fuzzyMatches: plans.filter((plan) => plan.fuzzy).length,
+    fuzzyMatches,
     path: filePath,
     replacements: plans.length,
   };
 }
 
+// Matching semantics follow Pi's edit-diff.ts (ce5ec9ca355a852fb1f25c088cf409df47a95213).
 interface PlannedEdit {
   end: number;
-  fuzzy: boolean;
   index: number;
   newText: string;
   start: number;
@@ -522,217 +548,105 @@ interface PlannedEdit {
 function planEdit(
   content: string,
   edit: EditFileInput["edits"][number],
-  index: number,
-  lineEnding: string
+  index: number
 ): PlannedEdit {
-  if (edit.oldText === edit.newText) {
-    throw new Error(
-      `Edit ${index + 1} makes no change: oldText and newText are identical.`
-    );
+  const exactStart = content.indexOf(edit.oldText);
+  const normalizedSearch = normalizeForEditMatch(edit.oldText);
+  const normalizedContent = normalizeForEditMatch(content);
+  const fuzzyStart = normalizedContent.indexOf(normalizedSearch);
+  if (exactStart === -1 && (fuzzyStart === -1 || !normalizedSearch)) {
+    throw new Error(`Edit ${index + 1} oldText not found in file.`);
   }
-
-  const exactMatches = findAllOccurrences(content, edit.oldText);
-
-  if (exactMatches.length > 1) {
-    throw new Error(
-      `Edit ${index + 1} is ambiguous: oldText matched ${exactMatches.length} times.`
-    );
-  }
-
-  const [exactStart] = exactMatches;
-  if (exactStart !== undefined) {
-    return {
-      end: exactStart + edit.oldText.length,
-      fuzzy: false,
-      index,
-      newText: normalizeReplacementLineEndings(edit.newText, lineEnding),
-      start: exactStart,
-    };
-  }
-
-  const fuzzyMatches = findNormalizedMatches(content, edit.oldText);
-
-  if (fuzzyMatches.length > 1) {
+  if (normalizedContent.split(normalizedSearch).length - 1 > 1) {
     throw new Error(
       `Edit ${index + 1} is ambiguous after normalized matching.`
     );
   }
-
-  const [match] = fuzzyMatches;
-  if (!match) {
-    throw new Error(`Edit ${index + 1} oldText not found in file.`);
-  }
-
+  const start = exactStart === -1 ? fuzzyStart : exactStart;
   return {
-    end: match.end,
-    fuzzy: true,
+    end:
+      start +
+      (exactStart === -1 ? normalizedSearch.length : edit.oldText.length),
     index,
-    newText: normalizeReplacementLineEndings(edit.newText, lineEnding),
-    start: match.start,
+    newText: edit.newText,
+    start,
   };
 }
 
 function detectLineEnding(content: string): string {
-  const crlf = content.match(/\r\n/g)?.length ?? 0;
-  const lf = content.match(/(?<!\r)\n/g)?.length ?? 0;
-  const cr = content.match(/\r(?!\n)/g)?.length ?? 0;
-
-  if (crlf >= lf && crlf >= cr && crlf > 0) {
-    return "\r\n";
-  }
-
-  if (cr > lf && cr > 0) {
-    return "\r";
-  }
-
-  return "\n";
+  const lf = content.indexOf("\n");
+  const crlf = content.indexOf("\r\n");
+  return lf !== -1 && crlf !== -1 && crlf < lf ? "\r\n" : "\n";
 }
 
-function normalizeReplacementLineEndings(
-  value: string,
-  lineEnding: string
+function normalizeToLF(value: string): string {
+  return value.replace(/\r\n|\r/g, "\n");
+}
+
+function normalizeForEditMatch(value: string): string {
+  return value
+    .normalize("NFKC")
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .join("\n")
+    .replace(/[\u2018\u2019\u201A\u201B]/g, "'")
+    .replace(/[\u201C\u201D\u201E\u201F]/g, '"')
+    .replace(/[\u2010-\u2015\u2212]/g, "-")
+    .replace(/[\u00A0\u2002-\u200A\u202F\u205F\u3000]/g, " ");
+}
+
+function applyEditsPreservingLines(
+  original: string,
+  base: string,
+  plans: PlannedEdit[]
 ): string {
-  return value.replace(/\r\n|\r|\n/g, lineEnding);
-}
-
-function findAllOccurrences(content: string, search: string): number[] {
-  const matches: number[] = [];
-  let index = 0;
-
-  while (true) {
-    index = content.indexOf(search, index);
-    if (index === -1) {
-      return matches;
+  const originalLines = original.match(/[^\n]*\n|[^\n]+/g) ?? [];
+  const baseLines = base.match(/[^\n]*\n|[^\n]+/g) ?? [];
+  if (originalLines.length !== baseLines.length) {
+    throw new Error(
+      "Cannot preserve unchanged lines: normalization changed the line count."
+    );
+  }
+  // Widen replacements to touched lines, copying every other line from the original.
+  let offset = 0;
+  const spans = baseLines.map((line) => {
+    const start = offset;
+    offset += line.length;
+    return { end: offset, start };
+  });
+  const groups: { first: number; last: number; plans: PlannedEdit[] }[] = [];
+  for (const plan of plans) {
+    const first = spans.findIndex(
+      (span) => plan.start >= span.start && plan.start < span.end
+    );
+    const last = spans.findIndex((span) => plan.end <= span.end);
+    if (first === -1 || last < first) {
+      throw new Error("Replacement range is outside the file.");
     }
-    matches.push(index);
-    index += search.length;
-  }
-}
-
-interface NormalizedMatch {
-  end: number;
-  start: number;
-}
-
-interface NormalizedChar {
-  char: string;
-  end: number;
-  start: number;
-}
-
-function findNormalizedMatches(
-  content: string,
-  search: string
-): NormalizedMatch[] {
-  const normalizedContent = normalizeForEditMatch(content);
-  const normalizedSearch = normalizeForEditMatch(search);
-  const needle = normalizedSearch.text;
-
-  if (!needle) {
-    return [];
-  }
-
-  const matches: NormalizedMatch[] = [];
-  let index = 0;
-
-  while (true) {
-    index = normalizedContent.text.indexOf(needle, index);
-    if (index === -1) {
-      return matches;
+    const previous = groups.at(-1);
+    if (previous && first <= previous.last) {
+      previous.last = Math.max(previous.last, last);
+      previous.plans.push(plan);
+    } else {
+      groups.push({ first, last, plans: [plan] });
     }
-
-    const firstChar = normalizedContent.chars[index];
-    const lastChar = normalizedContent.chars[index + needle.length - 1];
-
-    if (firstChar && lastChar) {
-      matches.push({ end: lastChar.end, start: firstChar.start });
-    }
-
-    index += needle.length;
   }
-}
-
-function normalizeForEditMatch(value: string): {
-  text: string;
-  chars: NormalizedChar[];
-} {
-  const chars: NormalizedChar[] = [];
-
-  for (let index = 0; index < value.length; ) {
-    const start = index;
-    const codePoint = value.codePointAt(index);
-
-    if (codePoint === undefined) {
-      break;
-    }
-
-    const rawChar = String.fromCodePoint(codePoint);
-    index += rawChar.length;
-    const normalizedChar = normalizeEditChar(rawChar);
-
-    if (normalizedChar === null) {
-      continue;
-    }
-
-    chars.push({ char: normalizedChar, end: index, start });
+  let cursor = 0;
+  let result = "";
+  for (const group of groups) {
+    result += originalLines.slice(cursor, group.first).join("");
+    const start = spans[group.first].start;
+    result += applyEditPlans(
+      base.slice(start, spans[group.last].end),
+      group.plans.map((plan) => ({
+        ...plan,
+        end: plan.end - start,
+        start: plan.start - start,
+      }))
+    );
+    cursor = group.last + 1;
   }
-
-  const filteredChars = removeTrailingWhitespaceTokens(chars);
-
-  return {
-    chars: filteredChars,
-    text: filteredChars.map((char) => char.char).join(""),
-  };
-}
-
-function normalizeEditChar(char: string): string | null {
-  if (char === "\r") {
-    return null;
-  }
-
-  if (char === "\u00A0") {
-    return " ";
-  }
-
-  if (char === "\u2018" || char === "\u2019") {
-    return "'";
-  }
-
-  if (char === "\u201C" || char === "\u201D") {
-    return '"';
-  }
-
-  if (char === "\u2013" || char === "\u2014") {
-    return "-";
-  }
-
-  return char;
-}
-
-function removeTrailingWhitespaceTokens(
-  chars: NormalizedChar[]
-): NormalizedChar[] {
-  const keep = new Array<boolean>(chars.length).fill(true);
-  let runStart: number | null = null;
-
-  for (let index = 0; index <= chars.length; index += 1) {
-    const char = chars[index]?.char;
-
-    if (char === " " || char === "\t") {
-      runStart ??= index;
-      continue;
-    }
-
-    if ((char === "\n" || char === undefined) && runStart !== null) {
-      for (let runIndex = runStart; runIndex < index; runIndex += 1) {
-        keep[runIndex] = false;
-      }
-    }
-
-    runStart = null;
-  }
-
-  return chars.filter((_char, index) => keep[index]);
+  return result + originalLines.slice(cursor).join("");
 }
 
 function assertNoOverlappingEdits(plans: PlannedEdit[]): void {


### PR DESCRIPTION
## Summary

Agents can edit files using Pi’s Unicode matching and batch replacement rules.

**Before:** matching trimmed `oldText`, missed Unicode equivalents, and accepted some normalized duplicate matches.
**After:** preserve search whitespace, match in Pi’s normalized text space, reject ambiguous/overlapping edits and no-op batches, and preserve untouched line blocks.

Why safe:
1. Existing workspace, protected-file, BOM, and size guards remain in place.
2. 130 tool/source tests pass, including 15 new regression cases; 338 direct comparisons match pinned Pi behavior.

Compatibility note: fuzzy edits normalize touched lines; mixed line endings follow the first newline’s style. The existing Nakama tool response remains unchanged; Pi’s diff rendering is outside this change.

Reference: [Pi edit-diff.ts at ce5ec9ca](https://github.com/earendil-works/pi/blob/ce5ec9ca355a852fb1f25c088cf409df47a95213/packages/coding-agent/src/core/tools/edit-diff.ts).

## Test plan
- [x] `bun test packages/core/src/tools apps/server/src/services/tool-source.test.ts` — 130 pass
- [x] Core build, changed-file Ultracite check, and `bun run knip` pass
