### PR TITLE
feat(orgs): deliver member invitations by email

### DIFF
--- a/apps/server/src/services/org-service.test.ts
+++ b/apps/server/src/services/org-service.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { getProfileSoulDir, NakamaApiError } from "@nakama/core";
+import {
+  type EmailOutboundAdapter,
+  getProfileSoulDir,
+  NakamaApiError,
+} from "@nakama/core";
 import { LOCAL_CLIENT_USER_ID } from "@nakama/core/local-auth";
 import { createInMemoryDatabaseAdapter } from "@nakama/db";
 import { setupTestConfigDir } from "../test-config-dir";
@@ -10,13 +14,21 @@ import { OrgService } from "./org-service";
 
 setupTestConfigDir("nakama-org-service-test-");
 
-function createOrgService() {
+function createOrgService(
+  email?: EmailOutboundAdapter,
+  getWebPublicUrl?: () => string | undefined
+) {
   const databaseAdapter = createInMemoryDatabaseAdapter();
   const authService = new AuthService();
   return {
     authService,
     databaseAdapter,
-    orgService: new OrgService(databaseAdapter, authService),
+    orgService: new OrgService(
+      databaseAdapter,
+      authService,
+      email,
+      getWebPublicUrl
+    ),
   };
 }
 
@@ -526,12 +538,66 @@ describe("OrgService", () => {
 
     const accepted = await orgService.acceptInvite({
       password: "secret123",
-      token: invite.token,
+      token: invite.token!,
     });
 
     expect(accepted.user.email).toBe("legacy@acme.com");
     expect(accepted.orgId).toBe(created.organization.id);
     expect(accepted.role).toBe("member");
+  });
+
+  test("emails an invite link without returning its raw token", async () => {
+    const sent: Array<{ subject: string; text: string; to: string }> = [];
+    const { orgService } = createOrgService(
+      {
+        send: async (input) => {
+          sent.push(input);
+          return { ok: true };
+        },
+      },
+      () => "https://nakama.example.com"
+    );
+    const created = await orgService.createOrganization({
+      name: "Acme",
+      slug: "acme-email-invite",
+    });
+
+    const invite = await orgService.createInvite({
+      email: "guest@acme.com",
+      invitedByUserId: "user_platform",
+      orgId: created.organization.id,
+      role: "viewer",
+    });
+
+    expect(invite.delivered).toBe(true);
+    expect(invite.token).toBeNull();
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.to).toBe("guest@acme.com");
+    expect(sent[0]?.subject).toBe("You're invited to Acme");
+    expect(sent[0]?.text).toContain(
+      "https://nakama.example.com/accept-invite?token="
+    );
+    expect(sent[0]?.text).toContain("join Acme as viewer");
+  });
+
+  test("returns the invite token when email delivery fails", async () => {
+    const { orgService } = createOrgService({
+      send: async () => ({ error: "SMTP unavailable", ok: false }),
+    });
+    const created = await orgService.createOrganization({
+      name: "Acme",
+      slug: "acme-manual-invite",
+    });
+
+    const invite = await orgService.createInvite({
+      email: "guest@acme.com",
+      invitedByUserId: "user_platform",
+      orgId: created.organization.id,
+      role: "member",
+    });
+
+    expect(invite.delivered).toBe(false);
+    expect(invite.token).toStartWith("tc_invite_");
   });
 
   test("rejects expired invites", async () => {
@@ -975,7 +1041,7 @@ describe("OrgService", () => {
     );
 
     await expect(
-      orgService.acceptInvite({ password: "secret123", token: invite.token })
+      orgService.acceptInvite({ password: "secret123", token: invite.token! })
     ).rejects.toMatchObject({ status: 404 });
   });
 

--- a/apps/server/src/services/org-service.ts
+++ b/apps/server/src/services/org-service.ts
@@ -1,8 +1,11 @@
 import {
+  createEmailOutboundAdapter,
+  type EmailOutboundAdapter,
   generateTemporaryPassword,
   getProfileSoulDir,
   initSoulDirectory,
   NakamaApiError,
+  resolveWebPublicUrl,
 } from "@nakama/core";
 import type {
   AcceptOrgInviteRequest,
@@ -59,7 +62,11 @@ function assertOrgMemberUserIdShape(userId: string): void {
 export class OrgService {
   constructor(
     private readonly databaseAdapter: DatabaseAdapter,
-    private readonly authService: AuthService
+    private readonly authService: AuthService,
+    private readonly email: EmailOutboundAdapter = createEmailOutboundAdapter(),
+    private readonly getWebPublicUrl: () =>
+      | string
+      | undefined = resolveWebPublicUrl
   ) {}
 
   async listOrganizations(): Promise<OrganizationSummary[]> {
@@ -766,7 +773,7 @@ export class OrgService {
     role: OrgRole;
     invitedByUserId: string;
   }): Promise<OrgInviteCreatedResponse> {
-    await this.requireActiveOrganization(input.orgId);
+    const organization = await this.requireActiveOrganization(input.orgId);
 
     const email = normalizeEmail(input.email);
     if (!EMAIL_PATTERN.test(email)) {
@@ -821,9 +828,27 @@ export class OrgService {
 
     await this.databaseAdapter.createOrgInvite(record);
 
+    const webPublicUrl = this.getWebPublicUrl();
+    const acceptInstruction = webPublicUrl
+      ? `Accept your invitation: ${webPublicUrl}/accept-invite?token=${encodeURIComponent(token)}`
+      : `Invitation token: ${token}`;
+    const delivery = await this.email.send({
+      orgId: input.orgId,
+      subject: `You're invited to ${organization.name}`,
+      text: [
+        `You've been invited to join ${organization.name} as ${input.role}.`,
+        "",
+        acceptInstruction,
+        "",
+        `This invitation expires on ${record.expiresAt}.`,
+      ].join("\n"),
+      to: email,
+    });
+
     return {
+      delivered: delivery.ok,
       invite: toOrgInviteSummary(record),
-      token,
+      token: delivery.ok ? null : token,
     };
   }
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -32,6 +32,10 @@ const IntegrationsPage = lazyPage(
   "IntegrationsPage"
 );
 const LoginPage = lazyPage(() => import("@/pages/LoginPage"), "LoginPage");
+const AcceptInvitePage = lazyPage(
+  () => import("@/pages/AcceptInvitePage"),
+  "AcceptInvitePage"
+);
 const NotificationsPage = lazyPage(
   () => import("@/pages/NotificationsPage"),
   "NotificationsPage"
@@ -87,6 +91,14 @@ function AppShell() {
         <AppQueryPrefetch />
         <AppProvider>
           <Routes>
+            <Route
+              element={
+                <RouteBoundary fullScreen>
+                  <AcceptInvitePage />
+                </RouteBoundary>
+              }
+              path="/accept-invite"
+            />
             <Route
               element={
                 <RouteBoundary fullScreen>

--- a/apps/web/src/components/settings/OrgMembersCard.tsx
+++ b/apps/web/src/components/settings/OrgMembersCard.tsx
@@ -1,5 +1,6 @@
 import type { OrgMemberSummary, OrgRole } from "@nakama/core/contract";
 import { Card, CardContent } from "@nakama/ui/card";
+import { toast } from "@nakama/ui/toast";
 import { useReducer } from "react";
 import {
   type OrgMemberAddCredentials,
@@ -196,11 +197,16 @@ export function OrgMembersCard() {
         onError: (err) =>
           dispatch({ type: "patch", values: { formError: formatError(err) } }),
         onSuccess: (result) => {
+          if (result.delivered) {
+            toast(`Invitation sent to ${email}.`);
+          }
           dispatch({
             type: "patch",
             values: {
               inviteOpen: false,
-              secretHint: "Share this invite token with the recipient.",
+              secretHint: result.token
+                ? "Email delivery failed. Share this invite token manually."
+                : null,
               secretValue: result.token,
             },
           });

--- a/apps/web/src/components/settings/org-member-dialogs.tsx
+++ b/apps/web/src/components/settings/org-member-dialogs.tsx
@@ -49,8 +49,8 @@ function OrgMemberInviteForm({
     <>
       {emailSettingsLoading || emailConfigured ? null : (
         <p className="rounded-md border border-border bg-muted/40 px-3 py-2 text-muted-foreground text-sm">
-          Configure the shared email mailbox before you can invite members by
-          email.{" "}
+          Email is not configured. You can still create an invite and share its
+          token manually.{" "}
           <Link
             className="font-medium text-foreground underline-offset-4 hover:underline"
             to="/system?tab=tools"

--- a/apps/web/src/pages/AcceptInvitePage.tsx
+++ b/apps/web/src/pages/AcceptInvitePage.tsx
@@ -1,0 +1,90 @@
+import { Button } from "@nakama/ui/button";
+import { Input } from "@nakama/ui/input";
+import { useState } from "react";
+import { Navigate, useNavigate, useSearchParams } from "react-router-dom";
+import { useAuth } from "@/context/use-auth";
+import { useTheme } from "@/context/use-theme";
+import { client, formatError } from "@/lib/client";
+import { ditherLogoSrc } from "@/lib/theme";
+
+export function AcceptInvitePage() {
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("token")?.trim() ?? "";
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { refreshSession } = useAuth();
+  const { resolvedTheme } = useTheme();
+  const navigate = useNavigate();
+
+  if (!token) {
+    return <Navigate replace to="/login" />;
+  }
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      await client.acceptOrgInvite({ password, token });
+      await refreshSession();
+      navigate("/chat", { replace: true });
+    } catch (cause) {
+      setError(formatError(cause));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="flex h-svh items-center justify-center bg-background px-4 pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
+      <div className="w-full max-w-sm space-y-6">
+        <div className="flex flex-col items-center text-center">
+          <img
+            alt="Nakama"
+            className="mb-4 size-14 rounded-xl"
+            src={ditherLogoSrc(resolvedTheme)}
+          />
+          <h1 className="font-semibold text-xl tracking-tight">
+            Accept invitation
+          </h1>
+        </div>
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div>
+            <label
+              className="mb-1 block font-medium text-sm"
+              htmlFor="password"
+            >
+              Password
+            </label>
+            <Input
+              autoComplete="current-password"
+              id="password"
+              minLength={8}
+              onChange={(event) => setPassword(event.target.value)}
+              required
+              type="password"
+              value={password}
+            />
+            <p className="mt-1 text-muted-foreground text-xs">
+              Use your existing password, or choose one if this is your first
+              time joining.
+            </p>
+          </div>
+          {error ? (
+            <div
+              className="rounded-md bg-red-50 px-3 py-2 text-red-800 text-sm dark:bg-red-950/30 dark:text-red-200"
+              role="alert"
+            >
+              {error}
+            </div>
+          ) : null}
+          <Button className="w-full" disabled={isSubmitting} type="submit">
+            {isSubmitting ? "Joining..." : "Join organization"}
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -4,6 +4,8 @@ import {
   readApiErrorMessage,
 } from "@nakama/core/api-error";
 import type {
+  AcceptOrgInviteRequest,
+  AcceptOrgInviteResponse,
   AddOrgMemberRequest,
   AddOrgMemberResponse,
   AddOrgMemoryFactRequest,
@@ -2117,6 +2119,21 @@ export class NakamaClient {
     });
 
     this.applyAuthUserResponse(response);
+    return response;
+  }
+
+  async acceptOrgInvite(
+    request: AcceptOrgInviteRequest
+  ): Promise<AcceptOrgInviteResponse> {
+    const response = await this.request<AcceptOrgInviteResponse>(
+      "/v1/auth/accept-invite",
+      {
+        body: JSON.stringify(request),
+        method: "POST",
+      }
+    );
+
+    this.setOrgId(response.orgId);
     return response;
   }
 

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -609,8 +609,9 @@ export interface OrganizationResponse {
 }
 
 export interface OrgInviteCreatedResponse {
+  delivered: boolean;
   invite: OrgInviteSummary;
-  token: string;
+  token: string | null;
 }
 
 export interface AddOrgMemberResponse {


### PR DESCRIPTION
## Summary

Invite an organization member → they receive a working acceptance link through the configured mailbox.

**Before:** creating an invite always exposed a raw token for manual sharing.
**After:** successful email delivery returns no raw token; failed or unavailable delivery keeps the manual-token fallback.

Why safe:
1. Existing token hashing, expiry, single-use acceptance, and role checks remain unchanged
2. SMTP failures preserve the created invite and return its token instead of blocking onboarding
3. The acceptance page uses the existing public endpoint and refreshes the authenticated organization session

Only move delivery to a background job if SMTP latency starts delaying invite creation.

## Test plan
- [x] `bun test apps/server/src/services/org-service.test.ts --timeout 15000` (38 pass)
- [x] `bun run --cwd packages/core build && bun run --cwd packages/client build && bun run --cwd apps/server build && bun run --cwd apps/web build`
- [x] `bun run knip`
- [ ] Configure SMTP, invite one new address, and accept from the emailed link

Part of #430