### PR TITLE
feat(providers): honour a custom model's own context window

### DIFF
--- a/apps/server/src/providers/models.test.ts
+++ b/apps/server/src/providers/models.test.ts
@@ -5,6 +5,7 @@ import {
   isOpenRouterModelSlug,
   modelSupportsVision,
   resolveModel,
+  resolveModelLimits,
 } from "./models";
 
 describe("isOpenRouterModelSlug", () => {
@@ -496,6 +497,37 @@ describe("modelSupportsVision", () => {
     expect(modelSupportsVision("sonar-pro", "perplexity")).toBe(true);
     expect(modelSupportsVision("sonar-deep-research", "perplexity")).toBe(
       false
+    );
+  });
+});
+
+describe("resolveModelLimits", () => {
+  test("uses the instance entry for a model the catalog does not know", () => {
+    expect(
+      resolveModelLimits("my-org/llama-4-1m", [
+        { contextWindow: 1_000_000, id: "my-org/llama-4-1m" },
+      ])
+    ).toEqual({ contextWindow: 1_000_000, maxOutputTokens: 8192 });
+  });
+
+  test("falls back to 128k when nothing declares a window", () => {
+    expect(resolveModelLimits("my-org/llama-4-1m").contextWindow).toBe(128_000);
+    expect(
+      resolveModelLimits("my-org/llama-4-1m", [{ id: "my-org/llama-4-1m" }])
+        .contextWindow
+    ).toBe(128_000);
+  });
+
+  test("prefers the instance entry over the catalog", () => {
+    const catalogModel = getModelById("gpt-5.4");
+
+    expect(catalogModel?.contextWindow).toBeGreaterThan(0);
+    expect(
+      resolveModelLimits("gpt-5.4", [{ contextWindow: 32_000, id: "gpt-5.4" }])
+        .contextWindow
+    ).toBe(32_000);
+    expect(resolveModelLimits("gpt-5.4").contextWindow).toBe(
+      catalogModel?.contextWindow
     );
   });
 });

--- a/apps/server/src/providers/models.ts
+++ b/apps/server/src/providers/models.ts
@@ -803,10 +803,6 @@ const BASE_MODELS: ProviderModelOption[] = withVisionDefaults([
   },
 ]);
 
-/** Used when neither the instance entry nor the catalog knows the model. */
-const FALLBACK_CONTEXT_WINDOW = 128_000;
-const FALLBACK_MAX_OUTPUT_TOKENS = 8192;
-
 export const AVAILABLE_MODELS: ProviderModelOption[] = [
   ...BASE_MODELS,
   ...deriveChatgptModels(BASE_MODELS),
@@ -916,14 +912,9 @@ export function resolveModelLimits(
   const custom = findCustomModel(customModels, modelId);
 
   return {
-    contextWindow:
-      custom?.contextWindow ??
-      catalog?.contextWindow ??
-      FALLBACK_CONTEXT_WINDOW,
+    contextWindow: custom?.contextWindow ?? catalog?.contextWindow ?? 128_000,
     maxOutputTokens:
-      custom?.maxOutputTokens ??
-      catalog?.maxOutputTokens ??
-      FALLBACK_MAX_OUTPUT_TOKENS,
+      custom?.maxOutputTokens ?? catalog?.maxOutputTokens ?? 8192,
   };
 }
 

--- a/apps/server/src/providers/models.ts
+++ b/apps/server/src/providers/models.ts
@@ -803,6 +803,10 @@ const BASE_MODELS: ProviderModelOption[] = withVisionDefaults([
   },
 ]);
 
