### PR TITLE
feat(security): add append-only audit events

### DIFF
--- a/apps/server/src/http/app.ts
+++ b/apps/server/src/http/app.ts
@@ -3,12 +3,14 @@ import { formatServerError, log, NakamaApiError } from "@nakama/core";
 import { bodyLimit } from "hono/body-limit";
 import { requestId } from "hono/request-id";
 import { tryServeStaticWeb } from "../static-web";
+import { createAuditLogMiddleware } from "./audit-log";
 import { createAuthMiddleware } from "./auth-middleware";
 import type { ServerOptions } from "./context";
 import { serializeHttpOpenApiSpec } from "./openapi";
 import { createOrgContextMiddleware } from "./org-middleware";
 import { createRateLimitMiddleware } from "./rate-limit-middleware";
 import { registerArtifactShareRoutes } from "./routes/artifact-shares";
+import { registerAuditEventRoutes } from "./routes/audit-events";
 import { registerAuthRoutes } from "./routes/auth";
 import { registerAutomationWorkerSettingsRoutes } from "./routes/automation-worker-settings";
 import { registerAutomationRoutes } from "./routes/automations";
@@ -225,7 +227,11 @@ export function createHonoApp(options: ServerOptions) {
   registerNotificationWebhookRoutes(app, options);
   registerComposioOAuthRoutes(app, options);
   app.use("*", createOrgContextMiddleware(options));
+  if (options.databaseAdapter) {
+    app.use("*", createAuditLogMiddleware(options.databaseAdapter));
+  }
   registerSystemRoutes(app, options);
+  registerAuditEventRoutes(app, options);
   registerAuthRoutes(app, options);
   registerSetupImportRoutes(app, options);
   registerWorkerRoutes(app, options);

--- a/apps/server/src/http/audit-log.test.ts
+++ b/apps/server/src/http/audit-log.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test";
+import { setupTestConfigDir } from "../test-config-dir";
+import { describeAuditEvent } from "./audit-log";
+import { createMinimalHonoApp } from "./test-app-helpers";
+import {
+  type AppFetch,
+  loginPlatformAdminSession,
+  loginUserSession,
+  seedOrgAdmin,
+} from "./test-session-helpers";
+
+setupTestConfigDir("nakama-audit-log-test-");
+
+describe("audit event coverage", () => {
+  test.each([
+    ["POST", "/v1/auth/login", "auth.login"],
+    ["POST", "/v1/auth/logout", "auth.logout"],
+    ["POST", "/v1/auth/change-password", "auth.password_change"],
+    ["POST", "/v1/auth/local-token/rotate", "auth.token_rotate"],
+    ["POST", "/v1/orgs/org_1/invites", "invite.create"],
+    ["PATCH", "/v1/orgs/org_1/members/user_1", "member.role_update"],
+    ["PUT", "/v1/settings/email", "settings.update"],
+    ["PATCH", "/v1/providers/provider_1", "provider.update"],
+    ["DELETE", "/v1/profiles/profile_1", "profile.delete"],
+    ["GET", "/v1/profiles/profile_1/pack/export", "profile.export"],
+    ["POST", "/v1/platform/data/import/restore", "data.import"],
+    ["DELETE", "/v1/sessions/session_1", "session.revoke"],
+  ])("classifies %s %s", (method, path, action) => {
+    expect(describeAuditEvent(method, path)?.action).toBe(action);
+  });
+});
+
+describe("audit event API", () => {
+  test("records actor, organization, outcome, and request", async () => {
+    const { app, authService, databaseAdapter } = createMinimalHonoApp();
+    const fetchApp = app as unknown as AppFetch;
+    const session = await loginPlatformAdminSession(
+      fetchApp,
+      authService,
+      databaseAdapter
+    );
+    const platformUser = await databaseAdapter.getUserByEmail(
+      "platform@example.com"
+    );
+
+    const createResponse = await app.fetch(
+      new Request("http://localhost:4310/v1/platform/orgs", {
+        body: JSON.stringify({ name: "Audit Org", slug: "audit-org" }),
+        headers: session.headers({ "X-CSRF-Token": session.csrfToken }),
+        method: "POST",
+      })
+    );
+    expect(createResponse.status).toBe(201);
+    const created = (await createResponse.json()) as {
+      organization: { id: string };
+    };
+
+    const failedLogin = await app.fetch(
+      new Request("http://localhost:4310/v1/auth/login", {
+        body: JSON.stringify({
+          email: "platform@example.com",
+          password: "wrong-password",
+        }),
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+      })
+    );
+    expect(failedLogin.status).toBe(401);
+
+    const listResponse = await app.fetch(
+      new Request(
+        `http://localhost:4310/v1/platform/audit-events?orgId=${created.organization.id}`,
+        { headers: session.headers() }
+      )
+    );
+    expect(listResponse.status).toBe(200);
+    const payload = (await listResponse.json()) as {
+      events: Array<{
+        action: string;
+        actorUserId: string | null;
+        metadata: Record<string, unknown>;
+        orgId: string | null;
+        requestId: string | null;
+        resourceId: string | null;
+      }>;
+    };
+    expect(payload.events).toEqual([
+      expect.objectContaining({
+        action: "organization.create",
+        actorUserId: platformUser?.id,
+        metadata: { outcome: "success", status: 201 },
+        orgId: created.organization.id,
+        requestId: expect.any(String),
+        resourceId: created.organization.id,
+      }),
+    ]);
+
+    const loginEvents = await databaseAdapter.listAuditEvents({
+      action: "auth.login",
+    });
+    expect(loginEvents).toHaveLength(2);
+    expect(loginEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          actorUserId: platformUser?.id,
+          metadata: { outcome: "failure", status: 401 },
+        }),
+      ])
+    );
+  });
+
+  test("blocks organization admins from reading the ledger", async () => {
+    const { app, databaseAdapter } = createMinimalHonoApp();
+    const fetchApp = app as unknown as AppFetch;
+    const member = await seedOrgAdmin(databaseAdapter);
+    const session = await loginUserSession(
+      fetchApp,
+      member.email,
+      member.password,
+      member.orgId
+    );
+
+    const response = await app.fetch(
+      new Request("http://localhost:4310/v1/platform/audit-events", {
+        headers: session.headers(),
+      })
+    );
+    expect(response.status).toBe(403);
+  });
+});

