### PR TITLE
ci: report duplication and coverage on every PR

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,65 @@
+name: Quality
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  duplication:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+
+      # Fails when duplication passes the threshold in .jscpd.json (3%).
+      - name: Detect copy-paste
+        run: bun run dupes
+
+      - name: Publish report
+        if: always()
+        run: cat .jscpd-report/jscpd-report.md >> "$GITHUB_STEP_SUMMARY"
+
+  coverage:
+    runs-on: ubuntu-latest
+    # A report, not a gate. Unit Tests is what blocks a merge.
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run tests with coverage
+        run: bun test --coverage --coverage-reporter=text | tee coverage.txt
+
+      - name: Publish summary
+        if: always()
+        run: |
+          table() {
+            awk '/^File .*% Funcs/{p=1} /^ *[0-9]+ (pass|fail)/{p=0} p' coverage.txt
+          }
+          {
+            echo '## Coverage'
+            echo '```'
+            table | head -3
+            echo '```'
+            echo '<details><summary>Per-file</summary>'
+            echo
+            echo '```'
+            table
+            echo '```'
+            echo '</details>'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ tmp-repro-artifacts/
 tmp-repro-setup-auth.mjs
 .tmp-test-config/
 .vscode/
+# jscpd duplication report
+.jscpd-report/

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,0 +1,16 @@
+{
+  "path": ["apps", "packages"],
+  "ignore": [
+    "**/node_modules/**",
+    "**/dist/**",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.d.ts"
+  ],
+  "minLines": 10,
+  "minTokens": 70,
+  "threshold": 3,
+  "reporters": ["markdown"],
+  "output": ".jscpd-report",
+  "absolute": false
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dev:web": "bun run --filter @nakama/web dev",
     "dev:whatsapp": "bun run --filter @nakama/whatsapp dev",
     "doctor": "npx react-doctor@latest",
+    "dupes": "bunx jscpd@4 --format typescript,tsx",
     "fix": "ultracite fix",
     "postinstall": "bun install --cwd docs/website",
     "knip": "knip",


### PR DESCRIPTION
## Summary

Every PR gets a copy-paste report and a coverage table, with no external service and no repository secret.

**Before:** CI covers tests, Knip and React Doctor. Duplication and coverage are invisible.
**After:** two more jobs. `duplication` fails past 3% (main measures 1.92% today), `coverage` publishes the table into the job summary and blocks nothing.

Why safe:
1. Additive. Nothing existing changes except one `.gitignore` line and one added script.
2. The coverage job is `continue-on-error`, so it cannot block a merge. Unit Tests stays the gate.
3. jscpd runs through `bunx`, so the lockfile is untouched.

Only revisit the 3% threshold if a real refactor pushes duplication past it. The number came from measuring main, not from a default.

## Test plan
- [x] `bun run dupes`: 155 clones, 3301 duplicated lines, 1.92% of 171921 lines, exit 0 under the threshold
- [x] `bun test --coverage --coverage-reporter=text`: `All files | 82.99 | 81.33`, and the summary awk pulls header plus totals out of that exact output
- [x] `bun run knip` clean. The coverage command sits in the workflow rather than a script because a root-level `bun test` script makes knip report `apps/server/src/testing/cassettes/serve.ts` as unused
- [x] `bun x ultracite check` clean on all four changed files. The two repo-wide errors are pre-existing in `packages/core`
- [ ] `bun run test`: 52 failures in `@nakama/server` plugin tests on this machine, identical on an untouched checkout of this base commit, because they need npm network access. Upstream CI is green on c4572e6f