+/** Used when neither the instance entry nor the catalog knows the model. */
+const FALLBACK_CONTEXT_WINDOW = 128_000;
+const FALLBACK_MAX_OUTPUT_TOKENS = 8192;
+
 export const AVAILABLE_MODELS: ProviderModelOption[] = [
   ...BASE_MODELS,
   ...deriveChatgptModels(BASE_MODELS),
@@ -896,6 +900,31 @@ export function validateOpenCodeGoCustomModels(
 
 export function getModelById(modelId: string): ProviderModelOption | undefined {
   return AVAILABLE_MODELS.find((model) => model.id === modelId);
+}
+
+/** Compaction sizing for one model.
+ *
+ * A custom model id is never in the built-in catalog, so without the instance
+ * entry every custom provider would silently compact at the fallback window.
+ * Entries that leave the sizes blank keep the catalog value, then the fallback.
+ */
+export function resolveModelLimits(
+  modelId: string,
+  customModels?: CustomModelEntry[]
+): { contextWindow: number; maxOutputTokens: number } {
+  const catalog = getModelById(modelId);
+  const custom = findCustomModel(customModels, modelId);
+
+  return {
+    contextWindow:
+      custom?.contextWindow ??
+      catalog?.contextWindow ??
+      FALLBACK_CONTEXT_WINDOW,
+    maxOutputTokens:
+      custom?.maxOutputTokens ??
+      catalog?.maxOutputTokens ??
+      FALLBACK_MAX_OUTPUT_TOKENS,
+  };
 }
 
 export function getModelsForProvider(

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -207,9 +207,9 @@ import {
   fetchFireworksGatewayModels,
   fetchOllamaModels,
   fetchRemoteOpenAIModels,
-  getModelById,
   getModelsForProviderInstance,
   isCostEstimated,
+  resolveModelLimits,
 } from "../providers";
 import {
   fetchChatgptCodexModels,
@@ -4075,12 +4075,7 @@ export class AgentService {
       return;
     }
 
-    const model = getModelById(resolved.model);
-
-    return {
-      contextWindow: model?.contextWindow ?? 128_000,
-      maxOutputTokens: model?.maxOutputTokens ?? 8192,
-    };
+    return resolveModelLimits(resolved.model, resolved.instance.customModels);
   }
 
   private resolveWorkspaceThinkingDefaults(): ThinkingSettings {

--- a/apps/web/src/components/ModelListEditor.tsx
+++ b/apps/web/src/components/ModelListEditor.tsx
@@ -58,7 +58,7 @@ export function ModelListEditor({
       {models.length > 0 ? (
         <div className="overflow-x-auto rounded-lg border border-border">
           <table
-            className={`w-full text-left text-xs ${showThinking || showVision ? "min-w-[44rem]" : "min-w-[32rem]"}`}
+            className={`w-full text-left text-xs ${showThinking || showVision ? "min-w-[51rem]" : "min-w-[39rem]"}`}
           >
             <thead className="border-border border-b bg-muted/30 text-muted-foreground">
               <tr>
@@ -76,6 +76,7 @@ export function ModelListEditor({
                     <th className="px-2 py-2 font-medium">$/1M out</th>
                   </>
                 ) : null}
+                <th className="px-2 py-2 font-medium">Context</th>
                 <th aria-label="Actions" className="w-10 px-2 py-2" />
               </tr>
             </thead>
@@ -180,6 +181,25 @@ export function ModelListEditor({
                       </td>
                     </>
                   ) : null}
+                  <td className="px-2 py-1.5">
+                    <InputGroup>
+                      <InputGroupInput
+                        disabled={disabled}
+                        min={1}
+                        onChange={(event) => {
+                          const value = event.target.value;
+                          updateRow(index, {
+                            contextWindow:
+                              value === "" ? undefined : Number(value),
+                          });
+                        }}
+                        placeholder="auto"
+                        step={1}
+                        type="number"
+                        value={row.contextWindow ?? ""}
+                      />
+                    </InputGroup>
+                  </td>
                   <td className="px-2 py-1.5 text-right">
                     <Button
                       aria-label="Remove model"
@@ -197,6 +217,13 @@ export function ModelListEditor({
             </tbody>
           </table>
         </div>
+      ) : null}
+
+      {models.length > 0 ? (
+        <p className="text-muted-foreground text-xs">
+          Context is the total token window the model accepts. Leave it on auto
+          to use the built-in catalog value, or 128k when the model is unknown.
+        </p>
       ) : null}
 
       <div className="flex flex-wrap items-center justify-between gap-2">

--- a/apps/web/src/components/model-list-editor.shared.test.ts
+++ b/apps/web/src/components/model-list-editor.shared.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { modelListRowVisionEnabled } from "./model-list-editor.shared";
+import {
+  modelListRowVisionEnabled,
+  normalizeModelListRows,
+} from "./model-list-editor.shared";
 
 describe("modelListRowVisionEnabled", () => {
   test("defaults on unless explicitly disabled", () => {
@@ -20,5 +23,19 @@ describe("modelListRowVisionEnabled", () => {
     expect(modelListRowVisionEnabled({ supportsVision: false }, false)).toBe(
       false
     );
+  });
+});
+
+describe("normalizeModelListRows context sizes", () => {
+  test("forwards the sizes and drops blank ones", () => {
+    expect(
+      normalizeModelListRows([
+        { contextWindow: 200_000, id: "a", maxOutputTokens: 16_384 },
+        { id: "b" },
+      ])
+    ).toEqual([
+      { contextWindow: 200_000, id: "a", maxOutputTokens: 16_384 },
+      { id: "b" },
+    ]);
   });
 });

--- a/apps/web/src/components/model-list-editor.shared.ts
+++ b/apps/web/src/components/model-list-editor.shared.ts
@@ -38,6 +38,12 @@ export function normalizeModelListRows(
         ...(row.outputPerMillionUsd === undefined
           ? {}
           : { outputPerMillionUsd: row.outputPerMillionUsd }),
+        ...(row.contextWindow === undefined
+          ? {}
+          : { contextWindow: row.contextWindow }),
+        ...(row.maxOutputTokens === undefined
+          ? {}
+          : { maxOutputTokens: row.maxOutputTokens }),
       },
     ];
   });

--- a/apps/web/src/hooks/use-provider-setup-form.ts
+++ b/apps/web/src/hooks/use-provider-setup-form.ts
@@ -282,13 +282,9 @@ export function useProviderSetupForm(
   );
 
   const selectOpenRouterModel = useCallback(
-    (
-      modelId: string,
-      modelName: string,
-      pricing?: { inputPerMillionUsd?: number; outputPerMillionUsd?: number }
-    ) => {
+    (modelId: string, modelName: string, extra?: Partial<CustomModelEntry>) => {
       setOpenRouterModels((current) =>
-        appendOpenRouterModelRow(current, modelId, modelName, pricing)
+        appendOpenRouterModelRow(current, modelId, modelName, extra)
       );
       setSelectedModel(modelId);
       setOpenRouterModelsError(null);
@@ -306,13 +302,18 @@ export function useProviderSetupForm(
         return;
       }
 
+      const browsedContext =
+        row.context > 0 ? { contextWindow: row.context } : {};
+
       handleProviderSelect(provider);
       if (provider === "openrouter") {
-        selectOpenRouterModel(modelId, row.modelName);
+        selectOpenRouterModel(modelId, row.modelName, browsedContext);
       } else if (provider === "openai_compatible") {
         setDisplayName(row.providerName);
         setBaseUrl(row.apiUrl.replace(/\/$/, ""));
-        setCustomModels([{ id: modelId, name: row.modelName }]);
+        setCustomModels([
+          { id: modelId, name: row.modelName, ...browsedContext },
+        ]);
         setSelectedModel(modelId);
         if (row.isZen && row.isFree && !row.deprecated) {
           setApiKey("public");

--- a/apps/web/src/lib/models.test.ts
+++ b/apps/web/src/lib/models.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { USER_PROVIDER_NAMES } from "@nakama/core/provider-resolution";
 import {
+  appendOpenRouterModelRow,
   buildCreateProviderRequest,
   encodeModelSelection,
   filterVisionCapableProviderGroups,
@@ -714,5 +715,44 @@ describe("validateCustomModelsInput", () => {
     expect(validateCustomModelsInput([{ id: " " }])).toBe(
       "Add at least one model."
     );
+  });
+});
+
+describe("appendOpenRouterModelRow", () => {
+  test("keeps the context window the browse row carried", () => {
+    expect(
+      appendOpenRouterModelRow(
+        [],
+        "anthropic/claude-sonnet-4-6",
+        "Sonnet 4.6",
+        {
+          contextWindow: 1_000_000,
+        }
+      )
+    ).toEqual([
+      {
+        contextWindow: 1_000_000,
+        default: true,
+        id: "anthropic/claude-sonnet-4-6",
+        name: "Sonnet 4.6",
+      },
+    ]);
+  });
+
+  test("preserves existing rows and moves the default to the picked model", () => {
+    expect(
+      appendOpenRouterModelRow(
+        [
+          { contextWindow: 32_000, default: true, id: "a/one", name: "One" },
+          { id: "a/two" },
+          { id: "   " },
+        ],
+        "a/two",
+        "Two"
+      )
+    ).toEqual([
+      { contextWindow: 32_000, default: false, id: "a/one", name: "One" },
+      { default: true, id: "a/two", name: "a/two" },
+    ]);
   });
 });

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -1,6 +1,7 @@
 import type {
   ConfigureProviderRequest,
   CreateProviderRequest,
+  CustomModelEntry,
   OllamaHostMode,
   ProviderModelOption,
   WireApi,
@@ -473,86 +474,25 @@ export function modelsFromOpenRouterRows(
 }
 
 export function appendOpenRouterModelRow(
-  rows: Array<{
-    id: string;
-    name?: string;
-    default?: boolean;
-    inputPerMillionUsd?: number;
-    outputPerMillionUsd?: number;
-  }>,
+  rows: CustomModelEntry[],
   modelId: string,
   modelName: string,
-  pricing?: { inputPerMillionUsd?: number; outputPerMillionUsd?: number }
-): Array<{
-  id: string;
-  name: string;
-  default?: boolean;
-  inputPerMillionUsd?: number;
-  outputPerMillionUsd?: number;
-}> {
-  const base: Array<{
-    id: string;
-    name: string;
-    default?: boolean;
-    inputPerMillionUsd?: number;
-    outputPerMillionUsd?: number;
-  }> = [];
-
-  for (const row of rows) {
-    if (!row.id.trim()) {
-      continue;
-    }
-
-    base.push({
-      id: row.id,
+  extra?: Partial<CustomModelEntry>
+): CustomModelEntry[] {
+  // Spread rather than copying known keys, so anything the browse row carries
+  // (pricing, context window) survives instead of being silently dropped.
+  const base = rows
+    .filter((row) => row.id.trim())
+    .map(({ default: _wasDefault, ...row }) => ({
+      ...row,
       name: row.name ?? row.id,
-      ...(row.default ? { default: true } : {}),
-      ...(row.inputPerMillionUsd === undefined
-        ? {}
-        : { inputPerMillionUsd: row.inputPerMillionUsd }),
-      ...(row.outputPerMillionUsd === undefined
-        ? {}
-        : { outputPerMillionUsd: row.outputPerMillionUsd }),
-    });
-  }
+    }));
 
   if (base.some((row) => row.id === modelId)) {
-    return base.map((row) => ({
-      default: row.id === modelId,
-      id: row.id,
-      name: row.name ?? row.id,
-      ...(row.inputPerMillionUsd === undefined
-        ? {}
-        : { inputPerMillionUsd: row.inputPerMillionUsd }),
-      ...(row.outputPerMillionUsd === undefined
-        ? {}
-        : { outputPerMillionUsd: row.outputPerMillionUsd }),
-    }));
+    return base.map((row) => ({ ...row, default: row.id === modelId }));
   }
 
-  return [
-    ...base.map((row) => ({
-      id: row.id,
-      name: row.name ?? row.id,
-      ...(row.inputPerMillionUsd === undefined
-        ? {}
-        : { inputPerMillionUsd: row.inputPerMillionUsd }),
-      ...(row.outputPerMillionUsd === undefined
-        ? {}
-        : { outputPerMillionUsd: row.outputPerMillionUsd }),
-    })),
-    {
-      default: true,
-      id: modelId,
-      name: modelName,
-      ...(pricing?.inputPerMillionUsd === undefined
-        ? {}
-        : { inputPerMillionUsd: pricing.inputPerMillionUsd }),
-      ...(pricing?.outputPerMillionUsd === undefined
-        ? {}
-        : { outputPerMillionUsd: pricing.outputPerMillionUsd }),
-    },
-  ];
+  return [...base, { ...extra, default: true, id: modelId, name: modelName }];
 }
 
 export function resolveOpenRouterSetupModel(

--- a/docs/website/content/docs/providers.mdx
+++ b/docs/website/content/docs/providers.mdx
@@ -75,6 +75,7 @@ Some capabilities depend on the active provider:
 - **Audio transcription** (Telegram voice notes) — requires an OpenAI provider and a transcription model in **Settings → Audio transcription model** (ChatGPT Plus/Pro cannot replace this)
 - **Image parsing** — used when the chat model cannot see images. Set **Settings → Image parsing model**. The list only includes models marked as vision-capable. For a custom endpoint, turn **Vision** on for that model under **Settings → LLM providers**
 - **Responses API endpoints**: a custom endpoint that serves `/responses` rather than `/chat/completions`. Set **API** to Responses under **Settings → LLM providers**, or answer `responses` in the CLI setup wizard. Required for endpoints that do not serve chat/completions at all, and it keeps reasoning available alongside tools on models that reject the pair on chat/completions
+- **Context window**: models in the built-in catalog carry their own size. A model Nakama does not recognise (a custom endpoint, an OpenRouter slug, a self-hosted build) falls back to 128k, which cuts history early on a larger model and overflows a smaller one. Set **Context** for that model under **Settings → LLM providers** to the real token window; leave it on auto to keep the fallback. Browsing models.dev fills it in for you
 - **Coding agent provider passthrough** — spawn-time credentials for Claude Code / Codex / OpenCode; see [Coding agent](/coding-agent)
 
 ## Per-profile models

--- a/packages/core/src/compatible-provider-config.test.ts
+++ b/packages/core/src/compatible-provider-config.test.ts
@@ -25,4 +25,27 @@ describe("validateCustomModels", () => {
       ])
     ).toThrow('Model "qwen3.6-35b" has invalid supportsThinking flag.');
   });
+
+  test("keeps context sizes and leaves them undefined when blank", () => {
+    const [sized, blank] = validateCustomModels([
+      {
+        contextWindow: 1_000_000,
+        id: "qwen3.6-35b",
+        maxOutputTokens: 32_768,
+      },
+      { contextWindow: "", id: "qwen3.6-7b" },
+    ]);
+
+    expect(sized?.contextWindow).toBe(1_000_000);
+    expect(sized?.maxOutputTokens).toBe(32_768);
+    expect(blank?.contextWindow).toBeUndefined();
+  });
+
+  test("rejects context sizes that are not positive whole token counts", () => {
+    for (const contextWindow of [0, -1, 1.5, "many"]) {
+      expect(() =>
+        validateCustomModels([{ contextWindow, id: "qwen3.6-35b" }])
+      ).toThrow(/invalid contextWindow/);
+    }
+  });
 });

--- a/packages/core/src/compatible-provider-config.ts
+++ b/packages/core/src/compatible-provider-config.ts
@@ -137,9 +137,22 @@ export function validateCustomModels(entries: unknown): CustomModelEntry[] {
       );
     }
 
+    const contextWindow = parseOptionalTokenCount(
+      record.contextWindow,
+      id,
+      "contextWindow"
+    );
+    const maxOutputTokens = parseOptionalTokenCount(
+      record.maxOutputTokens,
+      id,
+      "maxOutputTokens"
+    );
+
     result.push({
       id,
       ...(name ? { name } : {}),
+      ...(contextWindow === undefined ? {} : { contextWindow }),
+      ...(maxOutputTokens === undefined ? {} : { maxOutputTokens }),
       ...(isDefault ? { default: true } : {}),
       ...(supportsThinking === undefined ? {} : { supportsThinking }),
       ...(supportsVision === undefined ? {} : { supportsVision }),
@@ -153,6 +166,26 @@ export function validateCustomModels(entries: unknown): CustomModelEntry[] {
   }
 
   return result;
+}
+
+function parseOptionalTokenCount(
+  value: unknown,
+  modelId: string,
+  field: string
+): number | undefined {
+  if (value === undefined || value === null || value === "") {
+    return;
+  }
+
+  const numeric = typeof value === "number" ? value : Number(value);
+
+  if (!Number.isInteger(numeric) || numeric <= 0) {
+    throw new Error(
+      `Model "${modelId}" has invalid ${field}: expected a positive whole number of tokens.`
+    );
+  }
+
+  return numeric;
 }
 
 function parseOptionalUsdRate(value: unknown): number | undefined {

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -1650,9 +1650,13 @@ export interface ApiErrorResponse {
 }
 
 export interface CustomModelEntry {
+  /** Total context the model accepts. Blank falls back to the catalog entry,
+   * then to a conservative default, so existing entries keep their behaviour. */
+  contextWindow?: number;
   default?: boolean;
   id: string;
   inputPerMillionUsd?: number;
+  maxOutputTokens?: number;
   name?: string;
   outputPerMillionUsd?: number;
   supportsThinking?: boolean;


### PR DESCRIPTION
Closes #980

## What was wrong

`resolveCompactionConfig` looked the model up in the built-in catalog only, and a custom model id is never in it:

```ts
const model = getModelById(resolved.model);

return {
  contextWindow: model?.contextWindow ?? 128_000,
  maxOutputTokens: model?.maxOutputTokens ?? 8192,
};
```

So every custom provider, every OpenRouter slug and every self-hosted build resolved to a hardcoded 128k. That number drives history compaction **and** the context chip in chat, so a 1M model discarded turns that still fit, and a 32k model never compacted and was rejected by the provider instead.

There was also nowhere to record the real size: `CustomModelEntry` had pricing and capability flags but no context field, which is why the setup UI offered no way to set one.

## What this does

- `CustomModelEntry` gains `contextWindow` and `maxOutputTokens`, validated in `validateCustomModels` as positive whole token counts, the same shape as the existing pricing rates.
- New `resolveModelLimits(modelId, customModels)` in `apps/server/src/providers/models.ts` prefers the instance entry, then the catalog, then the fallback. `resolveCompactionConfig` is now a single call to it.
- `ModelListEditor` gets a **Context** column, so endpoints with no `/models` to discover from can be told the real window. Blank means auto, and the helper line under the table says what auto resolves to.
- The models.dev browse row already read `limit.context` and then dropped it. It now lands in the saved entry for both the OpenAI-compatible and OpenRouter paths.
- `appendOpenRouterModelRow` was rebuilding each row key by key and silently losing anything it did not name, which is why the browsed context never survived. It spreads now, which also removes about 60 lines.

Nothing changes for an entry that leaves the sizes blank: catalog value first, then the same 128k fallback as before.

## Test plan

- `bun test packages/core/src/compatible-provider-config.test.ts apps/server/src/providers/models.test.ts apps/web/src/lib/models.test.ts apps/web/src/components/model-list-editor.shared.test.ts` — 108 pass, 0 fail. New coverage: size validation and rejection of non-integer or non-positive values, `resolveModelLimits` precedence (instance over catalog, catalog over fallback, fallback when nobody declares one), and `appendOpenRouterModelRow` keeping the browsed context while moving the default.
- `bun run --filter @nakama/web build` (runs `tsc --noEmit`) — exit 0.
- `bun run check` — clean for every file in this diff. Two pre-existing `useSortedKeys` findings remain in `packages/core/src/document-content.ts` and `packages/core/src/provider-label.ts`, both untouched here.
- `bun test apps/server/src apps/web/src` — 1794 pass / 54 fail on this branch against 1784 pass / 54 fail on the same commit without these changes. The 54 are pre-existing failures in the plugin suites and the cassette replays, identical on both sides; the difference is the 10 tests added here.

## Not covered

Providers whose browse path does not persist `customModels` at all (the catalog providers and `opencode_go`) still fall back for an unrecognised model id. The Context column in **Settings → LLM providers** covers those by hand; wiring their save path is a larger change and did not belong here.
