### PR TITLE
feat(config): support mounted provider API keys

### DIFF
--- a/apps/server/src/setup.test.ts
+++ b/apps/server/src/setup.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -32,6 +32,35 @@ describe("isProviderConfigured", () => {
       )
     ).toBe(true);
   });
+
+  test("treats a mounted API key file as configured", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "nakama-provider-key-"));
+    const keyPath = join(directory, "openai");
+    await writeFile(keyPath, "sk-mounted\n");
+    const id = createProviderInstanceId();
+
+    try {
+      expect(
+        isProviderConfigured(
+          {
+            defaultProviderId: id,
+            providers: [
+              {
+                apiKey: "",
+                createdAt: "2026-06-07T10:00:00.000Z",
+                id,
+                label: "OpenAI",
+                type: "openai",
+              },
+            ],
+          },
+          { OPENAI_API_KEY_FILE: keyPath }
+        )
+      ).toBe(true);
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
 });
 
 describe("ensureProviderConfigured", () => {
@@ -40,6 +69,7 @@ describe("ensureProviderConfigured", () => {
     "NAKAMA_CONFIG_DIR",
     "NAKAMA_PROVIDER",
     "OPENAI_API_KEY",
+    "OPENAI_API_KEY_FILE",
     "ANTHROPIC_API_KEY",
     "OPENROUTER_API_KEY",
     "GEMINI_API_KEY",
@@ -89,5 +119,23 @@ describe("ensureProviderConfigured", () => {
     expect(loaded?.defaultProviderId).toBe(userConfig?.defaultProviderId);
     expect(isProviderConfigured(loaded, process.env)).toBe(true);
     expect(getUserConfigPath()).toContain(configDir);
+  });
+
+  test("bootstraps from a mounted API key without persisting the secret", async () => {
+    snapshotEnv();
+    configDir = await mkdtemp(join(tmpdir(), "nakama-setup-key-file-"));
+    const keyPath = join(configDir, "openai-secret");
+    await writeFile(keyPath, "sk-mounted\n");
+    process.env.NAKAMA_CONFIG_DIR = configDir;
+    process.env.NAKAMA_PROVIDER = "openai";
+    process.env.OPENAI_API_KEY_FILE = keyPath;
+
+    const { provider, userConfig } = await ensureProviderConfigured();
+
+    expect(provider).not.toBeNull();
+    expect(userConfig?.providers[0]?.apiKey).toBe("");
+    expect(await readFile(getUserConfigPath(), "utf8")).not.toContain(
+      "sk-mounted"
+    );
   });
 });

--- a/docs/website/content/docs/providers.mdx
+++ b/docs/website/content/docs/providers.mdx
@@ -19,6 +19,24 @@ During [First-time setup](/first-time-setup), the wizard uses the same provider 
 
 ![Configure your LLM provider in the setup wizard](/screenshots/setup-step-provider.png)
 
+## Mount provider API keys
+
+Keep provider secrets outside Nakama's data directory by setting the provider's
+API-key variable with a `_FILE` suffix. Its value is the path to a readable
+secret file:
+
+```sh
+OPENAI_API_KEY_FILE=/run/secrets/openai_api_key
+```
+
+This works for built-in providers that expose an API-key environment variable,
+including `ANTHROPIC_API_KEY_FILE` and `GEMINI_API_KEY_FILE`. On first boot,
+set `NAKAMA_PROVIDER` as well when more than one provider secret is mounted.
+
+Nakama trims the file contents and leaves the API key empty in its saved
+settings. A directly set API-key variable takes priority over its `_FILE`
+partner. Startup fails when a configured secret file cannot be read.
+
 ## Supported providers
 
 Nakama supports these built-in provider types:

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -3,7 +3,17 @@ export function readEnvValue(
   key: string
 ): string | undefined {
   const value = env[key]?.trim();
-  return value || undefined;
+  if (value) {
+    return value;
+  }
+
+  const filePath = env[`${key}_FILE`]?.trim();
+  if (!filePath) {
+    return;
+  }
+
+  const { readFileSync } = process.getBuiltinModule("node:fs");
+  return readFileSync(filePath, "utf8").trim() || undefined;
 }
 
 export interface AppConfig {

--- a/packages/core/src/provider-resolution.test.ts
+++ b/packages/core/src/provider-resolution.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   apiKeyEnvVarForProvider,
   defaultDiscoveryBaseUrl,
@@ -113,6 +116,41 @@ describe("resolveProvider", () => {
     });
 
     expect(provider).toBe("gemini");
+  });
+
+  test("uses an API key mounted through a companion file variable", () => {
+    const directory = mkdtempSync(join(tmpdir(), "nakama-provider-key-"));
+    const keyPath = join(directory, "gemini");
+    writeFileSync(keyPath, "mounted-secret\n");
+
+    try {
+      expect(
+        resolveProvider({
+          env: { GEMINI_API_KEY_FILE: keyPath },
+        })
+      ).toBe("gemini");
+    } finally {
+      rmSync(directory, { force: true, recursive: true });
+    }
+  });
+
+  test("prefers a direct API key over its companion file", () => {
+    expect(
+      resolveProvider({
+        env: {
+          GEMINI_API_KEY: "direct-secret",
+          GEMINI_API_KEY_FILE: "/missing/secret",
+        },
+      })
+    ).toBe("gemini");
+  });
+
+  test("fails when a configured API key file cannot be read", () => {
+    expect(() =>
+      resolveProvider({
+        env: { GEMINI_API_KEY_FILE: "/missing/secret" },
+      })
+    ).toThrow();
   });
 
   test("returns null when multiple env API keys are set", () => {

--- a/packages/core/src/user-config.ts
+++ b/packages/core/src/user-config.ts
@@ -10,6 +10,7 @@ import {
   serializeCustomModels,
   validateDisplayName,
 } from "./compatible-provider-config";
+import { readEnvValue } from "./config";
 import type {
   ChatgptOAuthCredentials,
   CustomModelEntry,
@@ -205,7 +206,7 @@ export function isProviderConfigured(
       }
 
       const envVar = apiKeyEnvVarForProvider(active.type);
-      return Boolean(envVar && env[envVar]?.trim());
+      return Boolean(envVar && readEnvValue(env, envVar));
     }
 
     return true;
@@ -216,7 +217,7 @@ export function isProviderConfigured(
   }
 
   const envVar = apiKeyEnvVarForProvider(active.type);
-  return Boolean(envVar && env[envVar]?.trim());
+  return Boolean(envVar && readEnvValue(env, envVar));
 }
 
 export function isValidTimezone(timezone: string): boolean {


### PR DESCRIPTION
## Summary

Mount a provider API key as a file → Nakama reads it without persisting the secret in settings.

**Before:** Provider startup accepted direct API-key environment variables only.
**After:** Every supported provider key also accepts a `_FILE` companion path; direct values still win.

Why safe:
1. Bootstrap coverage confirms the mounted secret never reaches `config.ini`
2. Missing files fail explicitly, while lazy filesystem access keeps the web bundle buildable

Only follow up if channel or other non-provider secrets need the same convention.

## Test plan
- [x] `bun test packages/core/src/provider-resolution.test.ts apps/server/src/setup.test.ts` (38 pass)
- [x] Targeted Ultracite check, `bun run knip`, `bun run build`, and `bun run build:docs`
- [ ] Start with `NAKAMA_PROVIDER=openai` and `OPENAI_API_KEY_FILE=/run/secrets/openai_api_key`

Progresses #364
