### PR TITLE
fix(server): skip platform tools when profile has no tools

### DIFF
--- a/apps/server/src/services/agent-service.test.ts
+++ b/apps/server/src/services/agent-service.test.ts
@@ -737,6 +737,18 @@ describe("AgentService skill_manage injection", () => {
   test("injects skill_manage for web/cli only when manage-skills is assigned", async () => {
     const db = createInMemoryDatabaseAdapter();
     await db.upsertProfile(createDefaultProfile());
+    // Give the profile at least one own tool so the platform groups (incl.
+    // skill_manage) are eligible; the no-tools case is covered separately.
+    await db.upsertTool({
+      createdAt: new Date().toISOString(),
+      description: "Test tool",
+      handlerConfig: { modulePath: "test.js" },
+      handlerType: "javascript",
+      id: "tool_for_skill_manage",
+      name: "test_tool",
+      updatedAt: new Date().toISOString(),
+    });
+    await db.assignToolToProfile("profile_default", "tool_for_skill_manage");
     const skills = new SkillsService(db);
     await ensureBundledSkillFiles();
     await skills.syncDiscoveredSkills();
@@ -780,6 +792,64 @@ describe("AgentService skill_manage injection", () => {
     expect(automationTools.some((tool) => tool.name === "skill_manage")).toBe(
       false
     );
+  });
+
+  test("skips platform tool groups for a profile with no tools", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    await db.upsertProfile(createDefaultProfile());
+    const service = new AgentService(null, null, db);
+
+    type ResolveTools = {
+      resolveProfileTools(
+        profile: StoredProfileRecord,
+        options?: {
+          includeAutomationTools?: boolean;
+          includeSkillManageTools?: boolean;
+          includeWorkflowTools?: boolean;
+          includeTodoTools?: boolean;
+          includeQuestionTools?: boolean;
+        }
+      ): Promise<Array<{ name: string }>>;
+    };
+
+    const resolve = (
+      service as unknown as ResolveTools
+    ).resolveProfileTools.bind(service);
+    const profile = createDefaultProfile();
+
+    // Profile with zero own tools: no platform groups, no session helpers.
+    const tools = await resolve(profile, {
+      includeAutomationTools: true,
+      includeQuestionTools: true,
+      includeSkillManageTools: true,
+      includeTodoTools: true,
+      includeWorkflowTools: true,
+    });
+    expect(tools).toHaveLength(0);
+
+    // Give the profile one own tool; platform groups come back.
+    await db.upsertTool({
+      createdAt: new Date().toISOString(),
+      description: "Test tool",
+      handlerConfig: { modulePath: "test.js" },
+      handlerType: "javascript",
+      id: "tool_for_platform_groups",
+      name: "test_tool",
+      updatedAt: new Date().toISOString(),
+    });
+    await db.assignToolToProfile("profile_default", "tool_for_platform_groups");
+    const withTools = await resolve(profile, {
+      includeAutomationTools: true,
+      includeQuestionTools: true,
+      includeSkillManageTools: true,
+      includeTodoTools: true,
+      includeWorkflowTools: true,
+    });
+    expect(withTools.some((tool) => tool.name === "test_tool")).toBe(true);
+    expect(withTools.some((tool) => tool.name === "ask_user_question")).toBe(
+      true
+    );
+    expect(withTools.some((tool) => tool.name === "todo_write")).toBe(true);
   });
 
   test("keeps raw /learn in history on web when manage-skills is assigned", async () => {

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -3426,19 +3426,30 @@ export class AgentService {
       ];
     }
 
-    if (includeAutomationTools && this.automationTools.length > 0) {
+    // A profile with no tools of its own (builtin, MCP, and Composio all
+    // empty) answers without tools.  Skip the platform groups below so an
+    // admin who stripped every tool from a profile actually gets an empty tool
+    // list on chat turns — injecting 16 helpers here makes small local models
+    // print a fake tool call as plain text instead of doing the work.
+    const hasOwnTools = resolved.length > 0;
+
+    if (
+      hasOwnTools &&
+      includeAutomationTools &&
+      this.automationTools.length > 0
+    ) {
       resolved = [...resolved, ...this.automationTools];
     }
 
-    if (includeWorkflowTools && this.workflowTools.length > 0) {
+    if (hasOwnTools && includeWorkflowTools && this.workflowTools.length > 0) {
       resolved = [...resolved, ...this.workflowTools];
     }
 
-    if (includeTodoTools && this.todoTools.length > 0) {
+    if (hasOwnTools && includeTodoTools && this.todoTools.length > 0) {
       resolved = [...resolved, ...this.todoTools];
     }
 
-    if (includeQuestionTools && this.questionTools.length > 0) {
+    if (hasOwnTools && includeQuestionTools && this.questionTools.length > 0) {
       resolved = [...resolved, ...this.questionTools];
     }
 
@@ -3456,7 +3467,7 @@ export class AgentService {
       resolved = [...resolved, ...skillTools];
 
       // Interactive web/cli only: messaging, automation, task, and subagent omit this.
-      if (includeSkillManageTools) {
+      if (hasOwnTools && includeSkillManageTools) {
         const assignedSkills = await this.skillsService.listSkillsForProfile(
           profile.id
         );
@@ -3476,7 +3487,9 @@ export class AgentService {
       resolved = [...resolved, ...this.superBotTools];
     }
 
-    resolved = [...resolved, ...this.orgMemoryTools];
+    if (hasOwnTools) {
+      resolved = [...resolved, ...this.orgMemoryTools];
+    }
 
     if (!includeSubAgentTool) {
       resolved = resolved.filter((tool) => tool.name !== SUB_AGENT_TOOL_NAME);
@@ -3502,7 +3515,7 @@ export class AgentService {
       includeSkillManageTools,
       userId,
     });
-    if (channel === "discord") {
+    if (channel === "discord" && tools.length > 0) {
       tools = [...tools, ...createSendDiscordArtifactTools()];
     }
     // Same table as the tools above on purpose: a channel that can manage
@@ -3534,7 +3547,12 @@ export class AgentService {
       : profile.model;
     const compaction = this.resolveCompactionConfig(profile, selectedModel);
     const harness = this.createHarnessForProfile(profile, selectedModel);
-    tools = [...tools, createReadSessionHistoryTool(orgId, sessionId)];
+    // Part of the "no tools" contract: session-history and channel-artifact
+    // helpers are also platform groups, so a profile that resolved to zero
+    // tools must not receive them either.
+    if (tools.length > 0) {
+      tools = [...tools, createReadSessionHistoryTool(orgId, sessionId)];
+    }
     const saveAttachment = createAttachmentSaver(this.db, {
       channel,
       orgId,


### PR DESCRIPTION
## Summary

A profile with zero tools answers with an empty tool list — no platform helpers injected.

**Before:** stripping every tool from a profile still left 16 platform tools (automation, workflow, todo, question, skill_manage, org-memory, session-history, discord artifacts) in every chat turn, so small models hallucinated fake tool calls.
**After:** `resolveProfileTools` returns `[]` when builtin + MCP + Composio are all empty; every platform group is gated on `hasOwnTools`.

Why safe:
1. Profiles with ≥1 own tool get exactly the same groups as before — only the zero-tool case changes
2. Skill_manage injection test updated to assign one own tool first, keeping the manage-skills gate covered
3. New test pins the no-tools contract both ways (empty list → no groups; one tool → groups return)

Only re-add platform groups for zero-tool profiles if a downstream caller turns out to depend on them (none do today: automation/workflow/sub-agent execution paths already omit most groups).

## Test plan
- [x] `bun test apps/server/src/services/agent-service.test.ts` (29 pass)
- [ ] Manual: strip all tools from a profile, send a chat turn, confirm the model tool list is empty