### PR TITLE
refactor: remove unused helpers and simplify request building

### DIFF
--- a/apps/server/src/services/composio-secret.ts
+++ b/apps/server/src/services/composio-secret.ts
@@ -1,9 +1,4 @@
-import {
-  createCipheriv,
-  createDecipheriv,
-  createHash,
-  randomBytes,
-} from "node:crypto";
+import { createCipheriv, createHash, randomBytes } from "node:crypto";
 
 function deriveKey(secret: string): Buffer {
   return createHash("sha256").update(`nakama-composio:${secret}`).digest();
@@ -22,20 +17,4 @@ export function encryptComposioSecret(
   ]);
   const tag = cipher.getAuthTag();
   return Buffer.concat([iv, tag, encrypted]).toString("base64url");
-}
-
-export function decryptComposioSecret(
-  ciphertext: string,
-  secret: string
-): string {
-  const key = deriveKey(secret);
-  const buffer = Buffer.from(ciphertext, "base64url");
-  const iv = buffer.subarray(0, 12);
-  const tag = buffer.subarray(12, 28);
-  const encrypted = buffer.subarray(28);
-  const decipher = createDecipheriv("aes-256-gcm", key, iv);
-  decipher.setAuthTag(tag);
-  return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString(
-    "utf8"
-  );
 }

--- a/apps/server/src/services/skills-service.ts
+++ b/apps/server/src/services/skills-service.ts
@@ -5,7 +5,6 @@ import type {
   InstallSkillRequest,
   ListSkillsResponse,
   PatchSkillRequest,
-  SkillDetail,
   SkillResponse,
   SkillSummary,
   SkillUsageSummary,
@@ -1168,14 +1167,4 @@ export function toSkillSummaries(
     ...toSkillSummary(record, usageBySkillId.get(record.id) ?? null),
     usage: toSkillUsageSummary(usageBySkillId.get(record.id)),
   }));
-}
-
-export function toSkillDetail(
-  record: StoredSkillRecord,
-  body = ""
-): SkillDetail {
-  return {
-    ...toSkillSummary(record),
-    body,
-  };
 }

