### PR TITLE
feat(config): support mounted channel bot tokens

### DIFF
--- a/docs/website/content/docs/discord.mdx
+++ b/docs/website/content/docs/discord.mdx
@@ -195,6 +195,9 @@ Environment-based setup is also supported. The main env var is:
 DISCORD_BOT_TOKEN
 ```
 
+For mounted secrets, set `DISCORD_BOT_TOKEN_FILE` to the path of a readable
+file containing the token. A directly set `DISCORD_BOT_TOKEN` takes priority.
+
 Nakama also supports:
 
 ```text

--- a/docs/website/content/docs/telegram/index.mdx
+++ b/docs/website/content/docs/telegram/index.mdx
@@ -192,6 +192,9 @@ Environment-based setup is also supported. The main env var is:
 TELEGRAM_BOT_TOKEN
 ```
 
+For mounted secrets, set `TELEGRAM_BOT_TOKEN_FILE` to the path of a readable
+file containing the token. A directly set `TELEGRAM_BOT_TOKEN` takes priority.
+
 Nakama also supports:
 
 ```text

--- a/packages/core/src/discord-config.ts
+++ b/packages/core/src/discord-config.ts
@@ -8,6 +8,7 @@ import {
   verifyAndPairBotChannelUser,
   writeBotChannelIniConfig,
 } from "./channel-config-shared";
+import { readEnvValue } from "./config";
 import { getUserConfigDir } from "./user-config";
 
 export {
@@ -364,7 +365,7 @@ export function resolveDiscordConfigFromSources(options: {
   const env = options.env ?? process.env;
   const file = options.file ?? null;
   const botToken =
-    env.DISCORD_BOT_TOKEN?.trim() || file?.botToken?.trim() || "";
+    readEnvValue(env, "DISCORD_BOT_TOKEN") || file?.botToken?.trim() || "";
 
   if (!botToken) {
     return null;

--- a/packages/core/src/telegram-config.ts
+++ b/packages/core/src/telegram-config.ts
@@ -9,6 +9,7 @@ import {
   verifyAndPairBotChannelUser,
   writeBotChannelIniConfig,
 } from "./channel-config-shared";
+import { readEnvValue } from "./config";
 import { ensureDir, pathExists, readDirectoryOrEmpty } from "./fs";
 import { getOrgConfigDir, getUserConfigDir } from "./user-config";
 
@@ -326,7 +327,7 @@ export function resolveTelegramConfigFromSources(options: {
   const env = options.env ?? process.env;
   const file = options.file ?? null;
   const botToken =
-    env.TELEGRAM_BOT_TOKEN?.trim() || file?.botToken?.trim() || "";
+    readEnvValue(env, "TELEGRAM_BOT_TOKEN") || file?.botToken?.trim() || "";
 
   if (!botToken) {
     return null;

--- a/packages/core/src/testing/channel-config-fixtures.ts
+++ b/packages/core/src/testing/channel-config-fixtures.ts
@@ -283,6 +283,32 @@ export function describeSharedChannelConfigTests<TId extends string | number>(
         });
       });
 
+      test("reads a bot token from a mounted secret file", async () => {
+        await withTempHomedir(tempPrefix, async (homeDir) => {
+          const secretPath = path.join(homeDir, "bot-token");
+          await writeFile(secretPath, "mounted-token\n", "utf8");
+
+          const resolved = tc.resolveConfigFromSources({
+            env: { [`${tc.env.botTokenKey}_FILE`]: secretPath },
+            file: null,
+          });
+
+          expect(resolved?.botToken).toBe("mounted-token");
+        });
+      });
+
+      test("prefers a direct bot token over its mounted-file companion", () => {
+        const resolved = tc.resolveConfigFromSources({
+          env: {
+            [tc.env.botTokenKey]: "direct-token",
+            [`${tc.env.botTokenKey}_FILE`]: "/missing/secret",
+          },
+          file: null,
+        });
+
+        expect(resolved?.botToken).toBe("direct-token");
+      });
+
       test("falls back to file config when env token is absent", () => {
         const resolved = tc.resolveConfigFromSources({
           env: {},


### PR DESCRIPTION
## Summary

Mount Telegram and Discord bot tokens as files → channel workers start without putting those secrets in environment values or saved settings.

**Before:** `TELEGRAM_BOT_TOKEN` and `DISCORD_BOT_TOKEN` had to contain the token directly, or the token lived in `config.ini`.
**After:** `TELEGRAM_BOT_TOKEN_FILE` and `DISCORD_BOT_TOKEN_FILE` accept readable secret paths; direct token values still win.

Why safe:
1. Reuses the existing mounted-secret resolver, including trimming and explicit file-read failures
2. Shared regression coverage exercises both channel resolvers and direct-value precedence
3. Existing env variables and saved channel configs keep their behavior

Only follow up if WhatsApp auth state or other integration secrets need an equivalent external-secret path.

## Test plan
- [x] `bun test packages/core/src/telegram-config.test.ts packages/core/src/discord-config.test.ts` (45 pass)
- [x] Targeted Ultracite check and `bun run knip`
- [x] `bun run build` and `bun run build:docs`
- [ ] Start each channel worker once with only its `_FILE` variable set

Progresses #364
