### PR TITLE
fix(web): open file previews by clicking cards

### DIFF
--- a/apps/web/src/components/chat/artifact-attachment-preview.tsx
+++ b/apps/web/src/components/chat/artifact-attachment-preview.tsx
@@ -16,8 +16,8 @@ interface ArtifactAttachmentPreviewProps {
   className?: string;
   id: string;
   profileId: string;
-  /** `chip` is the chat attachment chip; `icon` is an icon-only view button. */
-  variant?: "chip" | "icon";
+  /** `overlay` makes the containing file card the preview target. */
+  variant?: "chip" | "icon" | "overlay";
 }
 
 export function ArtifactAttachmentPreview({
@@ -62,8 +62,22 @@ function ArtifactAttachmentPreviewTrigger({
   isImage: boolean;
   isVideo: boolean;
   onOpen: () => void;
-  variant: "chip" | "icon";
+  variant: "chip" | "icon" | "overlay";
 }) {
+  if (variant === "overlay") {
+    return (
+      <button
+        aria-label={`View ${artifact.filename}`}
+        className={cn(
+          "absolute inset-0 cursor-pointer rounded-[inherit] focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:ring-inset",
+          className
+        )}
+        onClick={onOpen}
+        type="button"
+      />
+    );
+  }
+
   if (variant === "icon") {
     return (
       <Tooltip>

--- a/apps/web/src/pages/files/files-artifact-grid-card.tsx
+++ b/apps/web/src/pages/files/files-artifact-grid-card.tsx
@@ -1,5 +1,5 @@
 import type { ArtifactFile } from "@nakama/core/contract";
-import { ArtifactAttachmentPreview } from "@/components/chat/artifact-attachment-preview";
+import { useArtifactAttachmentPreviewPanel } from "@/components/chat/use-artifact-attachment-preview-panel";
 import {
   ARTIFACT_TYPE_FILTER_LABELS,
   classifyArtifactType,
@@ -8,11 +8,7 @@ import { formatBytes } from "@/lib/knowledge-base-files";
 import { artifactBasename } from "@/pages/files/files-artifact-folders";
 import { ArtifactIcon } from "@/pages/files/files-artifact-icon";
 import { ArtifactRowMenu } from "@/pages/files/files-artifact-row-menu";
-import {
-  formatTimestamp,
-  iconActionHitArea,
-  toChatArtifactRef,
-} from "@/pages/files/files-shared";
+import { formatTimestamp, toChatArtifactRef } from "@/pages/files/files-shared";
 
 export function ArtifactGridCard({
   profileId,
@@ -29,17 +25,20 @@ export function ArtifactGridCard({
 }) {
   const kind = classifyArtifactType(artifact);
   const typeLabel = ARTIFACT_TYPE_FILTER_LABELS[kind];
-  const isImage = kind === "image";
+  const { imagePreviewUrl, openPanel } = useArtifactAttachmentPreviewPanel({
+    artifact: toChatArtifactRef(artifact),
+    id: `files-page-grid:${artifact.path || artifact.filename}`,
+    profileId,
+  });
 
   return (
-    <li className="flex min-w-0 flex-col overflow-hidden rounded-md border border-border bg-background">
+    <li className="relative flex min-w-0 flex-col overflow-hidden rounded-md border border-border bg-background transition-colors hover:bg-muted/40">
       <div className="relative aspect-[4/3] overflow-hidden border-border border-b bg-muted/20">
-        {isImage ? (
-          <ArtifactAttachmentPreview
-            artifact={toChatArtifactRef(artifact)}
-            className="absolute inset-0 h-full w-full max-w-none gap-0 rounded-none border-0 bg-transparent p-0 hover:bg-transparent [&>div:first-child]:aspect-auto [&>div:first-child]:h-full [&>div:first-child]:rounded-none [&>div:first-child]:border-0 [&>div:last-child]:hidden [&_img]:aspect-auto [&_img]:h-full [&_img]:rounded-none [&_img]:border-0 [&_img]:outline-none"
-            id={`files-page-grid:${artifact.path || artifact.filename}`}
-            profileId={profileId}
+        {kind === "image" && imagePreviewUrl ? (
+          <img
+            alt=""
+            className="h-full w-full object-cover"
+            src={imagePreviewUrl}
           />
         ) : (
           <div className="flex h-full w-full items-center justify-center">
@@ -69,16 +68,13 @@ export function ArtifactGridCard({
             {formatTimestamp(artifact.updatedAt)}
           </p>
         </div>
-        <div className="mt-auto flex items-center justify-end gap-2">
-          {isImage ? null : (
-            <ArtifactAttachmentPreview
-              artifact={toChatArtifactRef(artifact)}
-              className={iconActionHitArea}
-              id={`files-page-grid-view:${artifact.path || artifact.filename}`}
-              profileId={profileId}
-              variant="icon"
-            />
-          )}
+        <button
+          aria-label={`View ${artifact.filename}`}
+          className="absolute inset-0 cursor-pointer rounded-[inherit] focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:ring-inset"
+          onClick={openPanel}
+          type="button"
+        />
+        <div className="relative z-10 mt-auto flex self-end">
           <ArtifactRowMenu
             artifact={artifact}
             deletePending={deletePending}

--- a/apps/web/src/pages/files/files-artifact-list-view.tsx
+++ b/apps/web/src/pages/files/files-artifact-list-view.tsx
@@ -10,11 +10,7 @@ import {
 } from "@/pages/files/files-artifact-folders";
 import { ArtifactIcon } from "@/pages/files/files-artifact-icon";
 import { ArtifactRowMenu } from "@/pages/files/files-artifact-row-menu";
-import {
-  formatTimestamp,
-  iconActionHitArea,
-  toChatArtifactRef,
-} from "@/pages/files/files-shared";
+import { formatTimestamp, toChatArtifactRef } from "@/pages/files/files-shared";
 
 function ArtifactFolderRow({
   folder,
@@ -88,7 +84,7 @@ export function ArtifactListView({
       ))}
       {artifacts.map((artifact) => (
         <li
-          className="flex items-center justify-between gap-3 px-4 py-3 transition-colors duration-100 ease-out hover:bg-muted/40"
+          className="relative flex items-center justify-between gap-3 px-4 py-3 transition-colors duration-100 ease-out hover:bg-muted/40"
           key={artifact.filename}
         >
           <div className="flex min-w-0 items-start gap-3">
@@ -113,14 +109,13 @@ export function ArtifactListView({
               </p>
             </div>
           </div>
-          <div className="flex items-center gap-3">
-            <ArtifactAttachmentPreview
-              artifact={toChatArtifactRef(artifact)}
-              className={iconActionHitArea}
-              id={`files-page:${artifact.path || artifact.filename}`}
-              profileId={profileId}
-              variant="icon"
-            />
+          <ArtifactAttachmentPreview
+            artifact={toChatArtifactRef(artifact)}
+            id={`files-page:${artifact.path || artifact.filename}`}
+            profileId={profileId}
+            variant="overlay"
+          />
+          <div className="relative z-10 shrink-0">
             <ArtifactRowMenu
               artifact={artifact}
               deletePending={deletePending}


### PR DESCRIPTION
## Summary

Open a file preview by clicking its row or grid card.

**Before:** Files used a separate View icon, and only image thumbnails opened directly.
**After:** The card opens the preview, with keyboard access; the three-dot menu remains separate.

Why safe:
1. Reuses the existing preview panel and file actions.
2. Menu controls remain separate buttons rather than nested preview targets.

## Test plan

- [x] `bun test apps/web/src/pages/files/files-artifact-folders.test.ts` (2 pass).
- [x] Web TypeScript, Ultracite, and React Doctor (100/100).
- [ ] In list and grid views, click a file, use Enter/Space, and open its menu; confirm only the intended action runs. Browser verification not run.