--- a/apps/web/src/lib/chat-stream.ts
+++ b/apps/web/src/lib/chat-stream.ts
@@ -467,16 +467,9 @@ export function deriveChatStatus(
 export function latestAssistantTurnMessages(
   messages: ChatListItem[]
 ): ChatListItem[] {
-  let start = 0;
-
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    if (messages[index]?.role === "user") {
-      start = index + 1;
-      break;
-    }
-  }
-
-  return messages.slice(start);
+  return messages.slice(
+    messages.findLastIndex((message) => message?.role === "user") + 1
+  );
 }
 
 /**

--- a/apps/web/src/lib/models.test.ts
+++ b/apps/web/src/lib/models.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { USER_PROVIDER_NAMES } from "@nakama/core/provider-resolution";
 import {
+  buildCreateProviderRequest,
   encodeModelSelection,
   filterVisionCapableProviderGroups,
   firstAvailableProviderOption,
@@ -14,6 +15,59 @@ import {
   resolveModelVisionSupport,
   validateCustomModelsInput,
 } from "./models";
+
+describe("buildCreateProviderRequest", () => {
+  test.each([
+    ["openai_compatible", true, true],
+    ["openrouter", true, false],
+    ["xai_oauth", true, false],
+    ["cerebras", true, false],
+    ["fireworks", true, false],
+    ["ollama", true, false],
+    ["opencode_go", true, false],
+    ["openai", false, false],
+  ] as const)(
+    "preserves custom-model handling for %s",
+    (provider, populated, empty) => {
+      for (const customModels of [undefined, [], [{ id: "custom-model" }]]) {
+        const request = buildCreateProviderRequest({
+          apiKey: "key",
+          customModels,
+          provider,
+        });
+        const include =
+          customModels && (customModels.length ? populated : empty);
+        expect(request).toEqual({
+          apiKey: "key",
+          type: provider,
+          ...(include ? { customModels } : {}),
+        });
+      }
+    }
+  );
+
+  test("keeps normalized connection fields and model selection", () => {
+    expect(
+      buildCreateProviderRequest({
+        apiKey: "key",
+        baseUrl: " http://localhost:11434 ",
+        displayName: " Local ",
+        hostMode: "local",
+        model: "model-1",
+        provider: "ollama",
+        wireApi: "responses",
+      })
+    ).toEqual({
+      apiKey: "key",
+      baseUrl: "http://localhost:11434",
+      hostMode: "local",
+      label: "Local",
+      model: "model-1",
+      type: "ollama",
+      wireApi: "responses",
+    });
+  });
+});
 
 function group(
   providerId: string,

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -606,97 +606,34 @@ export function buildCreateProviderRequest(options: {
   chatgptOAuth?: CreateProviderRequest["chatgptOAuth"];
   xaiOAuth?: CreateProviderRequest["xaiOAuth"];
 }): CreateProviderRequest {
-  const request = buildConfigureProviderRequest(options);
+  const customModels =
+    options.provider === "openai_compatible" ||
+    ([
+      "openrouter",
+      "xai_oauth",
+      "cerebras",
+      "fireworks",
+      "ollama",
+      "opencode_go",
+    ].includes(options.provider) &&
+      options.customModels?.length)
+      ? options.customModels
+      : undefined;
 
   return {
-    apiKey: request.apiKey,
-    type: request.provider,
+    apiKey: options.apiKey,
+    type: options.provider,
     ...(options.xaiOAuth ? { xaiOAuth: options.xaiOAuth } : {}),
     ...(options.chatgptOAuth ? { chatgptOAuth: options.chatgptOAuth } : {}),
-    ...(request.model ? { model: request.model } : {}),
+    ...(options.model ? { model: options.model } : {}),
     ...(options.displayName?.trim()
       ? { label: options.displayName.trim() }
       : {}),
     ...(options.baseUrl?.trim() ? { baseUrl: options.baseUrl.trim() } : {}),
     ...(options.hostMode ? { hostMode: options.hostMode } : {}),
-    ...(request.customModels ? { customModels: request.customModels } : {}),
+    ...(customModels ? { customModels } : {}),
     ...(options.wireApi === "responses" ? { wireApi: options.wireApi } : {}),
   };
-}
-
-export function buildConfigureProviderRequest(options: {
-  apiKey: string;
-  provider: SelectedProvider;
-  model?: string;
-  displayName?: string;
-  baseUrl?: string;
-  hostMode?: OllamaHostMode;
-  customModels?: ConfigureProviderRequest["customModels"];
-}): ConfigureProviderRequest {
-  const request: ConfigureProviderRequest = {
-    apiKey: options.apiKey,
-    provider: options.provider,
-    ...(options.model ? { model: options.model } : {}),
-  };
-
-  if (options.provider === "openai_compatible") {
-    return {
-      ...request,
-      baseUrl: options.baseUrl?.trim(),
-      customModels: options.customModels,
-      displayName: options.displayName?.trim(),
-    };
-  }
-
-  if (
-    (options.provider === "openrouter" || options.provider === "xai_oauth") &&
-    options.customModels?.length
-  ) {
-    return {
-      ...request,
-      customModels: options.customModels,
-    };
-  }
-
-  if (options.provider === "cerebras" && options.customModels?.length) {
-    return {
-      ...request,
-      customModels: options.customModels,
-    };
-  }
-
-  if (options.provider === "fireworks" && options.customModels?.length) {
-    return {
-      ...request,
-      customModels: options.customModels,
-    };
-  }
-
-  if (options.provider === "ollama" && options.customModels?.length) {
-    return {
-      ...request,
-      baseUrl: options.baseUrl?.trim(),
-      customModels: options.customModels,
-    };
-  }
-
-  if (options.provider === "opencode_go" && options.customModels?.length) {
-    return {
-      ...request,
-      customModels: options.customModels,
-    };
-  }
-
-  if (options.provider === "opencode_go") {
-    return request;
-  }
-
-  const baseUrl = options.baseUrl?.trim();
-  if (baseUrl) {
-    return { ...request, baseUrl };
-  }
-
-  return request;
 }
 
 export function encodeModelSelection(

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -144,20 +144,6 @@ export const STANDALONE_PAGES: Partial<Record<PageId, NavItem>> = {
   ),
 };
 
-const navItemsWithIcons = [
-  ...NAV_ITEMS,
-  ...Object.values(STANDALONE_PAGES).filter(
-    (item): item is NavItem => item !== undefined
-  ),
-];
-
-/** Compatibility lookup for consumers that only need an icon by page id. */
-export const NAV_ITEM_ICONS: Record<PageId, NavIcon> = {
-  ...(Object.fromEntries(
-    navItemsWithIcons.map((item) => [item.id, item.icon])
-  ) as Record<PageId, NavIcon>),
-};
-
 export const SETUP_PATH = "/setup";
 
 export const PLATFORM_ADMIN_PAGE_IDS: ReadonlySet<PageId> = new Set([


### PR DESCRIPTION
## Summary

Keep provider setup and chat behavior with 116 fewer production lines to maintain.

**Before:** provider creation built an intermediate request, chat searched backwards manually, and three unused helpers remained.
**After:** build the final request directly, use `findLastIndex`, and remove the unused helpers.

Why safe:
1. Regression tests cover absent, empty, and populated custom models across eight provider types.
2. Removed helpers have no callers; existing navigation, chat, skills, and Composio tests pass.

Only revisit if provider-specific request rules change.

## Test plan

- [x] `bun test apps/web/src/lib/models.test.ts apps/web/src/lib/navigation.test.ts apps/web/src/lib/chat-stream-awaiting.test.ts apps/server/src/services/composio-service.test.ts apps/server/src/services/skills-service.test.ts` (93 tests pass across the runs)
- [x] `bun run --cwd apps/web build`, `bun run knip`, and targeted Ultracite checks pass; type check passes after adding regression tests.
- [x] `npx react-doctor@latest --verbose --scope changed` (100/100, no issues)
