### PR TITLE
fix(auth): require reauthentication for email changes

### DIFF
--- a/apps/server/src/http/routes/auth.ts
+++ b/apps/server/src/http/routes/auth.ts
@@ -64,6 +64,7 @@ export function registerAuthRoutes(app: HonoApp, options: ServerOptions): void {
     .openapi("AuthUserResponse");
   const updateAuthProfileSchema = z
     .object({
+      currentPassword: z.string().optional(),
       email: z.string().optional(),
       name: z.string().nullable().optional(),
       phone: z.string().nullable().optional(),

--- a/apps/server/src/services/org-service.test.ts
+++ b/apps/server/src/services/org-service.test.ts
@@ -447,6 +447,7 @@ describe("OrgService", () => {
 
     const userId = created.adminMember!.member.userId;
     const updated = await orgService.updateOwnProfile(userId, {
+      currentPassword: created.adminMember!.temporaryPassword!,
       email: "updated@acme.com",
       name: "Updated Admin",
       phone: "",
@@ -456,6 +457,34 @@ describe("OrgService", () => {
     expect(updated.name).toBe("Updated Admin");
     expect(updated.email).toBe("updated@acme.com");
     expect(updated.phone).toBeNull();
+
+    const profileOnly = await orgService.updateOwnProfile(userId, {
+      name: "Renamed Admin",
+    });
+    expect(profileOnly.name).toBe("Renamed Admin");
+  });
+
+  test("requires the current password before changing email", async () => {
+    const { databaseAdapter, orgService } = createOrgService();
+    const created = await orgService.createOrganization({
+      admin: { email: "admin@acme.com", name: "Acme Admin" },
+      name: "Acme",
+      slug: "acme-email-reauth",
+    });
+    const userId = created.adminMember!.member.userId;
+
+    await expect(
+      orgService.updateOwnProfile(userId, { email: "attacker@example.com" })
+    ).rejects.toMatchObject({ status: 401 });
+    await expect(
+      orgService.updateOwnProfile(userId, {
+        currentPassword: "wrong-password",
+        email: "attacker@example.com",
+      })
+    ).rejects.toMatchObject({ status: 401 });
+    expect((await databaseAdapter.getUserById(userId))?.email).toBe(
+      "admin@acme.com"
+    );
   });
 
   test("rejects duplicate slugs", async () => {

--- a/apps/server/src/services/org-service.ts
+++ b/apps/server/src/services/org-service.ts
@@ -369,6 +369,7 @@ export class OrgService {
   async updateOwnProfile(
     userId: string,
     input: {
+      currentPassword?: string;
       name?: string | null;
       email?: string;
       phone?: string | null;
@@ -397,6 +398,14 @@ export class OrgService {
       }
 
       if (email !== user.email) {
+        const validPassword = await this.authService.verifyPassword(
+          input.currentPassword?.trim() ?? "",
+          user.passwordHash
+        );
+        if (!validPassword) {
+          throw new NakamaApiError("Current password is incorrect.", 401);
+        }
+
         const existing = await this.databaseAdapter.getUserByEmail(email);
         if (existing && existing.id !== user.id) {
           throw new NakamaApiError(

--- a/apps/web/src/components/SidebarUserMenu.tsx
+++ b/apps/web/src/components/SidebarUserMenu.tsx
@@ -246,9 +246,13 @@ function UserProfileDialog({
       return;
     }
 
-    const wantsPasswordChange = Boolean(
-      currentPassword || newPassword || confirmPassword
-    );
+    const emailChanged = trimmedEmail.toLowerCase() !== email.toLowerCase();
+    if (emailChanged && !currentPassword) {
+      setError("Enter your current password to change email.");
+      return;
+    }
+
+    const wantsPasswordChange = Boolean(newPassword || confirmPassword);
     if (wantsPasswordChange) {
       if (!(currentPassword && newPassword)) {
         setError("Enter your current password and a new password.");
@@ -263,6 +267,7 @@ function UserProfileDialog({
     setPending(true);
     try {
       await client.updateAuthProfile({
+        ...(emailChanged ? { currentPassword } : {}),
         email: trimmedEmail,
         name: formName,
         phone: formPhone,
@@ -351,7 +356,7 @@ function UserProfileDialog({
             <div>
               <p className="font-medium text-sm">Password</p>
               <p className="text-muted-foreground text-xs">
-                Leave blank to keep your current one.
+                Enter your current password to change email or password.
               </p>
             </div>
             <div>

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -475,6 +475,7 @@ export interface AuthUserResponse {
 }
 
 export interface UpdateAuthProfileRequest {
+  currentPassword?: string;
   email?: string;
   name?: string | null;
   phone?: string | null;


### PR DESCRIPTION
## Summary

Change an account email → the current password must verify before the identity changes.

**Before:** any valid browser session could replace its account email without reauthentication.
**After:** updateOwnProfile verifies the current password for real email changes, and the profile dialog sends it only when needed.

Why safe:
1. Missing or wrong passwords fail before duplicate lookup or database mutation
2. Name and phone updates still work without a password; password changes keep their existing flow

Only follow up here if passwordless sign-in lands; reset and invite delivery remain separate #430 work.

## Test plan
- [x] bun test apps/server/src/services/org-service.test.ts apps/server/src/http/org-invites.test.ts (38 pass)
- [x] Targeted Ultracite check, bun run knip, and bun run build
- [ ] Change only the account email in Profile and confirm the current password is required

Progresses #430