### PR TITLE
fix(workflows): resolve assert templates once

### DIFF
--- a/packages/plugins/workflows/actions/actions.js
+++ b/packages/plugins/workflows/actions/actions.js
@@ -418,17 +418,16 @@ class WorkflowRunner {
       return { input: { left, op: step.op, right }, output: result };
     }
     if (step.kind === "assert") {
-      const expected = resolveWorkflowValue(step.expected, bag);
       const result = executeAssert({
         bag,
-        expected,
+        expected: step.expected,
         path: step.path
       });
       if (!result.ok) {
         throw new Error(`Assert step ${step.id} failed: expected ${JSON.stringify(result.expected)}, got ${JSON.stringify(result.actual)}`);
       }
       return {
-        input: { expected, path: step.path },
+        input: { expected: result.expected, path: step.path },
         output: result
       };
     }

--- a/packages/plugins/workflows/src/workflow-runner.test.ts
+++ b/packages/plugins/workflows/src/workflow-runner.test.ts
@@ -136,6 +136,33 @@ describe("WorkflowRunner", () => {
     expect(result.error).toMatch(/cannot be executed locally/i);
     expect(summarizeCalled).toBe(false);
   });
+
+  test("compares template-shaped input strings without resolving them twice", async () => {
+    const workflow = {
+      ...createBaseWorkflow(),
+      steps: [
+        {
+          expected: "{{input.expected}}",
+          id: "check",
+          kind: "assert",
+          path: "input.actual",
+        },
+        { id: "summary", kind: "summarize", prompt: "Summarize" },
+      ] as WorkflowStep[],
+    };
+    const service = createWorkflowServiceStub(workflow);
+    const runner = new WorkflowRunner(service as never, {
+      executeTool: async () => ({}),
+      runWorkflowSummarize: async () => "done",
+    });
+
+    const result = await runner.run(workflow.id, {
+      actual: "{{literal}}",
+      expected: "{{literal}}",
+    });
+
+    expect(result).toMatchObject({ output: "done" });
+  });
 });
 
 function createBaseWorkflow(): StoredWorkflow {

--- a/packages/plugins/workflows/src/workflow-runner.ts
+++ b/packages/plugins/workflows/src/workflow-runner.ts
@@ -201,10 +201,9 @@ export class WorkflowRunner {
     }
 
     if (step.kind === "assert") {
-      const expected = resolveWorkflowValue(step.expected, bag);
       const result = executeAssert({
         bag,
-        expected,
+        expected: step.expected,
         path: step.path,
       });
       if (!result.ok) {
@@ -213,7 +212,7 @@ export class WorkflowRunner {
         );
       }
       return {
-        input: { expected, path: step.path },
+        input: { expected: result.expected, path: step.path },
         output: result,
       };
     }


### PR DESCRIPTION
## Summary

Workflow asserts compare template-shaped input strings after exactly one resolution.

**Before:** `WorkflowRunner` resolved `expected`, then `executeAssert` resolved the resulting value again; a literal such as `{{literal}}` became a missing reference.
**After:** `executeAssert` owns the single resolution and the run receipt records that resolved value.

Why safe:
1. Compare, tool, template, and summarize steps are unchanged.
2. The regression failed on current `main`, passes with the fix, and runs through the real runner lifecycle.

Only revisit if workflows intentionally gain recursive template expansion.

## Test plan
- [x] `bun test packages/plugins/workflows/src apps/server/src/services/official-workflows.test.ts` (19 pass)
- [x] Plugin build, `bun run check`, and `bun run knip`
- [ ] Run an assert where both runtime values equal the literal `{{literal}}` — workflow completes

Follow-up to #826
