### PR TITLE
fix(auth): protect install-wide settings

### DIFF
--- a/apps/server/src/http/routes/coding-harnesses.ts
+++ b/apps/server/src/http/routes/coding-harnesses.ts
@@ -7,7 +7,7 @@ import {
 import type { ServerOptions } from "../context";
 import {
   requireActiveOrgIdFromContext,
-  requireOrgAdminOrPlatformAdminFromContext,
+  requirePlatformAdminFromContext,
 } from "../org-guards";
 import { json, readJson } from "../shared";
 import type { HonoApp } from "../types";
@@ -31,7 +31,7 @@ export function registerCodingHarnessSettingsRoutes(
   app.put("/v1/settings/coding-harnesses", async (c) => {
     // Workspace-global, same bar as other install-wide settings (#305).
     // Per-org isolation of this flag is #307.
-    requireOrgAdminOrPlatformAdminFromContext(c);
+    requirePlatformAdminFromContext(c);
     const body = await readJson<{ providerPassthroughEnabled?: boolean }>(
       c.req.raw
     );

--- a/apps/server/src/http/routes/error-tracking.test.ts
+++ b/apps/server/src/http/routes/error-tracking.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { createInMemoryDatabaseAdapter } from "@nakama/db";
 import { AgentService } from "../../services/agent-service";
 import { createMinimalHonoApp } from "../test-app-helpers";
-import { loginUserSession, seedOrgAdmin } from "../test-session-helpers";
+import { setupFreshInstallSession } from "../test-session-helpers";
 
 const DSN = "https://publickey@errors.example.com/42";
 
@@ -23,10 +23,9 @@ async function createApp() {
 }
 
 describe("error tracking routes", () => {
-  test("an org admin saves a DSN and reads it back masked", async () => {
+  test("a platform admin saves a DSN and reads it back masked", async () => {
     const { app, databaseAdapter } = await createApp();
-    const { email, password, orgId } = await seedOrgAdmin(databaseAdapter);
-    const session = await loginUserSession(app, email, password, orgId);
+    const session = await setupFreshInstallSession(app, databaseAdapter);
 
     const saved = await app.fetch(
       new Request("http://localhost:4310/v1/settings/error-tracking", {
@@ -52,8 +51,7 @@ describe("error tracking routes", () => {
 
   test("an empty DSN clears a saved one instead of keeping it", async () => {
     const { app, databaseAdapter } = await createApp();
-    const { email, password, orgId } = await seedOrgAdmin(databaseAdapter);
-    const session = await loginUserSession(app, email, password, orgId);
+    const session = await setupFreshInstallSession(app, databaseAdapter);
 
     const put = (dsn: string) =>
       app.fetch(
@@ -81,8 +79,7 @@ describe("error tracking routes", () => {
 
   test("a malformed DSN is rejected instead of being saved", async () => {
     const { app, databaseAdapter } = await createApp();
-    const { email, password, orgId } = await seedOrgAdmin(databaseAdapter);
-    const session = await loginUserSession(app, email, password, orgId);
+    const session = await setupFreshInstallSession(app, databaseAdapter);
 
     const response = await app.fetch(
       new Request("http://localhost:4310/v1/settings/error-tracking", {
@@ -100,8 +97,7 @@ describe("error tracking routes", () => {
 
   test("the test event is refused before a DSN is saved", async () => {
     const { app, databaseAdapter } = await createApp();
-    const { email, password, orgId } = await seedOrgAdmin(databaseAdapter);
-    const session = await loginUserSession(app, email, password, orgId);
+    const session = await setupFreshInstallSession(app, databaseAdapter);
 
     const response = await app.fetch(
       new Request("http://localhost:4310/v1/settings/error-tracking/test", {

--- a/apps/server/src/http/routes/models.ts
+++ b/apps/server/src/http/routes/models.ts
@@ -1636,7 +1636,7 @@ export function registerModelRoutes(
   });
 
   app.put("/v1/settings/email", async (c) => {
-    requireOrgAdminFromContext(c);
+    requirePlatformAdminFromContext(c);
     const body = await readJson<UpdateEmailSettingsRequest>(c.req.raw);
 
     try {
@@ -1651,7 +1651,7 @@ export function registerModelRoutes(
   });
 
   app.post("/v1/settings/email/test", async (c) => {
-    const auth = requireOrgAdminFromContext(c);
+    const auth = requirePlatformAdminFromContext(c);
     const body = await readOptionalJson<SendEmailTestRequest>(c.req.raw, {});
 
     try {
@@ -1697,7 +1697,7 @@ export function registerModelRoutes(
   });
 
   app.post("/v1/settings/agent-browser/install", async (c) => {
-    requireOrgAdminFromContext(c);
+    requirePlatformAdminFromContext(c);
 
     return streamAgentBrowserInstall(
       async (send, signal) => {

--- a/apps/server/src/http/routes/models.ts
+++ b/apps/server/src/http/routes/models.ts
@@ -67,6 +67,7 @@ import {
   requireNotViewerFromContext,
   requireOrgAdminFromContext,
   requireOrgAdminOrPlatformAdminFromContext,
+  requirePlatformAdminFromContext,
 } from "../org-guards";
 import {
   errorResponse,
@@ -1355,7 +1356,7 @@ export function registerModelRoutes(
   });
 
   app.post("/v1/providers", async (c) => {
-    requireOrgAdminOrPlatformAdminFromContext(c);
+    requirePlatformAdminFromContext(c);
     const body = await readJson<CreateProviderRequest>(c.req.raw);
 
     try {
@@ -1371,7 +1372,7 @@ export function registerModelRoutes(
   });
 
   app.patch("/v1/providers/:providerId", async (c) => {
-    requireOrgAdminOrPlatformAdminFromContext(c);
+    requirePlatformAdminFromContext(c);
     const body = await readJson<UpdateProviderRequest>(c.req.raw);
 
     try {
@@ -1392,14 +1393,14 @@ export function registerModelRoutes(
   });
 
   app.delete("/v1/providers/:providerId", async (c) => {
-    requireOrgAdminOrPlatformAdminFromContext(c);
+    requirePlatformAdminFromContext(c);
     return json<DeleteProviderResponse>(
       await agent.deleteProvider(decodeURIComponent(c.req.param("providerId")))
     );
   });
 
   app.post("/v1/xai-oauth/device/start", async (c) => {
-    const auth = requireOrgAdminOrPlatformAdminFromContext(c);
+    const auth = requirePlatformAdminFromContext(c);
     const owner = JSON.stringify([auth.user.id, auth.activeOrgId]);
 
     try {
@@ -1415,7 +1416,7 @@ export function registerModelRoutes(
   });
 
   app.post("/v1/xai-oauth/device/complete", async (c) => {
-    const auth = requireOrgAdminOrPlatformAdminFromContext(c);
+    const auth = requirePlatformAdminFromContext(c);
     const owner = JSON.stringify([auth.user.id, auth.activeOrgId]);
     const body = await readJson<{ sessionId?: string }>(c.req.raw);
     const sessionId =
@@ -1448,7 +1449,7 @@ export function registerModelRoutes(
   });
 
   app.post("/v1/chatgpt-oauth/device/start", async (c) => {
-    requireOrgAdminOrPlatformAdminFromContext(c);
+    requirePlatformAdminFromContext(c);
 
     try {
       return json(await startChatgptOAuthDeviceSession());
@@ -1463,7 +1464,7 @@ export function registerModelRoutes(
   });
 
   app.post("/v1/chatgpt-oauth/device/complete", async (c) => {
-    requireOrgAdminOrPlatformAdminFromContext(c);
+    requirePlatformAdminFromContext(c);
     const body = await readJson<{ sessionId?: string }>(c.req.raw);
     const sessionId = body.sessionId?.trim();
 
@@ -1488,7 +1489,7 @@ export function registerModelRoutes(
   });
 
   app.put("/v1/settings/provider", async (c) => {
-    requireOrgAdminOrPlatformAdminFromContext(c);
+    requirePlatformAdminFromContext(c);
     const body = await readJson<ConfigureProviderRequest>(c.req.raw);
     const result = await agent.configureProvider(body);
     return json<ConfigureProviderResponse>(result);
@@ -1507,7 +1508,7 @@ export function registerModelRoutes(
   });
 
   app.put("/v1/settings/timezone", async (c) => {
-    requireOrgAdminOrPlatformAdminFromContext(c);
+    requirePlatformAdminFromContext(c);
     const body = await readJson<UpdateTimezoneRequest>(c.req.raw);
     const timezone = await agent.setUserTimezone(body.timezone);
     return json<TimezoneSettingsResponse>({ timezone });
@@ -1519,7 +1520,7 @@ export function registerModelRoutes(
   });
 
   app.put("/v1/settings/thinking", async (c) => {
-    getRequestAuth(c);
+    requirePlatformAdminFromContext(c);
     const body = await readJson<UpdateThinkingRequest>(c.req.raw);
     return json<ThinkingSettingsResponse>(
       await agent.setThinkingSettings(body)
@@ -1532,7 +1533,7 @@ export function registerModelRoutes(
   });
 
   app.put("/v1/settings/vision", async (c) => {
-    requireOrgAdminOrPlatformAdminFromContext(c);
+    requirePlatformAdminFromContext(c);
     const body = await readJson<UpdateVisionRequest>(c.req.raw);
 
     try {
@@ -1555,7 +1556,7 @@ export function registerModelRoutes(
   });
 
   app.put("/v1/settings/transcription", async (c) => {
-    requireOrgAdminOrPlatformAdminFromContext(c);
+    requirePlatformAdminFromContext(c);
     const body = await readJson<UpdateTranscriptionRequest>(c.req.raw);
 
     try {
@@ -1596,7 +1597,7 @@ export function registerModelRoutes(
   });
 
   app.put("/v1/settings/image-generation", async (c) => {
-    requireOrgAdminOrPlatformAdminFromContext(c);
+    requirePlatformAdminFromContext(c);
     const body = await readJson<UpdateImageGenerationRequest>(c.req.raw);
 
     try {
@@ -1667,12 +1668,12 @@ export function registerModelRoutes(
   });
 
   app.get("/v1/settings/web-search", async (c) => {
-    requireOrgAdminFromContext(c);
+    requirePlatformAdminFromContext(c);
     return json<WebSearchSettingsResponse>(await agent.getWebSearchSettings());
   });
 
   app.put("/v1/settings/web-search", async (c) => {
-    requireOrgAdminFromContext(c);
+    requirePlatformAdminFromContext(c);
     const body = await readJson<UpdateWebSearchSettingsRequest>(c.req.raw);
 
     try {
@@ -1765,7 +1766,7 @@ export function registerModelRoutes(
   });
 
   app.put("/v1/settings/discord", async (c) => {
-    requireOrgAdminOrPlatformAdminFromContext(c);
+    requirePlatformAdminFromContext(c);
     const body = await readJson<UpdateDiscordSettingsRequest>(c.req.raw);
 
     try {
@@ -1782,7 +1783,7 @@ export function registerModelRoutes(
   });
 
   app.post("/v1/settings/discord/handshake", async (c) => {
-    requireOrgAdminOrPlatformAdminFromContext(c);
+    requirePlatformAdminFromContext(c);
     try {
       return json<DiscordSettingsResponse>(
         await agent.regenerateDiscordHandshake()
@@ -1799,7 +1800,7 @@ export function registerModelRoutes(
   });
 
   app.put("/v1/settings/composio", async (c) => {
-    requireOrgAdminOrPlatformAdminFromContext(c);
+    requirePlatformAdminFromContext(c);
     const body = await readJson<UpdateComposioSettingsRequest>(c.req.raw);
 
     try {
@@ -1824,7 +1825,7 @@ export function registerModelRoutes(
   app.put("/v1/settings/error-tracking", async (c) => {
     // Workspace-global config, so there is no org to scope it to and a role guard is
     // the only thing standing between a viewer and the whole install's error routing.
-    requireOrgAdminOrPlatformAdminFromContext(c);
+    requirePlatformAdminFromContext(c);
     const body = await readJson<UpdateErrorTrackingSettingsRequest>(c.req.raw);
 
     try {
@@ -1841,7 +1842,7 @@ export function registerModelRoutes(
   });
 
   app.post("/v1/settings/error-tracking/test", async (c) => {
-    requireOrgAdminOrPlatformAdminFromContext(c);
+    requirePlatformAdminFromContext(c);
 
     try {
       return json<SendErrorTrackingTestResponse>(
@@ -1862,7 +1863,7 @@ export function registerModelRoutes(
   });
 
   app.put("/v1/settings/whatsapp", async (c) => {
-    requireOrgAdminOrPlatformAdminFromContext(c);
+    requirePlatformAdminFromContext(c);
     const body = await readJson<UpdateWhatsAppSettingsRequest>(c.req.raw);
 
     try {
@@ -1880,7 +1881,7 @@ export function registerModelRoutes(
   });
 
   app.post("/v1/settings/whatsapp/pairing-code", async (c) => {
-    requireOrgAdminOrPlatformAdminFromContext(c);
+    requirePlatformAdminFromContext(c);
     try {
       return json<WhatsAppSettingsResponse>(
         await agent.regenerateWhatsAppPairingCode()
@@ -1892,7 +1893,7 @@ export function registerModelRoutes(
   });
 
   app.post("/v1/settings/whatsapp/reconnect", async (c) => {
-    requireOrgAdminOrPlatformAdminFromContext(c);
+    requirePlatformAdminFromContext(c);
     try {
       await workerManager.stopWorker("whatsapp").catch(() => {});
       const settings = await resetWhatsAppSessionForReconnect();

--- a/apps/server/src/http/routes/settings-rbac.test.ts
+++ b/apps/server/src/http/routes/settings-rbac.test.ts
@@ -11,13 +11,18 @@ setupTestConfigDir("nakama-settings-rbac-test-");
 const ORG_ID = "org_settings_rbac";
 const PASSWORD = "password123";
 
-// Provider and channel settings are workspace-global: whoever writes them
-// changes the config every org runs on.
-const GLOBAL_WRITES: Array<{ body?: unknown; method: string; path: string }> = [
+// These settings are install-wide: changing them affects every organization.
+const INSTALL_WRITES: { body?: unknown; method: string; path: string }[] = [
   { method: "POST", path: "/v1/xai-oauth/device/start" },
   {
     method: "POST",
     path: "/v1/xai-oauth/device/complete",
+    body: { sessionId: "invalid" },
+  },
+  { method: "POST", path: "/v1/chatgpt-oauth/device/start" },
+  {
+    method: "POST",
+    path: "/v1/chatgpt-oauth/device/complete",
     body: { sessionId: "invalid" },
   },
   { body: { provider: "openai" }, method: "POST", path: "/v1/providers" },
@@ -32,11 +37,15 @@ const GLOBAL_WRITES: Array<{ body?: unknown; method: string; path: string }> = [
     method: "PUT",
     path: "/v1/settings/provider",
   },
-  { body: { provider: "openai" }, method: "POST", path: "/v1/models/discover" },
   {
     body: { timezone: "Asia/Jakarta" },
     method: "PUT",
     path: "/v1/settings/timezone",
+  },
+  {
+    body: { effort: "medium", enabled: true },
+    method: "PUT",
+    path: "/v1/settings/thinking",
   },
   { body: { enabled: true }, method: "PUT", path: "/v1/settings/vision" },
   {
@@ -48,12 +57,6 @@ const GLOBAL_WRITES: Array<{ body?: unknown; method: string; path: string }> = [
     body: { enabled: true },
     method: "PUT",
     path: "/v1/settings/image-generation",
-  },
-  { body: { botToken: "t" }, method: "PUT", path: "/v1/settings/telegram" },
-  {
-    body: { botToken: "t" },
-    method: "POST",
-    path: "/v1/settings/telegram/handshake",
   },
   { body: { botToken: "d" }, method: "PUT", path: "/v1/settings/discord" },
   {
@@ -104,6 +107,7 @@ function createApp() {
       setErrorTrackingSettings: record("setErrorTrackingSettings"),
       setImageGenerationSettings: record("setImageGenerationSettings"),
       setTelegramSettings: record("setTelegramSettings"),
+      setThinkingSettings: record("setThinkingSettings"),
       setTranscriptionSettings: record("setTranscriptionSettings"),
       setUserTimezone: record("setUserTimezone"),
       setVisionSettings: record("setVisionSettings"),
@@ -178,8 +182,8 @@ async function callRoute(
   );
 }
 
-describe("workspace-global settings writes require an org admin", () => {
-  for (const route of GLOBAL_WRITES) {
+describe("install-wide settings writes require a platform admin", () => {
+  for (const route of INSTALL_WRITES) {
     test(`${route.method} ${route.path} -> 403 for a viewer`, async () => {
       const { app, calls, session } = await login("viewer");
       const response = await callRoute(app, session, route);
@@ -191,6 +195,14 @@ describe("workspace-global settings writes require an org admin", () => {
 
     test(`${route.method} ${route.path} -> 403 for a member`, async () => {
       const { app, calls, session } = await login("member");
+      const response = await callRoute(app, session, route);
+
+      expect(response.status).toBe(403);
+      expect(calls).toEqual([]);
+    });
+
+    test(`${route.method} ${route.path} -> 403 for an org admin`, async () => {
+      const { app, calls, session } = await login("admin");
       const response = await callRoute(app, session, route);
 
       expect(response.status).toBe(403);
@@ -210,21 +222,21 @@ describe("workspace-global settings writes require an org admin", () => {
     expect(calls).toEqual(["updateProvider"]);
   });
 
-  test("an org admin still reaches provider settings", async () => {
+  test("an org admin can still change org-scoped Telegram settings", async () => {
     const { app, calls, session } = await login("admin");
     const response = await callRoute(app, session, {
-      body: { baseUrl: "https://example.com/v1" },
-      method: "PATCH",
-      path: "/v1/providers/provider_1",
+      body: { botToken: "telegram-token" },
+      method: "PUT",
+      path: "/v1/settings/telegram",
     });
 
     expect(response.status).not.toBe(403);
-    expect(calls).toEqual(["updateProvider"]);
+    expect(calls).toEqual(["setTelegramSettings"]);
   });
 });
 
-test("an admin completes Grok device sign-in through authenticated HTTP routes", async () => {
-  const { app, session } = await login("admin");
+test("a platform admin completes Grok device sign-in through authenticated HTTP routes", async () => {
+  const { app, session } = await login("admin", true);
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (async (input) => {
     const url = String(input);

--- a/apps/server/src/http/routes/settings-rbac.test.ts
+++ b/apps/server/src/http/routes/settings-rbac.test.ts
@@ -71,6 +71,18 @@ const INSTALL_WRITES: { body?: unknown; method: string; path: string }[] = [
     path: "/v1/settings/web-search",
   },
   {
+    body: { smtpHost: "smtp.example.com" },
+    method: "PUT",
+    path: "/v1/settings/email",
+  },
+  { method: "POST", path: "/v1/settings/email/test" },
+  { method: "POST", path: "/v1/settings/agent-browser/install" },
+  {
+    body: { providerPassthroughEnabled: false },
+    method: "PUT",
+    path: "/v1/settings/coding-harnesses",
+  },
+  {
     body: { dsn: "https://publickey@errors.example.com/42" },
     method: "PUT",
     path: "/v1/settings/error-tracking",

--- a/apps/server/src/http/routes/settings-rbac.test.ts
+++ b/apps/server/src/http/routes/settings-rbac.test.ts
@@ -184,30 +184,16 @@ async function callRoute(
 
 describe("install-wide settings writes require a platform admin", () => {
   for (const route of INSTALL_WRITES) {
-    test(`${route.method} ${route.path} -> 403 for a viewer`, async () => {
-      const { app, calls, session } = await login("viewer");
-      const response = await callRoute(app, session, route);
+    for (const role of ["viewer", "member", "admin"] as const) {
+      test(`${route.method} ${route.path} -> 403 for ${role}`, async () => {
+        const { app, calls, session } = await login(role);
+        const response = await callRoute(app, session, route);
 
-      expect(response.status).toBe(403);
-      // The guard must reject before the global config is touched.
-      expect(calls).toEqual([]);
-    });
-
-    test(`${route.method} ${route.path} -> 403 for a member`, async () => {
-      const { app, calls, session } = await login("member");
-      const response = await callRoute(app, session, route);
-
-      expect(response.status).toBe(403);
-      expect(calls).toEqual([]);
-    });
-
-    test(`${route.method} ${route.path} -> 403 for an org admin`, async () => {
-      const { app, calls, session } = await login("admin");
-      const response = await callRoute(app, session, route);
-
-      expect(response.status).toBe(403);
-      expect(calls).toEqual([]);
-    });
+        expect(response.status).toBe(403);
+        // The guard must reject before the global config is touched.
+        expect(calls).toEqual([]);
+      });
+    }
   }
 
   test("a platform admin who is only a viewer in the org still reaches them", async () => {

--- a/apps/web/src/components/CodingAgentsSettingsCard.tsx
+++ b/apps/web/src/components/CodingAgentsSettingsCard.tsx
@@ -6,6 +6,7 @@ import { cn } from "@nakama/ui/utils";
 import { CheckmarkCircle01Icon, Copy01Icon } from "hugeicons-react";
 import { useEffect, useState } from "react";
 import { CodingAgentLogo } from "@/components/coding-agent-logos";
+import { useAuth } from "@/context/use-auth";
 import { client, formatError } from "@/lib/client";
 
 function CopyCommandButton({ command }: { command: string }) {
@@ -103,6 +104,8 @@ function AgentRow({
 }
 
 export function CodingAgentsSettingsCard() {
+  const { user } = useAuth();
+  const canManageSettings = user?.isPlatformAdmin === true;
   const [settings, setSettings] =
     useState<CodingHarnessSettingsResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -174,7 +177,7 @@ export function CodingAgentsSettingsCard() {
           aria-label="Use Nakama keys"
           checked={passthrough}
           className="relative after:absolute after:top-1/2 after:left-1/2 after:size-10 after:-translate-x-1/2 after:-translate-y-1/2"
-          disabled={saving || !settings}
+          disabled={!canManageSettings || saving || !settings}
           onCheckedChange={toggle}
         />
       </div>

--- a/apps/web/src/components/SkillAssignPicker.tsx
+++ b/apps/web/src/components/SkillAssignPicker.tsx
@@ -29,6 +29,7 @@ import {
   Download04Icon,
 } from "hugeicons-react";
 import { type SyntheticEvent, useState } from "react";
+import { useAuth } from "@/context/use-auth";
 import {
   useAgentBrowserSettings,
   useInstallAgentBrowser,
@@ -847,6 +848,8 @@ export function SkillAssignPicker({
   onAssignBash,
   className,
 }: SkillAssignPickerProps) {
+  const { user } = useAuth();
+  const canInstallAgentBrowser = user?.isPlatformAdmin === true;
   const [open, setOpen] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<{
     id: string;
@@ -887,7 +890,12 @@ export function SkillAssignPicker({
 
   function handleInstallAgentBrowser(event: SyntheticEvent) {
     stopCommandItemSelect(event);
-    if (disabled || installingAgentBrowser || !bashAssigned) {
+    if (
+      disabled ||
+      !canInstallAgentBrowser ||
+      installingAgentBrowser ||
+      !bashAssigned
+    ) {
       return;
     }
 
@@ -962,7 +970,9 @@ export function SkillAssignPicker({
           <SkillAssignDialogBody
             agentBrowserInstallError={agentBrowserInstallError}
             agentBrowserInstallProgress={agentBrowserInstallProgress}
-            agentBrowserNeedsInstall={agentBrowserNeedsInstall}
+            agentBrowserNeedsInstall={
+              agentBrowserNeedsInstall && canInstallAgentBrowser
+            }
             agentBrowserReady={agentBrowserSettings?.ready}
             assigningBash={assigningBash}
             availableSkills={availableSkills}
@@ -991,7 +1001,10 @@ export function SkillAssignPicker({
             setDeleting={setDeleting}
             setOpen={setOpen}
             setPendingDelete={setPendingDelete}
-            showAgentBrowserPrereqs={showAgentBrowserPrereqs}
+            showAgentBrowserPrereqs={
+              showAgentBrowserPrereqs &&
+              (bashNeedsAssign || canInstallAgentBrowser)
+            }
           />
         </DialogContent>
       </Dialog>

--- a/apps/web/src/components/soul-tools/ToolsTab.tsx
+++ b/apps/web/src/components/soul-tools/ToolsTab.tsx
@@ -46,7 +46,7 @@ function isListedCustomTool(tool: ToolDetail): boolean {
 export function ToolsTab({ embedded = false }: { embedded?: boolean } = {}) {
   const { navigateToNewChat } = useAppNavigation();
   const { user, activeOrg } = useAuth();
-  const isOrgAdmin = activeOrg?.role === "admin";
+  const canConfigureEmail = user?.isPlatformAdmin === true;
   const canUsePlayground = canUseToolPlayground(
     user?.isPlatformAdmin === true,
     activeOrg?.role
@@ -138,8 +138,8 @@ export function ToolsTab({ embedded = false }: { embedded?: boolean } = {}) {
         <div className="space-y-6">
           <ToolListSection
             busy={busy}
+            canConfigureEmail={canConfigureEmail}
             canUsePlayground={canUsePlayground}
-            isOrgAdmin={isOrgAdmin}
             onConfigureEmail={() => setEmailConfigOpen(true)}
             onCreateTool={goToCreateTool}
             onDelete={requestDeleteTool}
@@ -149,8 +149,8 @@ export function ToolsTab({ embedded = false }: { embedded?: boolean } = {}) {
 
           <ToolListSection
             busy={busy}
+            canConfigureEmail={canConfigureEmail}
             canUsePlayground={canUsePlayground}
-            isOrgAdmin={isOrgAdmin}
             onConfigureEmail={() => setEmailConfigOpen(true)}
             onDelete={requestDeleteTool}
             title="Built-in tools"
@@ -179,7 +179,7 @@ export function ToolsTab({ embedded = false }: { embedded?: boolean } = {}) {
         )}
       </div>
 
-      {isOrgAdmin ? (
+      {canConfigureEmail ? (
         <EmailSettingsDialog
           onOpenChange={setEmailConfigOpen}
           open={emailConfigOpen}
@@ -233,7 +233,7 @@ function ToolListSection({
   tools,
   busy,
   canUsePlayground,
-  isOrgAdmin,
+  canConfigureEmail,
   onCreateTool,
   onDelete,
   onConfigureEmail,
@@ -242,7 +242,7 @@ function ToolListSection({
   tools: ToolDetail[];
   busy: boolean;
   canUsePlayground: boolean;
-  isOrgAdmin: boolean;
+  canConfigureEmail: boolean;
   onCreateTool?: () => void;
   onDelete: (toolId: string, toolName: string) => void;
   onConfigureEmail: () => void;
@@ -327,7 +327,7 @@ function ToolListSection({
                   busy={busy}
                   key={tool.id}
                   onConfigure={
-                    isOrgAdmin && tool.id === BUILTIN_TOOL_IDS.email
+                    canConfigureEmail && tool.id === BUILTIN_TOOL_IDS.email
                       ? onConfigureEmail
                       : undefined
                   }

--- a/apps/web/src/pages/IntegrationsPage.tsx
+++ b/apps/web/src/pages/IntegrationsPage.tsx
@@ -94,11 +94,13 @@ function resolveSection(value: string | null): IntegrationSectionId {
 }
 
 function IntegrationSectionPanel({
+  canUseOrgIntegrations,
   section,
-  isOrgAdmin,
+  isPlatformAdmin,
 }: {
+  canUseOrgIntegrations: boolean;
   section: IntegrationSectionId;
-  isOrgAdmin: boolean;
+  isPlatformAdmin: boolean;
 }) {
   if (section === "token") {
     return <LocalAuthTokenCard />;
@@ -114,9 +116,11 @@ function IntegrationSectionPanel({
 
   if (section === "composio") {
     return (
-      <div className={cn(isOrgAdmin && "space-y-4")}>
-        {isOrgAdmin ? <ComposioSettingsCard embedded /> : null}
-        <ComposioConnectionsCard bordered embedded />
+      <div className={cn(isPlatformAdmin && "space-y-4")}>
+        {isPlatformAdmin ? <ComposioSettingsCard embedded /> : null}
+        {canUseOrgIntegrations ? (
+          <ComposioConnectionsCard bordered embedded />
+        ) : null}
       </div>
     );
   }
@@ -140,14 +144,33 @@ function IntegrationSectionPanel({
   return <WhatsAppSettingsCard />;
 }
 
-function IntegrationsPageBody({ isOrgAdmin }: { isOrgAdmin: boolean }) {
+function IntegrationsPageBody({
+  canUseOrgIntegrations,
+  isOrgAdmin,
+  isPlatformAdmin,
+}: {
+  canUseOrgIntegrations: boolean;
+  isOrgAdmin: boolean;
+  isPlatformAdmin: boolean;
+}) {
   const [searchParams, setSearchParams] = useSearchParams();
-  const section = resolveSection(
-    isOrgAdmin ? searchParams.get("section") : "composio"
-  );
-  const visibleSections = isOrgAdmin
-    ? INTEGRATION_SECTIONS
-    : INTEGRATION_SECTIONS.filter((item) => item.id === "composio");
+  const requestedSection = resolveSection(searchParams.get("section"));
+  const visibleSections = INTEGRATION_SECTIONS.filter((item) => {
+    if (item.id === "composio") {
+      return true;
+    }
+    if (
+      item.id === "discord" ||
+      item.id === "whatsapp" ||
+      item.id === "error-tracking"
+    ) {
+      return isPlatformAdmin;
+    }
+    return isOrgAdmin;
+  });
+  const section = visibleSections.some((item) => item.id === requestedSection)
+    ? requestedSection
+    : visibleSections[0].id;
 
   function setSection(nextSection: IntegrationSectionId) {
     setSearchParams(
@@ -190,7 +213,11 @@ function IntegrationsPageBody({ isOrgAdmin }: { isOrgAdmin: boolean }) {
         </aside>
 
         <div className="min-w-0 flex-1 p-4 sm:p-5">
-          <IntegrationSectionPanel isOrgAdmin={isOrgAdmin} section={section} />
+          <IntegrationSectionPanel
+            canUseOrgIntegrations={canUseOrgIntegrations}
+            isPlatformAdmin={isPlatformAdmin}
+            section={section}
+          />
         </div>
       </div>
     </section>
@@ -198,7 +225,8 @@ function IntegrationsPageBody({ isOrgAdmin }: { isOrgAdmin: boolean }) {
 }
 
 export function IntegrationsPage() {
-  const { activeOrg, isLoading } = useAuth();
+  const { activeOrg, isLoading, user } = useAuth();
+  const isPlatformAdmin = user?.isPlatformAdmin === true;
 
   if (isLoading) {
     return (
@@ -208,11 +236,17 @@ export function IntegrationsPage() {
     );
   }
 
-  if (activeOrg?.role === "viewer") {
+  if (activeOrg?.role === "viewer" && !isPlatformAdmin) {
     return <Navigate replace to="/chat" />;
   }
 
-  return <IntegrationsPageBody isOrgAdmin={activeOrg?.role === "admin"} />;
+  return (
+    <IntegrationsPageBody
+      canUseOrgIntegrations={Boolean(activeOrg && activeOrg.role !== "viewer")}
+      isOrgAdmin={activeOrg?.role === "admin"}
+      isPlatformAdmin={isPlatformAdmin}
+    />
+  );
 }
 
 function SidebarButton({

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -88,63 +88,57 @@ export function SettingsPage() {
             </div>
           ) : null}
 
-          {isOrgAdmin ? (
-            <>
-              <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
-                <div className="min-w-0 space-y-0.5">
-                  <p className="font-medium text-foreground text-sm">
-                    Timezone
-                  </p>
-                  {timezoneHint ? (
-                    <p
-                      className="text-emerald-700 text-xs dark:text-emerald-300"
-                      role="status"
-                    >
-                      {timezoneHint}
-                    </p>
-                  ) : null}
-                </div>
-                <div className="flex items-center gap-2">
-                  <TimezoneSelect
-                    className="w-44 min-w-0 sm:w-52"
-                    disabled={saveTimezoneMutation.isPending}
-                    emptyLabel="Select timezone"
-                    id="timezone"
-                    onValueChange={(nextTimezone) => {
-                      if (nextTimezone) {
-                        setTimezone(nextTimezone);
-                        setTimezoneHint(null);
-                      }
-                    }}
-                    value={timezone}
-                  />
-                  <Button
-                    disabled={
-                      saveTimezoneMutation.isPending || !timezone.trim()
-                    }
-                    onClick={handleSaveTimezone}
-                    size="sm"
-                    type="button"
+          {isPlatformAdmin ? (
+            <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
+              <div className="min-w-0 space-y-0.5">
+                <p className="font-medium text-foreground text-sm">Timezone</p>
+                {timezoneHint ? (
+                  <p
+                    className="text-emerald-700 text-xs dark:text-emerald-300"
+                    role="status"
                   >
-                    {saveTimezoneMutation.isPending ? (
-                      <>
-                        <Spinner className="mr-2" />
-                        Saving…
-                      </>
-                    ) : (
-                      "Save"
-                    )}
-                  </Button>
-                </div>
+                    {timezoneHint}
+                  </p>
+                ) : null}
               </div>
-
-              <WebPublicUrlSettingsRow />
-            </>
+              <div className="flex items-center gap-2">
+                <TimezoneSelect
+                  className="w-44 min-w-0 sm:w-52"
+                  disabled={saveTimezoneMutation.isPending}
+                  emptyLabel="Select timezone"
+                  id="timezone"
+                  onValueChange={(nextTimezone) => {
+                    if (nextTimezone) {
+                      setTimezone(nextTimezone);
+                      setTimezoneHint(null);
+                    }
+                  }}
+                  value={timezone}
+                />
+                <Button
+                  disabled={saveTimezoneMutation.isPending || !timezone.trim()}
+                  onClick={handleSaveTimezone}
+                  size="sm"
+                  type="button"
+                >
+                  {saveTimezoneMutation.isPending ? (
+                    <>
+                      <Spinner className="mr-2" />
+                      Saving…
+                    </>
+                  ) : (
+                    "Save"
+                  )}
+                </Button>
+              </div>
+            </div>
           ) : null}
+
+          {isOrgAdmin ? <WebPublicUrlSettingsRow /> : null}
         </CardContent>
       </Card>
 
-      {isOrgAdmin ? (
+      {isPlatformAdmin ? (
         <>
           <ProviderSettingsCard
             formError={formError}

--- a/apps/web/src/pages/chat/use-chat-page.ts
+++ b/apps/web/src/pages/chat/use-chat-page.ts
@@ -323,11 +323,12 @@ export function useChatPage() {
 
   const readOnlySession = isReadOnlySessionChannel(sessionChannel);
   const showThinking = shouldShowThinkingEffort(activeModelSupportsThinking);
-  const thinkingEffortVisible =
-    canManageInstallSettings &&
-    shouldShowThinkingEffort(activeModelSupportsThinking);
+  const thinkingEffortVisible = shouldShowThinkingEffort(
+    activeModelSupportsThinking
+  );
   const thinkingEffort = thinkingSettings?.effort ?? DEFAULT_THINKING_EFFORT;
   const thinkingEffortDisabled =
+    !canManageInstallSettings ||
     busy ||
     thinkingSettingsLoading ||
     saveThinkingSettingsMutation.isPending ||

--- a/apps/web/src/pages/chat/use-chat-page.ts
+++ b/apps/web/src/pages/chat/use-chat-page.ts
@@ -163,6 +163,7 @@ export function useChatPage() {
   const routeSession = useMemo(() => parseChatRouteParams(params), [params]);
   const { health, models } = useAppContext();
   const { user, activeOrg } = useAuth();
+  const canManageInstallSettings = user?.isPlatformAdmin === true;
   const {
     profileId: storeProfileId,
     setProfileId,
@@ -322,9 +323,9 @@ export function useChatPage() {
 
   const readOnlySession = isReadOnlySessionChannel(sessionChannel);
   const showThinking = shouldShowThinkingEffort(activeModelSupportsThinking);
-  const thinkingEffortVisible = shouldShowThinkingEffort(
-    activeModelSupportsThinking
-  );
+  const thinkingEffortVisible =
+    canManageInstallSettings &&
+    shouldShowThinkingEffort(activeModelSupportsThinking);
   const thinkingEffort = thinkingSettings?.effort ?? DEFAULT_THINKING_EFFORT;
   const thinkingEffortDisabled =
     busy ||
@@ -434,7 +435,10 @@ export function useChatPage() {
 
   const handleThinkingEffortChange = useCallback(
     (effort: ThinkingEffort) => {
-      if (!profileId || effort === thinkingEffort) {
+      if (
+        !(canManageInstallSettings && profileId) ||
+        effort === thinkingEffort
+      ) {
         return;
       }
 
@@ -451,22 +455,31 @@ export function useChatPage() {
           setError(formatError(err));
         });
     },
-    [profileId, thinkingEffort, busy, saveThinkingSettingsMutation]
+    [
+      canManageInstallSettings,
+      profileId,
+      thinkingEffort,
+      busy,
+      saveThinkingSettingsMutation,
+    ]
   );
 
   useEffect(() => {
     if (
-      !shouldAutoEnableThinking(
-        thinkingSettings,
-        activeModelSupportsThinking,
-        busy,
-        thinkingAutoEnableRef.current,
-        {
-          hasMessages: messages.length > 0,
-          hasProfileId: Boolean(profileId),
-          hasRouteSession: Boolean(routeSession),
-          hasSession: Boolean(session),
-        }
+      !(
+        canManageInstallSettings &&
+        shouldAutoEnableThinking(
+          thinkingSettings,
+          activeModelSupportsThinking,
+          busy,
+          thinkingAutoEnableRef.current,
+          {
+            hasMessages: messages.length > 0,
+            hasProfileId: Boolean(profileId),
+            hasRouteSession: Boolean(routeSession),
+            hasSession: Boolean(session),
+          }
+        )
       )
     ) {
       return;
@@ -506,6 +519,7 @@ export function useChatPage() {
     };
   }, [
     thinkingSettings,
+    canManageInstallSettings,
     activeModelSupportsThinking,
     busy,
     profileId,

--- a/apps/web/src/pages/profiles/profile-tools-section.tsx
+++ b/apps/web/src/pages/profiles/profile-tools-section.tsx
@@ -26,7 +26,7 @@ export function ProfileToolsSection({
   onRemove: (target: RemoveAssignmentTarget) => void;
 }) {
   const { user, activeOrg } = useAuth();
-  const isOrgAdmin = activeOrg?.role === "admin";
+  const canConfigureEmail = user?.isPlatformAdmin === true;
   const canOpenPlayground = canUseToolPlayground(
     user?.isPlatformAdmin === true,
     activeOrg?.role
@@ -72,7 +72,7 @@ export function ProfileToolsSection({
               </div>
             );
             const onConfigure =
-              isOrgAdmin && tool.id === BUILTIN_TOOL_IDS.email
+              canConfigureEmail && tool.id === BUILTIN_TOOL_IDS.email
                 ? () => setEmailConfigOpen(true)
                 : undefined;
 
@@ -136,10 +136,12 @@ export function ProfileToolsSection({
         </ul>
       )}
 
-      <EmailSettingsDialog
-        onOpenChange={setEmailConfigOpen}
-        open={emailConfigOpen}
-      />
+      {canConfigureEmail ? (
+        <EmailSettingsDialog
+          onOpenChange={setEmailConfigOpen}
+          open={emailConfigOpen}
+        />
+      ) : null}
     </div>
   );
 }

--- a/docs/website/content/docs/composio.mdx
+++ b/docs/website/content/docs/composio.mdx
@@ -26,13 +26,13 @@ You do not need to set anything up inside Composio beyond creating the account. 
 
 Take the **project API key**. Composio also has an *MCP consumer key* that starts with `ck_`, found under AI Clients. That one looks like a key and does not work here, so if Nakama rejects what you pasted, this is usually why.
 
-**2. Paste it into Nakama.** Open **Integrations**, then **Composio**, paste the key in the **Project API key** box, and press **Save**.
+**2. Paste it into Nakama.** As a platform admin, open **Integrations**, then **Composio**, paste the key in the **Project API key** box, and press **Save**. The project key is shared by every organization on this installation.
 
 ![The Composio page in Nakama before a key is saved, with the Project API key box and a link to the dashboard](/screenshots/composio-api-key.png)
 
 Nakama checks the key against Composio right then. A wrong key fails on the spot with the reason, so you never have to wonder whether it took. A good one turns the badge in the corner to connected.
 
-**3. Enable the app you want.** Still on the Composio page, find the app and press **Enable**. This decides what your organisation is allowed to use. It does not touch anyone's account yet.
+**3. Enable the app you want.** As an org admin, find the app and press **Enable**. This decides what your organisation is allowed to use. It does not touch anyone's account yet.
 
 The list opens on the apps teams ask for most. If yours is not there, search for it, or press **Show all 200 apps**.
 

--- a/docs/website/content/docs/discord.mdx
+++ b/docs/website/content/docs/discord.mdx
@@ -60,7 +60,7 @@ Keep the token secret. If you enable Message Content Intent after the bot is alr
 
 ## Step 2: Save in Nakama
 
-Open **Integrations → Discord**, then:
+Sign in as a platform admin and open **Integrations → Discord**, then:
 
 1. Paste the bot token
 2. Choose the default Nakama profile for Discord replies

--- a/docs/website/content/docs/multi-tenancy.mdx
+++ b/docs/website/content/docs/multi-tenancy.mdx
@@ -80,6 +80,19 @@ That hides the organization from the switcher, chat, and workers. Members, profi
 
 ## Important limitation
 
+Organizations share a small set of installation settings. Only a **platform
+admin** can change:
+
+- provider credentials, endpoints, and defaults
+- timezone, thinking, vision, transcription, and image-generation defaults
+- web search and error tracking
+- Discord and WhatsApp bridge settings
+- the Composio project API key
+
+Those changes affect every organization. Telegram settings, enabled Composio
+apps, personal Composio connections, profiles, sessions, and organization
+memory stay scoped to one organization.
+
 Org admins manage members, but creating and cloning profiles (and most tool / MCP / skill provisioning) is still a platform-admin responsibility.
 
 **Exception:** org admins can **export and import a single profile pack** (secrets-free zip) for profiles in their active org. Import creates a new profile and re-links tools/MCP by name when they already exist in the destination — it does not open general profile create/clone or unrestricted tool assignment. See [Profiles → Export and import a profile pack](/profiles#export-and-import-a-profile-pack).

--- a/docs/website/content/docs/providers.mdx
+++ b/docs/website/content/docs/providers.mdx
@@ -5,7 +5,7 @@ description: "Configure LLM providers, API keys, and models in Nakama Settings."
 
 ## Configure a provider
 
-1. Open **Settings** in the Nakama dashboard
+1. Sign in as a platform admin and open **Settings**
 2. Go to **LLM providers**
 3. Add a provider and paste your API key
 4. Browse or enter models for that provider

--- a/docs/website/content/docs/whatsapp.mdx
+++ b/docs/website/content/docs/whatsapp.mdx
@@ -43,7 +43,7 @@ This keeps replies readable in WhatsApp without depending on web-style Markdown 
 
 ### 1. Enable WhatsApp in Nakama
 
-1. Open **Integrations → WhatsApp** in the Nakama web app
+1. Sign in as a platform admin and open **Integrations → WhatsApp**
 2. Choose which profile should reply
 3. Click **Enable WhatsApp**
 


### PR DESCRIPTION
## Summary

Keep install-wide credentials under platform-admin control → an org admin can no longer change another organization's effective providers or shared bridges.

**Before:** An org admin could update provider defaults, shared channel credentials, and other installation settings used by every organization.
**After:** Platform admins own installation writes; Telegram and organization-level Composio operations keep their existing tenant scope.

Why safe:
1. Authorization runs before configuration or worker side effects across every protected route
2. The UI hides installation controls from org admins, while regression coverage preserves Telegram and Composio organization workflows

Only revisit this boundary if these settings gain organization-scoped storage and migration.

## Test plan
- [x] `bun test apps/server/src/http/routes/error-tracking.test.ts apps/server/src/http/routes/settings-rbac.test.ts apps/server/src/http/routes/composio.test.ts` (77 pass)
- [x] Targeted Ultracite check, `bun run knip`, `bun run build`, and `bun run build:docs`
- [ ] Sign in as an org admin and confirm shared provider, Discord, WhatsApp, and Composio credential controls are unavailable

Closes #967