--- a/apps/server/src/http/audit-log.ts
+++ b/apps/server/src/http/audit-log.ts
@@ -1,0 +1,297 @@
+import { log } from "@nakama/core";
+import type { DatabaseAdapter, StoredAuditEvent } from "@nakama/db";
+import type { MiddlewareHandler } from "hono";
+import type { AppEnv } from "./types";
+
+type AuditDescriptor = Pick<
+  StoredAuditEvent,
+  "action" | "resourceId" | "resourceType"
+> & { orgId?: string | null };
+
+const FIXED_EVENTS = new Map<string, AuditDescriptor>([
+  ["PATCH /v1/auth/me", event("account.update", "user")],
+  ["POST /v1/auth/accept-invite", event("invite.accept", "invite")],
+  ["POST /v1/auth/change-password", event("auth.password_change", "user")],
+  ["POST /v1/auth/local-token/rotate", event("auth.token_rotate", "token")],
+  ["POST /v1/auth/login", event("auth.login", "user")],
+  ["POST /v1/auth/logout", event("auth.logout", "session")],
+  ["POST /v1/auth/orgs", event("organization.create", "organization")],
+  ["POST /v1/auth/setup", event("auth.setup", "user")],
+  ["GET /v1/platform/data/export", event("data.export", "installation")],
+  [
+    "POST /v1/platform/data/import/restore",
+    event("data.import", "installation"),
+  ],
+  ["POST /v1/profiles/pack/import", event("profile.import", "profile")],
+]);
+
+/**
+ * Security-event coverage checklist:
+ * - authentication: setup, login success/failure, logout, password change, token rotation
+ * - authorization: organization/member/invite lifecycle and role changes
+ * - configuration: providers and installation settings
+ * - sensitive resources: profile/org CRUD, export/import, session revocation
+ *
+ * Add a rule here whenever a new route joins one of those classes. Request
+ * bodies are intentionally never recorded, so credentials cannot enter metadata.
+ */
+export function describeAuditEvent(
+  method: string,
+  pathname: string
+): AuditDescriptor | null {
+  const fixed = FIXED_EVENTS.get(`${method} ${pathname}`);
+  if (fixed) {
+    return fixed;
+  }
+
+  let match = pathname.match(/^\/v1\/providers\/([^/]+)$/);
+  if (match && (method === "PATCH" || method === "DELETE")) {
+    return event(
+      method === "PATCH" ? "provider.update" : "provider.delete",
+      "provider",
+      match[1]
+    );
+  }
+  if (pathname === "/v1/providers" && method === "POST") {
+    return event("provider.create", "provider");
+  }
+
+  match = pathname.match(/^\/v1\/settings\/([^/]+)$/);
+  if (match && method === "PUT") {
+    return event("settings.update", "setting", match[1]);
+  }
+
+  match = pathname.match(/^\/v1\/platform\/orgs\/([^/]+)$/);
+  if (match && (method === "PATCH" || method === "DELETE")) {
+    return {
+      ...event(
+        method === "PATCH" ? "organization.update" : "organization.archive",
+        "organization",
+        match[1]
+      ),
+      orgId: decodePathPart(match[1]),
+    };
+  }
+  if (pathname === "/v1/platform/orgs" && method === "POST") {
+    return event("organization.create", "organization");
+  }
+
+  match = pathname.match(
+    /^\/v1\/(?:platform\/)?orgs\/([^/]+)\/invites(?:\/([^/]+))?$/
+  );
+  if (match && (method === "POST" || method === "DELETE")) {
+    return {
+      ...event(
+        method === "POST" ? "invite.create" : "invite.revoke",
+        "invite",
+        match[2]
+      ),
+      orgId: decodePathPart(match[1]),
+    };
+  }
+
+  match = pathname.match(
+    /^\/v1\/(?:platform\/)?orgs\/([^/]+)\/members\/([^/]+)(?:\/(disable|enable))?$/
+  );
+  if (match && ["DELETE", "PATCH", "POST"].includes(method)) {
+    const operation = match[3];
+    const action =
+      operation === "disable"
+        ? "member.disable"
+        : operation === "enable"
+          ? "member.enable"
+          : method === "DELETE"
+            ? "member.remove"
+            : "member.role_update";
+    return {
+      ...event(action, "user", match[2]),
+      orgId: decodePathPart(match[1]),
+    };
+  }
+
+  match = pathname.match(/^\/v1\/orgs\/([^/]+)\/members$/);
+  if (match && method === "POST") {
+    return {
+      ...event("member.add", "user"),
+      orgId: decodePathPart(match[1]),
+    };
+  }
+
+  match = pathname.match(/^\/v1\/orgs\/([^/]+)$/);
+  if (match && method === "PATCH") {
+    return {
+      ...event("organization.update", "organization", match[1]),
+      orgId: decodePathPart(match[1]),
+    };
+  }
+
+  match = pathname.match(/^\/v1\/profiles\/([^/]+)(?:\/(clone|move))?$/);
+  if (match && ["DELETE", "POST", "PUT"].includes(method)) {
+    const operation = match[2];
+    const action = operation
+      ? `profile.${operation}`
+      : method === "DELETE"
+        ? "profile.delete"
+        : "profile.update";
+    return event(action, "profile", match[1]);
+  }
+  if (pathname === "/v1/profiles" && method === "POST") {
+    return event("profile.create", "profile");
+  }
+
+  match = pathname.match(/^\/v1\/profiles\/([^/]+)\/pack\/export$/);
+  if (match && method === "GET") {
+    return event("profile.export", "profile", match[1]);
+  }
+
+  match = pathname.match(/^\/v1\/sessions\/([^/]+)$/);
+  if (match && method === "DELETE") {
+    return event("session.revoke", "session", match[1]);
+  }
+
+  return null;
+}
+
+export function createAuditLogMiddleware(
+  databaseAdapter: DatabaseAdapter
+): MiddlewareHandler<AppEnv> {
+  return async (c, next) => {
+    const descriptor = describeAuditEvent(c.req.method, c.req.path);
+    if (!descriptor) {
+      await next();
+      return;
+    }
+
+    let attemptedUserId: string | null = null;
+    if (descriptor.action === "auth.login") {
+      attemptedUserId = await resolveLoginUserId(c.req.raw, databaseAdapter);
+    }
+
+    await next();
+
+    const status = c.res.status;
+    if (status >= 400 && descriptor.action !== "auth.login") {
+      return;
+    }
+
+    const auth = c.get("auth");
+    const responseIdentity = await resolveResponseIdentity(c.res);
+    const responseUserId = responseIdentity.email
+      ? ((await databaseAdapter.getUserByEmail(responseIdentity.email))?.id ??
+        null)
+      : null;
+    const actorUserId =
+      auth?.user.id ??
+      responseIdentity.userId ??
+      responseUserId ??
+      attemptedUserId;
+    const orgId =
+      descriptor.orgId ?? auth?.activeOrgId ?? responseIdentity.orgId ?? null;
+
+    try {
+      await databaseAdapter.createAuditEvent({
+        action: descriptor.action,
+        actorUserId,
+        createdAt: new Date().toISOString(),
+        id: `audit_${crypto.randomUUID()}`,
+        metadata: {
+          outcome: status < 400 ? "success" : "failure",
+          status,
+        },
+        orgId,
+        requestId: c.get("requestId") ?? null,
+        resourceId:
+          descriptor.resourceId ??
+          responseIdentity.resourceId ??
+          (descriptor.resourceType === "user" ? actorUserId : null),
+        resourceType: descriptor.resourceType,
+      });
+    } catch (error) {
+      log("error", "audit.write_failed", {
+        action: descriptor.action,
+        error: error instanceof Error ? error.message : String(error),
+        requestId: c.get("requestId"),
+      });
+    }
+  };
+}
+
+function event(
+  action: string,
+  resourceType: string,
+  resourceId?: string
+): AuditDescriptor {
+  return {
+    action,
+    resourceId: resourceId ? decodePathPart(resourceId) : null,
+    resourceType,
+  };
+}
+
+function decodePathPart(value: string | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+async function resolveLoginUserId(
+  request: Request,
+  databaseAdapter: DatabaseAdapter
+): Promise<string | null> {
+  try {
+    const body = (await request.clone().json()) as { email?: unknown };
+    if (typeof body.email !== "string") {
+      return null;
+    }
+    return (await databaseAdapter.getUserByEmail(body.email))?.id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveResponseIdentity(response: Response): Promise<{
+  email: string | null;
+  orgId: string | null;
+  resourceId: string | null;
+  userId: string | null;
+}> {
+  if (!response.headers.get("content-type")?.includes("application/json")) {
+    return { email: null, orgId: null, resourceId: null, userId: null };
+  }
+
+  try {
+    const body = (await response.clone().json()) as Record<string, unknown>;
+    const organization = body.organization as
+      | Record<string, unknown>
+      | undefined;
+    const profile = body.profile as Record<string, unknown> | undefined;
+    const invite = body.invite as Record<string, unknown> | undefined;
+    const member = body.member as Record<string, unknown> | undefined;
+    return {
+      email: stringValue(body.email),
+      orgId:
+        stringValue(body.activeOrgId) ??
+        stringValue(body.orgId) ??
+        stringValue(organization?.id),
+      resourceId:
+        stringValue(body.profileId) ??
+        stringValue(profile?.id) ??
+        stringValue(invite?.id) ??
+        stringValue(member?.userId) ??
+        stringValue(organization?.id) ??
+        stringValue(body.id),
+      userId: stringValue(body.id),
+    };
+  } catch {
+    return { email: null, orgId: null, resourceId: null, userId: null };
+  }
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value ? value : null;
+}

--- a/apps/server/src/http/routes/audit-events.ts
+++ b/apps/server/src/http/routes/audit-events.ts
@@ -1,0 +1,82 @@
+import { createRoute, z } from "@hono/zod-openapi";
+import type { ServerOptions } from "../context";
+import { requirePlatformAdminFromContext } from "../org-guards";
+import { errorResponse, json } from "../shared";
+import type { HonoApp } from "../types";
+
+const auditEventSchema = z.object({
+  action: z.string(),
+  actorUserId: z.string().nullable(),
+  createdAt: z.string(),
+  id: z.string(),
+  metadata: z.record(
+    z.string(),
+    z.union([z.boolean(), z.null(), z.number(), z.string()])
+  ),
+  orgId: z.string().nullable(),
+  requestId: z.string().nullable(),
+  resourceId: z.string().nullable(),
+  resourceType: z.string(),
+});
+
+const listAuditEventsQuerySchema = z.object({
+  action: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(200).default(100),
+  offset: z.coerce.number().int().min(0).default(0),
+  orgId: z.string().optional(),
+});
+
+const listAuditEventsRoute = createRoute({
+  method: "get",
+  operationId: "listAuditEvents",
+  path: "/v1/platform/audit-events",
+  request: {
+    query: listAuditEventsQuerySchema,
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: z.object({ events: z.array(auditEventSchema) }),
+        },
+      },
+      description: "Append-only security audit events",
+    },
+    400: {
+      content: {
+        "application/json": { schema: z.object({ error: z.string() }) },
+      },
+      description: "Invalid query",
+    },
+    403: {
+      content: {
+        "application/json": { schema: z.object({ error: z.string() }) },
+      },
+      description: "Platform admin access required",
+    },
+  },
+  summary: "List security audit events",
+  tags: ["Platform"],
+});
+
+export function registerAuditEventRoutes(
+  app: HonoApp,
+  options: ServerOptions
+): void {
+  app.openAPIRegistry.registerPath(listAuditEventsRoute);
+  app.get("/v1/platform/audit-events", async (c) => {
+    requirePlatformAdminFromContext(c);
+    const { databaseAdapter } = options;
+    if (!databaseAdapter) {
+      return errorResponse("Database not configured", 500);
+    }
+
+    const parsed = listAuditEventsQuerySchema.safeParse(c.req.query());
+    if (!parsed.success) {
+      return errorResponse("Invalid audit event query", 400);
+    }
+
+    const events = await databaseAdapter.listAuditEvents(parsed.data);
+    return json({ events });
+  });
+}

