### PR TITLE
fix(web): preserve model selections and allow System collapse

### DIFF
--- a/apps/web/src/components/AppSidebar.tsx
+++ b/apps/web/src/components/AppSidebar.tsx
@@ -183,9 +183,7 @@ function SidebarNavGroup({
   toggleSystemNav: () => void;
   unreadTotal: number;
 }) {
-  const containsActive =
-    group.collapsible === true && group.items.some((item) => item.id === page);
-  const groupExpanded = !systemNavCollapsed || containsActive;
+  const groupExpanded = !systemNavCollapsed;
   // Icon rail always shows every destination; tree collapse only
   // applies when labels are visible.
   const itemsVisible = !group.collapsible || collapsed || groupExpanded;
@@ -202,12 +200,7 @@ function SidebarNavGroup({
         <button
           aria-expanded={groupExpanded}
           className="sidebar-nav-group-label"
-          onClick={() => {
-            if (groupExpanded && containsActive) {
-              return;
-            }
-            toggleSystemNav();
-          }}
+          onClick={toggleSystemNav}
           type="button"
         >
           <ArrowDown01Icon

--- a/apps/web/src/components/settings/provider-settings-seed.ts
+++ b/apps/web/src/components/settings/provider-settings-seed.ts
@@ -8,55 +8,14 @@ export function seedManageModelRows(
   customModels: CustomModelEntry[] | undefined,
   configuredModels: ProviderModelOption[]
 ): ModelListRow[] {
-  if (customModels?.length) {
-    return customModels.map((model) => ({
-      default: model.default,
-      id: model.id,
-      inputPerMillionUsd: model.inputPerMillionUsd,
-      name: model.name ?? model.id,
-      outputPerMillionUsd: model.outputPerMillionUsd,
-      supportsThinking: model.supportsThinking,
-    }));
-  }
-
-  return configuredModels.map((model) => ({
+  const models = customModels?.length ? customModels : configuredModels;
+  return models.map((model) => ({
     default: model.default,
     id: model.id,
     inputPerMillionUsd: model.inputPerMillionUsd,
     name: model.name ?? model.id,
     outputPerMillionUsd: model.outputPerMillionUsd,
     supportsThinking: model.supportsThinking,
+    supportsVision: model.supportsVision,
   }));
-}
-
-/** Seeds OpenRouter / Cerebras (and similar) manage dialogs. */
-export function seedShortlistManageModelRows(
-  customModels: CustomModelEntry[] | undefined,
-  currentModel?: string | null,
-  currentModelName?: string | null
-): ModelListRow[] {
-  if (customModels?.length) {
-    return customModels.map((model) => ({
-      default: model.default,
-      id: model.id,
-      inputPerMillionUsd: model.inputPerMillionUsd,
-      name: model.name ?? model.id,
-      outputPerMillionUsd: model.outputPerMillionUsd,
-      supportsThinking: model.supportsThinking,
-      supportsVision: model.supportsVision,
-    }));
-  }
-
-  const trimmed = currentModel?.trim();
-  if (trimmed) {
-    return [
-      {
-        default: true,
-        id: trimmed,
-        name: currentModelName?.trim() || trimmed,
-      },
-    ];
-  }
-
-  return [];
 }

--- a/apps/web/src/components/settings/use-provider-instance-card.test.tsx
+++ b/apps/web/src/components/settings/use-provider-instance-card.test.tsx
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  ProviderInstanceSummary,
+  ProviderModelOption,
+} from "@nakama/core/contract";
+import { DISCOVERY_MODEL_PROVIDERS } from "@nakama/core/discovery-providers";
+import { renderToString } from "react-dom/server";
+import { CATALOG_SHORTLIST_PROVIDERS } from "@/components/catalog-provider-model-fields.shared";
+import { useProviderInstanceCard } from "./use-provider-instance-card";
+
+const instance: ProviderInstanceSummary = {
+  createdAt: "2026-01-01T00:00:00Z",
+  hasApiKey: true,
+  id: "chatgpt-personal",
+  label: "ChatGPT",
+  modelCount: 2,
+  type: "chatgpt",
+};
+
+const catalog: ProviderModelOption[] = [
+  {
+    default: true,
+    id: "model-a",
+    inputPerMillionUsd: 2,
+    name: "Model A",
+    outputPerMillionUsd: 8,
+    provider: "chatgpt",
+    providerId: instance.id,
+    supportsThinking: true,
+    supportsVision: false,
+  },
+  {
+    id: "model-b",
+    name: "Model B",
+    provider: "chatgpt",
+    providerId: instance.id,
+  },
+  {
+    id: "other-model",
+    name: "Other model",
+    provider: "chatgpt",
+    providerId: "other-account",
+  },
+];
+
+function openManage(provider: ProviderInstanceSummary) {
+  let rows: ReturnType<typeof useProviderInstanceCard>["manageModels"] = [];
+  function Probe() {
+    const card = useProviderInstanceCard({
+      catalog: catalog.map((model) => ({ ...model, provider: provider.type })),
+      instance: provider,
+      onDelete: async () => {},
+      onError: () => {},
+      onUpdate: async () => {},
+    });
+    if (!card.manageOpen) {
+      card.openManage();
+    }
+    rows = card.manageModels;
+    return null;
+  }
+  renderToString(<Probe />);
+  return rows;
+}
+
+describe("provider model management", () => {
+  test.each([
+    ...CATALOG_SHORTLIST_PROVIDERS,
+    "openrouter",
+    "cerebras",
+    "fireworks",
+    "ollama",
+    ...DISCOVERY_MODEL_PROVIDERS,
+  ] as const)(
+    "opens %s with its active models when no custom shortlist is saved",
+    (type) => {
+      const rows = openManage({ ...instance, type });
+      expect(rows.map((row) => row.id)).toEqual(["model-a", "model-b"]);
+      expect(rows[0]?.default).toBe(true);
+      expect(rows[0]?.supportsVision).toBe(false);
+      expect(rows[0]?.supportsThinking).toBe(true);
+      expect(rows[0]?.inputPerMillionUsd).toBe(2);
+      expect(rows[0]?.outputPerMillionUsd).toBe(8);
+    }
+  );
+
+  test("keeps a saved shortlist instead of adding other catalog models", () => {
+    const rows = openManage({
+      ...instance,
+      customModels: [
+        {
+          default: true,
+          id: "model-b",
+          name: "My model",
+          supportsVision: false,
+        },
+      ],
+    });
+    expect(rows.map((row) => row.id)).toEqual(["model-b"]);
+    expect(rows[0]?.name).toBe("My model");
+    expect(rows[0]?.default).toBe(true);
+    expect(rows[0]?.supportsVision).toBe(false);
+  });
+});

--- a/apps/web/src/components/settings/use-provider-instance-card.ts
+++ b/apps/web/src/components/settings/use-provider-instance-card.ts
@@ -14,10 +14,7 @@ import { useMemo, useState } from "react";
 import { isCatalogShortlistProvider } from "@/components/catalog-provider-model-fields.shared";
 import type { ModelListRow } from "@/components/ModelListEditor";
 import { normalizeModelListRows } from "@/components/model-list-editor.shared";
-import {
-  seedManageModelRows,
-  seedShortlistManageModelRows,
-} from "@/components/settings/provider-settings-seed";
+import { seedManageModelRows } from "@/components/settings/provider-settings-seed";
 import { isShortlistBrowseProvider } from "@/components/shortlist-browse-providers.shared";
 import { formatError } from "@/lib/client";
 import {
@@ -90,26 +87,7 @@ export function useProviderInstanceCard({
   const openManage = () => {
     setDialogError(null);
 
-    if (isCompatibleLike) {
-      setManageModels(
-        seedManageModelRows(instance.customModels, instanceModels)
-      );
-    } else if (isOpenRouter || isShortlistBrowse) {
-      setManageModels(
-        seedShortlistManageModelRows(
-          instance.customModels,
-          null,
-          instanceModels[0]?.name
-        )
-      );
-    } else if (isCatalogShortlist) {
-      setManageModels(
-        seedManageModelRows(
-          instance.customModels,
-          instance.customModels?.length ? instanceModels : []
-        )
-      );
-    }
+    setManageModels(seedManageModelRows(instance.customModels, instanceModels));
 
     setManageOpen(true);
   };


### PR DESCRIPTION
## Summary

Collapse System from any page and open Manage models with the provider’s existing selections intact.

**Before:** System stayed expanded on active pages; some providers opened an empty model list, and vision settings could disappear.
**After:** The sidebar follows its toggle, and all providers load saved selections or their active models with settings preserved.

Why safe:
1. Saved custom lists take priority; fallback models stay scoped to the provider instance.
2. Regression coverage exercises all 23 provider types; no backend or schema changes.

## Test plan

- [x] `bun test apps/web/src/components/settings/use-provider-instance-card.test.tsx apps/web/src/components/model-list-editor.shared.test.ts` (26 pass); sidebar/navigation tests (12 pass).
- [x] Web TypeScript, Ultracite, Knip, and React Doctor (100/100).
- [ ] In Settings, collapse/reopen System and open Manage models to verify selections remain visible (browser check not run).
