### PR TITLE
docs(bash): clarify unrestricted host access

### DIFF
--- a/apps/server/src/tools/bash.ts
+++ b/apps/server/src/tools/bash.ts
@@ -91,7 +91,7 @@ export function resetBashSandboxManagerForTests(): void {
 }
 
 const BASH_TOOL_DESCRIPTION_BASE =
-  "Run a one-off shell command in the active profile workspace and return stdout, stderr, and exit code. Do not use this to create persistent tools, tool files, shell wrappers, or .sh scripts. If the user wants a reusable tool, translate shell examples into JavaScript instead.";
+  "Run a one-off shell command starting in the active profile workspace and return stdout, stderr, and exit code. Do not use this to create persistent tools, tool files, shell wrappers, or .sh scripts. If the user wants a reusable tool, translate shell examples into JavaScript instead.";
 
 function bashToolDescription(): string {
   try {
@@ -101,7 +101,7 @@ function bashToolDescription(): string {
   } catch {
     // Invalid backend config — keep the host description.
   }
-  return BASH_TOOL_DESCRIPTION_BASE;
+  return `${BASH_TOOL_DESCRIPTION_BASE} Host execution is unrestricted by Nakama and uses the server process's OS permissions. Commands can access files outside the profile workspace, including other profiles' files when OS permissions allow. Assign host bash only to trusted profiles.`;
 }
 
 export const bashTool: ToolDefinition<BashInput, BashOutput> = {

--- a/docs/website/content/docs/builtin-tools.mdx
+++ b/docs/website/content/docs/builtin-tools.mdx
@@ -310,7 +310,7 @@ The notice rides inside `text` rather than in a field of its own because the too
 
 ### `bash`
 
-Run a one-off shell command in the profile workspace and return stdout, stderr, and exit code.
+Run a one-off shell command starting in the profile workspace and return stdout, stderr, and exit code.
 
 | Parameter | Type | Required | Notes |
 |-----------|------|----------|-------|
@@ -326,7 +326,9 @@ Run a one-off shell command in the profile workspace and return stdout, stderr, 
 
 **Coding-agent spawn env:** When the command starts with a known harness binary (`codex`, `claude`, `opencode`, `pi`, or `agent`), or when `codingAgent: true` is set with such a command, Nakama merges provider passthrough env vars on the server before spawn. `codingAgent: true` without a known binary fails closed. See [Coding agent — Provider passthrough](/coding-agent#provider-passthrough). Optional `env` keys are merged on top (credential keys cannot override passthrough).
 
-**Scope:** Profile workspace only. Do not use `bash` to create persistent tools or `.sh` wrappers — register JavaScript tools under `~/.nakama/tools/` instead.
+**Host access:** Host Bash is unrestricted by Nakama and runs with the server process's OS permissions. The profile workspace is only the starting directory; commands can access files outside it, including other profiles' files when OS permissions allow. Checking `cwd` does not isolate commands. Assign host Bash only to trusted profiles; use MicroSandbox when profile isolation is required.
+
+Do not use `bash` to create persistent tools or `.sh` wrappers — register JavaScript tools under `~/.nakama/tools/` instead.
 
 **Availability:** When assigned to the profile. Super Bot receives `bash` by default. Required for the [coding agent](/coding-agent) workflow and the opt-in [agent-browser](/agent-browser) skill. Interactive browser runs inherit host `AGENT_BROWSER_EXECUTABLE_PATH` / `AGENT_BROWSER_ARGS` when you opt into Cloak.
 

--- a/docs/website/content/docs/docker.mdx
+++ b/docs/website/content/docs/docker.mdx
@@ -91,6 +91,8 @@ See [Agent browser](/agent-browser#3-optional-cloakbrowser-for-antibot-sites).
 
 Stock `docker run` / `./scripts/docker-build-run.sh` does **not** pass `/dev/kvm` (or nested virtualization). Keep `NAKAMA_BASH_BACKEND=host` (the default) inside Docker unless you deliberately add hypervisor access.
 
+In Docker, host Bash runs inside the Nakama container with the server process's OS permissions. It can access mounted data outside the active profile workspace, including other profiles' files when permissions allow. The shared container does not isolate profiles from each other. Assign host Bash only to trusted profiles.
+
 If you set `NAKAMA_BASH_BACKEND=microsandbox` without a working MicroSandbox runtime / KVM device, **every** `bash` tool call fails closed — there is no silent host fallback. Coding-agent harness runs require `host` for now. See [Built-in tools — bash](/builtin-tools#bash).
 
 ## Next steps


### PR DESCRIPTION
## Summary

Operators and agents get an explicit warning that host Bash can access files outside the profile workspace.

**Before:** Docs claimed profile-workspace-only scope.
**After:** The tool description and docs explain server OS permissions, cross-profile file access, and the shared Docker container boundary.

Why safe:
1. Only descriptions and documentation change; execution and permissions stay unchanged.
2. The host warning is separate from the MicroSandbox tool description.

Follow-up: enforcing sandbox isolation remains separate work.

Related: #529

## Test plan
- [x] `bun x ultracite check apps/server/src/tools/bash.ts` (passed)
- [x] `git diff origin/main...HEAD --check` (passed)
- [ ] Read the Bash and Docker docs together to confirm the access boundary is clear.