--- a/packages/db/sql/schema.sql
+++ b/packages/db/sql/schema.sql
@@ -517,6 +517,38 @@ CREATE UNIQUE INDEX IF NOT EXISTS artifact_shares_active_path_unique
   ON artifact_shares (org_id, profile_id, source_path)
   WHERE revoked_at IS NULL;
 
+-- Security audit ledger. Deliberately has no foreign keys so account or org
+-- erasure cannot remove the historical record.
+CREATE TABLE IF NOT EXISTS audit_events (
+  id TEXT PRIMARY KEY NOT NULL,
+  actor_user_id TEXT,
+  org_id TEXT,
+  action TEXT NOT NULL,
+  resource_type TEXT NOT NULL,
+  resource_id TEXT,
+  metadata TEXT NOT NULL DEFAULT '{}',
+  request_id TEXT,
+  created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS audit_events_created
+  ON audit_events (created_at DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS audit_events_org_created
+  ON audit_events (org_id, created_at DESC, id DESC);
+
+CREATE TRIGGER IF NOT EXISTS audit_events_no_update
+BEFORE UPDATE ON audit_events
+BEGIN
+  SELECT RAISE(ABORT, 'audit_events are append-only');
+END;
+
+CREATE TRIGGER IF NOT EXISTS audit_events_no_delete
+BEFORE DELETE ON audit_events
+BEGIN
+  SELECT RAISE(ABORT, 'audit_events are append-only');
+END;
+
 -- Append-only profile change ledger (no UPDATE/DELETE API; cascade only with org/profile cleanup).
 CREATE TABLE IF NOT EXISTS profile_change_events (
   id TEXT PRIMARY KEY NOT NULL,

--- a/packages/db/src/adapters/sqlite.ts
+++ b/packages/db/src/adapters/sqlite.ts
@@ -19,6 +19,7 @@ import type {
   PublishOrgPluginReleaseInput,
   StoredArtifactShareRecord,
   StoredAttachmentRecord,
+  StoredAuditEvent,
   StoredAutomationRecord,
   StoredAutomationRunRecord,
   StoredBrowserSessionRecord,
@@ -73,6 +74,18 @@ interface AutomationRow {
   profile_id: string;
   updated_at: string;
   version: number;
+}
+
+interface AuditEventRow {
+  action: string;
+  actor_user_id: string | null;
+  created_at: string;
+  id: string;
+  metadata: string;
+  org_id: string | null;
+  request_id: string | null;
+  resource_id: string | null;
+  resource_type: string;
 }
 
 interface AutomationRunRow {
@@ -1637,6 +1650,23 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
     "SELECT * FROM users WHERE is_platform_admin = 1"
   );
 
+  const createAuditEventStmt = db.prepare(`
+    INSERT INTO audit_events (
+      id, actor_user_id, org_id, action, resource_type, resource_id,
+      metadata, request_id, created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const listAuditEventsStmt = db.prepare(`
+    SELECT
+      id, actor_user_id, org_id, action, resource_type, resource_id,
+      metadata, request_id, created_at
+    FROM audit_events
+    WHERE (? IS NULL OR org_id = ?)
+      AND (? IS NULL OR action = ?)
+    ORDER BY created_at DESC, id DESC
+    LIMIT ? OFFSET ?
+  `);
+
   const createBrowserSessionStmt = db.prepare(`
     INSERT INTO browser_sessions (
       id,
@@ -2474,6 +2504,19 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
         record.revokedAt
       );
     },
+    async createAuditEvent(record) {
+      createAuditEventStmt.run(
+        record.id,
+        record.actorUserId,
+        record.orgId,
+        record.action,
+        record.resourceType,
+        record.resourceId,
+        JSON.stringify(record.metadata),
+        record.requestId,
+        record.createdAt
+      );
+    },
 
     async createBrowserSession(record) {
       createBrowserSessionStmt.run(
@@ -3175,6 +3218,20 @@ function createSqliteDatabaseAdapter(db: Database): DatabaseAdapter {
       return listAttachmentsForSessionStmt
         .all(sessionId)
         .map((row) => toAttachmentRecord(row as AttachmentRow));
+    },
+
+    async listAuditEvents(options = {}) {
+      const action = options.action ?? null;
+      const orgId = options.orgId ?? null;
+      const rows = listAuditEventsStmt.all(
+        orgId,
+        orgId,
+        action,
+        action,
+        options.limit ?? 100,
+        options.offset ?? 0
+      ) as AuditEventRow[];
+      return rows.map(toAuditEventRecord);
     },
 
     async listAutomationRuns(automationId, limit = 20) {
@@ -4582,6 +4639,27 @@ function toOrganizationRecord(row: OrganizationRow): StoredOrganizationRecord {
     skillsWriteApproval: row.skills_write_approval !== 0,
     slug: row.slug,
     updatedAt: row.updated_at,
+  };
+}
+
+function toAuditEventRecord(row: AuditEventRow): StoredAuditEvent {
+  let metadata: StoredAuditEvent["metadata"] = {};
+  try {
+    metadata = JSON.parse(row.metadata) as StoredAuditEvent["metadata"];
+  } catch {
+    metadata = {};
+  }
+
+  return {
+    action: row.action,
+    actorUserId: row.actor_user_id,
+    createdAt: row.created_at,
+    id: row.id,
+    metadata,
+    orgId: row.org_id,
+    requestId: row.request_id,
+    resourceId: row.resource_id,
+    resourceType: row.resource_type,
   };
 }
 

--- a/packages/db/src/audit-events.test.ts
+++ b/packages/db/src/audit-events.test.ts
@@ -1,0 +1,78 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { createSqliteMemoryAdapter } from "./adapters/sqlite";
+import { migrateDatabase } from "./migrate";
+
+describe("audit events", () => {
+  test("stores append-only events and filters them", async () => {
+    const adapter = createSqliteMemoryAdapter();
+    await adapter.createAuditEvent({
+      action: "provider.update",
+      actorUserId: "user_admin",
+      createdAt: "2026-09-12T01:00:00.000Z",
+      id: "audit_1",
+      metadata: { outcome: "success", status: 200 },
+      orgId: "org_1",
+      requestId: "request_1",
+      resourceId: "provider_1",
+      resourceType: "provider",
+    });
+    await adapter.createAuditEvent({
+      action: "auth.login",
+      actorUserId: null,
+      createdAt: "2026-09-12T02:00:00.000Z",
+      id: "audit_2",
+      metadata: { outcome: "failure", status: 401 },
+      orgId: null,
+      requestId: "request_2",
+      resourceId: null,
+      resourceType: "user",
+    });
+
+    await expect(adapter.listAuditEvents({ limit: 1 })).resolves.toEqual([
+      expect.objectContaining({ action: "auth.login", id: "audit_2" }),
+    ]);
+    await expect(adapter.listAuditEvents({ orgId: "org_1" })).resolves.toEqual([
+      {
+        action: "provider.update",
+        actorUserId: "user_admin",
+        createdAt: "2026-09-12T01:00:00.000Z",
+        id: "audit_1",
+        metadata: { outcome: "success", status: 200 },
+        orgId: "org_1",
+        requestId: "request_1",
+        resourceId: "provider_1",
+        resourceType: "provider",
+      },
+    ]);
+  });
+
+  test("database rejects updates and deletes", () => {
+    const database = new Database(":memory:");
+    migrateDatabase(database);
+    database
+      .prepare(`
+        INSERT INTO audit_events (
+          id, action, resource_type, metadata, created_at
+        ) VALUES (?, ?, ?, ?, ?)
+      `)
+      .run(
+        "audit_locked",
+        "auth.login",
+        "user",
+        "{}",
+        "2026-09-12T00:00:00.000Z"
+      );
+
+    expect(() =>
+      database
+        .prepare("UPDATE audit_events SET action = ? WHERE id = ?")
+        .run("changed", "audit_locked")
+    ).toThrow("audit_events are append-only");
+    expect(() =>
+      database
+        .prepare("DELETE FROM audit_events WHERE id = ?")
+        .run("audit_locked")
+    ).toThrow("audit_events are append-only");
+  });
+});

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -55,8 +55,43 @@ export function migrateDatabase(db: Database): void {
   atomic(migrateWorkflowsTables);
   atomic(migrateComposioTables);
   atomic(migrateComposioUserConnections);
+  atomic(migrateAuditEventsTable);
   atomic(migrateProfileChangeEventsTable);
   atomic(migratePluginTables);
+}
+
+function migrateAuditEventsTable(db: Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS audit_events (
+      id TEXT PRIMARY KEY NOT NULL,
+      actor_user_id TEXT,
+      org_id TEXT,
+      action TEXT NOT NULL,
+      resource_type TEXT NOT NULL,
+      resource_id TEXT,
+      metadata TEXT NOT NULL DEFAULT '{}',
+      request_id TEXT,
+      created_at TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS audit_events_created
+      ON audit_events (created_at DESC, id DESC);
+
+    CREATE INDEX IF NOT EXISTS audit_events_org_created
+      ON audit_events (org_id, created_at DESC, id DESC);
+
+    CREATE TRIGGER IF NOT EXISTS audit_events_no_update
+    BEFORE UPDATE ON audit_events
+    BEGIN
+      SELECT RAISE(ABORT, 'audit_events are append-only');
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS audit_events_no_delete
+    BEFORE DELETE ON audit_events
+    BEGIN
+      SELECT RAISE(ABORT, 'audit_events are append-only');
+    END;
+  `);
 }
 
 function applyBootstrapSchema(db: Database): void {

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -625,6 +625,18 @@ export interface StoredBrowserSessionRecord {
   userId: string;
 }
 
+export interface StoredAuditEvent {
+  action: string;
+  actorUserId: string | null;
+  createdAt: string;
+  id: string;
+  metadata: Record<string, boolean | null | number | string>;
+  orgId: string | null;
+  requestId: string | null;
+  resourceId: string | null;
+  resourceType: string;
+}
+
 export interface DatabaseAdapter {
   appendMessagesForSession(
     sessionId: string,
@@ -666,6 +678,8 @@ export interface DatabaseAdapter {
   countUsers(): Promise<number>;
 
   createArtifactShare(record: StoredArtifactShareRecord): Promise<void>;
+  /** Append-only insert. Adapters must not expose update/delete for this table. */
+  createAuditEvent(record: StoredAuditEvent): Promise<void>;
 
   createBrowserSession(record: StoredBrowserSessionRecord): Promise<void>;
 
@@ -888,6 +902,13 @@ export interface DatabaseAdapter {
   listAttachmentsForSession(
     sessionId: string
   ): Promise<StoredAttachmentRecord[]>;
+
+  listAuditEvents(options?: {
+    action?: string;
+    limit?: number;
+    offset?: number;
+    orgId?: string;
+  }): Promise<StoredAuditEvent[]>;
 
   listAutomationRuns(
     automationId: string,


### PR DESCRIPTION
## Summary

Inspect a security event → see who changed what, in which organization, and under which request ID.

**Before:** Login, role, provider, profile, organization, import/export, and session changes left no durable audit trail.
**After:** Covered mutations append immutable `audit_events` rows, and platform admins can query them through `GET /v1/platform/audit-events`.

Why safe:
1. SQLite triggers reject updates and deletes; no foreign keys means account or organization erasure cannot remove history
2. Event metadata contains only response outcome and status, never request bodies, credentials, or tokens
3. Coverage tests exercise every security-event class and the read API rejects organization admins

Only follow up if a new security-sensitive route is added; add its rule beside the coverage checklist and test table.

## Test plan
- [x] `bun test packages/db/src/audit-events.test.ts apps/server/src/http/audit-log.test.ts` (16 pass)
- [x] Targeted Ultracite check, `bun run knip`, and `bun run build`
- [ ] Make one successful and one failed login, then query `/v1/platform/audit-events?action=auth.login`

Closes #369
