### PR TITLE
fix(server): remove session attachments on purge

### DIFF
--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -124,6 +124,7 @@ import {
   DEFAULT_THINKING_ENABLED,
   defaultOllamaBaseUrl,
   deleteArtifactFile,
+  deleteAttachmentBytes,
   extractImageParts,
   findProviderInstance,
   getActiveProviderInstance,
@@ -1908,6 +1909,11 @@ export class AgentService {
     this.agentTodoState.clearSession(sessionId);
     this.agentQuestionnaireState.clearSession(sessionId);
     await deleteSessionHistoryArchive(orgId, sessionId);
+    const attachments = await this.db.listAttachmentsForSession(sessionId);
+    for (const attachment of attachments) {
+      await deleteAttachmentBytes(orgId, attachment.profileId, attachment.id);
+      await this.db.deleteAttachment(attachment.id);
+    }
     await this.db.deleteSession(sessionId);
     return true;
   }

--- a/apps/server/src/services/session-persistence.test.ts
+++ b/apps/server/src/services/session-persistence.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { mkdir, readFile, rm } from "node:fs/promises";
 import { type AgentChatSession, createAgentChatSession } from "@nakama/agent";
-import type { ChatMessage, ProviderClient } from "@nakama/core";
+import {
+  type ChatMessage,
+  type ProviderClient,
+  saveAttachmentBytes,
+} from "@nakama/core";
 import {
   createInMemoryDatabaseAdapter,
   createSqliteDatabase,
@@ -264,6 +268,49 @@ describe("session persistence", () => {
       readFile(sessionHistoryArchivePath("org_1", branch!.sessionId))
     ).rejects.toThrow();
     expect(await loadSessionHistory(db, branch!.sessionId)).toEqual([]);
+  });
+
+  test("purge removes attachment bytes and metadata", async () => {
+    const db = createInMemoryDatabaseAdapter();
+    const now = new Date().toISOString();
+    await db.upsertProfile({
+      createdAt: now,
+      id: "profile",
+      isDefault: true,
+      isSuper: false,
+      model: null,
+      name: "Test",
+      orgId: "org_1",
+      systemPrompt: "",
+      updatedAt: now,
+    });
+    const service = new AgentService(null, null, db);
+    const sessionId = await service.createSession("org_1", "web", "profile");
+    const attachmentPath = await saveAttachmentBytes(
+      "org_1",
+      "profile",
+      "attachment",
+      Buffer.from("attachment")
+    );
+    await db.insertAttachment({
+      channel: "web",
+      createdAt: now,
+      filename: "attachment.txt",
+      id: "attachment",
+      kind: "document",
+      mediaType: "text/plain",
+      orgId: "org_1",
+      profileId: "profile",
+      sessionId,
+      sizeBytes: 10,
+      storagePath: attachmentPath,
+    });
+
+    expect(await service.purgeSession(sessionId, "other-org")).toBe(false);
+    expect(await readFile(attachmentPath, "utf8")).toBe("attachment");
+    expect(await service.purgeSession(sessionId, "org_1")).toBe(true);
+    await expect(readFile(attachmentPath)).rejects.toThrow();
+    expect(await db.getAttachment("attachment")).toBeNull();
   });
 
   test("clear during an archive write does not resurrect history or leave an archive", async () => {

--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -1016,6 +1016,9 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
   const getAttachmentStmt = db.prepare(
     "SELECT * FROM attachments WHERE id = ?"
   );
+  const listAttachmentsForSessionStmt = db.prepare(
+    "SELECT * FROM attachments WHERE session_id = ?"
+  );
   const deleteAttachmentStmt = db.prepare(
     "DELETE FROM attachments WHERE id = ?"
   );
@@ -3115,6 +3118,12 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
       return listArtifactSharesForProfileStmt
         .all(orgId, profileId)
         .map((row) => toArtifactShareRecord(row as ArtifactShareRow));
+    },
+
+    async listAttachmentsForSession(sessionId) {
+      return listAttachmentsForSessionStmt
+        .all(sessionId)
+        .map((row) => toAttachmentRecord(row as AttachmentRow));
     },
 
     async listAutomationRuns(automationId, limit = 20) {

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -879,6 +879,10 @@ export interface DatabaseAdapter {
     profileId: string
   ): Promise<StoredArtifactShareRecord[]>;
 
+  listAttachmentsForSession(
+    sessionId: string
+  ): Promise<StoredAttachmentRecord[]>;
+
   listAutomationRuns(
     automationId: string,
     limit?: number


### PR DESCRIPTION
## Summary

Purge a chat session → its stored attachment bytes and metadata are removed with it.

**Before:** session purge deleted messages and the session row but left attachment files and detached metadata behind.
**After:** `purgeSession` finds attachments for the session, removes their bytes, then deletes their metadata before deleting the session.

Why safe:
1. Organization ownership is checked before any attachment cleanup starts
2. Cleanup is limited to attachment rows linked to the exact session; missing files remain harmless on retry

Only follow up if non-purge chat clearing should also erase attachments.

## Test plan
- [x] `bun test packages/db/src apps/server/src/services/session-persistence.test.ts` (120 pass)
- [x] `bun run check && bun run knip && bun run build`
- [ ] Upload one attachment, purge its session, and confirm the attachment path no longer exists

Progresses #368