### PR TITLE
fix(artifacts): stop creating metadata sidecars

### DIFF
--- a/apps/server/src/tools/generate-image-tool.test.ts
+++ b/apps/server/src/tools/generate-image-tool.test.ts
@@ -9,7 +9,7 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import type { UserConfig } from "@nakama/core";
+import { inferArtifactMimeType, type UserConfig } from "@nakama/core";
 import { GENERATE_IMAGE_TOOL_ID } from "@nakama/core/tools/protected";
 import {
   createInMemoryDatabaseAdapter,
@@ -206,7 +206,7 @@ describe("generate_image tool persistence (U4)", () => {
     process.env.NAKAMA_CONFIG_DIR = tempConfigDir;
   }
 
-  test("prompt produces PNG path + sidecar + attachmentId", async () => {
+  test("prompt saves only the image and returns an attachmentId", async () => {
     await setupWorkspace();
     const db = createInMemoryDatabaseAdapter();
     const usage: Array<{ model: string; input: number; output: number }> = [];
@@ -253,16 +253,7 @@ describe("generate_image tool persistence (U4)", () => {
 
     const absolute = path.join(workspaceRoot, result.path);
     expect(await readFile(absolute)).toEqual(Buffer.from(PNG_BYTES));
-    const meta = JSON.parse(
-      await readFile(`${absolute}.nakama-meta.json`, "utf8")
-    ) as {
-      mimeType: string;
-      sizeBytes: number;
-      savedAt: string;
-    };
-    expect(meta.mimeType).toBe("image/png");
-    expect(meta.sizeBytes).toBe(PNG_BYTES.byteLength);
-    expect(meta.savedAt.length).toBeGreaterThan(0);
+    expect(await readdir(path.dirname(absolute))).toEqual(["cat.png"]);
 
     const attachment = await db.getAttachment(result.attachmentId);
     expect(attachment).toMatchObject({
@@ -277,7 +268,7 @@ describe("generate_image tool persistence (U4)", () => {
     expect(usage).toEqual([{ input: 8, model: "gpt-image-2", output: 200 }]);
   });
 
-  test("filename collision gets unique suffix and remapped sidecar pairs on disk", async () => {
+  test("filename collision saves a unique image without overwriting the original", async () => {
     await setupWorkspace();
     const db = createInMemoryDatabaseAdapter();
     const artifactsDir = path.join(workspaceRoot, "artifacts");
@@ -317,12 +308,43 @@ describe("generate_image tool persistence (U4)", () => {
 
     const absolute = path.join(workspaceRoot, result.path);
     expect(await readFile(absolute)).toEqual(Buffer.from(PNG_BYTES));
-    const meta = JSON.parse(
-      await readFile(`${absolute}.nakama-meta.json`, "utf8")
-    ) as {
-      mimeType: string;
-    };
-    expect(meta.mimeType).toBe("image/png");
+    expect(await readFile(path.join(artifactsDir, "cat.png"), "utf8")).toBe(
+      "existing"
+    );
+    expect((await readdir(artifactsDir)).sort()).toEqual(
+      ["cat.png", path.basename(absolute)].sort()
+    );
+  });
+
+  test.each([
+    ["cat.jpg", "image/png"],
+    [undefined, "image/jpeg"],
+    ["cat.png", "image/webp"],
+  ])("filename %s matches generated type %s", async (filename, mediaType) => {
+    await setupWorkspace();
+    const result = await runGenerateImageTool(
+      { filename, prompt: "a cat" },
+      { orgId: "org_1", profileId: "profile_1", workspaceRoot },
+      {
+        db: createInMemoryDatabaseAdapter(),
+        ensureSettingsLoaded: async () => {},
+        generateImage: async () => ({
+          data: PNG_BYTES,
+          mediaType,
+          model: "gpt-image-2",
+          size: "1024x1024",
+        }),
+        getUserConfig: () =>
+          openaiConfig({ imageModel: IMAGE_GENERATION_SELECTION }),
+      }
+    );
+    if (!("path" in result)) {
+      throw new Error("expected success");
+    }
+    expect(inferArtifactMimeType(result.path)).toBe(mediaType);
+    expect(await readFile(path.join(workspaceRoot, result.path))).toEqual(
+      Buffer.from(PNG_BYTES)
+    );
   });
 
   test("unset model returns error and writes no files (AE2)", async () => {

--- a/apps/server/src/tools/generate-image-tool.ts
+++ b/apps/server/src/tools/generate-image-tool.ts
@@ -2,6 +2,7 @@ import { mkdir, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import {
   getProfileSoulDir,
+  inferArtifactMimeType,
   MAX_IMAGE_BYTES,
   NakamaApiError,
   pathExists,
@@ -21,7 +22,6 @@ import {
 
 export const GENERATE_IMAGE_TOOL_NAME = "generate_image";
 
-const ARTIFACT_META_SUFFIX = ".nakama-meta.json";
 const DEFAULT_FILENAME = "generated-image.png";
 
 export interface GenerateImageToolInput {
@@ -177,29 +177,14 @@ export async function runGenerateImageTool(
   const relativePath = normalizeRelativePath(
     path.relative(workspaceRoot, targetPath)
   );
-  const metaPath = `${targetPath}${ARTIFACT_META_SUFFIX}`;
-  const savedAt = new Date().toISOString();
   const sizeBytes = result.data.byteLength;
 
   await mkdir(artifactsDir, { recursive: true });
 
   try {
     await writeFile(targetPath, result.data);
-    await writeFile(
-      metaPath,
-      JSON.stringify(
-        {
-          mimeType: result.mediaType,
-          savedAt,
-          sizeBytes,
-        },
-        null,
-        2
-      ),
-      "utf8"
-    );
   } catch (error) {
-    await cleanupArtifactPair(targetPath, metaPath);
+    await unlink(targetPath).catch(() => undefined);
     return { error: errorMessage(error) };
   }
 
@@ -223,7 +208,7 @@ export async function runGenerateImageTool(
       });
       attachmentId = saved.attachmentId;
     } catch (error) {
-      await cleanupArtifactPair(targetPath, metaPath);
+      await unlink(targetPath).catch(() => undefined);
       return { error: errorMessage(error) };
     }
   }
@@ -283,8 +268,8 @@ function resolveOutputFilename(
     base = DEFAULT_FILENAME;
   }
 
-  if (!path.extname(base)) {
-    base = `${base}${extension}`;
+  if (inferArtifactMimeType(base) !== mediaType) {
+    base = `${path.basename(base, path.extname(base))}${extension}`;
   }
 
   return base;
@@ -292,14 +277,6 @@ function resolveOutputFilename(
 
 function normalizeRelativePath(relativePath: string): string {
   return relativePath.replace(/\\/g, "/");
-}
-
-async function cleanupArtifactPair(
-  filePath: string,
-  metaPath: string
-): Promise<void> {
-  await unlink(filePath).catch(() => undefined);
-  await unlink(metaPath).catch(() => undefined);
 }
 
 function hasOwnKey(input: unknown, key: string): boolean {

--- a/docs/website/content/docs/artifacts.mdx
+++ b/docs/website/content/docs/artifacts.mdx
@@ -23,7 +23,7 @@ The artifact list gives you:
 
 ![The Files page grouping nested coding-agent-runs logs into a folder](/screenshots/files-artifacts-after-folders.png)
 
-Each row shows the resolved MIME type, size, and last modified time. Those come from the `{filename}.nakama-meta.json` sidecar the agent writes next to the file. Without a sidecar, Nakama infers the type from the extension, and sniffs the bytes for valid UTF-8 when the extension is unknown, so a `Dockerfile` or a `notes.abc` still previews as text instead of being written off as binary.
+Each row shows the file type, size, and last modified time. Nakama infers the type from the extension and reads the size and modification time from the file. Files with unknown extensions are checked for valid UTF-8 when previewed, so a `Dockerfile` or a `notes.abc` still previews as text instead of being written off as binary. Existing metadata files remain supported.
 
 ## Previews by content type
 
@@ -75,7 +75,7 @@ Three things to know:
 
 - **Markdown only.** The write path refuses anything whose resolved type is not `text/markdown` with a 400, so a `.docx` cannot be replaced by the markdown its own preview was converted into.
 - **A failed save keeps your buffer** and shows the error, rather than dropping what you typed.
-- **The sidecar is refreshed**, so the Files list does not show a stale size and timestamp.
+- **The size and timestamp update** in the Files list after saving.
 
 A failed save looks like this. The error is shown, the buffer is still there, and Save is still available:
 

--- a/docs/website/content/docs/builtin-tools.mdx
+++ b/docs/website/content/docs/builtin-tools.mdx
@@ -90,11 +90,11 @@ Active `MEMORY.md` has a **4096-byte** soft limit. Default and super-bot profile
 
 Artifacts are files your agent creates and saves for you — reports, summaries, generated text, Word documents, and other outputs you can preview or download later from the dashboard [Files page](/artifacts) or from web chat.
 
-They are not a separate builtin. Agents use `write_file` or `write_docx` with the `save-artifact` bundled skill under `artifacts/`. The skill also documents writing a `{filename}.nakama-meta.json` sidecar so the Files page shows MIME types and timestamps.
+They are not a separate builtin. Agents use `write_file` or `write_docx` with the `save-artifact` bundled skill under `artifacts/`. Nakama derives the file type, size, and timestamp automatically.
 
 On web chat, `write_file` and `write_docx` saves under `artifacts/` appear as attachment chips on the assistant message. Click a chip to open a resizable preview panel with copy, download, and fullscreen:
 
-On **Telegram**, **Discord**, and **WhatsApp**, the same paired saves post a Publish share link after the agent reply; ask to “send the file” when you want a native attachment. See [Telegram](/telegram/chat#saved-artifacts-and-share-links), [Discord](/discord#saved-artifacts-and-share-links), and [WhatsApp](/whatsapp#saved-artifacts-and-share-links).
+On **Telegram**, **Discord**, and **WhatsApp**, the same saves post a Publish share link after the agent reply; ask to “send the file” when you want a native attachment. See [Telegram](/telegram/chat#saved-artifacts-and-share-links), [Discord](/discord#saved-artifacts-and-share-links), and [WhatsApp](/whatsapp#saved-artifacts-and-share-links).
 
 | Content type | Preview behavior |
 |--------------|------------------|

--- a/docs/website/content/docs/discord.mdx
+++ b/docs/website/content/docs/discord.mdx
@@ -167,7 +167,7 @@ Discord has a 2000-character limit per message. Nakama automatically chunks long
 
 ## Saved artifacts and share links
 
-When your agent saves a file for you with the `save-artifact` skill (content file plus `.nakama-meta.json` sidecar in the same turn), Nakama posts a **Publish-style share link** after the reply in Discord.
+When your agent saves a file for you with the `save-artifact` skill, Nakama posts a **Publish-style share link** after the reply in Discord.
 
 - The link uses the same unguessable `/s/{token}` URLs as dashboard Publish — no Nakama login required to open it.
 - Anyone who can read the Discord message can open the link until the share is revoked from the web app.
@@ -175,7 +175,7 @@ When your agent saves a file for you with the `save-artifact` skill (content fil
 
 To receive the file itself in Discord, ask in plain language — for example, “send the file” or “attach the PDF”. The agent uses the Discord-only `send_discord_artifact` tool to upload a native attachment when the file is within Discord’s size limit. You can also type `/attach` as a shortcut for the most recent saved artifact. If the file is too large, use the share link instead.
 
-Unpaired saves (content without a sidecar in the same turn) do not produce share links or attachments.
+Only successful artifact saves produce share links or attachments.
 
 ## Configuration notes
 

--- a/docs/website/content/docs/image-generation.mdx
+++ b/docs/website/content/docs/image-generation.mdx
@@ -36,7 +36,7 @@ Each generated image is written under the profile workspace:
 ~/.nakama/orgs/{orgId}/profiles/{profileId}/artifacts/
 ```
 
-alongside a `.nakama-meta.json` sidecar, so it appears in **Files** with the right type and timestamp. When the call happens inside a chat session, the image is also saved as a session attachment, which is what makes it render inline in the conversation rather than only in the Files list. Web chat and the channel bridges both recognize `generate_image` output, so a Telegram or Discord turn gets the picture too.
+The image appears in **Files** with its type, size, and timestamp detected automatically. When the call happens inside a chat session, the image is also saved as a session attachment, which is what makes it render inline in the conversation rather than only in the Files list. Web chat and the channel bridges both recognize `generate_image` output, so a Telegram or Discord turn gets the picture too.
 
 Attachments are capped at 5 MB.
 

--- a/docs/website/content/docs/skills.mdx
+++ b/docs/website/content/docs/skills.mdx
@@ -183,7 +183,7 @@ Org admins can enable **skill write approval** under **System â†’ Organization â
 
 - **Memory write path:** read or create `MEMORY.md`, append a dated `- bullet` under the user's timezone date, keep the `# Memory Log` preamble, stay under 4096 bytes
 - **Archive path:** copy exact bullets to `memory-archive/YYYY-MM.md`, then remove them from `MEMORY.md`
-- **Artifact path:** save the file the agent produced with `write_file` or `write_docx` under `artifacts/{filename}`, then write `{filename}.nakama-meta.json` with MIME metadata for the dashboard. Use `write_file` for text, Markdown, HTML, JSON, and code; use `write_docx` when the user wants a real Word document.
+- **Artifact path:** save the file the agent produced with `write_file` or `write_docx` under `artifacts/{filename}` with the correct file extension. Nakama derives the file type, size, and timestamp automatically. Use `write_file` for text, Markdown, HTML, JSON, and code; use `write_docx` when the user wants a real Word document.
 
 These skills use `include-body-on-match: true`, so the full procedure loads when the user's message matches the skill description. The chat wrapper also mentions memory skills when `read_file` and `edit_file` are available, and `save-artifact` when `write_file` is available.
 

--- a/docs/website/content/docs/telegram/chat.mdx
+++ b/docs/website/content/docs/telegram/chat.mdx
@@ -85,7 +85,7 @@ If Telegram rejects the rich rendering, Nakama falls back to plain text.
 
 ## Saved artifacts and share links
 
-When your agent saves a file for you with the `save-artifact` skill (content file plus `.nakama-meta.json` sidecar in the same turn), Nakama posts a **Publish-style share link** after the reply in Telegram chat.
+When your agent saves a file for you with the `save-artifact` skill, Nakama posts a **Publish-style share link** after the reply in Telegram chat.
 
 - The link uses the same unguessable `/s/{token}` URLs as dashboard Publish — no Nakama login required to open it.
 - Anyone who can read the Telegram message can open the link until the share is revoked from the web app.
@@ -93,7 +93,7 @@ When your agent saves a file for you with the `save-artifact` skill (content fil
 
 To receive the file itself in Telegram, ask in plain language — for example, “send the file” or “attach it”. Nakama sends a native Telegram document when the file is within Telegram’s size limit. If the file is too large, use the share link instead.
 
-Unpaired saves (content without a sidecar in the same turn) do not produce share links or attachments.
+Only successful artifact saves produce share links or attachments.
 
 ## Next steps
 

--- a/docs/website/content/docs/whatsapp.mdx
+++ b/docs/website/content/docs/whatsapp.mdx
@@ -116,7 +116,7 @@ Useful WhatsApp commands:
 
 ## Saved artifacts and share links
 
-When your agent saves a file for you with the `save-artifact` skill (content file plus `.nakama-meta.json` sidecar in the same turn), Nakama posts a **Publish-style share link** after the reply in WhatsApp.
+When your agent saves a file for you with the `save-artifact` skill, Nakama posts a **Publish-style share link** after the reply in WhatsApp.
 
 Opening that link does not require a Nakama login. Anyone who can read the WhatsApp message can open the file until the share is revoked from the dashboard.
 
@@ -124,7 +124,7 @@ To receive the file itself in WhatsApp, ask in plain language — for example, �
 
 In a WhatsApp **group**, both the share link and a requested document go to the whole group (same visibility as the bot’s other replies).
 
-Unpaired saves (content without a sidecar in the same turn) do not produce share links or attachments.
+Only successful artifact saves produce share links or attachments.
 
 ## Troubleshooting
 

--- a/packages/core/src/skills/bundled/create-automation.test.ts
+++ b/packages/core/src/skills/bundled/create-automation.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { readBundledSkillMarkdown } from "./index";
 import { ensureBundledSkillFiles } from "./install";
 
 describe("ensureBundledSkillFiles", () => {
@@ -78,5 +79,19 @@ describe("ensureBundledSkillFiles", () => {
     expect(created).toContain("manage-skills");
     expect(content).toContain("skill_manage");
     expect(content).not.toContain("description: stale");
+  });
+
+  test("refreshes an installed save-artifact skill on startup", async () => {
+    const directory = join(configDir, "agent", "skills", "save-artifact");
+    const skillPath = join(directory, "SKILL.md");
+    await mkdir(directory, { recursive: true });
+    await Bun.write(skillPath, "outdated bundled skill");
+
+    const refreshed = await ensureBundledSkillFiles();
+
+    expect(refreshed).toContain("save-artifact");
+    expect(await readFile(skillPath, "utf8")).toBe(
+      await readBundledSkillMarkdown("save-artifact")
+    );
   });
 });

--- a/packages/core/src/skills/bundled/install.ts
+++ b/packages/core/src/skills/bundled/install.ts
@@ -10,6 +10,7 @@ const FORCE_REFRESH_BUNDLED_SKILL_NAMES = new Set<string>([
   "coding-agent",
   "coding-backend-cursor",
   "agent-browser",
+  "save-artifact",
 ]);
 
 const RENAMED_BUNDLED_SKILL_DIRS = [

--- a/packages/core/src/skills/bundled/save-artifact/SKILL.md
+++ b/packages/core/src/skills/bundled/save-artifact/SKILL.md
@@ -15,37 +15,10 @@ Use this skill to save **durable deliverables** the user may revisit later.
 - Reports, summaries, generated code snippets, logs, or structured notes the user asked to keep
 - Outputs they may download or review later in the profile **Artifacts** tab
 
-## Metadata sidecar
-
-After writing the artifact file, write a JSON sidecar at `artifacts/{filename}.nakama-meta.json` so the dashboard shows the correct MIME type and timestamp.
-
-Example for `artifacts/report.md`:
-
-```json
-{
-  "mimeType": "text/markdown",
-  "savedAt": "2026-07-12T05:13:00.000Z",
-  "sizeBytes": 1234
-}
-```
-
-- `mimeType`: choose an accurate type (`text/markdown`, `text/plain`, `application/json`, `text/html`, etc.)
-- `savedAt`: current time in ISO 8601 UTC
-- `sizeBytes`: UTF-8 byte length of the artifact file content (not the sidecar)
-
 ## Workflow
 
-1. Choose a short, descriptive filename under `artifacts/` (use subdirectories when grouping related files, e.g. `artifacts/weekly/report.md`).
+1. Choose a short, descriptive filename with the correct extension under `artifacts/` (use subdirectories when grouping related files, e.g. `artifacts/weekly/report.md`).
 2. `write_file` the artifact content to `artifacts/{filename}`. If that name already exists, a date suffix is added automatically (e.g. `report-2026-07-14.md`).
-3. `write_file` the metadata sidecar to `artifacts/{filename}.nakama-meta.json` using the same base filename from step 2.
-4. Confirm both paths in your reply so the user knows where to find the file. On web chat, saved artifacts also appear as attachment chips on the assistant message (with preview) in addition to the profile **Artifacts** tab.
+3. Confirm the saved path returned by the tool. On web chat, saved artifacts also appear as attachment chips on the assistant message (with preview) in addition to the profile **Artifacts** tab.
 
-## MIME type guidance
-
-| Content | mimeType |
-|---------|----------|
-| Markdown | `text/markdown` |
-| Plain text / logs | `text/plain` |
-| JSON | `application/json` |
-| HTML | `text/html` |
-| Source code | `text/plain` or a specific `text/x-*` when obvious |
+Save only the deliverable; Nakama derives the file type, size, and timestamp automatically.


### PR DESCRIPTION
## Summary

Agents save deliverables without creating an extra `.nakama-meta.json` file.

**Before:** artifact saves required metadata bookkeeping, and generated images wrote a separate JSON file.
**After:** Nakama uses the existing file metadata fallback; the updated skill refreshes on server startup.

Why safe:
1. Existing metadata files remain supported, including updates after editing old artifacts.
2. Files, chat attachments, and channel delivery already support saves without metadata files.
3. Generated-image extensions now match their output format so file-type detection stays accurate.

Follow up if an artifact needs a custom file type that its extension cannot express.

## Test plan

- [x] `bun test apps/server/src/tools/generate-image-tool.test.ts packages/core/src/artifacts.test.ts packages/core/src/channel-artifacts.test.ts packages/core/src/channel-artifact-delivery.test.ts apps/web/src/lib/chat-artifacts.test.ts` (71 pass)
- [x] `bun test packages/core/src/skills/bundled apps/server/src/services/skills-service.test.ts apps/server/src/services/skills-service-org-scope.test.ts` (30 pass); changed-file Ultracite check and `bun run knip` pass.

Full TypeScript check reports errors outside the changed files. Docs build stalled during production compilation and was stopped. Live browser verification was not run.
