### PR TITLE
fix(discord): use pickers for safe org and profile selection

### DIFF
--- a/apps/platform/discord/src/bot.ts
+++ b/apps/platform/discord/src/bot.ts
@@ -3,6 +3,7 @@ import {
   Events,
   GatewayIntentBits,
   type Message,
+  MessageFlags,
   Partials,
 } from "discord.js";
 import {
@@ -67,6 +68,34 @@ export async function createBot(
   // HTTP interaction endpoint, verify signatures with the app public key before
   // handling the body; do not copy this gateway-only handler as-is.
   client.on(Events.InteractionCreate, async (interaction) => {
+    if (
+      (interaction.isStringSelectMenu() || interaction.isButton()) &&
+      /^nakama:(org|profile):/.test(interaction.customId)
+    ) {
+      try {
+        // Private pickers can update in place; copied/foreign controls cannot mutate state.
+        if (interaction.customId.split(":")[2] !== interaction.user.id) {
+          await interaction.reply({
+            content: "Open your own /org or /profile picker.",
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+        await interaction.deferUpdate();
+        await handler.handleSelectionInteraction(interaction);
+      } catch (error) {
+        if (!isIgnorableInteractionError(error)) {
+          console.error("Selection interaction error:", error);
+          await interaction
+            .editReply({
+              components: [],
+              content: "Something went wrong. Open the picker again.",
+            })
+            .catch(() => {});
+        }
+      }
+      return;
+    }
     if (!interaction.isChatInputCommand()) {
       return;
     }

--- a/apps/platform/discord/src/chat-handler.test.ts
+++ b/apps/platform/discord/src/chat-handler.test.ts
@@ -37,7 +37,8 @@ import { ThreadStore } from "./thread-store";
 function createPickerInteraction(
   customId: string,
   values?: string[],
-  userId?: string
+  userId?: string,
+  payload?: ReturnType<ReturnType<typeof readPickerPayload>>
 ) {
   const mock = createSlashInteraction({
     commandName: "org",
@@ -50,13 +51,26 @@ function createPickerInteraction(
     interaction: {
       ...interaction,
       customId,
+      message: {
+        components:
+          payload?.components.map((row) => ({
+            components: row.components.map(({ custom_id, ...component }) => ({
+              ...component,
+              customId: custom_id,
+            })),
+            type: 1,
+          })) ?? [],
+      },
       ...(values ? { values } : {}),
     } as unknown as StringSelectMenuInteraction | ButtonInteraction,
   };
 }
 
 function readPickerPayload(
-  interaction: ReturnType<typeof createSlashInteraction>["interaction"]
+  interaction:
+    | ReturnType<typeof createSlashInteraction>["interaction"]
+    | ButtonInteraction
+    | StringSelectMenuInteraction
 ) {
   const edit = spyOn(interaction, "editReply");
   return () =>
@@ -64,11 +78,31 @@ function readPickerPayload(
       components: Array<{
         components: Array<{
           custom_id: string;
-          options?: Array<{ value: string }>;
+          type: number;
+          label?: string;
+          options?: Array<{ value: string; default?: boolean }>;
           disabled?: boolean;
         }>;
       }>;
     };
+}
+
+async function selectAndApply(
+  handler: ReturnType<typeof createChatHandler>,
+  customId: string,
+  value: string
+) {
+  const pick = createPickerInteraction(customId, [value]);
+  const preview = readPickerPayload(pick.interaction);
+  await handler.handleSelectionInteraction(pick.interaction);
+  const apply = preview()
+    .components.flatMap((row) => row.components)
+    .find((button) => button.label === "Apply")!;
+  expect(apply.disabled).toBe(false);
+  await handler.handleSelectionInteraction(
+    createPickerInteraction(apply.custom_id, undefined, undefined, preview())
+      .interaction
+  );
 }
 
 afterEach(() => {
@@ -236,6 +270,57 @@ describe("createChatHandler logging", () => {
 });
 
 describe("Discord selection pickers", () => {
+  test("selecting previews the choice until Apply, and Cancel preserves the session", async () => {
+    await withTempHome(async (homeDir) => {
+      const handler = await createPairedHandler(homeDir, {
+        orgs: createMultiTestOrgs(),
+      });
+      const key = "g:guild_channel_1:t:thread_1";
+      handler.orgStore.set(key, "org_a");
+      handler.threadStore.add("thread_1");
+      await handler.handleMessage(
+        createGuildChatMessage({
+          content: "hello",
+          inThread: true,
+          threadId: "thread_1",
+        }).message
+      );
+      const session = handler.sessionStore.get(key);
+      const command = createSlashInteraction({
+        commandName: "org",
+        inThread: true,
+      });
+      const initial = readPickerPayload(command.interaction);
+      await handler.handleSlashCommand(command.interaction);
+      expect(
+        initial()
+          .components.flatMap((row) => row.components)
+          .find((button) => button.label === "Apply")?.disabled
+      ).toBe(true);
+      const pick = createPickerInteraction("nakama:org:424242424242424242:0", [
+        "org_b",
+      ]);
+      const preview = readPickerPayload(
+        pick.interaction as unknown as typeof command.interaction
+      );
+      await handler.handleSelectionInteraction(pick.interaction);
+      expect(handler.orgStore.get(key)?.orgId).toBe("org_a");
+      expect(handler.sessionStore.get(key)).toEqual(session);
+      const cancel = preview()
+        .components.flatMap((row) => row.components)
+        .find((button) => button.label === "Cancel")!;
+      await handler.handleSelectionInteraction(
+        createPickerInteraction(
+          cancel.custom_id,
+          undefined,
+          undefined,
+          preview()
+        ).interaction
+      );
+      expect(handler.orgStore.get(key)?.orgId).toBe("org_a");
+      expect(handler.sessionStore.get(key)).toEqual(session);
+    });
+  });
   test("a failed org save cannot leave the previous session hot", async () => {
     await withTempHome(async (homeDir) => {
       const handler = await createPairedHandler(homeDir, {
@@ -256,9 +341,10 @@ describe("Discord selection pickers", () => {
       );
       const log = spyOn(console, "error").mockImplementation(() => {});
       try {
-        await handler.handleSelectionInteraction(
-          createPickerInteraction("nakama:org:424242424242424242:0", ["org_b"])
-            .interaction
+        await selectAndApply(
+          handler,
+          "nakama:org:424242424242424242:0",
+          "org_b"
         );
         expect(handler.sessionStore.get(key)).toBeUndefined();
         expect(handler.sessionStore.getHotSession(key)).toBeUndefined();
@@ -345,10 +431,7 @@ describe("Discord selection pickers", () => {
         "org_b",
         "org_a",
       ]);
-      await handler.handleSelectionInteraction(
-        createPickerInteraction("nakama:org:424242424242424242:0", ["org_b"])
-          .interaction
-      );
+      await selectAndApply(handler, "nakama:org:424242424242424242:0", "org_b");
       await send("thread_1", "continue");
       expect(sent.at(-1)?.orgId).toBe("org_b");
       expect(sent.at(-1)?.sessionId).not.toBe(sent[0]?.sessionId);
@@ -381,11 +464,10 @@ describe("Discord selection pickers", () => {
           (option) => option.value
         )
       ).toEqual(["org_25"]);
-      await handler.handleSelectionInteraction(
-        createPickerInteraction(
-          nextPayload().components[0]!.components[0]!.custom_id,
-          ["org_25"]
-        ).interaction
+      await selectAndApply(
+        handler,
+        nextPayload().components[0]!.components[0]!.custom_id,
+        "org_25"
       );
       expect(handler.orgStore.get("g:guild_channel_1:t:thread_1")?.orgId).toBe(
         "org_25"
@@ -410,15 +492,9 @@ describe("Discord selection pickers", () => {
       const siblingKey = "g:guild_channel_1:t:thread_2";
       const sibling =
         handler.sessionStore.getHotSession<RemoteChatSession>(siblingKey);
-      await handler.handleSelectionInteraction(
-        createPickerInteraction("nakama:org:424242424242424242:0", ["org_a"])
-          .interaction
-      );
+      await selectAndApply(handler, "nakama:org:424242424242424242:0", "org_a");
       expect(handler.sessionStore.getHotSession(key)).toBeDefined();
-      await handler.handleSelectionInteraction(
-        createPickerInteraction("nakama:org:424242424242424242:0", ["org_b"])
-          .interaction
-      );
+      await selectAndApply(handler, "nakama:org:424242424242424242:0", "org_b");
       expect(handler.sessionStore.get(key)).toBeUndefined();
       expect(handler.sessionStore.getHotSession(key)).toBeUndefined();
       expect(
@@ -463,13 +539,30 @@ describe("Discord selection pickers", () => {
         createPickerInteraction(menu.custom_id, ["super"]).interaction
       );
       expect(handler.calls.createSession).toBe(0);
+      const pick = createPickerInteraction(menu.custom_id, ["support"]);
+      const preview = readPickerPayload(pick.interaction);
+      await handler.handleSelectionInteraction(pick.interaction);
+      expect(handler.createdSessionProfileIds).toEqual([]);
+      const apply = preview()
+        .components.flatMap((row) => row.components)
+        .find((button) => button.label === "Apply")!;
       await handler.handleSelectionInteraction(
-        createPickerInteraction(menu.custom_id, ["support"]).interaction
+        createPickerInteraction(
+          apply.custom_id,
+          undefined,
+          undefined,
+          preview()
+        ).interaction
       );
       expect(handler.createdSessionProfileIds).toEqual(["support"]);
       handler.orgStore.set("g:guild_channel_1:t:thread_1", "org_b");
       await handler.handleSelectionInteraction(
-        createPickerInteraction(menu.custom_id, ["default"]).interaction
+        createPickerInteraction(
+          apply.custom_id,
+          undefined,
+          undefined,
+          preview()
+        ).interaction
       );
       expect(handler.createdSessionProfileIds).toEqual(["support"]);
     });
@@ -482,12 +575,33 @@ describe("Discord selection pickers", () => {
         orgs: createMultiTestOrgs(),
       });
       const id = "nakama:org:424242424242424242:0";
+      const pick = createPickerInteraction(id, ["org_b"]);
+      const preview = readPickerPayload(pick.interaction);
+      await handler.handleSelectionInteraction(pick.interaction);
+      const applyId = preview()
+        .components.flatMap((row) => row.components)
+        .find((button) => button.label === "Apply")!.custom_id;
       await handler.handleSelectionInteraction(
-        createPickerInteraction(id, ["org_b"], "999999999999999999").interaction
+        createPickerInteraction(
+          applyId,
+          undefined,
+          "999999999999999999",
+          preview()
+        ).interaction
       );
+      const unauthorizedPayload = JSON.parse(
+        JSON.stringify(preview()).replaceAll(
+          "424242424242424242",
+          "888888888888888888"
+        )
+      ) as ReturnType<typeof preview>;
       await handler.handleSelectionInteraction(
-        createPickerInteraction("nakama:org:888:0", ["org_b"], "888")
-          .interaction
+        createPickerInteraction(
+          "nakama:org:888888888888888888:apply",
+          undefined,
+          "888888888888888888",
+          unauthorizedPayload
+        ).interaction
       );
       expect(
         handler.orgStore.get("g:guild_channel_1:t:thread_1")

--- a/apps/platform/discord/src/chat-handler.test.ts
+++ b/apps/platform/discord/src/chat-handler.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import path from "node:path";
+import { NakamaClient, type RemoteChatSession } from "@nakama/client";
 import {
   hasActiveStreams,
   resetActiveStreamsForTests,
@@ -7,6 +8,10 @@ import {
 import { ChannelSessionStore as SessionStore } from "@nakama/core/channel-session-store";
 import type { ChatMessage } from "@nakama/core/contract";
 import { loadDiscordConfigFile } from "@nakama/core/discord-config";
+import type {
+  ButtonInteraction,
+  StringSelectMenuInteraction,
+} from "discord.js";
 import { DiscordAuthStore } from "./auth-store";
 import {
   chatLockOptions,
@@ -28,6 +33,43 @@ import {
   writeDiscordConfigIni,
 } from "./test-helpers";
 import { ThreadStore } from "./thread-store";
+
+function createPickerInteraction(
+  customId: string,
+  values?: string[],
+  userId?: string
+) {
+  const mock = createSlashInteraction({
+    commandName: "org",
+    inThread: true,
+    userId,
+  });
+  const { commandName: _commandName, ...interaction } = mock.interaction;
+  return {
+    ...mock,
+    interaction: {
+      ...interaction,
+      customId,
+      ...(values ? { values } : {}),
+    } as unknown as StringSelectMenuInteraction | ButtonInteraction,
+  };
+}
+
+function readPickerPayload(
+  interaction: ReturnType<typeof createSlashInteraction>["interaction"]
+) {
+  const edit = spyOn(interaction, "editReply");
+  return () =>
+    JSON.parse(JSON.stringify(edit.mock.calls.at(-1)?.[0])) as {
+      components: Array<{
+        components: Array<{
+          custom_id: string;
+          options?: Array<{ value: string }>;
+          disabled?: boolean;
+        }>;
+      }>;
+    };
+}
 
 afterEach(() => {
   resetChatLocksForTests();
@@ -63,16 +105,8 @@ async function waitForCondition(
 
 async function createPairedHandler(
   homeDir: string,
-  options: {
-    messages?: ChatMessage[];
-    onSendStream?: Parameters<typeof createMockClient>[0]["onSendStream"];
-    questionnaire?: Parameters<typeof createMockClient>[0]["questionnaire"];
-    orgs?: Parameters<typeof createMockClient>[0]["orgs"];
-    profiles?: Parameters<typeof createMockClient>[0]["profiles"];
-    listedArtifacts?: Parameters<typeof createMockClient>[0]["listedArtifacts"];
-    artifactContentBytes?: Parameters<
-      typeof createMockClient
-    >[0]["artifactContentBytes"];
+  options: NonNullable<Parameters<typeof createMockClient>[0]> & {
+    apiClient?: NakamaClient;
     configProfileId?: string;
     pairedUserIds?: string[];
     allowedUserIds?: string[];
@@ -86,7 +120,9 @@ async function createPairedHandler(
 
   const authStore = new DiscordAuthStore();
   await authStore.reload();
-  const { client, calls, createdSessionProfileIds } = createMockClient(options);
+  const mockClient = createMockClient(options);
+  const { calls, createdSessionProfileIds } = mockClient;
+  const client = options.apiClient ?? mockClient.client;
   const sessionStore = new SessionStore(
     path.join(homeDir, ".nakama", "discord", "chat-sessions.json")
   );
@@ -121,6 +157,28 @@ async function createPairedHandler(
 }
 
 describe("createChatHandler logging", () => {
+  test("numeric chat replies preserve the selected org and session", async () => {
+    await withTempHome(async (homeDir) => {
+      const inputs: unknown[] = [];
+      const { handleMessage, orgStore, calls } = await createPairedHandler(
+        homeDir,
+        {
+          onSendStream: async (input) => {
+            inputs.push(input);
+            return "ok";
+          },
+          orgs: createMultiTestOrgs(),
+        }
+      );
+      orgStore.set("u:424242424242424242", "org_a");
+      for (const content of ["hello", "2", "continue"]) {
+        await handleMessage(createDmMessage({ content }).message);
+      }
+      expect(inputs).toHaveLength(3);
+      expect(orgStore.get("u:424242424242424242")?.orgId).toBe("org_a");
+      expect(calls.createSession).toBe(1);
+    });
+  });
   test("logs message metadata without private content when debug is on", async () => {
     await withTempHome(async (homeDir) => {
       const privateMessage = "private 🔒 message";
@@ -173,6 +231,267 @@ describe("createChatHandler logging", () => {
           process.env.NAKAMA_CH_DEBUG = previousDebug;
         }
       }
+    });
+  });
+});
+
+describe("Discord selection pickers", () => {
+  test("a failed org save cannot leave the previous session hot", async () => {
+    await withTempHome(async (homeDir) => {
+      const handler = await createPairedHandler(homeDir, {
+        orgs: createMultiTestOrgs(),
+      });
+      const key = "g:guild_channel_1:t:thread_1";
+      handler.orgStore.set(key, "org_a");
+      handler.threadStore.add("thread_1");
+      await handler.handleMessage(
+        createGuildChatMessage({
+          content: "hello",
+          inThread: true,
+          threadId: "thread_1",
+        }).message
+      );
+      const save = spyOn(handler.orgStore, "save").mockRejectedValueOnce(
+        new Error("disk unavailable")
+      );
+      const log = spyOn(console, "error").mockImplementation(() => {});
+      try {
+        await handler.handleSelectionInteraction(
+          createPickerInteraction("nakama:org:424242424242424242:0", ["org_b"])
+            .interaction
+        );
+        expect(handler.sessionStore.get(key)).toBeUndefined();
+        expect(handler.sessionStore.getHotSession(key)).toBeUndefined();
+      } finally {
+        save.mockRestore();
+        log.mockRestore();
+      }
+    });
+  });
+  test("concurrent real client sessions retain their org across a picker switch", async () => {
+    await withTempHome(async (homeDir) => {
+      const sessionOrgs = new Map<string, string>();
+      const sent: Array<{ sessionId: string; orgId: string | null }> = [];
+      let releaseFirst!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      let firstStarted = false;
+      const apiClient = new NakamaClient({
+        baseUrl: "http://discord-test.invalid",
+        fetch: (async (input, init) => {
+          const request = new Request(input, init);
+          const pathname = new URL(request.url).pathname;
+          const orgId = request.headers.get("X-Org-Id");
+          if (pathname === "/v1/auth/orgs") {
+            return Response.json({ orgs: createMultiTestOrgs() });
+          }
+          if (pathname === "/v1/profiles") {
+            return Response.json({
+              profiles: [{ id: "default", name: "Default" }],
+            });
+          }
+          if (pathname === "/v1/sessions") {
+            const sessionId = `session_${sessionOrgs.size}`;
+            sessionOrgs.set(sessionId, orgId!);
+            return Response.json({ sessionId });
+          }
+          const sessionId = pathname.split("/")[3]!;
+          if (pathname.endsWith("/messages") && request.method === "POST") {
+            sent.push({ orgId, sessionId });
+            if (sent.length === 1) {
+              firstStarted = true;
+              await gate;
+            }
+            if (sessionOrgs.get(sessionId) !== orgId) {
+              return Response.json(
+                { error: "Session not found" },
+                { status: 404 }
+              );
+            }
+            return new Response('data: {"type":"done","reply":"ok"}\n\n', {
+              headers: { "Content-Type": "text/event-stream" },
+            });
+          }
+          if (pathname.endsWith("/messages")) {
+            return Response.json({ messages: [] });
+          }
+          throw new Error(`Unexpected request: ${pathname}`);
+        }) as typeof fetch,
+      });
+      const handler = await createPairedHandler(homeDir, { apiClient });
+      handler.orgStore.set("g:guild_channel_1", "org_a");
+      handler.orgStore.set("g:guild_channel_1:t:thread_2", "org_b");
+      handler.threadStore.add("thread_1");
+      handler.threadStore.add("thread_2");
+      const send = (threadId: string, content: string) =>
+        handler.handleMessage(
+          createGuildChatMessage({ content, inThread: true, threadId }).message
+        );
+      const first = send("thread_1", "hello");
+      try {
+        await waitForCondition(
+          () => firstStarted,
+          "first stream never started"
+        );
+        await send("thread_2", "hello");
+      } finally {
+        releaseFirst();
+      }
+      await first;
+      await send("thread_1", "2");
+      expect(sent.map((entry) => entry.orgId)).toEqual([
+        "org_a",
+        "org_b",
+        "org_a",
+      ]);
+      await handler.handleSelectionInteraction(
+        createPickerInteraction("nakama:org:424242424242424242:0", ["org_b"])
+          .interaction
+      );
+      await send("thread_1", "continue");
+      expect(sent.at(-1)?.orgId).toBe("org_b");
+      expect(sent.at(-1)?.sessionId).not.toBe(sent[0]?.sessionId);
+      expect(sessionOrgs.size).toBe(3);
+    });
+  });
+  test("org picker paginates and accepts a choice beyond the first 25", async () => {
+    await withTempHome(async (homeDir) => {
+      const orgs = Array.from({ length: 26 }, (_, index) => ({
+        ...createMultiTestOrgs()[0]!,
+        id: `org_${index}`,
+        name: `Org ${index}`,
+      }));
+      const handler = await createPairedHandler(homeDir, { orgs });
+      const command = createSlashInteraction({
+        commandName: "org",
+        inThread: true,
+      });
+      const payload = readPickerPayload(command.interaction);
+      await handler.handleSlashCommand(command.interaction);
+      expect(payload().components[0]?.components[0]?.options).toHaveLength(25);
+      const nextId = payload().components[1]!.components[1]!.custom_id;
+      const next = createPickerInteraction(nextId);
+      const nextPayload = readPickerPayload(
+        next.interaction as unknown as typeof command.interaction
+      );
+      await handler.handleSelectionInteraction(next.interaction);
+      expect(
+        nextPayload().components[0]?.components[0]?.options?.map(
+          (option) => option.value
+        )
+      ).toEqual(["org_25"]);
+      await handler.handleSelectionInteraction(
+        createPickerInteraction(
+          nextPayload().components[0]!.components[0]!.custom_id,
+          ["org_25"]
+        ).interaction
+      );
+      expect(handler.orgStore.get("g:guild_channel_1:t:thread_1")?.orgId).toBe(
+        "org_25"
+      );
+    });
+  });
+
+  test("org switch drops the old hot session and leaves sibling threads alone", async () => {
+    await withTempHome(async (homeDir) => {
+      const handler = await createPairedHandler(homeDir, {
+        orgs: createMultiTestOrgs(),
+      });
+      handler.orgStore.set("g:guild_channel_1", "org_a");
+      for (const threadId of ["thread_1", "thread_2"]) {
+        handler.threadStore.add(threadId);
+        await handler.handleMessage(
+          createGuildChatMessage({ content: "hello", inThread: true, threadId })
+            .message
+        );
+      }
+      const key = "g:guild_channel_1:t:thread_1";
+      const siblingKey = "g:guild_channel_1:t:thread_2";
+      const sibling =
+        handler.sessionStore.getHotSession<RemoteChatSession>(siblingKey);
+      await handler.handleSelectionInteraction(
+        createPickerInteraction("nakama:org:424242424242424242:0", ["org_a"])
+          .interaction
+      );
+      expect(handler.sessionStore.getHotSession(key)).toBeDefined();
+      await handler.handleSelectionInteraction(
+        createPickerInteraction("nakama:org:424242424242424242:0", ["org_b"])
+          .interaction
+      );
+      expect(handler.sessionStore.get(key)).toBeUndefined();
+      expect(handler.sessionStore.getHotSession(key)).toBeUndefined();
+      expect(
+        handler.sessionStore.getHotSession<RemoteChatSession>(siblingKey)
+      ).toBe(sibling);
+      expect(handler.orgStore.get(siblingKey)?.orgId).toBe("org_a");
+      expect(handler.orgStore.get("g:guild_channel_1")?.orgId).toBe("org_a");
+      await handler.handleMessage(
+        createGuildChatMessage({
+          content: "continue",
+          inThread: true,
+          threadId: "thread_1",
+        }).message
+      );
+      expect(handler.calls.createSession).toBe(3);
+    });
+  });
+
+  test("profile picker excludes Super Bot and rejects stale or unavailable choices", async () => {
+    await withTempHome(async (homeDir) => {
+      const handler = await createPairedHandler(homeDir, {
+        orgs: createMultiTestOrgs(),
+        profiles: [
+          { id: "default" },
+          { id: "support" },
+          { id: "super", isSuper: true },
+        ],
+      });
+      handler.orgStore.set("g:guild_channel_1", "org_a");
+      const command = createSlashInteraction({
+        commandName: "profile",
+        inThread: true,
+      });
+      const payload = readPickerPayload(command.interaction);
+      await handler.handleSlashCommand(command.interaction);
+      const menu = payload().components[0]!.components[0]!;
+      expect(menu.options?.map((option) => option.value)).toEqual([
+        "default",
+        "support",
+      ]);
+      await handler.handleSelectionInteraction(
+        createPickerInteraction(menu.custom_id, ["super"]).interaction
+      );
+      expect(handler.calls.createSession).toBe(0);
+      await handler.handleSelectionInteraction(
+        createPickerInteraction(menu.custom_id, ["support"]).interaction
+      );
+      expect(handler.createdSessionProfileIds).toEqual(["support"]);
+      handler.orgStore.set("g:guild_channel_1:t:thread_1", "org_b");
+      await handler.handleSelectionInteraction(
+        createPickerInteraction(menu.custom_id, ["default"]).interaction
+      );
+      expect(handler.createdSessionProfileIds).toEqual(["support"]);
+    });
+  });
+
+  test("foreign and unauthorized users cannot apply picker selections", async () => {
+    await withTempHome(async (homeDir) => {
+      const handler = await createPairedHandler(homeDir, {
+        allowedUserIds: ["999999999999999999"],
+        orgs: createMultiTestOrgs(),
+      });
+      const id = "nakama:org:424242424242424242:0";
+      await handler.handleSelectionInteraction(
+        createPickerInteraction(id, ["org_b"], "999999999999999999").interaction
+      );
+      await handler.handleSelectionInteraction(
+        createPickerInteraction("nakama:org:888:0", ["org_b"], "888")
+          .interaction
+      );
+      expect(
+        handler.orgStore.get("g:guild_channel_1:t:thread_1")
+      ).toBeUndefined();
     });
   });
 });

--- a/apps/platform/discord/src/chat-handler.ts
+++ b/apps/platform/discord/src/chat-handler.ts
@@ -37,6 +37,7 @@ import {
   type ButtonInteraction,
   ButtonStyle,
   type ChatInputCommandInteraction,
+  ComponentType,
   type Message,
   StringSelectMenuBuilder,
   type StringSelectMenuInteraction,
@@ -920,6 +921,11 @@ function createScopedChatHandler(deps: ChatHandlerDeps) {
     );
     const reply = (content: string) =>
       interaction.editReply({ components: [], content });
+    const action = selection?.[3];
+    if (action === "cancel") {
+      await reply("Selection cancelled.");
+      return;
+    }
     if (orgs.length === 0) {
       await reply("No organizations are configured yet.");
       return;
@@ -942,16 +948,36 @@ function createScopedChatHandler(deps: ChatHandlerDeps) {
       return;
     }
 
-    if ("values" in interaction) {
-      const picked = choices.find(
-        (entry) => entry.id === interaction.values[0]
-      );
-      if (interaction.values.length !== 1 || !picked) {
-        await reply(
-          "That choice is no longer available. Open the picker again."
+    let selectedId: string | undefined;
+    if ("values" in interaction && interaction.values.length === 1) {
+      selectedId = interaction.values[0];
+    } else if (action === "apply" && "message" in interaction) {
+      // The bot-rendered default option holds the pending choice without persisting it.
+      const menu = interaction.message.components
+        .flatMap((row) =>
+          row.type === ComponentType.ActionRow ? row.components : []
+        )
+        .find(
+          (component) =>
+            component.type === ComponentType.StringSelect &&
+            component.customId.startsWith(
+              `nakama:${kind}:${interaction.user.id}:`
+            ) &&
+            component.customId.split(":")[4] === selection?.[4]
         );
-        return;
+      if (menu?.type === ComponentType.StringSelect) {
+        const selected = menu.options.filter((option) => option.default);
+        if (selected.length === 1) {
+          selectedId = selected[0]?.value;
+        }
       }
+    }
+    const picked = choices.find((entry) => entry.id === selectedId);
+    if (("values" in interaction || action === "apply") && !picked) {
+      await reply("That choice is no longer available. Open the picker again.");
+      return;
+    }
+    if (action === "apply" && picked) {
       if (kind === "org") {
         if (picked.id !== org?.id) {
           orgStore.set(channelOrgKey, picked.id);
@@ -975,7 +1001,7 @@ function createScopedChatHandler(deps: ChatHandlerDeps) {
     const page = Number.isSafeInteger(requestedPage)
       ? Math.max(0, Math.min(requestedPage, lastPage))
       : 0;
-    const customId = (pageIndex: number) =>
+    const customId = (pageIndex: number | "apply" | "cancel") =>
       `nakama:${kind}:${interaction.user.id}:${pageIndex}${kind === "profile" ? `:${org!.id}` : ""}`;
     const currentId =
       kind === "org" ? org?.id : await resolveSessionProfileId(conversationKey);
@@ -986,7 +1012,7 @@ function createScopedChatHandler(deps: ChatHandlerDeps) {
       )
       .addOptions(
         choices.slice(page * 25, (page + 1) * 25).map((entry) => ({
-          default: entry.id === currentId,
+          default: entry.id === (selectedId ?? currentId),
           label: (entry.name || entry.id).slice(0, 100),
           value: entry.id,
         }))
@@ -1011,6 +1037,19 @@ function createScopedChatHandler(deps: ChatHandlerDeps) {
         )
       );
     }
+    components.push(
+      new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+          .setCustomId(customId("apply"))
+          .setLabel("Apply")
+          .setStyle(ButtonStyle.Primary)
+          .setDisabled(!picked),
+        new ButtonBuilder()
+          .setCustomId(customId("cancel"))
+          .setLabel("Cancel")
+          .setStyle(ButtonStyle.Secondary)
+      )
+    );
     await interaction.editReply({
       components,
       content: kind === "org" ? "Organization" : `Profile · ${org!.name}`,

--- a/apps/platform/discord/src/chat-handler.ts
+++ b/apps/platform/discord/src/chat-handler.ts
@@ -15,7 +15,6 @@ import { createChatLock } from "@nakama/core/channel-chat-lock";
 import {
   type ChannelOrgStore,
   findOrgBySelectionInput,
-  formatOrgSelectionPrompt,
   formatOrgSwitchConfirmation,
   prepareChannelOrgContext,
 } from "@nakama/core/channel-org";
@@ -25,7 +24,6 @@ import type { ImageAttachment, SendMessageInput } from "@nakama/core/contract";
 import { addDiscordAllowedUserId } from "@nakama/core/discord-config";
 import {
   filterProfilesForChatAccess,
-  formatProfileSelectionPrompt,
   formatProfileSwitchConfirmation,
   isProfileSelectionIndexInput,
   type ProfileScope,
@@ -33,11 +31,17 @@ import {
   resolveProfileInput,
   resolveProfileInScopes,
 } from "@nakama/core/profiles";
-import type {
-  ChatInputCommandInteraction,
-  Message,
-  TextBasedChannel,
-  ThreadChannel,
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  type ButtonInteraction,
+  ButtonStyle,
+  type ChatInputCommandInteraction,
+  type Message,
+  StringSelectMenuBuilder,
+  type StringSelectMenuInteraction,
+  type TextBasedChannel,
+  type ThreadChannel,
 } from "discord.js";
 import type { DiscordAuthStore } from "./auth-store";
 import {
@@ -116,6 +120,20 @@ export interface ChatHandlerDeps {
 }
 
 export function createChatHandler(deps: ChatHandlerDeps) {
+  // Each event owns its API client. Concurrent threads must not borrow setOrgId.
+  const scoped = () =>
+    createScopedChatHandler({ ...deps, client: deps.client.forOrg(null) });
+  return {
+    handleMessage: (message: Message) => scoped().handleMessage(message),
+    handleSelectionInteraction: (
+      interaction: ButtonInteraction | StringSelectMenuInteraction
+    ) => scoped().handleSlashCommand(interaction),
+    handleSlashCommand: (interaction: ChatInputCommandInteraction) =>
+      scoped().handleSlashCommand(interaction),
+  };
+}
+
+function createScopedChatHandler(deps: ChatHandlerDeps) {
   const {
     client,
     config,
@@ -184,18 +202,14 @@ export function createChatHandler(deps: ChatHandlerDeps) {
       isGuild,
       parentResolution
     );
-    // Threads share the parent channel's org selection — do not key by thread id.
-    const channelOrgKey = resolveChannelOrgKey(
-      parentChannelId,
-      userId,
-      isGuild
-    );
+    const parentOrgKey = resolveChannelOrgKey(parentChannelId, userId, isGuild);
     const conversationKey = resolveConversationKey(
       message,
       channelId,
       isGuild,
       parentResolution
     );
+    const channelOrgKey = isThread ? conversationKey : parentOrgKey;
 
     // Auth reload + pairing under the conversation lock so concurrent DMs cannot
     // race reload against a just-written pairing. Agent work still locks later so
@@ -226,6 +240,8 @@ export function createChatHandler(deps: ChatHandlerDeps) {
       return;
     }
 
+    await inheritThreadOrg(channelOrgKey, parentOrgKey);
+
     if (isGuild && text && looksLikeHandshakeAttempt(text)) {
       await messenger.send(LINK_IN_PRIVATE_REPLY);
       return;
@@ -240,15 +256,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
       : [];
 
     if (!bypassOrgGate) {
-      const orgGateText =
-        isGuild && text && botInfo
-          ? stripBotMention(text, botInfo, mentionedBotRoleIds)
-          : text;
-      const orgReady = await ensureOrgReady(
-        messenger,
-        channelOrgKey,
-        orgGateText
-      );
+      const orgReady = await ensureOrgReady(messenger, channelOrgKey);
       if (!orgReady) {
         debugLog(`[discord] skip org-gate ${channelOrgKey}`);
         return;
@@ -319,6 +327,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
       if (thread) {
         replyChannel = thread;
         replyConversationKey = `g:${channelId}:t:${thread.id}`;
+        await inheritThreadOrg(replyConversationKey, channelOrgKey);
         replyMessenger = createDiscordMessenger(thread);
         replyIsThread = true;
         debugLog(`[discord] thread created ${thread.id}`);
@@ -335,6 +344,15 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     );
 
     await withChatLock(replyConversationKey, async () => {
+      // A picker may have changed the org while this message waited for a turn.
+      if (
+        !(await ensureOrgReady(
+          replyMessenger,
+          replyIsThread ? replyConversationKey : channelOrgKey
+        ))
+      ) {
+        return;
+      }
       await handleChatMessage(
         replyChannel,
         replyConversationKey,
@@ -465,7 +483,10 @@ export function createChatHandler(deps: ChatHandlerDeps) {
   }
 
   async function handleSlashCommand(
-    interaction: ChatInputCommandInteraction
+    interaction:
+      | ChatInputCommandInteraction
+      | ButtonInteraction
+      | StringSelectMenuInteraction
   ): Promise<void> {
     // Caller (bot.ts) already deferred — do not wait on withChatLock here.
     // Agent replies hold that lock for a long time and would leave commands stuck.
@@ -486,12 +507,17 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     }
     const orgChannelId =
       isGuild && isThread ? (threadParentId ?? channelId) : channelId;
-    const channelOrgKey = resolveChannelOrgKey(orgChannelId, userId, isGuild);
+    const parentOrgKey = resolveChannelOrgKey(orgChannelId, userId, isGuild);
     const conversationKey = isGuild
       ? isThread
         ? `g:${threadParentId ?? channelId}:t:${interaction.channel!.id}`
         : channelId
       : channelId;
+    const channelOrgKey = isThread ? conversationKey : parentOrgKey;
+    const selection =
+      "customId" in interaction ? interaction.customId.split(":") : undefined;
+    const commandName =
+      "commandName" in interaction ? interaction.commandName : selection?.[1];
 
     const messenger = createInteractionMessenger(
       (content) => interaction.followUp({ content: content.slice(0, 2000) }),
@@ -501,7 +527,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     try {
       await authStore.reload();
 
-      if (interaction.commandName === "allow") {
+      if (commandName === "allow" && "commandName" in interaction) {
         await handleAllowCommand(interaction, messenger, userId);
         return;
       }
@@ -512,11 +538,8 @@ export function createChatHandler(deps: ChatHandlerDeps) {
           return;
         }
 
-        if (
-          interaction.commandName === "start" ||
-          interaction.commandName === "help"
-        ) {
-          await handlePairingSlash(interaction.commandName, messenger);
+        if (commandName === "start" || commandName === "help") {
+          await handlePairingSlash(commandName, messenger);
           return;
         }
 
@@ -524,15 +547,12 @@ export function createChatHandler(deps: ChatHandlerDeps) {
         return;
       }
 
-      if (
-        interaction.commandName === "start" ||
-        interaction.commandName === "help"
-      ) {
+      if (commandName === "start" || commandName === "help") {
         await messenger.send(HELP_TEXT);
         return;
       }
 
-      if (interaction.commandName === "stop") {
+      if (commandName === "stop") {
         if (stopActiveStream(conversationKey)) {
           await messenger.send("Stopping…");
         } else {
@@ -541,21 +561,39 @@ export function createChatHandler(deps: ChatHandlerDeps) {
         return;
       }
 
-      if (interaction.commandName === "close") {
+      if (commandName === "close" && "commandName" in interaction) {
         await handleCloseThread(interaction, conversationKey, messenger);
         return;
       }
 
-      const orgReady = await ensureOrgReady(
-        messenger,
-        channelOrgKey,
-        undefined
-      );
+      if (commandName === "org" || commandName === "profile") {
+        if (
+          selection &&
+          (selection[0] !== "nakama" || selection[2] !== userId)
+        ) {
+          await messenger.send("Open your own /org or /profile picker.");
+          return;
+        }
+        await withChatLock(conversationKey, async () => {
+          await inheritThreadOrg(channelOrgKey, parentOrgKey);
+          await handlePicker(
+            interaction,
+            commandName,
+            selection,
+            channelOrgKey,
+            conversationKey
+          );
+        });
+        return;
+      }
+
+      await inheritThreadOrg(channelOrgKey, parentOrgKey);
+      const orgReady = await ensureOrgReady(messenger, channelOrgKey);
       if (!orgReady) {
         return;
       }
 
-      switch (interaction.commandName) {
+      switch (commandName) {
         case "clear": {
           stopActiveStream(conversationKey);
           const session = await resolveSession(conversationKey);
@@ -827,8 +865,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
 
   async function ensureOrgReady(
     messenger: DiscordMessenger,
-    channelOrgKey: string,
-    messageText: string | undefined
+    channelOrgKey: string
   ): Promise<boolean> {
     const orgContext = await prepareChannelOrgContext({
       getSelectedOrgId: () => orgStore.get(channelOrgKey)?.orgId,
@@ -837,7 +874,6 @@ export function createChatHandler(deps: ChatHandlerDeps) {
         orgStore.set(channelOrgKey, orgId);
         await orgStore.save();
       },
-      text: messageText?.startsWith("/") ? undefined : messageText,
     });
 
     if (orgContext.status === "empty") {
@@ -846,18 +882,139 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     }
 
     if (orgContext.status === "prompt") {
-      await replyChunks(messenger, orgContext.message);
+      await messenger.send(
+        "Use /org from Discord's command menu to choose an organization."
+      );
       return false;
     }
 
     client.setOrgId(orgContext.orgId);
 
-    if (orgContext.justSelected) {
-      await messenger.send(formatOrgSwitchConfirmation(orgContext.orgName));
-      return false;
+    return true;
+  }
+
+  async function inheritThreadOrg(
+    key: string,
+    parentKey: string
+  ): Promise<void> {
+    const parent = orgStore.get(parentKey);
+    if (key !== parentKey && !orgStore.get(key) && parent) {
+      orgStore.set(key, parent.orgId);
+      await orgStore.save();
+    }
+  }
+
+  async function handlePicker(
+    interaction:
+      | ChatInputCommandInteraction
+      | ButtonInteraction
+      | StringSelectMenuInteraction,
+    kind: "org" | "profile",
+    selection: string[] | undefined,
+    channelOrgKey: string,
+    conversationKey: string
+  ): Promise<void> {
+    const { orgs } = await client.listUserOrgs();
+    const org = orgs.find(
+      (entry) => entry.id === orgStore.get(channelOrgKey)?.orgId
+    );
+    const reply = (content: string) =>
+      interaction.editReply({ components: [], content });
+    if (orgs.length === 0) {
+      await reply("No organizations are configured yet.");
+      return;
+    }
+    if (kind === "profile" && !org) {
+      await reply("Choose an organization with /org first.");
+      return;
+    }
+    if (selection && kind === "profile" && selection[4] !== org?.id) {
+      await reply("Organization changed. Open /profile again.");
+      return;
+    }
+    if (org) {
+      client.setOrgId(org.id);
+    }
+    const profiles = kind === "profile" ? await listSelectableProfiles() : [];
+    const choices = kind === "org" ? orgs : profiles;
+    if (choices.length === 0) {
+      await reply("No profiles are available.");
+      return;
     }
 
-    return true;
+    if ("values" in interaction) {
+      const picked = choices.find(
+        (entry) => entry.id === interaction.values[0]
+      );
+      if (interaction.values.length !== 1 || !picked) {
+        await reply(
+          "That choice is no longer available. Open the picker again."
+        );
+        return;
+      }
+      if (kind === "org") {
+        if (picked.id !== org?.id) {
+          orgStore.set(channelOrgKey, picked.id);
+          sessionStore.delete(conversationKey);
+          await sessionStore.save();
+          await orgStore.save();
+        }
+        await reply(`Using ${picked.name}.`);
+      } else {
+        const currentProfileId = await resolveSessionProfileId(conversationKey);
+        if (picked.id !== currentProfileId) {
+          await createAndBindSession(conversationKey, picked.id);
+        }
+        await reply(`Using ${org!.name} · ${picked.name}.`);
+      }
+      return;
+    }
+
+    const lastPage = Math.floor((choices.length - 1) / 25);
+    const requestedPage = Number(selection?.[3] ?? 0);
+    const page = Number.isSafeInteger(requestedPage)
+      ? Math.max(0, Math.min(requestedPage, lastPage))
+      : 0;
+    const customId = (pageIndex: number) =>
+      `nakama:${kind}:${interaction.user.id}:${pageIndex}${kind === "profile" ? `:${org!.id}` : ""}`;
+    const currentId =
+      kind === "org" ? org?.id : await resolveSessionProfileId(conversationKey);
+    const menu = new StringSelectMenuBuilder()
+      .setCustomId(customId(page))
+      .setPlaceholder(
+        kind === "org" ? "Choose an organization" : "Choose a profile"
+      )
+      .addOptions(
+        choices.slice(page * 25, (page + 1) * 25).map((entry) => ({
+          default: entry.id === currentId,
+          label: (entry.name || entry.id).slice(0, 100),
+          value: entry.id,
+        }))
+      );
+    const components: Array<
+      | ActionRowBuilder<StringSelectMenuBuilder>
+      | ActionRowBuilder<ButtonBuilder>
+    > = [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu)];
+    if (lastPage > 0) {
+      components.push(
+        new ActionRowBuilder<ButtonBuilder>().addComponents(
+          new ButtonBuilder()
+            .setCustomId(customId(page - 1))
+            .setLabel("Previous")
+            .setStyle(ButtonStyle.Secondary)
+            .setDisabled(page === 0),
+          new ButtonBuilder()
+            .setCustomId(customId(page + 1))
+            .setLabel("Next")
+            .setStyle(ButtonStyle.Secondary)
+            .setDisabled(page === lastPage)
+        )
+      );
+    }
+    await interaction.editReply({
+      components,
+      content: kind === "org" ? "Organization" : `Profile · ${org!.name}`,
+    });
   }
 
   async function handleOrgCommand(
@@ -876,9 +1033,8 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     const arg = text.trim().split(/\s+/).slice(1).join(" ");
 
     if (!arg) {
-      await replyChunks(
-        messenger,
-        formatOrgSelectionPrompt(orgs, orgStore.get(channelOrgKey)?.orgId)
+      await messenger.send(
+        "Use /org from Discord's command menu to choose an organization."
       );
       return;
     }
@@ -912,6 +1068,7 @@ export function createChatHandler(deps: ChatHandlerDeps) {
   ): Promise<void> {
     const { orgs } = await client.listUserOrgs();
     const currentOrgId = orgStore.get(channelOrgKey)?.orgId;
+    client.setOrgId(currentOrgId ?? null);
     const currentOrg = currentOrgId
       ? orgs.find((org) => org.id === currentOrgId)
       : undefined;
@@ -919,20 +1076,8 @@ export function createChatHandler(deps: ChatHandlerDeps) {
     const currentProfileId = await resolveSessionProfileId(conversationKey);
 
     if (!arg) {
-      const profiles = await listSelectableProfiles();
-
-      if (profiles.length === 0) {
-        await messenger.send("No profiles are available.");
-        return;
-      }
-
-      await replyChunks(
-        messenger,
-        formatProfileSelectionPrompt(
-          profiles,
-          currentProfileId,
-          currentOrg?.name
-        )
+      await messenger.send(
+        "Use /profile from Discord's command menu to choose a profile."
       );
       return;
     }

--- a/apps/platform/discord/src/format.ts
+++ b/apps/platform/discord/src/format.ts
@@ -121,8 +121,8 @@ export const HELP_TEXT = `Nakama Discord commands:
 /new — start a new conversation
 /close — close this bot conversation thread
 /allow — add a Discord user to the allowed list (admin)
-/org — choose or switch organization (send as text)
-/profile — choose or switch bot profile (send as text)
+/org — choose an organization from a dropdown
+/profile — choose a bot profile from a dropdown
 /status — server and model status
 
 In servers, @mention the bot (or a role it holds) or reply to it to chat — each mention in a parent channel opens a new thread. @mention inside another thread claims it. Pair in a DM first.`;

--- a/apps/platform/discord/src/interaction-errors.test.ts
+++ b/apps/platform/discord/src/interaction-errors.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { MessageFlags } from "discord.js";
 import {
   deferSlashInteraction,
   getDiscordErrorCode,
@@ -33,6 +34,20 @@ describe("getDiscordErrorCode", () => {
 });
 
 describe("deferSlashInteraction", () => {
+  test("org and profile pickers are private", async () => {
+    for (const commandName of ["org", "profile"]) {
+      let flags: number | undefined;
+      await deferSlashInteraction({
+        commandName,
+        deferReply: async (options) => {
+          flags = options?.flags;
+        },
+        editReply: async () => {},
+        reply: async () => {},
+      });
+      expect(flags).toBe(MessageFlags.Ephemeral);
+    }
+  });
   test("returns true when deferReply succeeds", async () => {
     const interaction = {
       commandName: "help",

--- a/apps/platform/discord/src/interaction-errors.ts
+++ b/apps/platform/discord/src/interaction-errors.ts
@@ -1,3 +1,5 @@
+import { MessageFlags } from "discord.js";
+
 /** Discord: Unknown interaction (expired or already handled). */
 const UNKNOWN_INTERACTION = 10_062;
 /** Discord: Interaction has already been acknowledged. */
@@ -23,7 +25,9 @@ export function isIgnorableInteractionError(error: unknown): boolean {
 
 type SlashDeferInteraction = {
   commandName: string;
-  deferReply: () => Promise<unknown>;
+  deferReply: (options?: {
+    flags: typeof MessageFlags.Ephemeral;
+  }) => Promise<unknown>;
   reply: (options: { content: string }) => Promise<unknown>;
   editReply: (options: { content: string }) => Promise<unknown>;
 };
@@ -36,7 +40,11 @@ export async function deferSlashInteraction(
   interaction: SlashDeferInteraction
 ): Promise<boolean> {
   try {
-    await interaction.deferReply();
+    await interaction.deferReply(
+      interaction.commandName === "org" || interaction.commandName === "profile"
+        ? { flags: MessageFlags.Ephemeral }
+        : undefined
+    );
     return true;
   } catch (error) {
     if (isIgnorableInteractionError(error)) {

--- a/apps/platform/discord/src/slash-commands.test.ts
+++ b/apps/platform/discord/src/slash-commands.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, test } from "bun:test";
 import { buildSlashCommands } from "./slash-commands";
 
 describe("buildSlashCommands", () => {
+  test("registers org and profile pickers", () => {
+    const names = buildSlashCommands().map((command) => command.name);
+    expect(names).toContain("org");
+    expect(names).toContain("profile");
+  });
   test("registers allow with a required user option", () => {
     const commands = buildSlashCommands();
     expect(commands.map((command) => command.name)).toContain("allow");

--- a/apps/platform/discord/src/slash-commands.ts
+++ b/apps/platform/discord/src/slash-commands.ts
@@ -14,6 +14,8 @@ const COMMAND_NAMES = [
   "close",
   "status",
   "allow",
+  "org",
+  "profile",
 ] as const;
 
 export function buildSlashCommands(): SlashCommandBuilder[] {
@@ -24,6 +26,8 @@ export function buildSlashCommands(): SlashCommandBuilder[] {
     compact: "Compact conversation history",
     help: "Show available commands",
     new: "Start a new conversation",
+    org: "Choose an organization",
+    profile: "Choose a bot profile",
     start: "Welcome and pairing help",
     status: "Show server and model status",
     stop: "Stop the current agent reply",

--- a/apps/platform/discord/src/test-helpers.ts
+++ b/apps/platform/discord/src/test-helpers.ts
@@ -121,6 +121,7 @@ export function createMockClient(
       }
       return session;
     },
+    forOrg: () => client,
     getModels: async () => ({
       currentProviderId: null,
       displayName: null,

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -6,6 +6,31 @@ import { join } from "node:path";
 import { getUserConfigDir, saveUserConfig } from "@nakama/core";
 import { NakamaAuthExpiredError, NakamaClient } from "./index";
 
+test("scoped clients keep session requests in their original organization", async () => {
+  const requests: Request[] = [];
+  const client = new NakamaClient({
+    authToken: "test-token",
+    baseUrl: "http://localhost:4310",
+    fetch: (async (input, init) => {
+      requests.push(new Request(input, init));
+      return Response.json({ messages: [] });
+    }) as typeof fetch,
+  });
+  const first = client.forOrg("org_a").createChatSession("first", "discord");
+  const second = client.forOrg("org_b").createChatSession("second", "discord");
+  client.setOrgId("org_c");
+  await Promise.all([first.getMessages(), second.getMessages()]);
+  expect(requests.map((request) => request.headers.get("X-Org-Id"))).toEqual([
+    "org_a",
+    "org_b",
+  ]);
+  expect(
+    requests.every(
+      (request) => request.headers.get("Authorization") === "Bearer test-token"
+    )
+  ).toBe(true);
+});
+
 test("plugin access requests retain their explicit organization", async () => {
   const requests: Request[] = [];
   const client = new NakamaClient({

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -274,6 +274,18 @@ export class NakamaClient {
     this.orgId = orgId?.trim() || null;
   }
 
+  /** Independent request scope; changing its org never changes the parent client. */
+  forOrg(orgId: string | null): NakamaClient {
+    return new NakamaClient({
+      authToken: this.authToken ?? undefined,
+      baseUrl: this.baseUrl,
+      clientOrigin: this.clientOrigin ?? undefined,
+      credentials: this.credentials,
+      fetch: this.fetchImpl,
+      orgId,
+    });
+  }
+
   private applyAuthUserResponse(response: AuthUserResponse): void {
     const activeOrgId = response.activeOrgId ?? response.orgId ?? null;
     this.setOrgId(activeOrgId);


### PR DESCRIPTION
## Summary

Choose Discord organizations and profiles with private dropdowns while keeping each thread's conversation in the correct organization.

**Before:** replying “2” could switch organizations and leave the thread reporting “Session not found.”
**After:** `/org` and `/profile` open paginated pickers with Apply and Cancel; selecting previews the choice until Apply, ordinary replies remain chat messages, and organization switches invalidate the old session.

Why safe:
1. Selections recheck authorization, available choices, and stale profile context.
2. Each event uses an independent API client; sibling threads retain their organization.

Follow up if live Discord selection produces interaction errors or another session/org mismatch. Restart the Discord worker to register the new commands.

## Test plan

- [x] `bun test apps/platform/discord/src packages/client/src` — 149 pass; scoped lint, Discord build, and `bun run knip` pass.
- [ ] After deployment, select then Apply/Cancel in both pickers, reply “2,” and confirm a sibling thread still works.

Repository-wide TypeScript checking remains blocked by existing errors. Live Discord validation has not been performed.
